### PR TITLE
feat(chat): change the regenerate button to an icon in compare mode (Issue #924)

### DIFF
--- a/apps/chat/src/components/Chat/Chat.tsx
+++ b/apps/chat/src/components/Chat/Chat.tsx
@@ -568,13 +568,7 @@ export const ChatView = memo(() => {
   }, []);
 
   const showLastMessageRegenerate =
-    !isPlayback &&
-    !isExternal &&
-    !messageIsStreaming &&
-    !isLastMesssageError &&
-    selectedConversationsIds.length === 1;
-  const showBigRegenerate =
-    isLastMesssageError || selectedConversationsIds.length > 1;
+    !isPlayback && !isExternal && !messageIsStreaming && !isLastMesssageError;
 
   return (
     <div
@@ -851,7 +845,7 @@ export const ChatView = memo(() => {
                     onSend={onSendMessage}
                     onScrollDownClick={handleScrollDown}
                     onRegenerate={
-                      showBigRegenerate ? onRegenerateMessage : undefined
+                      isLastMesssageError ? onRegenerateMessage : undefined
                     }
                     onStopConversation={() => {
                       dispatch(ConversationsActions.stopStreamMessage());

--- a/apps/chat/src/components/Chat/Chat.tsx
+++ b/apps/chat/src/components/Chat/Chat.tsx
@@ -102,7 +102,7 @@ export const ChatView = memo(() => {
     useState<boolean>(false);
   const [mergedMessages, setMergedMessages] = useState<MergedMessages[]>([]);
   const [isShowChatSettings, setIsShowChatSettings] = useState(false);
-  const [isLastMesssageError, setIsLastMesssageError] = useState(false);
+  const [isLastMessageError, setIsLastMessageError] = useState(false);
 
   const selectedConversationsTemporarySettings = useRef<
     Record<string, ConversationsTemporarySettings>
@@ -237,7 +237,7 @@ export const ChatView = memo(() => {
         (mergedStr: [Conversation, Message, number]) =>
           !!mergedStr[1].errorMessage,
       );
-      setIsLastMesssageError(isErrorInSomeLastMessage);
+      setIsLastMessageError(isErrorInSomeLastMessage);
     }
   }, [mergedMessages]);
 
@@ -568,7 +568,7 @@ export const ChatView = memo(() => {
   }, []);
 
   const showLastMessageRegenerate =
-    !isPlayback && !isExternal && !messageIsStreaming && !isLastMesssageError;
+    !isPlayback && !isExternal && !messageIsStreaming && !isLastMessageError;
 
   return (
     <div
@@ -845,7 +845,7 @@ export const ChatView = memo(() => {
                     onSend={onSendMessage}
                     onScrollDownClick={handleScrollDown}
                     onRegenerate={
-                      isLastMesssageError ? onRegenerateMessage : undefined
+                      isLastMessageError ? onRegenerateMessage : undefined
                     }
                     onStopConversation={() => {
                       dispatch(ConversationsActions.stopStreamMessage());


### PR DESCRIPTION
**Description:**

Change the regenerate button to an icon in compare mode

Issues:

- https://github.com/epam/ai-dial-chat/issues/924

**UI changes**

![image](https://github.com/epam/ai-dial-chat/assets/98586297/bbb91a6f-ec99-4ad7-891d-3b1e069cc679)

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
