### PR TITLE
fix(chat): add `{` and `}` in not allowed symbols (Issue #928)

### DIFF
--- a/apps/chat-e2e/src/tests/chatBarConversation.test.ts
+++ b/apps/chat-e2e/src/tests/chatBarConversation.test.ts
@@ -23,7 +23,7 @@ const request = 'What is epam official name';
 const notMatchingSearchTerm = 'abc';
 const secondSearchTerm = 'epam official';
 const matchingConversationName = `${secondSearchTerm} name`;
-const specialSymbolsName = '_!@$epam official^&()_{}[]"\'.<>-`~';
+const specialSymbolsName = '_!@$epam official^&()_[]"\'.<>-`~';
 
 dialTest.beforeAll(async () => {
   gpt35Model = ModelsUtil.getDefaultModel()!;
@@ -316,7 +316,7 @@ dialTest(
     setTestIds('EPMRTC-595', 'EPMRTC-1276');
     const conversation = conversationData.prepareDefaultConversation(
       gpt35Model,
-      '!@$^&()_{}[]"\'.<>-`~',
+      '!@$^&()_[]"\'.<>-`~',
     );
     await dataInjector.createConversations([conversation]);
     await localStorageManager.setSelectedConversation(conversation);

--- a/apps/chat-e2e/src/tests/prompts.test.ts
+++ b/apps/chat-e2e/src/tests/prompts.test.ts
@@ -190,7 +190,7 @@ dialTest(
     setTestIds,
   }) => {
     setTestIds('EPMRTC-955', 'EPMRTC-1278');
-    const nameWithSpecialSymbols = '!@$^()_{}[]"\'.<>-`~';
+    const nameWithSpecialSymbols = '!@$^()_[]"\'.<>-`~';
     const prompt = promptData.prepareDefaultPrompt();
     await dataInjector.createPrompts([prompt]);
 
@@ -663,7 +663,7 @@ dialTest(
       fourthPrompt = promptData.prepareDefaultPrompt();
       promptData.resetData();
       fifthPrompt = promptData.prepareDefaultPrompt(
-        'Prompt_!@$^&()_{}[]"\'.<>-`~',
+        'Prompt_!@$^&()_[]"\'.<>-`~',
       );
 
       await dataInjector.createPrompts([

--- a/apps/chat/src/utils/app/file.ts
+++ b/apps/chat/src/utils/app/file.ts
@@ -104,7 +104,7 @@ export const getFilesWithInvalidFileType = (
     ? []
     : files.filter((file) => !isAllowedMimeType(allowedFileTypes, file.type));
 };
-export const notAllowedSymbols = ':;,=/';
+export const notAllowedSymbols = ':;,=/{}';
 export const notAllowedSymbolsRegex = new RegExp(
   `[${escapeRegExp(notAllowedSymbols)}]|(\r\n|\n|\r)`,
   'gm',


### PR DESCRIPTION
**Description:**

add `{` and `}` in not allowed symbols

Issues:

- Issue #928

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
