### PR TITLE
fix(chat): not allow dots in the end of name (Issue #1003)

### DIFF
--- a/apps/chat/src/components/Chatbar/Conversation.tsx
+++ b/apps/chat/src/components/Chatbar/Conversation.tsx
@@ -16,6 +16,7 @@ import { useTranslation } from 'next-i18next';
 import classNames from 'classnames';
 
 import {
+  isEntityNameInvalid,
   isEntityNameOnSameLevelUnique,
   prepareEntityName,
 } from '@/src/utils/app/common';
@@ -210,18 +211,26 @@ export const ConversationComponent = ({ item: conversation, level }: Props) => {
       !isEntityNameOnSameLevelUnique(newName, conversation, allConversations)
     ) {
       dispatch(
-        UIActions.showToast({
-          message: t(
+        UIActions.showErrorToast(
+          t(
             'Conversation with name "{{newName}}" already exists in this folder.',
             {
               ns: 'chat',
               newName,
             },
           ),
-          type: 'error',
-        }),
+        ),
       );
 
+      return;
+    }
+
+    if (isEntityNameInvalid(newName)) {
+      dispatch(
+        UIActions.showErrorToast(
+          t('Using a dot at the end of a name is not permitted.'),
+        ),
+      );
       return;
     }
 

--- a/apps/chat/src/components/Chatbar/Conversation.tsx
+++ b/apps/chat/src/components/Chatbar/Conversation.tsx
@@ -16,7 +16,7 @@ import { useTranslation } from 'next-i18next';
 import classNames from 'classnames';
 
 import {
-  isEntityNameInvalid,
+  doesHaveDotsInTheEnd,
   isEntityNameOnSameLevelUnique,
   prepareEntityName,
 } from '@/src/utils/app/common';
@@ -225,7 +225,7 @@ export const ConversationComponent = ({ item: conversation, level }: Props) => {
       return;
     }
 
-    if (isEntityNameInvalid(newName)) {
+    if (doesHaveDotsInTheEnd(newName)) {
       dispatch(
         UIActions.showErrorToast(
           t('Using a dot at the end of a name is not permitted.'),

--- a/apps/chat/src/components/Files/PreUploadModal.tsx
+++ b/apps/chat/src/components/Files/PreUploadModal.tsx
@@ -184,7 +184,7 @@ export const PreUploadDialog = ({
     if (incorrectFileNames.length > 0) {
       errors.push(
         t(
-          `The symbols {{notAllowedSymbols}} are not allowed in file name. Please rename or remove them from uploading files list: {{fileNames}}`,
+          `The symbols {{notAllowedSymbols}} are not allowed in file name. Also using a dot at the end of a name is not permitted. Please rename or remove them from uploading files list: {{fileNames}}`,
           {
             notAllowedSymbols,
             fileNames: incorrectFileNames.join(', '),

--- a/apps/chat/src/components/Folder/Folder.tsx
+++ b/apps/chat/src/components/Folder/Folder.tsx
@@ -20,7 +20,7 @@ import { useTranslation } from 'next-i18next';
 import classNames from 'classnames';
 
 import {
-  isEntityNameInvalid,
+  doesHaveDotsInTheEnd,
   isEntityNameOnSameLevelUnique,
   prepareEntityName,
 } from '@/src/utils/app/common';
@@ -277,7 +277,7 @@ const Folder = <T extends ConversationInfo | PromptInfo | DialFile>({
       return;
     }
 
-    if (isEntityNameInvalid(newName)) {
+    if (doesHaveDotsInTheEnd(newName)) {
       dispatch(
         UIActions.showErrorToast(
           t('Using a dot at the end of a name is not permitted.'),

--- a/apps/chat/src/components/Folder/Folder.tsx
+++ b/apps/chat/src/components/Folder/Folder.tsx
@@ -20,6 +20,7 @@ import { useTranslation } from 'next-i18next';
 import classNames from 'classnames';
 
 import {
+  isEntityNameInvalid,
   isEntityNameOnSameLevelUnique,
   prepareEntityName,
 } from '@/src/utils/app/common';
@@ -263,18 +264,25 @@ const Folder = <T extends ConversationInfo | PromptInfo | DialFile>({
       )
     ) {
       dispatch(
-        UIActions.showToast({
-          message: t(
+        UIActions.showErrorToast(
+          t(
             'Folder with name "{{folderName}}" already exists in this folder.',
             {
               ns: 'folder',
               folderName: newName,
             },
           ),
-          type: 'error',
-        }),
+        ),
       );
+      return;
+    }
 
+    if (isEntityNameInvalid(newName)) {
+      dispatch(
+        UIActions.showErrorToast(
+          t('Using a dot at the end of a name is not permitted.'),
+        ),
+      );
       return;
     }
 

--- a/apps/chat/src/components/Promptbar/components/PromptModal.tsx
+++ b/apps/chat/src/components/Promptbar/components/PromptModal.tsx
@@ -14,7 +14,7 @@ import { useTranslation } from 'next-i18next';
 import classNames from 'classnames';
 
 import {
-  isEntityNameInvalid,
+  doesHaveDotsInTheEnd,
   isEntityNameOnSameLevelUnique,
   prepareEntityName,
 } from '@/src/utils/app/common';
@@ -98,7 +98,7 @@ export const PromptModal: FC<Props> = ({ isOpen, onClose, onUpdatePrompt }) => {
         return;
       }
 
-      if (isEntityNameInvalid(newName)) {
+      if (doesHaveDotsInTheEnd(newName)) {
         dispatch(
           UIActions.showErrorToast(
             t('Using a dot at the end of a name is not permitted.'),

--- a/apps/chat/src/components/Promptbar/components/PromptModal.tsx
+++ b/apps/chat/src/components/Promptbar/components/PromptModal.tsx
@@ -14,6 +14,7 @@ import { useTranslation } from 'next-i18next';
 import classNames from 'classnames';
 
 import {
+  isEntityNameInvalid,
   isEntityNameOnSameLevelUnique,
   prepareEntityName,
 } from '@/src/utils/app/common';
@@ -86,18 +87,23 @@ export const PromptModal: FC<Props> = ({ isOpen, onClose, onUpdatePrompt }) => {
 
       if (!isEntityNameOnSameLevelUnique(newName, selectedPrompt, allPrompts)) {
         dispatch(
-          UIActions.showToast({
-            message: t(
-              'Prompt with name "{{newName}}" already exists in this folder.',
-              {
-                ns: 'prompt',
-                newName,
-              },
-            ),
-            type: 'error',
-          }),
+          UIActions.showErrorToast(
+            t('Prompt with name "{{newName}}" already exists in this folder.', {
+              ns: 'prompt',
+              newName,
+            }),
+          ),
         );
 
+        return;
+      }
+
+      if (isEntityNameInvalid(newName)) {
+        dispatch(
+          UIActions.showErrorToast(
+            t('Using a dot at the end of a name is not permitted.'),
+          ),
+        );
         return;
       }
 

--- a/apps/chat/src/utils/app/common.ts
+++ b/apps/chat/src/utils/app/common.ts
@@ -39,7 +39,7 @@ export const isEntityNameOnSameLevelUnique = (
   return !sameLevelEntities.some((e) => nameToBeUnique === e.name);
 };
 
-export const isEntityNameInvalid = (name: string) => {
+export const doesHaveDotsInTheEnd = (name: string) => {
   return name.trim().endsWith('.');
 };
 

--- a/apps/chat/src/utils/app/common.ts
+++ b/apps/chat/src/utils/app/common.ts
@@ -6,6 +6,7 @@ import { FolderInterface, FolderType } from '@/src/types/folder';
 
 import { MAX_ENTITY_LENGTH } from '@/src/constants/default-ui-settings';
 
+import trimEnd from 'lodash-es/trimEnd';
 import uniq from 'lodash-es/uniq';
 
 /**
@@ -86,6 +87,8 @@ export const updateEntitiesFoldersAndIds = (
   return { updatedFolders, updatedOpenedFoldersIds };
 };
 
+const trimEndDots = (str: string) => trimEnd(str, '. \t\r\n');
+
 export const prepareEntityName = (name: string, forRenaming = false) => {
   const clearName = forRenaming
     ? name.replace(notAllowedSymbolsRegex, '').trim()
@@ -96,8 +99,8 @@ export const prepareEntityName = (name: string, forRenaming = false) => {
         .filter(Boolean)[0] ?? '';
 
   if (clearName.length > MAX_ENTITY_LENGTH) {
-    return clearName.substring(0, MAX_ENTITY_LENGTH);
+    return trimEndDots(clearName.substring(0, MAX_ENTITY_LENGTH));
   }
 
-  return clearName;
+  return trimEndDots(clearName);
 };

--- a/apps/chat/src/utils/app/common.ts
+++ b/apps/chat/src/utils/app/common.ts
@@ -39,7 +39,7 @@ export const isEntityNameOnSameLevelUnique = (
 };
 
 export const isEntityNameInvalid = (name: string) => {
-  return name.endsWith('.');
+  return name.trim().endsWith('.');
 };
 
 export const filterOnlyMyEntities = <T extends ShareEntity>(

--- a/apps/chat/src/utils/app/common.ts
+++ b/apps/chat/src/utils/app/common.ts
@@ -38,6 +38,10 @@ export const isEntityNameOnSameLevelUnique = (
   return !sameLevelEntities.some((e) => nameToBeUnique === e.name);
 };
 
+export const isEntityNameInvalid = (name: string) => {
+  return name.endsWith('.');
+};
+
 export const filterOnlyMyEntities = <T extends ShareEntity>(
   entities: T[],
 ): T[] =>
@@ -92,7 +96,7 @@ export const prepareEntityName = (name: string, forRenaming = false) => {
         .filter(Boolean)[0] ?? '';
 
   if (clearName.length > MAX_ENTITY_LENGTH) {
-    return clearName.substring(0, MAX_ENTITY_LENGTH - 3) + '...';
+    return clearName.substring(0, MAX_ENTITY_LENGTH);
   }
 
   return clearName;

--- a/apps/chat/src/utils/app/file.ts
+++ b/apps/chat/src/utils/app/file.ts
@@ -4,7 +4,7 @@ import { DialFile } from '@/src/types/files';
 import { FolderInterface } from '@/src/types/folder';
 
 import { ApiUtils } from '../server/api';
-import { isEntityNameInvalid } from './common';
+import { doesHaveDotsInTheEnd } from './common';
 import { getPathToFolderById } from './folders';
 
 import escapeRegExp from 'lodash-es/escapeRegExp';
@@ -115,7 +115,7 @@ export const getFilesWithInvalidFileName = <T extends { name: string }>(
 ): T[] => {
   return files.filter(
     ({ name }) =>
-      name.match(notAllowedSymbolsRegex) || isEntityNameInvalid(name),
+      name.match(notAllowedSymbolsRegex) || doesHaveDotsInTheEnd(name),
   );
 };
 

--- a/apps/chat/src/utils/app/file.ts
+++ b/apps/chat/src/utils/app/file.ts
@@ -4,6 +4,7 @@ import { DialFile } from '@/src/types/files';
 import { FolderInterface } from '@/src/types/folder';
 
 import { ApiUtils } from '../server/api';
+import { isEntityNameInvalid } from './common';
 import { getPathToFolderById } from './folders';
 
 import escapeRegExp from 'lodash-es/escapeRegExp';
@@ -112,7 +113,10 @@ export const notAllowedSymbolsRegex = new RegExp(
 export const getFilesWithInvalidFileName = <T extends { name: string }>(
   files: T[],
 ): T[] => {
-  return files.filter(({ name }) => name.match(notAllowedSymbolsRegex));
+  return files.filter(
+    ({ name }) =>
+      name.match(notAllowedSymbolsRegex) || isEntityNameInvalid(name),
+  );
 };
 
 export const getFilesWithInvalidFileSize = (

--- a/apps/chat/src/utils/app/folders.ts
+++ b/apps/chat/src/utils/app/folders.ts
@@ -19,6 +19,7 @@ import { EntityFilters } from '@/src/types/search';
 
 import { DEFAULT_FOLDER_NAME } from '@/src/constants/default-ui-settings';
 
+import { isEntityNameInvalid } from './common';
 import { isRootId } from './id';
 
 import escapeRegExp from 'lodash-es/escapeRegExp';
@@ -363,6 +364,10 @@ export const validateFolderRenaming = (
 
   if (newName.match(notAllowedSymbolsRegex)) {
     return `The symbols ${notAllowedSymbols} are not allowed in folder name`;
+  }
+
+  if (isEntityNameInvalid(newName)) {
+    return 'Using a dot at the end of a name is not permitted.';
   }
 };
 

--- a/apps/chat/src/utils/app/folders.ts
+++ b/apps/chat/src/utils/app/folders.ts
@@ -19,7 +19,7 @@ import { EntityFilters } from '@/src/types/search';
 
 import { DEFAULT_FOLDER_NAME } from '@/src/constants/default-ui-settings';
 
-import { isEntityNameInvalid } from './common';
+import { doesHaveDotsInTheEnd } from './common';
 import { isRootId } from './id';
 
 import escapeRegExp from 'lodash-es/escapeRegExp';
@@ -366,7 +366,7 @@ export const validateFolderRenaming = (
     return `The symbols ${notAllowedSymbols} are not allowed in folder name`;
   }
 
-  if (isEntityNameInvalid(newName)) {
+  if (doesHaveDotsInTheEnd(newName)) {
     return 'Using a dot at the end of a name is not permitted.';
   }
 };


### PR DESCRIPTION
**Description:**

not allow dots in the end of name

Issues:

- Issue #1003

**UI changes**

![image](https://github.com/epam/ai-dial-chat/assets/20163971/829b1ae6-926c-4be5-8adb-e932d6fb71e4)

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
