### PR TITLE
fix(chat): remove empty chat regenerate button if was an error in previous chat (Issue #1081)

### DIFF
--- a/apps/chat/src/components/Chat/Chat.tsx
+++ b/apps/chat/src/components/Chat/Chat.tsx
@@ -233,16 +233,18 @@ export const ChatView = memo(() => {
   }, []);
 
   useEffect(() => {
-    const lastMergedMessages = mergedMessages[mergedMessages.length - 1];
+    const lastMergedMessages = mergedMessages.length
+      ? mergedMessages[mergedMessages.length - 1]
+      : [];
 
-    if (lastMergedMessages) {
+    if (!messageIsStreaming) {
       const isErrorInSomeLastMessage = lastMergedMessages.some(
         (mergedStr: [Conversation, Message, number]) =>
           !!mergedStr[1].errorMessage,
       );
       setIsLastMessageError(isErrorInSomeLastMessage);
     }
-  }, [mergedMessages]);
+  }, [mergedMessages, messageIsStreaming]);
 
   useEffect(() => {
     const observer = new IntersectionObserver(

--- a/apps/chat/src/components/Chat/ChatInput/ChatControls.tsx
+++ b/apps/chat/src/components/Chat/ChatInput/ChatControls.tsx
@@ -41,7 +41,6 @@ export const ChatControls: FC<Props> = ({
   const dispatch = useAppDispatch();
 
   const isOverlay = useAppSelector(SettingsSelectors.selectIsOverlay);
-
   const isError = useAppSelector(
     ConversationsSelectors.selectIsErrorReplayConversations,
   );


### PR DESCRIPTION
**Description:**

Remove empty chat regenerate button if was an error in previous chat
 
Issues:

- https://github.com/epam/ai-dial-chat/issues/1081

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
