### PR TITLE
fix(chat): hide scroll down button if there no messages in selected conversations (Issue #927)

### DIFF
--- a/apps/chat/src/components/Chat/Chat.tsx
+++ b/apps/chat/src/components/Chat/Chat.tsx
@@ -285,12 +285,13 @@ export const ChatView = memo(() => {
         );
       }
 
-      handleScroll();
       setMergedMessages([...mergedMessages]);
     }
 
-    if (selectedConversations.some((conv) => conv.messages.length === 0)) {
+    if (selectedConversations.every((conv) => conv.messages.length === 0)) {
       setShowScrollDownButton(false);
+    } else {
+      handleScroll();
     }
   }, [handleScroll, selectedConversations]);
 


### PR DESCRIPTION
**Description:**

Hide scroll down button if there no messages in selected conversations

Issues:

- https://github.com/epam/ai-dial-chat/issues/927

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
