### PR TITLE
fix: remove redundant condition (Issue #974)

### DIFF
--- a/apps/chat/src/utils/app/share.ts
+++ b/apps/chat/src/utils/app/share.ts
@@ -100,7 +100,7 @@ export const getShareType = (
   featureType?: FeatureType,
   isFolder?: boolean,
 ): SharingType | undefined => {
-  if (!featureType || !isFolder) {
+  if (!featureType) {
     return undefined;
   }
 


### PR DESCRIPTION
**Description:**

Fixed wrong condition in the getShareType utility function.

Issues:

- Issue #974 

**UI changes**

![image](https://github.com/epam/ai-dial-chat/assets/143205282/262c1af5-1df4-4912-9c5a-816630b92659)

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
