### PR TITLE
chore: reorder coversations and prompts settings (#300)

### DIFF
--- a/src/components/Chatbar/components/ChatbarSettings.tsx
+++ b/src/components/Chatbar/components/ChatbarSettings.tsx
@@ -36,9 +36,6 @@ export const ChatbarSettings = () => {
 
   const dispatch = useAppDispatch();
 
-  const conversations = useAppSelector(
-    ConversationsSelectors.selectConversations,
-  );
   const isStreaming = useAppSelector(
     ConversationsSelectors.selectIsConversationsStreaming,
   );
@@ -65,12 +62,13 @@ export const ChatbarSettings = () => {
   const menuItems: DisplayMenuItemProps[] = useMemo(
     () => [
       {
-        name: t('Delete all conversations'),
-        display: conversations.length > 0,
-        dataQa: 'delete-conversations',
-        Icon: IconTrashX,
+        name: t('Create new folder'),
+        dataQa: 'create-folder',
+        Icon: FolderPlus,
         onClick: () => {
-          setIsClearModalOpen(true);
+          dispatch(
+            ConversationsActions.createFolder({ name: t('New folder') }),
+          );
         },
       },
       {
@@ -93,13 +91,11 @@ export const ChatbarSettings = () => {
         },
       },
       {
-        name: t('Create new folder'),
-        dataQa: 'create-folder',
-        Icon: FolderPlus,
+        name: t('Delete all conversations'),
+        dataQa: 'delete-conversations',
+        Icon: IconTrashX,
         onClick: () => {
-          dispatch(
-            ConversationsActions.createFolder({ name: t('New folder') }),
-          );
+          setIsClearModalOpen(true);
         },
       },
       {
@@ -122,14 +118,7 @@ export const ChatbarSettings = () => {
         },
       },
     ],
-    [
-      conversations,
-      dispatch,
-      enabledFeatures,
-      handleToggleCompare,
-      isStreaming,
-      t,
-    ],
+    [dispatch, enabledFeatures, handleToggleCompare, isStreaming, t],
   );
 
   return (

--- a/src/components/Promptbar/components/PromptbarSettings.tsx
+++ b/src/components/Promptbar/components/PromptbarSettings.tsx
@@ -13,8 +13,10 @@ import { Prompt } from '@/src/types/prompt';
 import { Translation } from '@/src/types/translation';
 
 import { useAppDispatch, useAppSelector } from '@/src/store/hooks';
-import { PromptsActions } from '@/src/store/prompts/prompts.reducers';
-import { SettingsSelectors } from '@/src/store/settings/settings.reducers';
+import {
+  PromptsActions,
+  PromptsSelectors,
+} from '@/src/store/prompts/prompts.reducers';
 
 import { ConfirmDialog } from '@/src/components/Common/ConfirmDialog';
 import SidebarMenu from '@/src/components/Common/SidebarMenu';
@@ -31,19 +33,16 @@ export const PromptbarSettings: FC<PromptbarSettingsProps> = ({
   const { t } = useTranslation(Translation.PromptBar);
   const dispatch = useAppDispatch();
   const [isOpen, setIsOpen] = useState(false);
-  const enabledFeatures = useAppSelector(
-    SettingsSelectors.selectEnabledFeatures,
-  );
+  const folders = useAppSelector(PromptsSelectors.selectFolders);
 
   const menuItems: DisplayMenuItemProps[] = useMemo(
     () => [
       {
-        name: t('Delete all prompts'),
-        display: allPrompts.length > 0,
-        dataQa: 'delete-prompts',
-        Icon: IconTrashX,
+        name: t('Create new folder'),
+        dataQa: 'create-prompt-folder',
+        Icon: FolderPlus,
         onClick: () => {
-          setIsOpen(true);
+          dispatch(PromptsActions.createFolder({ name: t('New folder') }));
         },
       },
       {
@@ -58,6 +57,7 @@ export const PromptbarSettings: FC<PromptbarSettingsProps> = ({
         CustomTriggerRenderer: Import,
       },
       {
+        display: allPrompts.length > 0 || folders.length > 0,
         name: t('Export prompts'),
         dataQa: 'export-prompts',
         Icon: IconFileArrowRight,
@@ -66,15 +66,16 @@ export const PromptbarSettings: FC<PromptbarSettingsProps> = ({
         },
       },
       {
-        name: t('Create new folder'),
-        dataQa: 'create-prompt-folder',
-        Icon: FolderPlus,
+        name: t('Delete all'),
+        display: allPrompts.length > 0 || folders.length > 0,
+        dataQa: 'delete-prompts',
+        Icon: IconTrashX,
         onClick: () => {
-          dispatch(PromptsActions.createFolder({ name: t('New folder') }));
+          setIsOpen(true);
         },
       },
     ],
-    [allPrompts, dispatch, enabledFeatures, t],
+    [allPrompts.length, dispatch, folders.length, t],
   );
 
   return (


### PR DESCRIPTION
### Description
- Issue #300 

#### Changes:
- change "create folder" and "delete all" positions
- hide "export" if no prompts/folders
- show "delete all" if have only folders

conversations:
![image](https://github.com/epam/ai-dial-chat/assets/20163971/eb349091-c5f8-44ef-a6d7-f89e8dcf39f4)

prompts(empty):
![image](https://github.com/epam/ai-dial-chat/assets/20163971/2f7091b5-ec82-4674-9ef1-e290477bba68)
prompts(not empty):
![image](https://github.com/epam/ai-dial-chat/assets/20163971/dc8fd5ef-ef70-4a07-b868-c4641df3b1bf)