### PR TITLE
fix(chat): hide context menu options for empty folders (Issue #756)

### DIFF
--- a/apps/chat/src/components/Common/FolderContextMenu.tsx
+++ b/apps/chat/src/components/Common/FolderContextMenu.tsx
@@ -30,6 +30,7 @@ interface FolderContextMenuProps {
   folder: FolderInterface;
   featureType: FeatureType;
   isOpen?: boolean;
+  isEmpty?: boolean;
   onDelete?: MouseEventHandler<unknown>;
   onRename?: MouseEventHandler<unknown>;
   onAddFolder?: MouseEventHandler;
@@ -54,6 +55,7 @@ export const FolderContextMenu = ({
   onPublishUpdate,
   onUpload,
   isOpen,
+  isEmpty,
 }: FolderContextMenuProps) => {
   const { t } = useTranslation(Translation.SideBar);
   const isPublishingEnabled = useAppSelector((state) =>
@@ -83,7 +85,7 @@ export const FolderContextMenu = ({
       },
       {
         name: t('Share'),
-        display: isSharingEnabled && !!onShare && !isExternal,
+        display: !isEmpty && isSharingEnabled && !!onShare && !isExternal,
         dataQa: 'share',
         Icon: IconUserShare,
         onClick: onShare,
@@ -92,6 +94,7 @@ export const FolderContextMenu = ({
         name: t('Publish'),
         dataQa: 'publish',
         display:
+          !isEmpty &&
           isPublishingEnabled &&
           !folder.isPublished &&
           !!onPublish &&
@@ -103,14 +106,21 @@ export const FolderContextMenu = ({
         name: t('Update'),
         dataQa: 'update-publishing',
         display:
-          isPublishingEnabled && !!folder.isPublished && !!onPublishUpdate,
+          !isEmpty &&
+          isPublishingEnabled &&
+          !!folder.isPublished &&
+          !!onPublishUpdate,
         Icon: IconClockShare,
         onClick: onPublishUpdate,
       },
       {
         name: t('Unpublish'),
         dataQa: 'unpublish',
-        display: isPublishingEnabled && !!folder.isPublished && !!onUnpublish,
+        display:
+          !isEmpty &&
+          isPublishingEnabled &&
+          !!folder.isPublished &&
+          !!onUnpublish,
         Icon: UnpublishIcon,
         onClick: onUnpublish,
       },
@@ -134,6 +144,7 @@ export const FolderContextMenu = ({
       onUpload,
       isExternal,
       onRename,
+      isEmpty,
       isSharingEnabled,
       onShare,
       isPublishingEnabled,

--- a/apps/chat/src/components/Folder/Folder.tsx
+++ b/apps/chat/src/components/Folder/Folder.tsx
@@ -730,6 +730,7 @@ const Folder = <T extends ConversationInfo | PromptInfo | DialFile>({
                     onOpenChange={setIsContextMenu}
                     onUpload={onFileUpload && onUpload}
                     isOpen={isContextMenu}
+                    isEmpty={!hasChildElements}
                   />
                 </div>
               )}

--- a/apps/chat/src/components/Folder/Folder.tsx
+++ b/apps/chat/src/components/Folder/Folder.tsx
@@ -228,6 +228,15 @@ const Folder = <T extends ConversationInfo | PromptInfo | DialFile>({
     return filteredChildFolders.length > 0 || filteredChildItems.length > 0;
   }, [filteredChildFolders.length, filteredChildItems.length]);
 
+  const hasChildItemOnAnyLevel = useMemo(() => {
+    const prefix = `${currentFolder.id}/`;
+    return allItemsWithoutFilters.some(
+      (entity) =>
+        entity.folderId === currentFolder.id ||
+        entity.folderId.startsWith(prefix),
+    );
+  }, [allItemsWithoutFilters, currentFolder.id]);
+
   const { refs, context } = useFloating({
     open: isContextMenu,
     onOpenChange: setIsContextMenu,
@@ -730,7 +739,7 @@ const Folder = <T extends ConversationInfo | PromptInfo | DialFile>({
                     onOpenChange={setIsContextMenu}
                     onUpload={onFileUpload && onUpload}
                     isOpen={isContextMenu}
-                    isEmpty={!hasChildElements}
+                    isEmpty={!hasChildItemOnAnyLevel}
                   />
                 </div>
               )}


### PR DESCRIPTION
- Issue #756