### PR TITLE
fix(chat): add `\` in not allowed symbols (Issue #821)

### DIFF
--- a/apps/chat/src/utils/app/file.ts
+++ b/apps/chat/src/utils/app/file.ts
@@ -121,7 +121,7 @@ export const getFilesWithInvalidFileType = (
     ? []
     : files.filter((file) => !isAllowedMimeType(allowedFileTypes, file.type));
 };
-export const notAllowedSymbols = ':;,=/{}';
+export const notAllowedSymbols = ':;,=/{}\\';
 export const notAllowedSymbolsRegex = new RegExp(
   `[${escapeRegExp(notAllowedSymbols)}]|(\r\n|\n|\r)`,
   'gm',


### PR DESCRIPTION
**Description:**

add `\` in not allowed symbols

Issues:

- Issue #821

**UI changes**

<img width="200" alt="image" src="https://github.com/epam/ai-dial-chat/assets/20163971/5e86e3e7-0742-4c87-8ab2-962f4e61ce95">

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
