### PR TITLE
fix(chat): revoke access to folder if folder renamed (Issue #833)

### DIFF
--- a/apps/chat/src/components/Folder/Folder.tsx
+++ b/apps/chat/src/components/Folder/Folder.tsx
@@ -285,7 +285,9 @@ const Folder = <T extends ConversationInfo | PromptInfo | DialFile>({
       return;
     }
 
-    newName && onRenameFolder(newName, currentFolder.id);
+    if (newName && newName !== currentFolder.name) {
+      onRenameFolder(newName, currentFolder.id);
+    }
     setRenameValue('');
     setIsRenaming(false);
     setIsContextMenu(false);

--- a/apps/chat/src/store/share/share.epics.ts
+++ b/apps/chat/src/store/share/share.epics.ts
@@ -753,6 +753,92 @@ const discardSharedWithMeFailEpic: AppEpic = (action$) =>
     }),
   );
 
+const deleteSharedConversationFolderEpic: AppEpic = (action$, state$) =>
+  action$.pipe(
+    filter(ConversationsActions.deleteFolder.match),
+    switchMap(({ payload }) => {
+      const folders = ConversationsSelectors.selectFolders(state$.value);
+      const isSharedFolder = folders.find(
+        (folder) => folder.id === payload.folderId,
+      )?.isShared;
+
+      return payload.folderId && isSharedFolder
+        ? of(
+            ShareActions.revokeAccess({
+              resourceId: payload.folderId,
+              featureType: FeatureType.Chat,
+              isFolder: true,
+            }),
+          )
+        : EMPTY;
+    }),
+  );
+
+const deleteSharedPromptFolderEpic: AppEpic = (action$, state$) =>
+  action$.pipe(
+    filter(PromptsActions.deleteFolder.match),
+    switchMap(({ payload }) => {
+      const folders = PromptsSelectors.selectFolders(state$.value);
+      const isSharedFolder = folders.find(
+        (folder) => folder.id === payload.folderId,
+      )?.isShared;
+
+      return payload.folderId && isSharedFolder
+        ? of(
+            ShareActions.revokeAccess({
+              resourceId: payload.folderId,
+              featureType: FeatureType.Prompt,
+              isFolder: true,
+            }),
+          )
+        : EMPTY;
+    }),
+  );
+
+const renameSharedConversationFolderEpic: AppEpic = (action$, state$) =>
+  action$.pipe(
+    filter(ConversationsActions.updateFolder.match),
+    switchMap(({ payload }) => {
+      const folders = ConversationsSelectors.selectFolders(state$.value);
+      const isSharedFolder = folders.find(
+        (folder) => folder.id === payload.folderId,
+      )?.isShared;
+      const requireRevoke = !!payload.values.name;
+
+      return payload.folderId && isSharedFolder && requireRevoke
+        ? of(
+            ShareActions.revokeAccess({
+              resourceId: payload.folderId,
+              featureType: FeatureType.Chat,
+              isFolder: true,
+            }),
+          )
+        : EMPTY;
+    }),
+  );
+
+const renameSharedPromptFolderEpic: AppEpic = (action$, state$) =>
+  action$.pipe(
+    filter(PromptsActions.updateFolder.match),
+    switchMap(({ payload }) => {
+      const folders = PromptsSelectors.selectFolders(state$.value);
+      const isSharedFolder = folders.find(
+        (folder) => folder.id === payload.folderId,
+      )?.isShared;
+      const requireRevoke = payload.values.name;
+
+      return payload.folderId && isSharedFolder && requireRevoke
+        ? of(
+            ShareActions.revokeAccess({
+              resourceId: payload.folderId,
+              featureType: FeatureType.Prompt,
+              isFolder: true,
+            }),
+          )
+        : EMPTY;
+    }),
+  );
+
 export const ShareEpics = combineEpics(
   shareEpic,
   shareFailEpic,
@@ -780,4 +866,9 @@ export const ShareEpics = combineEpics(
 
   triggerGettingSharedListingsConversationsEpic,
   triggerGettingSharedListingsPromptsEpic,
+
+  deleteSharedConversationFolderEpic,
+  deleteSharedPromptFolderEpic,
+  renameSharedConversationFolderEpic,
+  renameSharedPromptFolderEpic,
 );

--- a/apps/chat/src/store/share/share.epics.ts
+++ b/apps/chat/src/store/share/share.epics.ts
@@ -753,85 +753,27 @@ const discardSharedWithMeFailEpic: AppEpic = (action$) =>
     }),
   );
 
