### PR TITLE
fix: fix Playback empty info block style

### DIFF
--- a/src/components/Chat/PlaybackEmptyInfo.tsx
+++ b/src/components/Chat/PlaybackEmptyInfo.tsx
@@ -6,7 +6,7 @@ interface Props {
 export const PlaybackEmptyInfo = ({ appName, conversationName }: Props) => {
   return (
     <div className="flex h-full w-full flex-col items-center px-3 pt-5">
-      <div className="flex h-full flex-col items-center justify-center gap-6 rounded bg-gray-200 p-4 dark:bg-gray-800 lg:mx-auto lg:max-w-3xl">
+      <div className="flex h-full w-full flex-col items-center justify-center gap-2 rounded bg-gray-200 p-4 dark:bg-gray-800 lg:mx-auto lg:max-w-3xl">
         <h4 className="w-full text-center text-xl font-semibold">{appName}</h4>
 
         <h4 className="flex w-full justify-center text-center text-base font-semibold">


### PR DESCRIPTION
fixed:
- fixed width equals to message box for small titles
- smaller gap inside block
![image](https://github.com/epam/ai-dial-chat/assets/20163971/f10a139a-75b4-432b-8c7a-073b7840f3c0)
