### PR TITLE
fix(chat): use only first line for conversation name (Issue #912)

### DIFF
--- a/apps/chat/src/utils/app/common.ts
+++ b/apps/chat/src/utils/app/common.ts
@@ -4,7 +4,10 @@ import { getFoldersFromIds } from '@/src/utils/app/folders';
 import { Entity, ShareEntity } from '@/src/types/common';
 import { FolderInterface, FolderType } from '@/src/types/folder';
 
-import { MAX_ENTITY_LENGTH } from '@/src/constants/default-ui-settings';
+import {
+  DEFAULT_CONVERSATION_NAME,
+  MAX_ENTITY_LENGTH,
+} from '@/src/constants/default-ui-settings';
 
 import uniq from 'lodash-es/uniq';
 
@@ -83,9 +86,14 @@ export const updateEntitiesFoldersAndIds = (
 };
 
 export const prepareEntityName = (name: string, forRenaming = false) => {
-  const clearName = name
-    .replace(notAllowedSymbolsRegex, forRenaming ? '' : ' ')
-    .trim();
+  const clearName =
+    (forRenaming
+      ? name.replace(notAllowedSymbolsRegex, '')
+      : name
+          .replace(/\r\n|\r/gm, '\n')
+          .split('\n')
+          .map((s) => s.replace(notAllowedSymbolsRegex, ' ').trim())
+          .filter(Boolean)[0]) || DEFAULT_CONVERSATION_NAME;
 
   if (clearName.length > MAX_ENTITY_LENGTH) {
     return clearName.substring(0, MAX_ENTITY_LENGTH - 3) + '...';

--- a/apps/chat/src/utils/app/common.ts
+++ b/apps/chat/src/utils/app/common.ts
@@ -88,7 +88,7 @@ export const updateEntitiesFoldersAndIds = (
 export const prepareEntityName = (name: string, forRenaming = false) => {
   const clearName =
     (forRenaming
-      ? name.replace(notAllowedSymbolsRegex, '')
+      ? name.replace(notAllowedSymbolsRegex, '').trim()
       : name
           .replace(/\r\n|\r/gm, '\n')
           .split('\n')


### PR DESCRIPTION
**Description:**

use only first line for conversation name

Issues:

- Issue #912 

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
