### PR TITLE
fix(chat): disable send when last message error (Issue #532)

### DIFF
--- a/apps/chat/src/components/Chat/ChatInput/ChatInputMessage.tsx
+++ b/apps/chat/src/components/Chat/ChatInput/ChatInputMessage.tsx
@@ -86,14 +86,10 @@ export const ChatInputMessage = ({
   const isLastAssistantMessageEmpty = useAppSelector(
     ConversationsSelectors.selectIsLastAssistantMessageEmpty,
   );
-  const notModelConversations = useAppSelector(
-    ConversationsSelectors.selectNotModelConversations,
-  );
   const isModelsLoaded = useAppSelector(ModelsSelectors.selectIsModelsLoaded);
   const isChatFullWidth = useAppSelector(UISelectors.selectIsChatFullWidth);
 
-  const isError =
-    isLastAssistantMessageEmpty || (isMessageError && notModelConversations);
+  const isError = isLastAssistantMessageEmpty || isMessageError;
 
   const maxLength = useMemo(() => {
     const maxLengthArray = selectedConversations.map(

--- a/apps/chat/src/store/conversations/conversations.selectors.ts
+++ b/apps/chat/src/store/conversations/conversations.selectors.ts
@@ -325,16 +325,6 @@ export const selectIsLastAssistantMessageEmpty = createSelector(
   },
 );
 
-export const selectNotModelConversations = createSelector(
-  [selectSelectedConversations, ModelsSelectors.selectModelsMap],
-  (conversations, modelsMap) => {
-    return conversations.some(
-      (conv) =>
-        modelsMap[conv.model.id]?.type !== EntityType.Model ||
-        conv.selectedAddons.length > 0,
-    );
-  },
-);
 const selectSelectedConversationsModels = createSelector(
   [selectSelectedConversations, ModelsSelectors.selectModelsMap],
   (conversations, modelsMap) => {

--- a/apps/chat/src/store/conversations/conversations.selectors.ts
+++ b/apps/chat/src/store/conversations/conversations.selectors.ts
@@ -24,7 +24,7 @@ import {
 import { translate } from '@/src/utils/app/translation';
 
 import { Conversation, ConversationInfo, Role } from '@/src/types/chat';
-import { EntityType, FeatureType } from '@/src/types/common';
+import { FeatureType } from '@/src/types/common';
 import { DialFile } from '@/src/types/files';
 import { EntityFilters, SearchFilters } from '@/src/types/search';
 


### PR DESCRIPTION
**Description:**

Disable send when error

Issues:

- Issue #532 

**UI changes**

![image](https://github.com/epam/ai-dial-chat/assets/6322751/8c0446f2-4e0e-4d96-b407-3ad5a9147957)

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
