### PR TITLE
fix: fix cutting long header string in common modal (Issue #1064)

### DIFF
--- a/apps/chat/src/components/Common/Modal.tsx
+++ b/apps/chat/src/components/Common/Modal.tsx
@@ -124,7 +124,7 @@ function ModalView({
               {heading && typeof heading === 'string' ? (
                 <h4
                   className={classNames(
-                    'mb-2 max-h-[50px] whitespace-pre text-left text-base font-semibold',
+                    'mb-2 max-h-[50px] whitespace-pre-wrap text-left text-base font-semibold',
                     headingClassName,
                   )}
                 >


### PR DESCRIPTION
**Description:**

Fixed long name is not cutting on share/unshare pop-up

Issues:

- Issue #1064 

**UI changes**

![Screenshot 2024-03-15 190912](https://github.com/epam/ai-dial-chat/assets/143205282/d9b758df-1746-4ec1-8582-5b4af42ab445)

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
