### PR TITLE
fix(chat): remove ready to lose data checkbox if all backed up (Issue #959)

### DIFF
--- a/apps/chat/src/components/Chat/Migration/MigrationFailedModal.tsx
+++ b/apps/chat/src/components/Chat/Migration/MigrationFailedModal.tsx
@@ -337,27 +337,34 @@ export const MigrationFailedWindow = ({
           </div>
         </div>
         <footer className="flex flex-col items-center justify-end px-6 pt-4">
-          <div className="flex items-center gap-4">
-            <div className="relative flex size-[18px] group-hover/file-item:flex">
-              <input
-                className="checkbox peer size-[18px] bg-transparent"
-                type="checkbox"
-                onClick={() => setDontWantBackup((prev) => !prev)}
-                readOnly
-                checked={dontWantBackup}
-              />
-              {dontWantBackup && (
-                <IconCheck
-                  size={18}
-                  className="pointer-events-none invisible absolute text-accent-primary peer-checked:visible"
+          {!!(
+            (!isChatsBackedUp && failedMigratedConversations.length) ||
+            (!isPromptsBackedUp && failedMigratedPrompts.length)
+          ) && (
+            <div className="flex items-center gap-4">
+              <div className="relative flex size-[18px] group-hover/file-item:flex">
+                <input
+                  className="checkbox peer size-[18px] bg-transparent"
+                  type="checkbox"
+                  onClick={() => setDontWantBackup((prev) => !prev)}
+                  readOnly
+                  checked={dontWantBackup}
                 />
-              )}
+                {dontWantBackup && (
+                  <IconCheck
+                    size={18}
+                    className="pointer-events-none invisible absolute text-accent-primary peer-checked:visible"
+                  />
+                )}
+              </div>
+              <p className="text-secondary">
+                {t(
+                  "I don't want to backup conversations/prompts and I’m ready ",
+                )}
+                <span className="font-semibold">{t('TO LOSE DATA')}</span>
+              </p>
             </div>
-            <p className="text-secondary">
-              {t("I don't want to backup conversations/prompts and I’m ready ")}
-              <span className="font-semibold">{t('TO LOSE DATA')}</span>
-            </p>
-          </div>
+          )}
           <div className="mt-3 flex w-full justify-end">
             {!!failedMigratedPrompts.length && (
               <button


### PR DESCRIPTION
**Description:**

Remove ready to lose data checkbox if all backed up

Issues:

- https://github.com/epam/ai-dial-chat/issues/959

PRs:

- https://github.com/epam/ai-dial-chat/pull/961

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
