### PR TITLE
fix: fix extra space between text and attached docs in comparison mode when expand attached documents on other side

### DIFF
--- a/src/components/Markdown/ChatMDComponent.tsx
+++ b/src/components/Markdown/ChatMDComponent.tsx
@@ -100,7 +100,7 @@ const ChatMDComponent = ({
   return (
     <>
       <MemoizedReactMarkdown
-        className={`prose flex-1 dark:prose-invert prose-a:text-blue-500 prose-a:no-underline hover:prose-a:underline`}
+        className={`prose dark:prose-invert prose-a:text-blue-500 prose-a:no-underline hover:prose-a:underline`}
         remarkPlugins={[remarkGfm]}
         linkTarget="_blank"
         components={getMDComponents(isShowResponseLoader, isInner)}


### PR DESCRIPTION
issue #99: [Compare mode] If to expand attached documents on one side, it looks unfriendly on another side as huge big space appears between text and attached docs