### PR TITLE
chore: update workflow references

### DIFF
--- a/.github/workflows/deploy_dev.yml
+++ b/.github/workflows/deploy_dev.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   gitlab-dev-deploy:
     if: ${{ github.event.registry_package.package_version.container_metadata.tag.name == 'development' }}
-    uses: epam/ai-dial-ci/.github/workflows/deploy-development.yml@1.0.1
+    uses: epam/ai-dial-ci/.github/workflows/deploy-development.yml@1.0.2
     with:
       gitlab-project-id: '1827'
       gitlab-project-ref: 'master'

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -8,5 +8,5 @@ on:
 
 jobs:
   integration_tests:
-    uses: epam/ai-dial-ci/.github/workflows/trigger_integration_tests.yml@1.0.1
+    uses: epam/ai-dial-ci/.github/workflows/trigger_integration_tests.yml@1.0.2
     secrets: inherit

--- a/.github/workflows/pr_check_tests.yml
+++ b/.github/workflows/pr_check_tests.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   run_tests:
-    uses: epam/ai-dial-ci/.github/workflows/test_yarn_docker.yml@1.0.1
+    uses: epam/ai-dial-ci/.github/workflows/test_yarn_docker.yml@1.0.2
     secrets: inherit
     with:
       bypass_checks: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,5 +9,5 @@ env:
 
 jobs:
   release:
-    uses: epam/ai-dial-ci/.github/workflows/publish_yarn_docker.yml@1.0.1
+    uses: epam/ai-dial-ci/.github/workflows/publish_yarn_docker.yml@1.0.2
     secrets: inherit


### PR DESCRIPTION
This PR:
- replaces `npm i` with `npm ci`
- fixes release notes generation for newly-created `release-*` branches