### PR TITLE
chore: fix version calculations when publish npm packages

### DIFF
--- a/tools/publish-lib.mjs
+++ b/tools/publish-lib.mjs
@@ -159,12 +159,17 @@ execSync(`npm publish --access public --tag ${tag} --dry-run ${dry}`);
 
 function getDevVersion(potentialVersion) {
   const result = JSON.parse(execSync(`npm view ${PREFIX}-${name} versions --json`).toString());
-  const lastVersionToIncrement = result.filter(ver => ver.startsWith(mainPackageJson.version)).sort().reverse()[0];
+  const lastVersionToIncrement = result
+    .filter(ver => ver.startsWith(mainPackageJson.version))
+    .map(ver => ver.match(/\d+$/)?.[0])
+    .filter(Boolean)
+    .map(ver => parseInt(ver, 10))
+    .sort((a, b) => a - b)
+    .reverse()[0];
 
-  const lastNum = lastVersionToIncrement?.match(/\d+$/);
-  if (lastVersionToIncrement && lastNum) {
-    const incrementedNum = parseInt(lastNum[0], 10) + 1;
-    potentialVersion = lastVersionToIncrement.replace(/\d+$/, incrementedNum);
+  if (typeof lastVersionToIncrement !== 'undefined') {
+    const incrementedNum = lastVersionToIncrement + 1;
+    potentialVersion = `${mainPackageJson.version}.${incrementedNum}`;
   } else {
     potentialVersion = `${mainPackageJson.version}.0`;
   }


### PR DESCRIPTION
**Description:**

Fix version calculations for npm packages

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
