### PR TITLE
fix(chat): fix folder dots remains even if folder not in focus (Issue #599)

### DIFF
--- a/apps/chat/src/components/Folder/Folder.tsx
+++ b/apps/chat/src/components/Folder/Folder.tsx
@@ -147,7 +147,6 @@ const Folder = <T extends ConversationInfo | PromptInfo | DialFile>({
       !currentFolder.serverSynced,
   );
   const [renameValue, setRenameValue] = useState(currentFolder.name);
-  const [isSelected, setIsSelected] = useState(false);
   const [isDraggingOver, setIsDraggingOver] = useState(false);
   const [isContextMenu, setIsContextMenu] = useState(false);
   const [isConfirmRenaming, setIsConfirmRenaming] = useState(false);
@@ -689,8 +688,6 @@ const Folder = <T extends ConversationInfo | PromptInfo | DialFile>({
             }}
             onClick={() => {
               onClickFolder(currentFolder.id);
-
-              setIsSelected(true);
             }}
             draggable={!!handleDrop && !isExternal && !isNameInvalid}
             onDragStart={(e) => handleDragStart(e, currentFolder)}
@@ -752,8 +749,8 @@ const Folder = <T extends ConversationInfo | PromptInfo | DialFile>({
                   ref={refs.setFloating}
                   {...getFloatingProps()}
                   className={classNames(
-                    'invisible absolute right-3 z-50 flex justify-end md:group-hover/button:visible',
-                    (isSelected || isContextMenu) && 'max-md:visible',
+                    'invisible absolute right-3 z-50 flex justify-end group-hover/button:visible',
+                    isContextMenu && 'max-md:visible',
                   )}
                 >
                   <FolderContextMenu


### PR DESCRIPTION
**Description:**

Fix folder dots remains even if folder not in focus

Issues:

- https://github.com/epam/ai-dial-chat/issues/599

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
