### PR TITLE
feat: add ability to use supported types label insead of long extensions list (Issue #919)

### DIFF
--- a/apps/chat/src/components/Files/FileManagerModal.tsx
+++ b/apps/chat/src/components/Files/FileManagerModal.tsx
@@ -38,6 +38,7 @@ interface Props {
   isOpen: boolean;
   initialSelectedFilesIds?: string[];
   allowedTypes?: string[];
+  allowedTypesLabel?: string;
   maximumAttachmentsAmount?: number;
   headerLabel: string;
   customButtonLabel?: string;
@@ -48,6 +49,7 @@ interface Props {
 export const FileManagerModal = ({
   isOpen,
   allowedTypes = [],
+  allowedTypesLabel,
   initialSelectedFilesIds = [],
   headerLabel,
   customButtonLabel,
@@ -207,9 +209,8 @@ export const FileManagerModal = ({
     if (filesWithIncorrectTypes.length > 0) {
       setErrorMessage(
         t(
-          `Supported types: {{allowedExtensions}}. You've trying to upload files with incorrect type: {{incorrectTypeFileNames}}`,
+          `You've trying to upload files with incorrect type: {{incorrectTypeFileNames}}`,
           {
-            allowedExtensions: allowedExtensions.join(', '),
             incorrectTypeFileNames: filesWithIncorrectTypes.join(', '),
           },
         ) as string,
@@ -219,7 +220,6 @@ export const FileManagerModal = ({
 
     onClose(selectedFilesIds);
   }, [
-    allowedExtensions,
     allowedTypes,
     files,
     maximumAttachmentsAmount,
@@ -292,7 +292,9 @@ export const FileManagerModal = ({
             'Max file size up to 512 Mb. Supported types: {{allowedExtensions}}.',
             {
               allowedExtensions:
-                allowedExtensions.join(', ') || 'no available extensions',
+                allowedTypesLabel ||
+                allowedExtensions.join(', ') ||
+                'no available extensions',
             },
           )}
           &nbsp;
@@ -446,6 +448,7 @@ export const FileManagerModal = ({
           uploadFolderId={uploadFolderId}
           isOpen
           allowedTypes={allowedTypes}
+          allowedTypesLabel={allowedTypesLabel}
           initialFilesSelect
           onUploadFiles={handleUploadFiles}
           onClose={() => setIsUploadFromDeviceOpened(false)}

--- a/apps/chat/src/components/Files/PreUploadModal.tsx
+++ b/apps/chat/src/components/Files/PreUploadModal.tsx
@@ -41,6 +41,7 @@ interface Props {
   initialFilesSelect?: boolean;
   maximumAttachmentsAmount?: number;
   allowedTypes?: string[];
+  allowedTypesLabel?: string;
   onClose: (result: boolean) => void;
   onUploadFiles: (
     selectedFiles: Required<Pick<DialFile, 'fileContent' | 'id' | 'name'>>[],
@@ -57,6 +58,7 @@ export const PreUploadDialog = ({
   initialFilesSelect,
   maximumAttachmentsAmount = 0,
   allowedTypes = [],
+  allowedTypesLabel,
   onClose,
   onUploadFiles,
   uploadFolderId,
@@ -133,9 +135,8 @@ export const PreUploadDialog = ({
       if (incorrectTypeFiles.length > 0) {
         errors.push(
           t(
-            `Supported types: {{allowedExtensions}}. Next files haven't been uploaded: {{incorrectTypeFileNames}}`,
+            `You've trying to upload files with incorrect type: {{incorrectTypeFileNames}}`,
             {
-              allowedExtensions: allowedExtensions.join(', '),
               incorrectTypeFileNames: incorrectTypeFiles.join(', '),
             },
           ),
@@ -160,7 +161,7 @@ export const PreUploadDialog = ({
         uploadInputRef.current.value = '';
       }
     },
-    [allowedExtensions, allowedTypes, folderPath, t],
+    [allowedTypes, folderPath, t],
   );
 
   const handleUpload = useCallback(() => {
@@ -324,7 +325,9 @@ export const PreUploadDialog = ({
             'Max file size up to 512 Mb. Supported types: {{allowedExtensions}}.',
             {
               allowedExtensions:
-                allowedExtensions.join(', ') || 'no available extensions',
+                allowedTypesLabel ||
+                allowedExtensions.join(', ') ||
+                'no available extensions',
             },
           )}
         </p>

--- a/apps/chat/src/components/Settings/CustomLogoSelect.tsx
+++ b/apps/chat/src/components/Settings/CustomLogoSelect.tsx
@@ -59,6 +59,7 @@ export const CustomLogoSelect = ({
         <FileManagerModal
           isOpen
           allowedTypes={['image/*']}
+          allowedTypesLabel="images"
           maximumAttachmentsAmount={maximumAttachmentsAmount}
           onClose={(files: unknown) => {
             onLogoSelect(files as string[]);


### PR DESCRIPTION
**Description:**

Add ability to use label insead of long extensions list on Attachments and Select custom logo windows

Issues:

- Issue #919 

**UI changes**

![image](https://github.com/epam/ai-dial-chat/assets/143205282/456d6c74-48cc-4170-9908-6b2c7ef076a2)

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
