### PR TITLE
fix(chat): forbid % and & symbols and folder names preparing (Issue #1099)

### DIFF
--- a/apps/chat/src/utils/app/file.ts
+++ b/apps/chat/src/utils/app/file.ts
@@ -105,7 +105,7 @@ export const getFilesWithInvalidFileType = (
     ? []
     : files.filter((file) => !isAllowedMimeType(allowedFileTypes, file.type));
 };
-export const notAllowedSymbols = ':;,=/{}';
+export const notAllowedSymbols = ':;,=/{}%&\\';
 export const notAllowedSymbolsRegex = new RegExp(
   `[${escapeRegExp(notAllowedSymbols)}]|(\r\n|\n|\r)`,
   'gm',

--- a/apps/chat/src/utils/app/folders.ts
+++ b/apps/chat/src/utils/app/folders.ts
@@ -19,7 +19,7 @@ import { EntityFilters } from '@/src/types/search';
 
 import { DEFAULT_FOLDER_NAME } from '@/src/constants/default-ui-settings';
 
-import { doesHaveDotsInTheEnd } from './common';
+import { doesHaveDotsInTheEnd, prepareEntityName } from './common';
 import { isRootId } from './id';
 
 import escapeRegExp from 'lodash-es/escapeRegExp';
@@ -192,7 +192,7 @@ export const getFolderIdByPath = (path: string, folders: FolderInterface[]) => {
 export const getPathToFolderById = (
   folders: FolderInterface[],
   starterId: string | undefined,
-  removeNotAllowedSymbols = false,
+  prepareNames = false,
 ) => {
   const path: string[] = [];
   const createPath = (folderId: string) => {
@@ -200,8 +200,8 @@ export const getPathToFolderById = (
     if (!folder) return;
 
     path.unshift(
-      removeNotAllowedSymbols
-        ? folder.name.replace(notAllowedSymbolsRegex, '') || DEFAULT_FOLDER_NAME
+      prepareNames
+        ? prepareEntityName(folder.name) || DEFAULT_FOLDER_NAME
         : folder.name,
     );
 


### PR DESCRIPTION
**Description:**

Forbid % and & symbols and folder names preparing

Issues:

- https://github.com/epam/ai-dial-chat/issues/1099

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