-const deleteSharedConversationFolderEpic: AppEpic = (action$, state$) =>
+const deleteOrRenameSharedFolderEpic: AppEpic = (action$, state$) =>
   action$.pipe(
-    filter(ConversationsActions.deleteFolder.match),
+    filter(
+      (action) =>
+        ConversationsActions.deleteFolder.match(action) ||
+        PromptsActions.deleteFolder.match(action) ||
+        ConversationsActions.updateFolder.match(action) ||
+        PromptsActions.updateFolder.match(action),
+    ),
     switchMap(({ payload }) => {
       const folders = ConversationsSelectors.selectFolders(state$.value);
       const isSharedFolder = folders.find(
         (folder) => folder.id === payload.folderId,
       )?.isShared;
-
-      return payload.folderId && isSharedFolder
-        ? of(
-            ShareActions.revokeAccess({
-              resourceId: payload.folderId,
-              featureType: FeatureType.Chat,
-              isFolder: true,
-            }),
-          )
-        : EMPTY;
-    }),
-  );
-
-const deleteSharedPromptFolderEpic: AppEpic = (action$, state$) =>
-  action$.pipe(
-    filter(PromptsActions.deleteFolder.match),
-    switchMap(({ payload }) => {
-      const folders = PromptsSelectors.selectFolders(state$.value);
-      const isSharedFolder = folders.find(
-        (folder) => folder.id === payload.folderId,
-      )?.isShared;
-
-      return payload.folderId && isSharedFolder
-        ? of(
-            ShareActions.revokeAccess({
-              resourceId: payload.folderId,
-              featureType: FeatureType.Prompt,
-              isFolder: true,
-            }),
-          )
-        : EMPTY;
-    }),
-  );
-
-const renameSharedConversationFolderEpic: AppEpic = (action$, state$) =>
-  action$.pipe(
-    filter(ConversationsActions.updateFolder.match),
-    switchMap(({ payload }) => {
-      const folders = ConversationsSelectors.selectFolders(state$.value);
-      const isSharedFolder = folders.find(
-        (folder) => folder.id === payload.folderId,
-      )?.isShared;
-      const requireRevoke = !!payload.values.name;
+      const requireRevoke = payload.values ? payload.values.name : true;
 
       return payload.folderId && isSharedFolder && requireRevoke
         ? of(
             ShareActions.revokeAccess({
               resourceId: payload.folderId,
               featureType: FeatureType.Chat,
-              isFolder: true,
-            }),
-          )
-        : EMPTY;
-    }),
-  );
-
-const renameSharedPromptFolderEpic: AppEpic = (action$, state$) =>
-  action$.pipe(
-    filter(PromptsActions.updateFolder.match),
-    switchMap(({ payload }) => {
-      const folders = PromptsSelectors.selectFolders(state$.value);
-      const isSharedFolder = folders.find(
-        (folder) => folder.id === payload.folderId,
-      )?.isShared;
-      const requireRevoke = payload.values.name;
-
-      return payload.folderId && isSharedFolder && requireRevoke
-        ? of(
-            ShareActions.revokeAccess({
-              resourceId: payload.folderId,
-              featureType: FeatureType.Prompt,
               isFolder: true,
             }),
           )
@@ -867,8 +809,5 @@ export const ShareEpics = combineEpics(
   triggerGettingSharedListingsConversationsEpic,
   triggerGettingSharedListingsPromptsEpic,
 
-  deleteSharedConversationFolderEpic,
-  deleteSharedPromptFolderEpic,
-  renameSharedConversationFolderEpic,
-  renameSharedPromptFolderEpic,
+  deleteOrRenameSharedFolderEpic,
 );


### PR DESCRIPTION
**Description:**

Revoke access to folder if rename or delete

Issues:

- Issue #833

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
