### PR TITLE
fix(chat): fix chat name generation when have attachments (Issue #960)

### DIFF
--- a/apps/chat/src/utils/app/common.ts
+++ b/apps/chat/src/utils/app/common.ts
@@ -4,10 +4,7 @@ import { getFoldersFromIds } from '@/src/utils/app/folders';
 import { Entity, ShareEntity } from '@/src/types/common';
 import { FolderInterface, FolderType } from '@/src/types/folder';
 
-import {
-  DEFAULT_CONVERSATION_NAME,
-  MAX_ENTITY_LENGTH,
-} from '@/src/constants/default-ui-settings';
+import { MAX_ENTITY_LENGTH } from '@/src/constants/default-ui-settings';
 
 import uniq from 'lodash-es/uniq';
 
@@ -86,14 +83,13 @@ export const updateEntitiesFoldersAndIds = (
 };
 
 export const prepareEntityName = (name: string, forRenaming = false) => {
-  const clearName =
-    (forRenaming
-      ? name.replace(notAllowedSymbolsRegex, '').trim()
-      : name
-          .replace(/\r\n|\r/gm, '\n')
-          .split('\n')
-          .map((s) => s.replace(notAllowedSymbolsRegex, ' ').trim())
-          .filter(Boolean)[0]) || DEFAULT_CONVERSATION_NAME;
+  const clearName = forRenaming
+    ? name.replace(notAllowedSymbolsRegex, '').trim()
+    : name
+        .replace(/\r\n|\r/gm, '\n')
+        .split('\n')
+        .map((s) => s.replace(notAllowedSymbolsRegex, ' ').trim())
+        .filter(Boolean)[0] ?? '';
 
   if (clearName.length > MAX_ENTITY_LENGTH) {
     return clearName.substring(0, MAX_ENTITY_LENGTH - 3) + '...';


### PR DESCRIPTION
**Description:**

fix chat name generation when have attachments

Issues:

- Issue #960

**UI changes**

![image](https://github.com/epam/ai-dial-chat/assets/20163971/56e43902-fb24-4892-a501-3ef4a44a56c0)

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
