### PR TITLE
fix: chat2 highlight disappears if you navigate in its menu when chat1 is active #94

### DIFF
--- a/src/components/Chatbar/components/Conversation.tsx
+++ b/src/components/Chatbar/components/Conversation.tsx
@@ -279,6 +279,7 @@ export const ConversationComponent = ({ item: conversation, level }: Props) => {
         isSelected || isRenaming || isDeleting
           ? 'border-l-green bg-green/15'
           : 'border-l-transparent',
+        { 'bg-green/15': isContextMenu },
       )}
       style={{
         paddingLeft: (level && `${0.875 + level * 1.5}rem`) || '0.875rem',


### PR DESCRIPTION
fix: added highlight for the chat with open context menu

Refs: #94 