### PR TITLE
fix: automatically rename chat after clearing all messages

### DIFF
--- a/src/components/Chat/Chat.tsx
+++ b/src/components/Chat/Chat.tsx
@@ -271,13 +271,16 @@ export const Chat = memo(() => {
         confirm(t<string>('Are you sure you want to clear all messages?')) &&
         conversation
       ) {
-        const { messages } = conversation;
+        const { messages, isNameChanged, name } = conversation;
+        const newConversationName = isNameChanged
+          ? name
+          : DEFAULT_CONVERSATION_NAME;
 
         dispatch(
           ConversationsActions.updateConversation({
             id: conversation.id,
             values: {
-              name: DEFAULT_CONVERSATION_NAME,
+              name: newConversationName,
               messages: messages.filter((message) => message.role === 'system'),
             },
           }),

--- a/src/components/Chat/Chat.tsx
+++ b/src/components/Chat/Chat.tsx
@@ -33,7 +33,10 @@ import { PromptsSelectors } from '@/src/store/prompts/prompts.reducers';
 import { SettingsSelectors } from '@/src/store/settings/settings.reducers';
 import { UISelectors } from '@/src/store/ui/ui.reducers';
 
-import { DEFAULT_ASSISTANT_SUBMODEL } from '@/src/constants/default-settings';
+import {
+  DEFAULT_ASSISTANT_SUBMODEL,
+  DEFAULT_CONVERSATION_NAME,
+} from '@/src/constants/default-settings';
 
 import { ChatCompareRotate } from './ChatCompareRotate';
 import { ChatCompareSelect } from './ChatCompareSelect';
@@ -274,6 +277,7 @@ export const Chat = memo(() => {
           ConversationsActions.updateConversation({
             id: conversation.id,
             values: {
+              name: DEFAULT_CONVERSATION_NAME,
               messages: messages.filter((message) => message.role === 'system'),
             },
           }),

--- a/src/components/Chat/Chat.tsx
+++ b/src/components/Chat/Chat.tsx
@@ -34,10 +34,7 @@ import { PromptsSelectors } from '@/src/store/prompts/prompts.reducers';
 import { SettingsSelectors } from '@/src/store/settings/settings.reducers';
 import { UISelectors } from '@/src/store/ui/ui.reducers';
 
-import {
-  DEFAULT_ASSISTANT_SUBMODEL,
-  DEFAULT_CONVERSATION_NAME,
-} from '@/src/constants/default-settings';
+import { DEFAULT_ASSISTANT_SUBMODEL } from '@/src/constants/default-settings';
 
 import { ChatCompareRotate } from './ChatCompareRotate';
 import { ChatCompareSelect } from './ChatCompareSelect';
@@ -272,16 +269,12 @@ export const Chat = memo(() => {
         confirm(t<string>('Are you sure you want to clear all messages?')) &&
         conversation
       ) {
-        const { messages, isNameChanged, name } = conversation;
-        const newConversationName = isNameChanged
-          ? name
-          : DEFAULT_CONVERSATION_NAME;
+        const { messages } = conversation;
 
         dispatch(
           ConversationsActions.updateConversation({
             id: conversation.id,
             values: {
-              name: newConversationName,
               messages: messages.filter(
                 (message) => message.role === Role.System,
               ),

--- a/src/components/Chatbar/components/Conversation.tsx
+++ b/src/components/Chatbar/components/Conversation.tsx
@@ -97,6 +97,7 @@ export const ConversationComponent = ({ item: conversation, level }: Props) => {
             id: conversation.id,
             values: {
               name: renameValue.trim(),
+              isNameChanged: true,
             },
           }),
         );

--- a/src/store/conversations/conversations.epics.ts
+++ b/src/store/conversations/conversations.epics.ts
@@ -476,6 +476,15 @@ const sendMessageEpic: AppEpic = (action$, state$) =>
           : payload.conversation.messages
       ).concat(userMessage, assistantMessage);
 
+      const newConversationName =
+        !payload.conversation.replay.isReplay &&
+        updatedMessages.length === 2 &&
+        !payload.conversation.isNameChanged
+          ? payload.message.content.length > 160
+            ? payload.message.content.substring(0, 160) + '...'
+            : payload.message.content
+          : payload.conversation.name;
+
       const updatedConversation: Conversation = {
         ...payload.conversation,
         lastActivityDate: Date.now(),
@@ -484,14 +493,7 @@ const sendMessageEpic: AppEpic = (action$, state$) =>
           activeReplayIndex: payload.activeReplayIndex,
         },
         messages: updatedMessages,
-        name:
-          !payload.conversation.replay.isReplay &&
-          updatedMessages.length === 2 &&
-          payload.conversation.name === DEFAULT_CONVERSATION_NAME
-            ? payload.message.content.length > 160
-              ? payload.message.content.substring(0, 160) + '...'
-              : payload.message.content
-            : payload.conversation.name,
+        name: newConversationName,
         isMessageStreaming: true,
       };
 
@@ -882,16 +884,10 @@ const deleteMessageEpic: AppEpic = (action$, state$) =>
             );
           }
 
-          const newConversationName =
-            newMessages.length === 0 && !conv.isNameChanged
-              ? DEFAULT_CONVERSATION_NAME
-              : conv.name;
-
           return of(
             ConversationsActions.updateConversation({
               id: conv.id,
               values: {
-                name: newConversationName,
                 messages: newMessages,
               },
             }),

--- a/src/store/conversations/conversations.epics.ts
+++ b/src/store/conversations/conversations.epics.ts
@@ -881,10 +881,19 @@ const deleteMessageEpic: AppEpic = (action$, state$) =>
               (message, index) => index !== payload.index,
             );
           }
+
+          const newConversationName =
+            newMessages.length === 0 && !conv.isNameChanged
+              ? DEFAULT_CONVERSATION_NAME
+              : conv.name;
+
           return of(
             ConversationsActions.updateConversation({
               id: conv.id,
-              values: { messages: newMessages },
+              values: {
+                name: newConversationName,
+                messages: newMessages,
+              },
             }),
           );
         }),

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -81,6 +81,7 @@ export interface Conversation {
 
   isMessageStreaming: boolean;
   isShared?: boolean;
+  isNameChanged?: boolean;
 }
 export interface Replay {
   replayAsIs?: boolean;


### PR DESCRIPTION

Implemented renaming conversation to the default name in case of clearing all messages in it.
Moreover, added flag to not rename if it was renamed by user.

Issue refs: #86 