### PR TITLE
fix(chat): fix app name for migration backup (Issue #959)

### DIFF
--- a/apps/chat/src/store/import-export/importExport.epics.ts
+++ b/apps/chat/src/store/import-export/importExport.epics.ts
@@ -211,7 +211,7 @@ const exportLocalStorageChatsEpic: AppEpic = (action$, state$) => {
           .getConversations()
           .pipe(map(filterOnlyMyEntities)),
         conversationFolders: browserStorage.getConversationsFolders(),
-        appName: SettingsSelectors.selectAppName(state$.value),
+        appName: of(SettingsSelectors.selectAppName(state$.value)),
       }),
     ),
     tap(({ conversations, conversationFolders, appName }) => {
@@ -232,7 +232,7 @@ const exportLocalStoragePromptsEpic: AppEpic = (action$, state$) => {
       forkJoin({
         prompts: browserStorage.getPrompts().pipe(map(filterOnlyMyEntities)),
         promptFolders: browserStorage.getPromptsFolders(),
-        appName: SettingsSelectors.selectAppName(state$.value),
+        appName: of(SettingsSelectors.selectAppName(state$.value)),
       }),
     ),
     tap(({ prompts, promptFolders, appName }) => {


### PR DESCRIPTION
**Description:**

Fix app name for migration backup

Issues:

- https://github.com/epam/ai-dial-chat/issues/959

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
