### PR TITLE
fix: Disable the input field

### DIFF
--- a/src/components/Chat/ChatInput.tsx
+++ b/src/components/Chat/ChatInput.tsx
@@ -362,7 +362,10 @@ export const ChatInput = ({
             onKeyDown={handleKeyDown}
           />
 
-          <SendMessageButton handleSend={handleSend} />
+          <SendMessageButton
+            handleSend={handleSend}
+            isInputEmpty={!content || content.trim().length === 0}
+          />
 
           {showScrollDownButton && (
             <ScrollDownButton

--- a/src/components/Chat/SendMessageButton.tsx
+++ b/src/components/Chat/SendMessageButton.tsx
@@ -3,8 +3,6 @@ import { ReactNode } from 'react';
 
 import { useTranslation } from 'next-i18next';
 
-import classNames from 'classnames';
-
 import { ConversationsSelectors } from '@/src/store/conversations/conversations.reducers';
 import { useAppSelector } from '@/src/store/hooks';
 import { ModelsSelectors } from '@/src/store/models/models.reducers';
@@ -13,52 +11,40 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '../Common/Tooltip';
 
 interface Props {
   handleSend: () => void;
-}
-
-interface SendIconComponentProps {
-  isSendDisabled?: boolean;
+  isInputEmpty: boolean;
 }
 
 interface SendIconTooltipProps {
-  isSendDisabled?: boolean;
+  isShowTooltip?: boolean;
+  isError?: boolean;
   children: ReactNode;
 }
 
-const SendIconComponent = ({ isSendDisabled }: SendIconComponentProps) => (
-  <span
-    className={classNames(
-      isSendDisabled
-        ? 'text-gray-400 dark:text-gray-600'
-        : 'hover:text-blue-500',
-    )}
-  >
-    <IconSend size={24} stroke="1.5" />
-  </span>
-);
-
 const SendIconTooltip = ({
-  isSendDisabled,
+  isShowTooltip,
+  isError,
   children,
 }: SendIconTooltipProps) => {
   const { t } = useTranslation('chat');
 
+  const tooltipContent = isError
+    ? 'Please regenerate response to continue working with chat'
+    : 'Please type a message';
   return (
     <>
-      {!isSendDisabled ? (
+      {!isShowTooltip ? (
         children
       ) : (
         <Tooltip>
           <TooltipTrigger>{children}</TooltipTrigger>
-          <TooltipContent>
-            {t('Please regenerate response to continue working with chat')}
-          </TooltipContent>
+          <TooltipContent>{t(tooltipContent)}</TooltipContent>
         </Tooltip>
       )}
     </>
   );
 };
 
-export const SendMessageButton = ({ handleSend }: Props) => {
+export const SendMessageButton = ({ handleSend, isInputEmpty }: Props) => {
   const isModelsLoading = useAppSelector(ModelsSelectors.selectModelsIsLoading);
   const isMessageError = useAppSelector(
     ConversationsSelectors.selectIsMessagesError,
@@ -73,14 +59,16 @@ export const SendMessageButton = ({ handleSend }: Props) => {
     ConversationsSelectors.selectIsConversationsStreaming,
   );
 
-  const isSendDisabled =
+  const isError =
     isLastAssistantMessageEmpty || (isMessageError && notModelConversations);
 
   return (
     <button
-      className="absolute right-4 top-2.5 rounded disabled:cursor-not-allowed"
+      className="absolute right-4 top-2.5 rounded hover:text-blue-500 disabled:cursor-not-allowed disabled:text-gray-400 disabled:dark:text-gray-600"
       onClick={handleSend}
-      disabled={messageIsStreaming || isModelsLoading || isSendDisabled}
+      disabled={
+        messageIsStreaming || isModelsLoading || isError || isInputEmpty
+      }
     >
       {messageIsStreaming || isModelsLoading ? (
         <div
@@ -88,8 +76,11 @@ export const SendMessageButton = ({ handleSend }: Props) => {
           data-qa="message-input-spinner"
         ></div>
       ) : (
-        <SendIconTooltip isSendDisabled={isSendDisabled}>
-          <SendIconComponent isSendDisabled={isSendDisabled} />
+        <SendIconTooltip
+          isShowTooltip={isError || isInputEmpty}
+          isError={isError}
+        >
+          <IconSend size={24} stroke="1.5" />
         </SendIconTooltip>
       )}
     </button>

--- a/src/components/Chat/SendMessageButton.tsx
+++ b/src/components/Chat/SendMessageButton.tsx
@@ -1,4 +1,7 @@
 import { IconSend } from '@tabler/icons-react';
+import { ReactNode } from 'react';
+
+import { useTranslation } from 'next-i18next';
 
 import classNames from 'classnames';
 
@@ -6,9 +9,54 @@ import { ConversationsSelectors } from '@/src/store/conversations/conversations.
 import { useAppSelector } from '@/src/store/hooks';
 import { ModelsSelectors } from '@/src/store/models/models.reducers';
 
+import { Tooltip, TooltipContent, TooltipTrigger } from '../Common/Tooltip';
+
 interface Props {
   handleSend: () => void;
 }
+
+interface SendIconComponentProps {
+  isSendDisabled?: boolean;
+}
+
+interface SendIconTooltipProps {
+  isSendDisabled?: boolean;
+  children: ReactNode;
+}
+
+const SendIconComponent = ({ isSendDisabled }: SendIconComponentProps) => (
+  <span
+    className={classNames(
+      isSendDisabled
+        ? 'text-gray-400 dark:text-gray-600'
+        : 'hover:text-blue-500',
+    )}
+  >
+    <IconSend size={24} stroke="1.5" />
+  </span>
+);
+
+const SendIconTooltip = ({
+  isSendDisabled,
+  children,
+}: SendIconTooltipProps) => {
+  const { t } = useTranslation('chat');
+
+  return (
+    <>
+      {!isSendDisabled ? (
+        children
+      ) : (
+        <Tooltip>
+          <TooltipTrigger>{children}</TooltipTrigger>
+          <TooltipContent>
+            {t('Please regenerate response to continue working with chat')}
+          </TooltipContent>
+        </Tooltip>
+      )}
+    </>
+  );
+};
 
 export const SendMessageButton = ({ handleSend }: Props) => {
   const isModelsLoading = useAppSelector(ModelsSelectors.selectModelsIsLoading);
@@ -26,7 +74,7 @@ export const SendMessageButton = ({ handleSend }: Props) => {
   );
 
   const isSendDisabled =
-    isMessageError && (isLastAssistantMessageEmpty || notModelConversations);
+    isLastAssistantMessageEmpty || (isMessageError && notModelConversations);
 
   return (
     <button
@@ -40,13 +88,9 @@ export const SendMessageButton = ({ handleSend }: Props) => {
           data-qa="message-input-spinner"
         ></div>
       ) : (
-        <span
-          className={classNames(
-            isSendDisabled ? 'text-gray-600' : 'hover:text-blue-500',
-          )}
-        >
-          <IconSend size={24} stroke="1.5" />
-        </span>
+        <SendIconTooltip isSendDisabled={isSendDisabled}>
+          <SendIconComponent isSendDisabled={isSendDisabled} />
+        </SendIconTooltip>
       )}
     </button>
   );

--- a/src/store/conversations/conversations.reducers.ts
+++ b/src/store/conversations/conversations.reducers.ts
@@ -603,7 +603,9 @@ const selectIsLastAssistantMessageEmpty = createSelector(
 const selectNotModelConversations = createSelector(
   [selectSelectedConversations],
   (conversations) => {
-    return conversations.some((conv) => conv.model.type !== 'model');
+    return conversations.some(
+      (conv) => conv.model.type !== 'model' || conv.selectedAddons.length > 0,
+    );
   },
 );
 


### PR DESCRIPTION
**Disable the input field if the last request has failed.**

Fixed:
- Send icon is not disabled in Light mode. Also there should be tooltip-explanation on hover over
- Disable Send icon if there is empty response for Models/Assistants/Applications

Refs: #81, #82.