### PR TITLE
fix: fixed file name color in the File Manager(Issue #591)

### DIFF
--- a/apps/chat/src/components/Files/FileItem.tsx
+++ b/apps/chat/src/components/Files/FileItem.tsx
@@ -133,8 +133,7 @@ export const FileItem = ({
           className={classNames(
             'block max-w-full truncate',
             item.status === UploadStatus.FAILED && 'text-error',
-            (isSelected || item.status === UploadStatus.LOADING) &&
-              'text-accent-primary',
+            isSelected && 'text-accent-primary',
           )}
         >
           {item.name}


### PR DESCRIPTION
**Description:**

 In the FileManagerModal component. Made file name text color blue only if the file is selected.

Issues:

- Issue #591 

**UI changes**

![image](https://github.com/epam/ai-dial-chat/assets/143205282/c95a968f-71ff-46cb-be79-43ff2649d8fd)

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
