### PR TITLE
fix: change chat message border to the correct (secondary) color (issue #477)

### DIFF
--- a/src/components/Chat/ChatMessage.tsx
+++ b/src/components/Chat/ChatMessage.tsx
@@ -310,7 +310,7 @@ export const ChatMessage: FC<Props> = memo(
     return (
       <div
         className={classNames(
-          'group h-full min-h-[78px] border-b border-primary md:px-4 xl:px-8',
+          'group h-full min-h-[78px] border-b border-secondary md:px-4 xl:px-8',
           isAssistant && 'bg-layer-2',
         )}
         style={{ overflowWrap: 'anywhere' }}


### PR DESCRIPTION
![image](https://github.com/epam/ai-dial-chat/assets/143205282/86a41a1b-1056-4908-ad3e-5efa9eb8cfe4)
