### PR TITLE
fix(chat): Check auth state before sign in overlay chat

### DIFF
--- a/apps/chat/src/store/overlay/overlay.epics.ts
+++ b/apps/chat/src/store/overlay/overlay.epics.ts
@@ -287,20 +287,29 @@ const setOverlayOptionsEpic: AppEpic = (action$, state$) =>
           }
         }
 
-        if (signInOptions?.autoSignIn) {
-          signIn(signInOptions?.signInProvider);
-        }
-
         // after all actions will send notify that settings are set
         actions.push(
           of(
             OverlayActions.setOverlayOptionsSuccess({ hostDomain, requestId }),
+            OverlayActions.signInOptionsSet({ signInOptions }),
           ),
         );
 
         return merge(...actions);
       },
     ),
+  );
+
+const signInOptionsSet: AppEpic = (action$, state$) =>
+  action$.pipe(
+    filter(OverlayActions.signInOptionsSet.match),
+    filter(() => AuthSelectors.selectIsShouldLogin(state$.value)),
+    tap(({ payload: { signInOptions } }) => {
+      if (signInOptions?.autoSignIn) {
+        signIn(signInOptions?.signInProvider);
+      }
+    }),
+    ignoreElements(),
   );
 
 const setOverlayOptionsSuccessEpic: AppEpic = (action$) =>
@@ -368,4 +377,5 @@ export const OverlayEpics = combineEpics(
   sendMessageEpic,
   notifyHostGPTMessageStatus,
   setOverlayOptionsSuccessEpic,
+  signInOptionsSet,
 );

--- a/apps/chat/src/store/overlay/overlay.reducers.ts
+++ b/apps/chat/src/store/overlay/overlay.reducers.ts
@@ -42,6 +42,12 @@ export const overlaySlice = createSlice({
       state,
       _action: PayloadAction<WithRequestId<{ hostDomain: string }>>,
     ) => state,
+    signInOptionsSet: (
+      state,
+      _action: PayloadAction<{
+        signInOptions: ChatOverlayOptions['signInOptions'];
+      }>,
+    ) => state,
     setSystemPrompt: (
       state,
       { payload }: PayloadAction<WithRequestId<SetSystemPromptOptions>>,


### PR DESCRIPTION
**Description:**

A fix for the overlay chat auto sign in. Added auth check, because calling signIn in an already authorized chat causes some redraws and breaks the overlay.

**Checklist:**

- [X] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [X] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
