### PR TITLE
fix(chat): fix conversation name regeneration (Issue #921)

### DIFF
--- a/apps/chat/src/store/conversations/conversations.epics.ts
+++ b/apps/chat/src/store/conversations/conversations.epics.ts
@@ -1175,7 +1175,9 @@ const sendMessageEpic: AppEpic = (action$, state$) =>
         );
 
         const newConversationName =
-          updatedMessages.length > 2
+          payload.conversation.replay?.isReplay ||
+          updatedMessages.length > 2 ||
+          payload.conversation.isNameChanged
             ? payload.conversation.name
             : getNextDefaultName(
                 getNewConversationName(

--- a/apps/chat/src/utils/app/conversation.ts
+++ b/apps/chat/src/utils/app/conversation.ts
@@ -95,7 +95,7 @@ export const getNewConversationName = (
 
   if (
     conversation.replay?.isReplay ||
-    updatedMessages.length !== 2 ||
+    updatedMessages.length > 2 ||
     conversation.isNameChanged
   ) {
     return convName;


### PR DESCRIPTION
**Description:**

fix conversation name regeneration

Issues:

- Issue #921

**UI changes**

<Please, provide Screenshots or Figma links>

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
