### PR TITLE
feat: ChatOverlayManager missed styling, animation functionality

### DIFF
--- a/overlay-examples/chatOverlayManagerFlow.ts
+++ b/overlay-examples/chatOverlayManagerFlow.ts
@@ -16,8 +16,6 @@ export const chatOverlayManagerFlow = () => {
 
   manager.createOverlay(currentOptions);
 
-  manager.showOverlay('test');
-
   manager.subscribe('test', '@DIAL_OVERLAY/GPT_END_GENERATING', () =>
     // eslint-disable-next-line no-console
     console.log('END GENERATING'),

--- a/overlay-examples/chatOverlayManagerFlow.ts
+++ b/overlay-examples/chatOverlayManagerFlow.ts
@@ -11,6 +11,7 @@ export const chatOverlayManagerFlow = () => {
     enabledFeatures:
       'conversations-section,prompts-section,top-settings,top-clear-conversation,top-chat-info,top-chat-model-settings,empty-chat-settings,header,footer,request-api-key,report-an-issue,likes',
     modelId: 'statgpt-py',
+    allowFullscreen: true,
     requestTimeout: 20000,
   };
 

--- a/overlay-examples/main.ts
+++ b/overlay-examples/main.ts
@@ -2,7 +2,7 @@ import { chatOverlayFlow } from './chatOverlayFlow';
 import { chatOverlayManagerFlow } from './chatOverlayManagerFlow';
 
 // set the flag to display needed flow as example
-const isThroughManager = false;
+const isThroughManager = true;
 
 window.onload = () => {
   // checking that overlay doesn't scroll the page

--- a/overlay/ChatOverlayManager.ts
+++ b/overlay/ChatOverlayManager.ts
@@ -190,6 +190,8 @@ export class ChatOverlayManager {
 
     setStyles(controlsContainer, {
       display: 'flex',
+      justifyContent: 'end',
+      alignItems: 'end',
       backgroundColor: '#444654',
     });
 
@@ -262,6 +264,8 @@ export class ChatOverlayManager {
       height: '10px',
       width: '10px',
     });
+
+    button.appendChild(buttonInnerElement);
 
     return button;
   }

--- a/overlay/ChatOverlayManager.ts
+++ b/overlay/ChatOverlayManager.ts
@@ -162,11 +162,8 @@ export class ChatOverlayManager {
   public createOverlay(options: ChatOverlayFullOptions) {
     const container = document.createElement('div');
 
-    const overlay = new ChatOverlay(container, options);
-
-    if (options.allowFullscreen) {
-      overlay.allowFullscreen();
-    }
+    const overlayContainer = document.createElement('div');
+    const controlsContainer = document.createElement('div');
 
     const position = getPosition()[options?.position || 'right-bottom'];
 
@@ -174,13 +171,17 @@ export class ChatOverlayManager {
     const closeButton = this.createCloseButton();
     const fullscreenButton = this.createFullscreenButton();
 
-    const controlsContainer = document.createElement('div');
-
     setStyles(controlsContainer, {
       display: 'flex',
-      justifyContent: 'end',
       alignItems: 'end',
+      justifyContent: 'end',
+      height: '30px',
+      paddingRight: '10px',
       backgroundColor: '#444654',
+    });
+
+    setStyles(overlayContainer, {
+      height: 'calc(100% - 30px)',
     });
 
     toggleButton.onclick = () => this.showOverlay(options.id);
@@ -190,10 +191,13 @@ export class ChatOverlayManager {
     fullscreenButton.onclick = () => this.openFullscreen(options.id);
 
     controlsContainer.appendChild(closeButton);
-    controlsContainer.appendChild(fullscreenButton);
-    container.prepend(controlsContainer);
 
-    document.body.appendChild(container);
+    const overlay = new ChatOverlay(overlayContainer, options);
+
+    if (options.allowFullscreen) {
+      overlay.allowFullscreen();
+      controlsContainer.appendChild(fullscreenButton);
+    }
 
     this.overlays.push({
       container,
@@ -204,8 +208,13 @@ export class ChatOverlayManager {
       toggleButton,
     });
 
+    container.appendChild(controlsContainer);
+    container.appendChild(overlayContainer);
+
     this.updateOverlay(options.id);
     this.hideOverlay(options.id);
+
+    document.body.appendChild(container);
   }
 
   /**

--- a/overlay/ChatOverlayManager.ts
+++ b/overlay/ChatOverlayManager.ts
@@ -110,6 +110,7 @@ const defaultOverlayPlacementOptions: Pick<
 
 interface Overlay {
   container: HTMLElement;
+  toggleButton: HTMLElement;
 
   overlay: ChatOverlay;
 
@@ -169,23 +170,10 @@ export class ChatOverlayManager {
 
     const position = getPosition()[options?.position || 'right-bottom'];
 
-    const newOverlay = {
-      container,
-      overlay,
-      options,
-      isHidden: false,
-      position,
-    };
-
-    this.overlays.push(newOverlay);
-
-    this.updateOverlay(options.id);
-    this.hideOverlay(options.id);
-
-    const toggleButton = this.createOverlayToggle(newOverlay);
-
+    const toggleButton = this.createOverlayToggle(position, options);
     const closeButton = this.createCloseButton();
     const fullscreenButton = this.createFullscreenButton();
+
     const controlsContainer = document.createElement('div');
 
     setStyles(controlsContainer, {
@@ -203,16 +191,34 @@ export class ChatOverlayManager {
 
     controlsContainer.appendChild(closeButton);
     controlsContainer.appendChild(fullscreenButton);
-
     container.prepend(controlsContainer);
 
     document.body.appendChild(container);
+
+    this.overlays.push({
+      container,
+      overlay,
+      options,
+      isHidden: false,
+      position,
+      toggleButton,
+    });
+
+    this.updateOverlay(options.id);
+    this.hideOverlay(options.id);
   }
 
-  public createOverlayToggle(overlay: Overlay) {
+  /**
+   * Creates toggle button to show overlay
+   * @param position overlay placement, needed to show button in the same place where would be the overlay
+   * @param options overlay options, needed to show cu
+   * @returns {HTMLButtonElement} Reference to created toggle button
+   */
+  public createOverlayToggle(
+    position: Position,
+    options: ChatOverlayFullOptions,
+  ): HTMLButtonElement {
     const button = document.createElement('button');
-
-    const { options, position } = overlay;
 
     setStyles(button, {
       backgroundColor:
@@ -235,7 +241,11 @@ export class ChatOverlayManager {
     return button;
   }
 
-  public createFullscreenButton() {
+  /**
+   * Creates button to open overlay in fullscreen mode
+   * @returns {HTMLButtonElement} Reference to created fullscreen button
+   */
+  public createFullscreenButton(): HTMLButtonElement {
     const button = document.createElement('button');
 
     setStyles(button, {
@@ -270,7 +280,11 @@ export class ChatOverlayManager {
     return button;
   }
 
-  public createCloseButton() {
+  /**
+   * Creates button which hides overlay
+   * @returns {HTMLButtonElement} Reference to created close button
+   */
+  public createCloseButton(): HTMLButtonElement {
     const closeButton = document.createElement('button');
 
     setStyles(closeButton, {
@@ -309,13 +323,14 @@ export class ChatOverlayManager {
    * @param id {string} id of overlay that should be deleted
    */
   public removeOverlay(id: string) {
-    const { overlay, container } = this.getOverlay(id);
+    const { overlay, container, toggleButton } = this.getOverlay(id);
 
     overlay.destroy();
 
     this.overlays = this.overlays.filter(({ options }) => options.id !== id);
 
     document.body.removeChild(container);
+    document.body.removeChild(toggleButton);
   }
 
   public openFullscreen(id: string) {


### PR DESCRIPTION
During implementing more complex overlay logic we lost next things:

1. Showing button for opening overlay
2. Showing animation when showing overlay
3. Showing header with next buttons there: fullscreen and minimize

It was returned