### PR TITLE
fix(chat): remove input additional height if regenerate not big (Issue #878)

### DIFF
--- a/apps/chat/src/components/Chat/Chat.tsx
+++ b/apps/chat/src/components/Chat/Chat.tsx
@@ -783,7 +783,7 @@ export const ChatView = memo(() => {
                       style={{
                         height:
                           inputHeight +
-                          (showBigRegenerate ? 56 : isSmallScreen() ? 0 : 16),
+                          (isLastMessageError ? 56 : isSmallScreen() ? 0 : 16),
                       }}
                       ref={messagesEndRef}
                     />

--- a/apps/chat/src/components/Chat/Chat.tsx
+++ b/apps/chat/src/components/Chat/Chat.tsx
@@ -788,8 +788,10 @@ export const ChatView = memo(() => {
                       ),
                     )}
                     <div
-                      className="shrink-0 "
-                      style={{ height: inputHeight + 56 }}
+                      className="shrink-0"
+                      style={{
+                        height: inputHeight + (showBigRegenerate ? 56 : 0),
+                      }}
                       ref={messagesEndRef}
                     />
                   </div>

--- a/apps/chat/src/components/Chat/Chat.tsx
+++ b/apps/chat/src/components/Chat/Chat.tsx
@@ -210,7 +210,7 @@ export const ChatView = memo(() => {
     if (chatContainerRef.current) {
       const { scrollTop, scrollHeight, clientHeight } =
         chatContainerRef.current;
-      const bottomTolerance = 5;
+      const bottomTolerance = 25;
 
       if (lastScrollTop.current > scrollTop) {
         setAutoScrollEnabled(false);

--- a/apps/chat/src/components/Chat/Chat.tsx
+++ b/apps/chat/src/components/Chat/Chat.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from 'next-i18next';
 import classNames from 'classnames';
 
 import { clearStateForMessages } from '@/src/utils/app/clear-messages-state';
+import { isSmallScreen } from '@/src/utils/app/mobile';
 
 import {
   Conversation,
@@ -209,7 +210,7 @@ export const ChatView = memo(() => {
     if (chatContainerRef.current) {
       const { scrollTop, scrollHeight, clientHeight } =
         chatContainerRef.current;
-      const bottomTolerance = 25;
+      const bottomTolerance = 5;
 
       if (lastScrollTop.current > scrollTop) {
         setAutoScrollEnabled(false);
@@ -790,7 +791,9 @@ export const ChatView = memo(() => {
                     <div
                       className="shrink-0"
                       style={{
-                        height: inputHeight + (showBigRegenerate ? 56 : 0),
+                        height:
+                          inputHeight +
+                          (showBigRegenerate ? 56 : isSmallScreen() ? 0 : 16),
                       }}
                       ref={messagesEndRef}
                     />

--- a/apps/chat/src/components/Chat/ChatInput/ChatInput.tsx
+++ b/apps/chat/src/components/Chat/ChatInput/ChatInput.tsx
@@ -69,7 +69,7 @@ export const ChatInput = ({
   return (
     <div
       ref={inputRef}
-      className="gradient-top-bottom absolute bottom-0 left-0 w-full pt-6 md:pt-2"
+      className="gradient-top-bottom absolute bottom-0 left-0 w-full pt-2"
     >
       <div className="relative">
         {!Children.toArray(children).length &&

--- a/apps/chat/src/components/Chat/NotAllowedModel.tsx
+++ b/apps/chat/src/components/Chat/NotAllowedModel.tsx
@@ -19,7 +19,7 @@ export const NotAllowedModel = ({ type = EntityType.Model }) => {
   return (
     <div
       className={classNames(
-        'gradient-top-bottom absolute bottom-0 left-0 flex w-full flex-col items-center justify-center pt-6 md:pt-2',
+        'gradient-top-bottom absolute bottom-0 left-0 flex w-full flex-col items-center justify-center pt-2',
         { 'lg:pl-20 lg:pr-[84px]': isChatFullWidth },
       )}
     >

--- a/apps/chat/src/components/Chat/Playback/PlaybackControls.tsx
+++ b/apps/chat/src/components/Chat/Playback/PlaybackControls.tsx
@@ -207,7 +207,7 @@ export const PlaybackControls = ({
   return (
     <div
       ref={controlsContainerRef}
-      className="gradient-top-bottom absolute bottom-0 left-0 w-full pt-6 md:pt-2"
+      className="gradient-top-bottom absolute bottom-0 left-0 w-full pt-2"
     >
       <div
         className={classNames(

--- a/apps/chat/src/styles/globals.css
+++ b/apps/chat/src/styles/globals.css
@@ -33,7 +33,8 @@
   }
 
   :hover {
-    scrollbar-color: theme('backgroundColor.layer-4') theme('colors.transparent');
+    scrollbar-color: theme('backgroundColor.layer-4')
+      theme('colors.transparent');
   }
 
   /* TODO: fix calendar color for different themes */
@@ -126,7 +127,7 @@ pre:has(div.codeblock) {
   }
 
   .gradient-top-bottom {
-    @apply border-transparent bg-gradient-to-b from-transparent via-layer-1 via-[8px] md:via-[25px] to-layer-1;
+    @apply border-transparent bg-gradient-to-b from-transparent via-layer-1 via-[8px] to-layer-1 md:via-[25px];
   }
 }
 

--- a/apps/chat/src/styles/globals.css
+++ b/apps/chat/src/styles/globals.css
@@ -10,6 +10,7 @@
   ::-webkit-scrollbar-thumb {
     @apply cursor-pointer rounded bg-layer-4;
   }
+
   :not(:hover)::-webkit-scrollbar-thumb {
     @apply bg-transparent;
   }
@@ -17,6 +18,7 @@
   ::-webkit-scrollbar-track:hover {
     @apply bg-transparent;
   }
+
   ::-webkit-scrollbar-corner {
     @apply bg-transparent;
   }
@@ -31,8 +33,7 @@
   }
 
   :hover {
-    scrollbar-color: theme('backgroundColor.layer-4')
-      theme('colors.transparent');
+    scrollbar-color: theme('backgroundColor.layer-4') theme('colors.transparent');
   }
 
   /* TODO: fix calendar color for different themes */
@@ -97,6 +98,7 @@ pre:has(div.codeblock) {
   .button.button-primary {
     @apply text-controls-permanent;
   }
+
   .button.button-primary:not(:disabled) {
     @apply bg-controls-accent hover:bg-controls-accent-hover;
   }
@@ -108,6 +110,7 @@ pre:has(div.codeblock) {
   .button.button-secondary:not(:disabled) {
     @apply bg-transparent hover:bg-layer-4;
   }
+
   .button.button-secondary:disabled {
     @apply text-controls-disable;
   }
@@ -123,7 +126,7 @@ pre:has(div.codeblock) {
   }
 
   .gradient-top-bottom {
-    @apply border-transparent bg-gradient-to-b from-transparent via-layer-1 via-[25px] to-layer-1;
+    @apply border-transparent bg-gradient-to-b from-transparent via-layer-1 via-[8px] md:via-[25px] to-layer-1;
   }
 }
 
@@ -135,6 +138,7 @@ pre:has(div.codeblock) {
     --bg-accent-primary-alpha: var(--bg-accent-secondary-alpha, #37babc26);
     --bg-accent-primary: var(--bg-accent-secondary, #37babc);
   }
+
   .sidebar-right,
   .context-menu-prompt {
     --text-accent-primary: var(--text-accent-tertiary, #a972ff);


### PR DESCRIPTION
**Description:**

Remove input additional height if regenerate not big

Issues:

- https://github.com/epam/ai-dial-chat/issues/878

PRs:

- https://github.com/epam/ai-dial-chat/pull/897

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
