### PR TITLE
fix(chat): add \r to message splitting while editing (Issue #916)

### DIFF
--- a/apps/chat/src/components/Chat/ChatMessage/ChatMessageContent.tsx
+++ b/apps/chat/src/components/Chat/ChatMessage/ChatMessageContent.tsx
@@ -220,7 +220,7 @@ export const ChatMessageContent = ({
 
   useEffect(() => {
     if (textareaRef.current) {
-      textareaRef.current.rows = messageContent.split('\n').length;
+      textareaRef.current.rows = messageContent.split(/\r\n|\r|\n/).length;
     }
   }, [isEditing, messageContent]);
 


### PR DESCRIPTION
**Description:**

Add \r to message splitting

Issues:

- https://github.com/epam/ai-dial-chat/issues/916

PRs:

- https://github.com/epam/ai-dial-chat/pull/937

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
