### PR TITLE
fix(chat): fix compare name generation (Issue #921)

### DIFF
--- a/apps/chat/src/store/conversations/conversations.epics.ts
+++ b/apps/chat/src/store/conversations/conversations.epics.ts
@@ -1176,20 +1176,26 @@ const sendMessageEpic: AppEpic = (action$, state$) =>
           assistantMessage,
         );
 
-        const newConversationName = getNextDefaultName(
-          getNewConversationName(
-            payload.conversation,
-            payload.message,
-            updatedMessages,
-          ),
-          conversations.filter(
-            (conv) =>
-              conv.folderId === payload.conversation.folderId &&
-              !selectedConversationIds.includes(conv.id),
-          ),
-          Math.max(selectedConversationIds.indexOf(payload.conversation.id), 0),
-          true,
-        );
+        const newConversationName =
+          updatedMessages.length > 2
+            ? payload.conversation.name
+            : getNextDefaultName(
+                getNewConversationName(
+                  payload.conversation,
+                  payload.message,
+                  updatedMessages,
+                ),
+                conversations.filter(
+                  (conv) =>
+                    conv.folderId === payload.conversation.folderId &&
+                    !selectedConversationIds.includes(conv.id),
+                ),
+                Math.max(
+                  selectedConversationIds.indexOf(payload.conversation.id),
+                  0,
+                ),
+                true,
+              );
 
         const updatedConversation: Conversation = regenerateConversationId({
           ...payload.conversation,


### PR DESCRIPTION
**Description:**

fix compare name generation

Issues:

- Issue #921 

**UI changes**

![image](https://github.com/epam/ai-dial-chat/assets/20163971/211b0f7a-e0dd-46b2-9b42-752744e4091f)

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
