### PR TITLE
feat(chat): reload state if tab inactive more then five minutes (Issue #784)

### DIFF
--- a/apps/chat/src/constants/errors.ts
+++ b/apps/chat/src/constants/errors.ts
@@ -35,7 +35,7 @@ export const errorsMessages = {
   shareByMeListingFailed:
     'Getting shared by you resources failed. Please reload the page to get them again.',
   shareByMeReloadListingFailed:
-    'Getting shared by you resources failed. Please reload the page to get them again.',
+    'Reloading shared by you resources failed. Please reload the page to get them again.',
   shareWithMeListingFailed:
     'Getting shared with you resources failed. Please reload the page to get them again.',
   notValidEntityType:

--- a/apps/chat/src/constants/errors.ts
+++ b/apps/chat/src/constants/errors.ts
@@ -34,6 +34,8 @@ export const errorsMessages = {
     'Discarding shared with you resource failed. Please try again later.',
   shareByMeListingFailed:
     'Getting shared by you resources failed. Please reload the page to get them again.',
+  shareByMeReloadListingFailed:
+    'Getting shared by you resources failed. Please reload the page to get them again.',
   shareWithMeListingFailed:
     'Getting shared with you resources failed. Please reload the page to get them again.',
   notValidEntityType:

--- a/apps/chat/src/pages/index.tsx
+++ b/apps/chat/src/pages/index.tsx
@@ -127,7 +127,7 @@ export default function Home({ initialState }: HomeProps) {
     };
 
     const handleFocus = () => {
-      if (lastBlurTime && Date.now() - lastBlurTime > 1000) {
+      if (lastBlurTime && Date.now() - lastBlurTime > 1000 * 60 * 5) {
         dispatch(ConversationsActions.reloadState());
         dispatch(PromptsActions.reloadState());
       }

--- a/apps/chat/src/pages/index.tsx
+++ b/apps/chat/src/pages/index.tsx
@@ -127,7 +127,7 @@ export default function Home({ initialState }: HomeProps) {
     };
 
     const handleFocus = () => {
-      if (lastBlurTime && Date.now() - lastBlurTime > 1000 * 60 * 5) {
+      if (lastBlurTime && Date.now() - lastBlurTime > 5000) {
         dispatch(ConversationsActions.reloadState());
         dispatch(PromptsActions.reloadState());
       }

--- a/apps/chat/src/pages/index.tsx
+++ b/apps/chat/src/pages/index.tsx
@@ -127,7 +127,7 @@ export default function Home({ initialState }: HomeProps) {
     };
 
     const handleFocus = () => {
-      if (lastBlurTime && Date.now() - lastBlurTime > 60 * 1000) {
+      if (lastBlurTime && Date.now() - lastBlurTime > 1000) {
         dispatch(ConversationsActions.reloadConversationsState());
         dispatch(PromptsActions.reloadPromptsState());
       }

--- a/apps/chat/src/pages/index.tsx
+++ b/apps/chat/src/pages/index.tsx
@@ -128,8 +128,8 @@ export default function Home({ initialState }: HomeProps) {
 
     const handleFocus = () => {
       if (lastBlurTime && Date.now() - lastBlurTime > 1000) {
-        dispatch(ConversationsActions.reloadConversationsState());
-        dispatch(PromptsActions.reloadPromptsState());
+        dispatch(ConversationsActions.reloadState());
+        dispatch(PromptsActions.reloadState());
       }
       setLastBlurTime(null);
     };

--- a/apps/chat/src/pages/index.tsx
+++ b/apps/chat/src/pages/index.tsx
@@ -127,7 +127,7 @@ export default function Home({ initialState }: HomeProps) {
     };
 
     const handleFocus = () => {
-      if (lastBlurTime && Date.now() - lastBlurTime > 5000) {
+      if (lastBlurTime && Date.now() - lastBlurTime > 1000 * 60 * 5) {
         dispatch(ConversationsActions.reloadState());
         dispatch(PromptsActions.reloadState());
       }

--- a/apps/chat/src/store/conversations/conversations.epics.ts
+++ b/apps/chat/src/store/conversations/conversations.epics.ts
@@ -134,6 +134,11 @@ const reloadConversationsStateEpic: AppEpic = (action$, state$) =>
           const existingSelectedConversations = conversations.filter((conv) =>
             selectedConversationIds.includes(conv.id),
           );
+          const externalConversations =
+            ConversationsSelectors.selectExternalConversations(state$.value);
+          const externalFolders = ConversationsSelectors.selectExternalFolders(
+            state$.value,
+          );
 
           return concat(
             of(
@@ -145,6 +150,7 @@ const reloadConversationsStateEpic: AppEpic = (action$, state$) =>
               ConversationsActions.reloadConversationsStateSuccess({
                 paths: new Set(),
                 conversations,
+                externalConversations,
               }),
             ),
             of(
@@ -155,6 +161,7 @@ const reloadConversationsStateEpic: AppEpic = (action$, state$) =>
                   FolderType.Chat,
                   UploadStatus.LOADED,
                 ),
+                externalFolders,
               }),
             ),
             iif(

--- a/apps/chat/src/store/conversations/conversations.epics.ts
+++ b/apps/chat/src/store/conversations/conversations.epics.ts
@@ -1899,7 +1899,6 @@ const saveFoldersEpic: AppEpic = (action$, state$) =>
         ConversationsActions.clearConversations.match(action) ||
         ConversationsActions.importConversationsSuccess.match(action) ||
         ConversationsActions.addFolders.match(action) ||
-        ConversationsActions.addSharedFolders.match(action) ||
         ConversationsActions.unpublishFolder.match(action) ||
         ConversationsActions.setFolders.match(action),
     ),
@@ -1954,7 +1953,6 @@ const selectConversationsEpic: AppEpic = (action$, state$) =>
         ConversationsActions.importConversationsSuccess.match(action) ||
         ConversationsActions.deleteConversationsComplete.match(action) ||
         ConversationsActions.addConversations.match(action) ||
-        ConversationsActions.addSharedConversations.match(action) ||
         ConversationsActions.duplicateConversation.match(action),
     ),
     map(() =>

--- a/apps/chat/src/store/conversations/conversations.epics.ts
+++ b/apps/chat/src/store/conversations/conversations.epics.ts
@@ -1952,8 +1952,7 @@ const selectConversationsEpic: AppEpic = (action$, state$) =>
         ConversationsActions.saveNewConversationSuccess.match(action) ||
         ConversationsActions.importConversationsSuccess.match(action) ||
         ConversationsActions.deleteConversationsComplete.match(action) ||
-        ConversationsActions.addConversations.match(action) ||
-        ConversationsActions.duplicateConversation.match(action),
+        ConversationsActions.addConversations.match(action),
     ),
     map(() =>
       ConversationsSelectors.selectSelectedConversationsIds(state$.value),

--- a/apps/chat/src/store/conversations/conversations.epics.ts
+++ b/apps/chat/src/store/conversations/conversations.epics.ts
@@ -131,14 +131,17 @@ const reloadConversationsStateEpic: AppEpic = (action$, state$) =>
           );
           const selectedConversationIds =
             ConversationsSelectors.selectSelectedConversationsIds(state$.value);
-          const existingSelectedConversations = conversations.filter((conv) =>
-            selectedConversationIds.includes(conv.id),
-          );
           const externalConversations =
             ConversationsSelectors.selectExternalConversations(state$.value);
+          const existingSelectedConversations = [
+            ...externalConversations,
+            ...conversations,
+          ].filter((conv) => selectedConversationIds.includes(conv.id));
           const externalFolders = ConversationsSelectors.selectExternalFolders(
             state$.value,
           );
+
+          console.log(existingSelectedConversations);
 
           return concat(
             of(

--- a/apps/chat/src/store/conversations/conversations.epics.ts
+++ b/apps/chat/src/store/conversations/conversations.epics.ts
@@ -141,8 +141,6 @@ const reloadConversationsStateEpic: AppEpic = (action$, state$) =>
             state$.value,
           );
 
-          console.log(existingSelectedConversations);
-
           return concat(
             of(
               ConversationsActions.uploadConversationsWithFoldersRecursive({
@@ -1836,6 +1834,7 @@ const saveFoldersEpic: AppEpic = (action$, state$) =>
         ConversationsActions.clearConversations.match(action) ||
         ConversationsActions.importConversationsSuccess.match(action) ||
         ConversationsActions.addFolders.match(action) ||
+        ConversationsActions.addSharedFolders.match(action) ||
         ConversationsActions.unpublishFolder.match(action) ||
         ConversationsActions.setFolders.match(action),
     ),
@@ -1876,6 +1875,7 @@ const selectConversationsEpic: AppEpic = (action$, state$) =>
         ConversationsActions.importConversationsSuccess.match(action) ||
         ConversationsActions.deleteConversationsComplete.match(action) ||
         ConversationsActions.addConversations.match(action) ||
+        ConversationsActions.addSharedConversations.match(action) ||
         ConversationsActions.duplicateConversation.match(action),
     ),
     map(() =>

--- a/apps/chat/src/store/conversations/conversations.reducers.ts
+++ b/apps/chat/src/store/conversations/conversations.reducers.ts
@@ -16,7 +16,7 @@ import {
   LikeState,
   Message,
 } from '@/src/types/chat';
-import { UploadStatus } from '@/src/types/common';
+import { FeatureType, UploadStatus } from '@/src/types/common';
 import { FolderInterface, FolderType } from '@/src/types/folder';
 import { SearchFilters } from '@/src/types/search';
 import { PublishRequest } from '@/src/types/share';
@@ -696,13 +696,14 @@ export const conversationsSlice = createSlice({
       }: PayloadAction<{
         paths: Set<string | undefined>;
         folders: FolderInterface[];
+        externalFolders: FolderInterface[];
       }>,
     ) => {
       state.loadingFolderIds = state.loadingFolderIds.filter(
         (id) => !payload.paths.has(id),
       );
       state.foldersStatus = UploadStatus.LOADED;
-      state.folders = payload.folders;
+      state.folders = combineEntities(payload.folders, payload.externalFolders);
       state.conversationsLoaded = true;
       state.foldersStatus = UploadStatus.ALL_LOADED;
     },
@@ -767,6 +768,7 @@ export const conversationsSlice = createSlice({
       }: PayloadAction<{
         paths: Set<string | undefined>;
         conversations: ConversationInfo[];
+        externalConversations: ConversationInfo[];
       }>,
     ) => {
       const conversationMap = state.conversations.reduce((map, conv) => {
@@ -776,13 +778,16 @@ export const conversationsSlice = createSlice({
 
       const ids = new Set(payload.conversations.map((c) => c.id));
 
-      state.conversations = payload.conversations.map((conv) =>
-        ids.has(conv.id)
-          ? {
-              ...conversationMap.get(conv.id),
-              ...conv,
-            }
-          : conv,
+      state.conversations = combineEntities(
+        payload.conversations.map((conv) =>
+          ids.has(conv.id)
+            ? {
+                ...conversationMap.get(conv.id),
+                ...conv,
+              }
+            : conv,
+        ),
+        payload.externalConversations,
       );
       state.conversationsStatus = UploadStatus.LOADED;
     },

--- a/apps/chat/src/store/conversations/conversations.reducers.ts
+++ b/apps/chat/src/store/conversations/conversations.reducers.ts
@@ -718,11 +718,11 @@ export const conversationsSlice = createSlice({
       const ids = payload.folders.map((f) => f.id);
 
       state.folders = combineEntities(
+        payload.externalFolders,
         combineEntities(
           state.folders.filter((f) => ids.includes(f.id)),
           payload.folders,
         ),
-        payload.externalFolders,
       );
     },
     uploadFoldersSuccess: (

--- a/apps/chat/src/store/conversations/conversations.reducers.ts
+++ b/apps/chat/src/store/conversations/conversations.reducers.ts
@@ -373,7 +373,7 @@ export const conversationsSlice = createSlice({
         : combineEntities(state.conversations, payload.conversations);
       state.conversationsLoaded = true;
     },
-    addSharedConversations: (
+    addReloadedSharedConversations: (
       state,
       {
         payload,
@@ -543,13 +543,13 @@ export const conversationsSlice = createSlice({
     ) => {
       state.folders = payload.folders;
     },
-    addSharedFolders: (
+    addReloadedSharedFolders: (
       state,
       { payload }: PayloadAction<{ folders: FolderInterface[] }>,
     ) => {
       state.folders = combineEntities(
         payload.folders,
-        state.folders.filter((folder) => !folder.sharedWithMe), // select not external
+        state.folders.filter((folder) => !folder.sharedWithMe),
       );
     },
     addFolders: (

--- a/apps/chat/src/store/conversations/conversations.reducers.ts
+++ b/apps/chat/src/store/conversations/conversations.reducers.ts
@@ -377,6 +377,19 @@ export const conversationsSlice = createSlice({
         : combineEntities(state.conversations, payload.conversations);
       state.conversationsLoaded = true;
     },
+    addSharedConversations: (
+      state,
+      {
+        payload,
+      }: PayloadAction<{
+        conversations: ConversationInfo[];
+      }>,
+    ) => {
+      state.conversations = combineEntities(
+        payload.conversations,
+        state.conversations.filter((conv) => !conv.sharedWithMe),
+      );
+    },
     addConversations: (
       state,
       {
@@ -533,6 +546,15 @@ export const conversationsSlice = createSlice({
       { payload }: PayloadAction<{ folders: FolderInterface[] }>,
     ) => {
       state.folders = payload.folders;
+    },
+    addSharedFolders: (
+      state,
+      { payload }: PayloadAction<{ folders: FolderInterface[] }>,
+    ) => {
+      state.folders = combineEntities(
+        payload.folders,
+        state.folders.filter((folder) => !folder.sharedWithMe),
+      );
     },
     addFolders: (
       state,

--- a/apps/chat/src/store/conversations/conversations.reducers.ts
+++ b/apps/chat/src/store/conversations/conversations.reducers.ts
@@ -16,7 +16,7 @@ import {
   LikeState,
   Message,
 } from '@/src/types/chat';
-import { FeatureType, UploadStatus } from '@/src/types/common';
+import { UploadStatus } from '@/src/types/common';
 import { FolderInterface, FolderType } from '@/src/types/folder';
 import { SearchFilters } from '@/src/types/search';
 import { PublishRequest } from '@/src/types/share';

--- a/apps/chat/src/store/conversations/conversations.reducers.ts
+++ b/apps/chat/src/store/conversations/conversations.reducers.ts
@@ -105,10 +105,7 @@ export const conversationsSlice = createSlice({
       state,
       { payload: _ }: PayloadAction<{ idsToMarkAsMigrated: string[] }>,
     ) => state,
-    initSelectedConversations: (
-      state,
-      _action: PayloadAction<{ noLoader: boolean } | undefined>,
-    ) => state,
+    initSelectedConversations: (state) => state,
     initFoldersAndConversations: (state) => state,
     initFoldersAndConversationsSuccess: (state) => state,
     saveConversation: (state, _action: PayloadAction<Conversation>) => state,
@@ -185,9 +182,7 @@ export const conversationsSlice = createSlice({
     },
     selectConversations: (
       state,
-      {
-        payload,
-      }: PayloadAction<{ conversationIds: string[]; noLoader?: boolean }>,
+      { payload }: PayloadAction<{ conversationIds: string[] }>,
     ) => {
       const newSelectedIds = uniq(payload.conversationIds);
 

--- a/apps/chat/src/store/conversations/conversations.selectors.ts
+++ b/apps/chat/src/store/conversations/conversations.selectors.ts
@@ -136,6 +136,20 @@ export const selectSelectedConversationsIds = createSelector(
     return state.selectedConversationsIds;
   },
 );
+export const selectExternalConversations = createSelector(
+  [(state: RootState) => state, selectConversations],
+  (state, conversations) =>
+    conversations.filter((conv) =>
+      isEntityOrParentsExternal(state, conv, FeatureType.Chat),
+    ),
+);
+export const selectExternalFolders = createSelector(
+  [(state: RootState) => state, selectFolders],
+  (state, folders) =>
+    folders.filter((folder) =>
+      isEntityOrParentsExternal(state, folder, FeatureType.Chat),
+    ),
+);
 export const selectConversationSignal = createSelector(
   [rootSelector],
   (state) => {

--- a/apps/chat/src/store/prompts/prompts.epics.ts
+++ b/apps/chat/src/store/prompts/prompts.epics.ts
@@ -93,6 +93,12 @@ const reloadPromptsStateEpic: AppEpic = (action$, state$) =>
           const isSelectedPromptExists = prompts.some(
             (prompt) => selectedPromptId === prompt.id,
           );
+          const externalPrompts = PromptsSelectors.selectExternalPrompts(
+            state$.value,
+          );
+          const externalFolders = PromptsSelectors.selectExternalFolders(
+            state$.value,
+          );
 
           if (selectedPromptId) {
             if (!isSelectedPromptExists) {
@@ -123,10 +129,11 @@ const reloadPromptsStateEpic: AppEpic = (action$, state$) =>
             of(
               PromptsActions.setReloadedPrompts({
                 prompts,
+                externalPrompts,
               }),
             ),
             of(
-              PromptsActions.setFolders({
+              PromptsActions.setReloadedFolders({
                 folders: uniq(
                   prompts.flatMap((p) =>
                     getParentFolderIdsFromFolderId(p.folderId),
@@ -135,6 +142,7 @@ const reloadPromptsStateEpic: AppEpic = (action$, state$) =>
                   ...getFolderFromId(path, FolderType.Prompt),
                   status: UploadStatus.LOADED,
                 })),
+                externalFolders,
               }),
             ),
             of(PromptsActions.reloadPromptsStateSuccess()),

--- a/apps/chat/src/store/prompts/prompts.epics.ts
+++ b/apps/chat/src/store/prompts/prompts.epics.ts
@@ -90,11 +90,11 @@ const reloadPromptsStateEpic: AppEpic = (action$, state$) =>
           const selectedPromptId = PromptsSelectors.selectSelectedPromptId(
             state$.value,
           );
-          const isSelectedPromptExists = prompts.some(
-            (prompt) => selectedPromptId === prompt.id,
-          );
           const externalPrompts = PromptsSelectors.selectExternalPrompts(
             state$.value,
+          );
+          const isSelectedPromptExists = [...prompts, ...externalPrompts].some(
+            (prompt) => selectedPromptId === prompt.id,
           );
           const externalFolders = PromptsSelectors.selectExternalFolders(
             state$.value,

--- a/apps/chat/src/store/prompts/prompts.epics.ts
+++ b/apps/chat/src/store/prompts/prompts.epics.ts
@@ -142,7 +142,8 @@ const reloadStateEpic: AppEpic = (action$, state$) =>
             of(
               PromptsActions.setReloadedPrompts({
                 prompts: selectedPrompt
-                  ? combineEntities([selectedPrompt], prompts)
+                  ? // to avoid opened modal jumping
+                    combineEntities([selectedPrompt], prompts)
                   : prompts,
                 externalPrompts,
               }),
@@ -1174,6 +1175,7 @@ export const uploadPromptEpic: AppEpic = (action$, state$) =>
     filter(PromptsActions.uploadPrompt.match),
     switchMap(({ payload }) => {
       const {
+        // remove description and content to avoid overwriting with old data at mergeGetResult
         description: __description,
         content: __content,
         ...originalPrompt

--- a/apps/chat/src/store/prompts/prompts.reducers.ts
+++ b/apps/chat/src/store/prompts/prompts.reducers.ts
@@ -460,11 +460,11 @@ export const promptsSlice = createSlice({
       const ids = payload.folders.map((f) => f.id);
 
       state.folders = combineEntities(
+        payload.externalFolders,
         combineEntities(
           state.folders.filter((c) => ids.includes(c.id)),
           payload.folders,
         ),
-        payload.externalFolders,
       );
     },
     setFolders: (

--- a/apps/chat/src/store/prompts/prompts.reducers.ts
+++ b/apps/chat/src/store/prompts/prompts.reducers.ts
@@ -22,7 +22,7 @@ import { DEFAULT_FOLDER_NAME } from '@/src/constants/default-ui-settings';
 import * as PromptsSelectors from './prompts.selectors';
 import { PromptsState } from './prompts.types';
 
-import { isEqual } from 'lodash-es';
+import isEqual from 'lodash-es/isEqual';
 
 export { PromptsSelectors };
 

--- a/apps/chat/src/store/prompts/prompts.reducers.ts
+++ b/apps/chat/src/store/prompts/prompts.reducers.ts
@@ -254,11 +254,23 @@ export const promptsSlice = createSlice({
     duplicatePrompt: (state, _action: PayloadAction<PromptInfo>) => state,
     setReloadedPrompts: (
       state,
-      { payload }: PayloadAction<{ prompts: PromptInfo[] }>,
+      {
+        payload,
+      }: PayloadAction<{
+        prompts: PromptInfo[];
+        externalPrompts: PromptInfo[];
+      }>,
     ) => {
       state.prompts = combineEntities(
-        state.prompts.filter((prompt) => prompt.id === state.selectedPromptId),
-        payload.prompts,
+        [
+          ...state.prompts.filter(
+            (prompt) => prompt.id === state.selectedPromptId,
+          ),
+          ...payload.prompts.filter(
+            (prompt) => prompt.id !== state.selectedPromptId,
+          ),
+        ],
+        payload.externalPrompts,
       );
       state.promptsLoaded = true;
     },
@@ -425,6 +437,17 @@ export const promptsSlice = createSlice({
       state.folders = payload.folders;
       state.prompts = payload.prompts;
     },
+    setReloadedFolders: (
+      state,
+      {
+        payload,
+      }: PayloadAction<{
+        folders: FolderInterface[];
+        externalFolders: FolderInterface[];
+      }>,
+    ) => {
+      state.folders = combineEntities(payload.folders, payload.externalFolders);
+    },
     setFolders: (
       state,
       { payload }: PayloadAction<{ folders: FolderInterface[] }>,
@@ -435,7 +458,7 @@ export const promptsSlice = createSlice({
       state,
       { payload }: PayloadAction<{ folders: FolderInterface[] }>,
     ) => {
-      state.folders = state.folders.concat(payload.folders);
+      state.folders = combineEntities(payload.folders, state.folders);
     },
     setSearchTerm: (
       state,

--- a/apps/chat/src/store/prompts/prompts.reducers.ts
+++ b/apps/chat/src/store/prompts/prompts.reducers.ts
@@ -529,7 +529,7 @@ export const promptsSlice = createSlice({
         noLoader?: boolean;
       }>,
     ) => {
-      state.isPromptLoading = !payload.noLoader;
+      state.isPromptLoading = !!payload.noLoader;
     },
     uploadPromptSuccess: (
       state,

--- a/apps/chat/src/store/prompts/prompts.reducers.ts
+++ b/apps/chat/src/store/prompts/prompts.reducers.ts
@@ -283,7 +283,7 @@ export const promptsSlice = createSlice({
         : combineEntities(state.prompts, payload.prompts);
       state.promptsLoaded = true;
     },
-    addSharedPrompts: (
+    addReloadedSharedPrompts: (
       state,
       { payload }: PayloadAction<{ prompts: Prompt[] }>,
     ) => {
@@ -473,7 +473,7 @@ export const promptsSlice = createSlice({
     ) => {
       state.folders = payload.folders;
     },
-    addSharedFolders: (
+    addReloadedSharedFolders: (
       state,
       { payload }: PayloadAction<{ folders: FolderInterface[] }>,
     ) => {

--- a/apps/chat/src/store/prompts/prompts.reducers.ts
+++ b/apps/chat/src/store/prompts/prompts.reducers.ts
@@ -285,6 +285,15 @@ export const promptsSlice = createSlice({
         : combineEntities(state.prompts, payload.prompts);
       state.promptsLoaded = true;
     },
+    addSharedPrompts: (
+      state,
+      { payload }: PayloadAction<{ prompts: Prompt[] }>,
+    ) => {
+      state.prompts = combineEntities(
+        payload.prompts,
+        state.prompts.filter((prompt) => !prompt.sharedWithMe),
+      );
+    },
     addPrompts: (state, { payload }: PayloadAction<{ prompts: Prompt[] }>) => {
       state.prompts = combineEntities(payload.prompts, state.prompts);
     },
@@ -453,6 +462,15 @@ export const promptsSlice = createSlice({
       { payload }: PayloadAction<{ folders: FolderInterface[] }>,
     ) => {
       state.folders = payload.folders;
+    },
+    addSharedFolders: (
+      state,
+      { payload }: PayloadAction<{ folders: FolderInterface[] }>,
+    ) => {
+      state.folders = combineEntities(
+        payload.folders,
+        state.folders.filter((folder) => !folder.sharedWithMe),
+      );
     },
     addFolders: (
       state,

--- a/apps/chat/src/store/prompts/prompts.reducers.ts
+++ b/apps/chat/src/store/prompts/prompts.reducers.ts
@@ -520,25 +520,6 @@ export const promptsSlice = createSlice({
       state.selectedPromptId = payload.promptId;
       state.isPromptLoading = !!payload.promptId;
     },
-    clearPromptInfo: (
-      state,
-      { payload }: PayloadAction<{ promptId: string }>,
-    ) => {
-      state.prompts = state.prompts.map((prompt) => {
-        if (prompt.id === payload.promptId) {
-          const {
-            content: __content,
-            description: __description,
-            isShared: __isShared,
-            isPublished: __isPublished,
-            ...cleanPrompt
-          } = prompt as Prompt;
-          return cleanPrompt;
-        }
-
-        return prompt;
-      });
-    },
     uploadPrompt: (
       state,
       {

--- a/apps/chat/src/store/prompts/prompts.reducers.ts
+++ b/apps/chat/src/store/prompts/prompts.reducers.ts
@@ -22,6 +22,8 @@ import { DEFAULT_FOLDER_NAME } from '@/src/constants/default-ui-settings';
 import * as PromptsSelectors from './prompts.selectors';
 import { PromptsState } from './prompts.types';
 
+import { isEqual } from 'lodash-es';
+
 export { PromptsSelectors };
 
 const initialState: PromptsState = {
@@ -509,14 +511,18 @@ export const promptsSlice = createSlice({
       );
 
       if (foundPromptIdx !== -1) {
-        state.prompts[foundPromptIdx] = payload.prompt as Prompt;
+        if (
+          payload.prompt &&
+          !isEqual(state.prompts[foundPromptIdx], payload.prompt)
+        ) {
+          state.prompts[foundPromptIdx] = payload.prompt;
+        }
       } else {
         state.prompts = state.prompts.filter(
           (prompt) => prompt.id !== payload.originalPromptId,
         );
       }
     },
-
     toggleFolder: (state, _action: PayloadAction<{ id: string }>) => state,
     uploadChildPromptsWithFolders: (
       state,

--- a/apps/chat/src/store/prompts/prompts.selectors.ts
+++ b/apps/chat/src/store/prompts/prompts.selectors.ts
@@ -13,9 +13,13 @@ import {
   doesPromptOrConversationContainSearchTerm,
   getMyItemsFilters,
 } from '@/src/utils/app/search';
-import { isEntityExternal } from '@/src/utils/app/share';
+import {
+  isEntityExternal,
+  isEntityOrParentsExternal,
+} from '@/src/utils/app/share';
 import { translate } from '@/src/utils/app/translation';
 
+import { FeatureType } from '@/src/types/common';
 import { Prompt } from '@/src/types/prompt';
 import { EntityFilters, SearchFilters } from '@/src/types/search';
 
@@ -59,6 +63,22 @@ export const selectPrompt = createSelector(
 export const selectFolders = createSelector([rootSelector], (state) => {
   return state.folders;
 });
+
+export const selectExternalPrompts = createSelector(
+  [(state: RootState) => state, selectPrompts],
+  (state, prompts) =>
+    prompts.filter((prompt) =>
+      isEntityOrParentsExternal(state, prompt, FeatureType.Prompt),
+    ),
+);
+
+export const selectExternalFolders = createSelector(
+  [(state: RootState) => state, selectFolders],
+  (state, folders) =>
+    folders.filter((folder) =>
+      isEntityOrParentsExternal(state, folder, FeatureType.Prompt),
+    ),
+);
 
 export const selectEmptyFolderIds = createSelector(
   [selectFolders, selectPrompts],

--- a/apps/chat/src/store/share/share.epics.ts
+++ b/apps/chat/src/store/share/share.epics.ts
@@ -760,7 +760,7 @@ const reloadSharedListingSuccessEpic: AppEpic = (action$, state$) =>
           }
 
           actions.push(
-            ConversationsActions.addSharedConversations({
+            ConversationsActions.addReloadedSharedConversations({
               conversations: payload.resources.entities.map((res) => ({
                 ...(res.id === selectedConv?.id ? selectedConv : res),
                 sharedWithMe: true,
@@ -769,7 +769,7 @@ const reloadSharedListingSuccessEpic: AppEpic = (action$, state$) =>
           );
 
           actions.push(
-            ConversationsActions.addSharedFolders({
+            ConversationsActions.addReloadedSharedFolders({
               folders: payload.resources.folders.map((res) => ({
                 ...res,
                 sharedWithMe: true,
@@ -820,7 +820,7 @@ const reloadSharedListingSuccessEpic: AppEpic = (action$, state$) =>
           );
 
           actions.push(
-            PromptsActions.addSharedPrompts({
+            PromptsActions.addReloadedSharedPrompts({
               prompts: payload.resources.entities.map((res) => ({
                 ...(res.id === selectedPrompt?.id ? selectedPrompt : res),
                 sharedWithMe: true,
@@ -828,7 +828,7 @@ const reloadSharedListingSuccessEpic: AppEpic = (action$, state$) =>
             }),
           );
           actions.push(
-            PromptsActions.addSharedFolders({
+            PromptsActions.addReloadedSharedFolders({
               folders: payload.resources.folders.map((res) => ({
                 ...res,
                 sharedWithMe: true,

--- a/apps/chat/src/store/share/share.epics.ts
+++ b/apps/chat/src/store/share/share.epics.ts
@@ -364,13 +364,13 @@ const initReloadSharedConversationsEpic: AppEpic = (action$, state$) =>
     switchMap(() =>
       concat(
         of(
-          ShareActions.triggerReloadSharedItems({
+          ShareActions.reloadSharedItems({
             sharedWith: ShareRelations.me,
             featureType: FeatureType.Chat,
           }),
         ),
         of(
-          ShareActions.triggerReloadSharedItems({
+          ShareActions.reloadSharedItems({
             sharedWith: ShareRelations.others,
             featureType: FeatureType.Chat,
           }),
@@ -388,13 +388,13 @@ const initReloadSharedPromptsEpic: AppEpic = (action$, state$) =>
     switchMap(() =>
       concat(
         of(
-          ShareActions.triggerReloadSharedItems({
+          ShareActions.reloadSharedItems({
             sharedWith: ShareRelations.me,
             featureType: FeatureType.Prompt,
           }),
         ),
         of(
-          ShareActions.triggerReloadSharedItems({
+          ShareActions.reloadSharedItems({
             sharedWith: ShareRelations.others,
             featureType: FeatureType.Prompt,
           }),
@@ -403,9 +403,9 @@ const initReloadSharedPromptsEpic: AppEpic = (action$, state$) =>
     ),
   );
 
-const triggerReloadSharedItemsEpic: AppEpic = (action$, state$) =>
+const reloadSharedItemsEpic: AppEpic = (action$, state$) =>
   action$.pipe(
-    filter(ShareActions.triggerReloadSharedItems.match),
+    filter(ShareActions.reloadSharedItems.match),
     filter(({ payload }) =>
       SettingsSelectors.isSharingEnabled(state$.value, payload.featureType),
     ),
@@ -1053,7 +1053,7 @@ export const ShareEpics = combineEpics(
   // reload
   initReloadSharedConversationsEpic,
   initReloadSharedPromptsEpic,
-  triggerReloadSharedItemsEpic,
+  reloadSharedItemsEpic,
   reloadSharedListingFailEpic,
   reloadSharedListingSuccessEpic,
 );

--- a/apps/chat/src/store/share/share.epics.ts
+++ b/apps/chat/src/store/share/share.epics.ts
@@ -472,24 +472,23 @@ const getSharedListingSuccessEpic: AppEpic = (action$, state$) =>
             );
           }
 
-          payload.resources.entities.length &&
-            actions.push(
-              ConversationsActions.addConversations({
-                conversations: payload.resources.entities.map((res) => ({
-                  ...(res.id === selectedConv?.id ? selectedConv : res),
-                  sharedWithMe: true,
-                })) as Conversation[],
-              }),
-            );
-          payload.resources.folders.length &&
-            actions.push(
-              ConversationsActions.addFolders({
-                folders: payload.resources.folders.map((res) => ({
-                  ...res,
-                  sharedWithMe: true,
-                })) as FolderInterface[],
-              }),
-            );
+          actions.push(
+            ConversationsActions.addSharedConversations({
+              conversations: payload.resources.entities.map((res) => ({
+                ...(res.id === selectedConv?.id ? selectedConv : res),
+                sharedWithMe: true,
+              })) as Conversation[],
+            }),
+          );
+
+          actions.push(
+            ConversationsActions.addSharedFolders({
+              folders: payload.resources.folders.map((res) => ({
+                ...res,
+                sharedWithMe: true,
+              })) as FolderInterface[],
+            }),
+          );
         }
       }
       if (payload.featureType === FeatureType.Prompt) {
@@ -536,24 +535,22 @@ const getSharedListingSuccessEpic: AppEpic = (action$, state$) =>
             state$.value,
           );
 
-          payload.resources.entities.length &&
-            actions.push(
-              PromptsActions.addPrompts({
-                prompts: payload.resources.entities.map((res) => ({
-                  ...(res.id === selectedPrompt?.id ? selectedPrompt : res),
-                  sharedWithMe: true,
-                })) as Prompt[],
-              }),
-            );
-          payload.resources.folders.length &&
-            actions.push(
-              PromptsActions.addFolders({
-                folders: payload.resources.folders.map((res) => ({
-                  ...res,
-                  sharedWithMe: true,
-                })) as FolderInterface[],
-              }),
-            );
+          actions.push(
+            PromptsActions.addSharedPrompts({
+              prompts: payload.resources.entities.map((res) => ({
+                ...(res.id === selectedPrompt?.id ? selectedPrompt : res),
+                sharedWithMe: true,
+              })) as Prompt[],
+            }),
+          );
+          actions.push(
+            PromptsActions.addSharedFolders({
+              folders: payload.resources.folders.map((res) => ({
+                ...res,
+                sharedWithMe: true,
+              })) as FolderInterface[],
+            }),
+          );
         }
       }
 
@@ -567,7 +564,6 @@ const getSharedListingSuccessEpic: AppEpic = (action$, state$) =>
                 noLoader: true,
               }),
             );
-            actions.push(ShareActions.resetShareId());
           } else {
             actions.push(
               ConversationsActions.selectConversations({
@@ -583,7 +579,6 @@ const getSharedListingSuccessEpic: AppEpic = (action$, state$) =>
                 selectFirst: true,
               }),
             );
-            actions.push(ShareActions.resetShareId());
           } else {
             actions.push(
               PromptsActions.setSelectedPrompt({
@@ -603,6 +598,7 @@ const getSharedListingSuccessEpic: AppEpic = (action$, state$) =>
             }),
           );
         }
+        actions.push(ShareActions.resetShareId());
       }
 
       return concat(actions);

--- a/apps/chat/src/store/share/share.epics.ts
+++ b/apps/chat/src/store/share/share.epics.ts
@@ -476,7 +476,7 @@ const getSharedListingSuccessEpic: AppEpic = (action$, state$) =>
             actions.push(
               ConversationsActions.addConversations({
                 conversations: payload.resources.entities.map((res) => ({
-                  ...res,
+                  ...(res.id === selectedConv?.id ? selectedConv : res),
                   sharedWithMe: true,
                 })) as Conversation[],
               }),
@@ -532,11 +532,15 @@ const getSharedListingSuccessEpic: AppEpic = (action$, state$) =>
                 .filter(Boolean) as AnyAction[]),
             );
         } else {
+          const selectedPrompt = PromptsSelectors.selectSelectedPrompt(
+            state$.value,
+          );
+
           payload.resources.entities.length &&
             actions.push(
               PromptsActions.addPrompts({
                 prompts: payload.resources.entities.map((res) => ({
-                  ...res,
+                  ...(res.id === selectedPrompt?.id ? selectedPrompt : res),
                   sharedWithMe: true,
                 })) as Prompt[],
               }),

--- a/apps/chat/src/store/share/share.epics.ts
+++ b/apps/chat/src/store/share/share.epics.ts
@@ -398,6 +398,7 @@ const getSharedListingFailEpic: AppEpic = (action$) =>
   );
 
 // TODO: refactor it to something better
+// TODO: separate EPIC for reloading?
 const getSharedListingSuccessEpic: AppEpic = (action$, state$) =>
   action$.pipe(
     filter(ShareActions.getSharedListingSuccess.match),
@@ -470,6 +471,7 @@ const getSharedListingSuccessEpic: AppEpic = (action$, state$) =>
           }
 
           actions.push(
+            // TODO: rename or think how to do it better
             ConversationsActions.addSharedConversations({
               conversations: payload.resources.entities.map((res) => ({
                 ...(res.id === selectedConv?.id ? selectedConv : res),

--- a/apps/chat/src/store/share/share.epics.ts
+++ b/apps/chat/src/store/share/share.epics.ts
@@ -332,6 +332,7 @@ const triggerGettingSharedListingsPromptsEpic: AppEpic = (action$, state$) =>
     filter(
       (action) =>
         PromptsActions.initPromptsSuccess.match(action) ||
+        PromptsActions.reloadPromptsStateSuccess.match(action) ||
         ShareActions.acceptShareInvitationSuccess.match(action),
     ),
     filter(() =>

--- a/apps/chat/src/store/share/share.reducers.ts
+++ b/apps/chat/src/store/share/share.reducers.ts
@@ -40,6 +40,13 @@ export const shareSlice = createSlice({
   initialState,
   reducers: {
     init: (state) => state,
+    triggerReloadSharedItems: (
+      state,
+      _action: PayloadAction<{
+        sharedWith: ShareRelations;
+        featureType: FeatureType;
+      }>,
+    ) => state,
     share: (
       state,
       {
@@ -185,7 +192,19 @@ export const shareSlice = createSlice({
         };
       }>,
     ) => state,
+    reloadSharedListingSuccess: (
+      state,
+      _action: PayloadAction<{
+        featureType: FeatureType;
+        sharedWith: ShareRelations;
+        resources: {
+          entities: (ConversationInfo | Prompt)[];
+          folders: FolderInterface[];
+        };
+      }>,
+    ) => state,
     getSharedListingFail: (state) => state,
+    reloadSharedListingFail: (state) => state,
   },
 });
 

--- a/apps/chat/src/store/share/share.reducers.ts
+++ b/apps/chat/src/store/share/share.reducers.ts
@@ -40,7 +40,7 @@ export const shareSlice = createSlice({
   initialState,
   reducers: {
     init: (state) => state,
-    triggerReloadSharedItems: (
+    reloadSharedItems: (
       state,
       _action: PayloadAction<{
         sharedWith: ShareRelations;


### PR DESCRIPTION
**Description:**

Add state reload if tab inactive more then 5 minutes.

Issues:

- Issue: https://github.com/epam/ai-dial-chat/issues/784

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
