### PR TITLE
fix(chat): show import button instead export if there no my conversations and fix renaming text (Issues #989, #985)

### DIFF
--- a/apps/chat/src/components/Chatbar/ChatbarSettings.tsx
+++ b/apps/chat/src/components/Chatbar/ChatbarSettings.tsx
@@ -110,7 +110,6 @@ export const ChatbarSettings = () => {
             zipImportHandler(typedArgs.content as File);
           }
         },
-        display: isMyItemsExist,
         Icon: IconFileArrowLeft,
         dataQa: 'import',
         CustomTriggerRenderer: Import,
@@ -120,6 +119,7 @@ export const ChatbarSettings = () => {
         dataQa: 'export',
         className: 'max-w-[158px]',
         Icon: IconFileArrowRight,
+        display: isMyItemsExist,
         onClick: () => {
           dispatch(ImportExportActions.exportConversations());
         },

--- a/apps/chat/src/components/Folder/Folder.tsx
+++ b/apps/chat/src/components/Folder/Folder.tsx
@@ -922,7 +922,7 @@ const Folder = <T extends ConversationInfo | PromptInfo | DialFile>({
         cancelLabel={t('Cancel')}
         description={
           t(
-            'Renaming will stop sharing and other users will no longer see this conversation.',
+            'Renaming will stop sharing and other users will no longer see this folder.',
           ) || ''
         }
         onClose={(result) => {

--- a/apps/chat/src/components/Promptbar/components/PromptModal.tsx
+++ b/apps/chat/src/components/Promptbar/components/PromptModal.tsx
@@ -295,7 +295,7 @@ export const PromptModal: FC<Props> = ({ isOpen, onClose, onUpdatePrompt }) => {
             cancelLabel={t('Cancel')}
             description={
               t(
-                'Renaming will stop sharing and other users will no longer see this conversation.',
+                'Renaming will stop sharing and other users will no longer see this prompt.',
               ) || ''
             }
             onClose={(result) => {


### PR DESCRIPTION
**Description:**

- Show import button instead export if there no my conversations
- Fix renaming text

Issues:

- https://github.com/epam/ai-dial-chat/issues/985
- https://github.com/epam/ai-dial-chat/issues/989

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
