### PR TITLE
fix(chat-e2e): remove the deprecated "anthropic.claude-v1"

### DIFF
--- a/apps/chat-e2e/src/testData/expectedConstants.ts
+++ b/apps/chat-e2e/src/testData/expectedConstants.ts
@@ -157,7 +157,6 @@ export enum ModelIds {
   AI21_GRANDE = 'ai21.j2-grande-instruct',
   AI21_JUMBO = 'ai21.j2-jumbo-instruct',
   ANTHROPIC_CLAUDE_INSTANT_V1 = 'anthropic.claude-instant-v1',
-  ANTHROPIC_CLAUDE_V1 = 'anthropic.claude-v1',
   ANTHROPIC_CLAUDE_V2 = 'anthropic.claude-v2',
   ANTHROPIC_CLAUDE_V21 = 'anthropic.claude-v2-1',
   STABLE_DIFFUSION = 'stability.stable-diffusion-xl',

--- a/apps/chat-e2e/src/tests/chatApi/arithmeticRequest.test.ts
+++ b/apps/chat-e2e/src/tests/chatApi/arithmeticRequest.test.ts
@@ -26,7 +26,6 @@ const modelsForArithmeticRequest: {
   { modelId: ModelIds.AWS_TITAN, isSysPromptAllowed: true },
   { modelId: ModelIds.AI21_GRANDE, isSysPromptAllowed: true },
   { modelId: ModelIds.AI21_JUMBO, isSysPromptAllowed: true },
-  { modelId: ModelIds.ANTHROPIC_CLAUDE_V1, isSysPromptAllowed: true },
   { modelId: ModelIds.ANTHROPIC_CLAUDE_V2, isSysPromptAllowed: true },
   { modelId: ModelIds.ANTHROPIC_CLAUDE_V21, isSysPromptAllowed: true },
   {

--- a/apps/chat/src/types/openai.ts
+++ b/apps/chat/src/types/openai.ts
@@ -49,7 +49,6 @@ export enum OpenAIEntityModelID {
   AI21_J2_GRANDE_INSTRUCT = 'ai21.j2-grande-instruct',
   AI21_J2_JUMBO_INSTRUCT = 'ai21.j2-jumbo-instruct',
   ANTHROPIC_CLAUDE_INSTANT_V1 = 'anthropic.claude-instant-v1',
-  ANTHROPIC_CLAUDE_V1 = 'anthropic.claude-v1',
   STABILITY_STABLE_DIFFUSION_XL = 'stability.stable-diffusion-xl',
   GPT_WORLD = 'gpt-world',
   MIRROR = 'mirror',
@@ -154,13 +153,6 @@ export const OpenAIEntityModels: Record<string, OpenAIEntityModel> = {
   [OpenAIEntityModelID.ANTHROPIC_CLAUDE_INSTANT_V1]: {
     id: OpenAIEntityModelID.ANTHROPIC_CLAUDE_INSTANT_V1,
     name: 'Anthropic (Claude Instant)',
-    maxLength: 24000,
-    requestLimit: 6000,
-    type: EntityType.Model,
-  },
-  [OpenAIEntityModelID.ANTHROPIC_CLAUDE_V1]: {
-    id: OpenAIEntityModelID.ANTHROPIC_CLAUDE_V1,
-    name: 'Anthropic (Claude)',
     maxLength: 24000,
     requestLimit: 6000,
     type: EntityType.Model,


### PR DESCRIPTION
**Description:**

remove the deprecated `anthropic.claude-v1`

Issues:
- no issue

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
