### PR TITLE
fix: correct model highlighting for the model in the models list for the Playback and Replay (Issue #936)

### DIFF
--- a/apps/chat/src/components/Chat/ConversationSettingsModels.tsx
+++ b/apps/chat/src/components/Chat/ConversationSettingsModels.tsx
@@ -69,6 +69,7 @@ export const ConversationSettingsModel = ({
 
   const isPlayback = conversation.playback?.isPlayback;
   const isReplay = conversation.replay?.isReplay;
+  const isReplayAsIs = conversation.replay?.replayAsIs;
 
   return (
     <div className="w-full" data-qa="entity-selector">
@@ -83,7 +84,7 @@ export const ConversationSettingsModel = ({
               conversationId={conversation.id}
             />
           )}
-          {unavailableModelId && (
+          {!isPlayback && !isReplay && unavailableModelId && (
             <button className="flex items-center gap-3 rounded border border-accent-primary p-3 text-left text-xs">
               <ModelIcon entityId="" entity={undefined} size={24} />
               <div className="flex flex-col gap-1">
@@ -113,6 +114,7 @@ export const ConversationSettingsModel = ({
             disabled={isPlayback}
             notAllowExpandDescription
             allEntities={models}
+            isReplayAsIs={isReplayAsIs}
           />
         </div>
       </div>

--- a/apps/chat/src/components/Chat/ModelList.tsx
+++ b/apps/chat/src/components/Chat/ModelList.tsx
@@ -27,6 +27,7 @@ interface ModelGroupProps {
   notAllowExpandDescription?: boolean;
   searchTerm?: string;
   disabled?: boolean;
+  isReplayAsIs?: boolean;
 }
 
 const ModelGroup = ({
@@ -36,6 +37,7 @@ const ModelGroup = ({
   notAllowExpandDescription,
   searchTerm,
   disabled,
+  isReplayAsIs,
 }: ModelGroupProps) => {
   const [isOpened, setIsOpened] = useState(false);
   const recentModelsIds = useAppSelector(ModelsSelectors.selectRecentModelsIds);
@@ -73,7 +75,7 @@ const ModelGroup = ({
     <div
       className={classNames(
         'relative rounded border hover:border-hover',
-        !disabled && selectedModelId === currentEntity.id
+        !disabled && !isReplayAsIs && selectedModelId === currentEntity.id
           ? 'border-accent-primary'
           : 'border-primary',
         isOpened ? 'md:col-span-2' : 'md:col-span-1',
@@ -166,6 +168,7 @@ interface ModelListProps {
   allEntities: DialAIEntity[];
   searchTerm?: string;
   disabled?: boolean;
+  isReplayAsIs?: boolean;
 }
 
 export const ModelList = ({
@@ -179,6 +182,7 @@ export const ModelList = ({
   allEntities,
   searchTerm,
   disabled,
+  isReplayAsIs,
 }: ModelListProps) => {
   const groupedModels = useMemo(() => {
     const nameSet = new Set(entities.map((m) => m.name));
@@ -206,6 +210,7 @@ export const ModelList = ({
             notAllowExpandDescription={notAllowExpandDescription}
             disabled={disabled}
             searchTerm={searchTerm}
+            isReplayAsIs={isReplayAsIs}
           />
         ))}
       </div>

--- a/apps/chat/src/components/Chat/ReplayAsIsButton.tsx
+++ b/apps/chat/src/components/Chat/ReplayAsIsButton.tsx
@@ -2,14 +2,13 @@ import { useCallback } from 'react';
 
 import { useTranslation } from 'next-i18next';
 
-import classNames from 'classnames';
-
 import { Replay } from '@/src/types/chat';
 import { Translation } from '@/src/types/translation';
 
 import { ConversationsActions } from '@/src/store/conversations/conversations.reducers';
 import { useAppDispatch } from '@/src/store/hooks';
 
+import { NonModelButton } from '../Common/NonModelButton';
 import { ReplayAsIsIcon } from './ReplayAsIsIcon';
 
 interface Props {
@@ -35,22 +34,12 @@ export const ReplayAsIsButton = ({ replay, conversationId }: Props) => {
     );
   }, [conversationId, dispatch, replay]);
 
-  const asIsButtonClassName = classNames(
-    'flex items-center gap-3 rounded border p-3 text-left text-xs',
-    {
-      'border-blue-500': replay.replayAsIs,
-      'border-primary hover:border-hover': !replay.replayAsIs,
-    },
-  );
-
   return (
-    <button className={asIsButtonClassName} onClick={handleOnSelectReplayAsIs}>
-      <span className="relative inline-block shrink-0 leading-none">
-        <ReplayAsIsIcon />
-      </span>
-      <div className="flex flex-col gap-1">
-        <span>{t('Replay as is')}</span>
-      </div>
-    </button>
+    <NonModelButton
+      onClickHandler={handleOnSelectReplayAsIs}
+      icon={<ReplayAsIsIcon />}
+      buttonLabel={t('Replay as is')}
+      isSelected={replay.replayAsIs}
+    />
   );
 };

--- a/apps/chat/src/components/Common/NonModelButton.tsx
+++ b/apps/chat/src/components/Common/NonModelButton.tsx
@@ -16,8 +16,8 @@ export const NonModelButton = ({
   onClickHandler,
 }: Props) => {
   const asIsButtonClassName = classNames(
-    'flex items-center gap-3 rounded border p-3 text-left text-xs',
-    isSelected ? 'border-accent-primary' : 'border-primary hover:border-hover',
+    'flex items-center gap-3 rounded border p-3 text-left text-xs hover:border-hover',
+    isSelected ? 'border-accent-primary' : 'border-primary',
   );
 
   return (


### PR DESCRIPTION

**Description:**

Correct selected model highlightig in the models list for the Playback and Replay mode.
Changed ReplayAsIsButton to use same compnent as for the Playback to sync styles.

Issues:

- Issue #936 

**UI changes**

![image](https://github.com/epam/ai-dial-chat/assets/143205282/ae64e663-9cd6-45b7-9a7f-fead8de48af0)

![image](https://github.com/epam/ai-dial-chat/assets/143205282/b8220746-42aa-4055-b584-d3d85a37d224)


**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
