### PR TITLE
fix(chat): fix conversations migration (Issue #1106)

### DIFF
--- a/apps/chat/src/components/Chatbar/Conversation.tsx
+++ b/apps/chat/src/components/Chatbar/Conversation.tsx
@@ -230,7 +230,7 @@ export const ConversationComponent = ({ item: conversation, level }: Props) => {
   );
 
   const handleRename = useCallback(() => {
-    const newName = prepareEntityName(renameValue, true);
+    const newName = prepareEntityName(renameValue, { forRenaming: true });
     setRenameValue(newName);
 
     if (
@@ -744,7 +744,9 @@ export const ConversationComponent = ({ item: conversation, level }: Props) => {
           setIsConfirmRenaming(false);
 
           if (result) {
-            performRename(prepareEntityName(renameValue, true));
+            performRename(
+              prepareEntityName(renameValue, { forRenaming: true }),
+            );
           }
 
           setIsContextMenu(false);

--- a/apps/chat/src/components/Folder/Folder.tsx
+++ b/apps/chat/src/components/Folder/Folder.tsx
@@ -260,7 +260,7 @@ const Folder = <T extends ConversationInfo | PromptInfo | DialFile>({
       return;
     }
 
-    const newName = prepareEntityName(renameValue, true);
+    const newName = prepareEntityName(renameValue, { forRenaming: true });
     setRenameValue(newName);
 
     if (

--- a/apps/chat/src/components/Promptbar/components/PromptModal.tsx
+++ b/apps/chat/src/components/Promptbar/components/PromptModal.tsx
@@ -75,7 +75,7 @@ export const PromptModal: FC<Props> = ({ isOpen, onClose, onUpdatePrompt }) => {
   };
 
   const nameOnBlurHandler = (e: FocusEvent<HTMLInputElement>) => {
-    setName(prepareEntityName(e.target.value, true));
+    setName(prepareEntityName(e.target.value, { forRenaming: true }));
     onBlur(e);
   };
 
@@ -110,7 +110,7 @@ export const PromptModal: FC<Props> = ({ isOpen, onClose, onUpdatePrompt }) => {
     (selectedPrompt: Prompt) => {
       setSubmitted(true);
 
-      const newName = prepareEntityName(name, true);
+      const newName = prepareEntityName(name, { forRenaming: true });
       setName(newName);
 
       if (!newName) return;
@@ -185,7 +185,8 @@ export const PromptModal: FC<Props> = ({ isOpen, onClose, onUpdatePrompt }) => {
     setName(selectedPrompt?.name || '');
   }, [selectedPrompt?.name]);
 
-  const saveDisabled = !prepareEntityName(name, true) || !content.trim();
+  const saveDisabled =
+    !prepareEntityName(name, { forRenaming: true }) || !content.trim();
 
   return (
     <Modal

--- a/apps/chat/src/store/conversations/conversations.epics.ts
+++ b/apps/chat/src/store/conversations/conversations.epics.ts
@@ -881,12 +881,18 @@ const migrateConversationsIfRequiredEpic: AppEpic = (action$, state$) => {
           return EMPTY;
         }
 
-        const sortedConversations = notMigratedConversations.sort((a, b) => {
-          if (!a.lastActivityDate) return 1;
-          if (!b.lastActivityDate) return -1;
-
-          return a.lastActivityDate - b.lastActivityDate;
-        });
+        const conversationsWithDate = notMigratedConversations.filter(
+          (c) => c.lastActivityDate,
+        );
+        const conversationsWithoutDate = notMigratedConversations.filter(
+          (c) => !c.lastActivityDate,
+        );
+        const sortedConversations = [
+          ...conversationsWithoutDate,
+          ...conversationsWithDate.sort(
+            (a, b) => a.lastActivityDate! - b.lastActivityDate!,
+          ),
+        ];
         const preparedConversations = getPreparedConversations({
           conversations: notMigratedConversations,
           conversationsFolders,

--- a/apps/chat/src/store/conversations/conversations.epics.ts
+++ b/apps/chat/src/store/conversations/conversations.epics.ts
@@ -882,14 +882,12 @@ const migrateConversationsIfRequiredEpic: AppEpic = (action$, state$) => {
           return EMPTY;
         }
 
-        const sortedConversations = orderBy(
-          notMigratedConversations,
-          [(c) => c.lastActivityDate === null, (c) => c.lastActivityDate],
-          ['asc'],
-        );
-
         const preparedConversations = getPreparedConversations({
-          conversations: sortedConversations,
+          conversations: orderBy(
+            notMigratedConversations,
+            [(c) => c.lastActivityDate === null, (c) => c.lastActivityDate],
+            ['asc'],
+          ),
           conversationsFolders,
           addRoot: true,
         });
@@ -909,7 +907,7 @@ const migrateConversationsIfRequiredEpic: AppEpic = (action$, state$) => {
                 delay(1000),
                 switchMap(() => {
                   migratedConversationIds.push(
-                    sortedConversations[migratedConversationsCount].id,
+                    preparedConversations[migratedConversationsCount].id,
                   );
 
                   return concat(
@@ -927,7 +925,7 @@ const migrateConversationsIfRequiredEpic: AppEpic = (action$, state$) => {
                 }),
                 catchError(() => {
                   failedMigratedConversationIds.push(
-                    sortedConversations[migratedConversationsCount].id,
+                    preparedConversations[migratedConversationsCount].id,
                   );
 
                   return concat(

--- a/apps/chat/src/store/conversations/conversations.epics.ts
+++ b/apps/chat/src/store/conversations/conversations.epics.ts
@@ -1,68 +1,119 @@
 import { PlotParams } from 'react-plotly.js';
 
-
-
-import { EMPTY, Observable, Subject, TimeoutError, catchError, concat, concatMap, delay, filter, forkJoin, from, ignoreElements, iif, map, merge, mergeMap, of, startWith, switchMap, take, takeWhile, tap, throwError, timeout, zip } from 'rxjs';
+import {
+  EMPTY,
+  Observable,
+  Subject,
+  TimeoutError,
+  catchError,
+  concat,
+  concatMap,
+  delay,
+  filter,
+  forkJoin,
+  from,
+  ignoreElements,
+  iif,
+  map,
+  merge,
+  mergeMap,
+  of,
+  startWith,
+  switchMap,
+  take,
+  takeWhile,
+  tap,
+  throwError,
+  timeout,
+  zip,
+} from 'rxjs';
 import { fromFetch } from 'rxjs/fetch';
-
-
 
 import { AnyAction } from '@reduxjs/toolkit';
 
-
-
 import { combineEpics } from 'redux-observable';
 
-
-
 import { clearStateForMessages } from '@/src/utils/app/clear-messages-state';
-import { combineEntities, filterMigratedEntities, filterOnlyMyEntities, updateEntitiesFoldersAndIds } from '@/src/utils/app/common';
-import { getConversationInfoFromId, getGeneratedConversationId, getNewConversationName, isChosenConversationValidForCompare, isSettingsChanged, regenerateConversationId, sortByDateAndName } from '@/src/utils/app/conversation';
+import {
+  combineEntities,
+  filterMigratedEntities,
+  filterOnlyMyEntities,
+  updateEntitiesFoldersAndIds,
+} from '@/src/utils/app/common';
+import {
+  getConversationInfoFromId,
+  getGeneratedConversationId,
+  getNewConversationName,
+  isChosenConversationValidForCompare,
+  isSettingsChanged,
+  regenerateConversationId,
+  sortByDateAndName,
+} from '@/src/utils/app/conversation';
 import { ConversationService } from '@/src/utils/app/data/conversation-service';
 import { FileService } from '@/src/utils/app/data/file-service';
-import { getOrUploadConversation, getPreparedConversations } from '@/src/utils/app/data/storages/api/conversation-api-storage';
+import {
+  getOrUploadConversation,
+  getPreparedConversations,
+} from '@/src/utils/app/data/storages/api/conversation-api-storage';
 import { BrowserStorage } from '@/src/utils/app/data/storages/browser-storage';
-import { addGeneratedFolderId, generateNextName, getFolderFromId, getFoldersFromIds, getNextDefaultName, getParentFolderIdsFromEntityId, getParentFolderIdsFromFolderId, updateMovedEntityId, updateMovedFolderId } from '@/src/utils/app/folders';
+import {
+  addGeneratedFolderId,
+  generateNextName,
+  getFolderFromId,
+  getFoldersFromIds,
+  getNextDefaultName,
+  getParentFolderIdsFromEntityId,
+  getParentFolderIdsFromFolderId,
+  updateMovedEntityId,
+  updateMovedFolderId,
+} from '@/src/utils/app/folders';
 import { getConversationRootId } from '@/src/utils/app/id';
-import { mergeMessages, parseStreamMessages } from '@/src/utils/app/merge-streams';
+import {
+  mergeMessages,
+  parseStreamMessages,
+} from '@/src/utils/app/merge-streams';
 import { isSmallScreen } from '@/src/utils/app/mobile';
 import { updateSystemPromptInMessages } from '@/src/utils/app/overlay';
 import { filterUnfinishedStages } from '@/src/utils/app/stages';
 import { translate } from '@/src/utils/app/translation';
 import { ApiUtils } from '@/src/utils/server/api';
 
-
-
-import { ChatBody, Conversation, Message, MessageSettings, Playback, RateBody, Role } from '@/src/types/chat';
+import {
+  ChatBody,
+  Conversation,
+  Message,
+  MessageSettings,
+  Playback,
+  RateBody,
+  Role,
+} from '@/src/types/chat';
 import { EntityType, FeatureType, UploadStatus } from '@/src/types/common';
 import { FolderType } from '@/src/types/folder';
 import { MigrationStorageKeys, StorageType } from '@/src/types/storage';
 import { AppEpic } from '@/src/types/store';
 
-
-
 import { SettingsSelectors } from '@/src/store/settings/settings.reducers';
 
-
-
 import { resetShareEntity } from '@/src/constants/chat';
-import { DEFAULT_CONVERSATION_NAME, DEFAULT_SYSTEM_PROMPT, DEFAULT_TEMPERATURE } from '@/src/constants/default-ui-settings';
+import {
+  DEFAULT_CONVERSATION_NAME,
+  DEFAULT_SYSTEM_PROMPT,
+  DEFAULT_TEMPERATURE,
+} from '@/src/constants/default-ui-settings';
 import { errorsMessages } from '@/src/constants/errors';
 import { defaultReplay } from '@/src/constants/replay';
-
-
 
 import { AddonsActions } from '../addons/addons.reducers';
 import { ModelsActions, ModelsSelectors } from '../models/models.reducers';
 import { OverlaySelectors } from '../overlay/overlay.reducers';
 import { UIActions, UISelectors } from '../ui/ui.reducers';
-import { ConversationsActions, ConversationsSelectors } from './conversations.reducers';
-
-
+import {
+  ConversationsActions,
+  ConversationsSelectors,
+} from './conversations.reducers';
 
 import orderBy from 'lodash-es/orderBy';
 import uniq from 'lodash-es/uniq';
-
 
 const initEpic: AppEpic = (action$) =>
   action$.pipe(

--- a/apps/chat/src/store/conversations/conversations.epics.ts
+++ b/apps/chat/src/store/conversations/conversations.epics.ts
@@ -1,119 +1,68 @@
 import { PlotParams } from 'react-plotly.js';
 
-import {
-  EMPTY,
-  Observable,
-  Subject,
-  TimeoutError,
-  catchError,
-  concat,
-  concatMap,
-  delay,
-  filter,
-  forkJoin,
-  from,
-  ignoreElements,
-  iif,
-  map,
-  merge,
-  mergeMap,
-  of,
-  startWith,
-  switchMap,
-  take,
-  takeWhile,
-  tap,
-  throwError,
-  timeout,
-  zip,
-} from 'rxjs';
+
+
+import { EMPTY, Observable, Subject, TimeoutError, catchError, concat, concatMap, delay, filter, forkJoin, from, ignoreElements, iif, map, merge, mergeMap, of, startWith, switchMap, take, takeWhile, tap, throwError, timeout, zip } from 'rxjs';
 import { fromFetch } from 'rxjs/fetch';
+
+
 
 import { AnyAction } from '@reduxjs/toolkit';
 
+
+
 import { combineEpics } from 'redux-observable';
 
+
+
 import { clearStateForMessages } from '@/src/utils/app/clear-messages-state';
-import {
-  combineEntities,
-  filterMigratedEntities,
-  filterOnlyMyEntities,
-  updateEntitiesFoldersAndIds,
-} from '@/src/utils/app/common';
-import {
-  getConversationInfoFromId,
-  getGeneratedConversationId,
-  getNewConversationName,
-  isChosenConversationValidForCompare,
-  isSettingsChanged,
-  regenerateConversationId,
-  sortByDateAndName,
-} from '@/src/utils/app/conversation';
+import { combineEntities, filterMigratedEntities, filterOnlyMyEntities, updateEntitiesFoldersAndIds } from '@/src/utils/app/common';
+import { getConversationInfoFromId, getGeneratedConversationId, getNewConversationName, isChosenConversationValidForCompare, isSettingsChanged, regenerateConversationId, sortByDateAndName } from '@/src/utils/app/conversation';
 import { ConversationService } from '@/src/utils/app/data/conversation-service';
 import { FileService } from '@/src/utils/app/data/file-service';
-import {
-  getOrUploadConversation,
-  getPreparedConversations,
-} from '@/src/utils/app/data/storages/api/conversation-api-storage';
+import { getOrUploadConversation, getPreparedConversations } from '@/src/utils/app/data/storages/api/conversation-api-storage';
 import { BrowserStorage } from '@/src/utils/app/data/storages/browser-storage';
-import {
-  addGeneratedFolderId,
-  generateNextName,
-  getFolderFromId,
-  getFoldersFromIds,
-  getNextDefaultName,
-  getParentFolderIdsFromEntityId,
-  getParentFolderIdsFromFolderId,
-  updateMovedEntityId,
-  updateMovedFolderId,
-} from '@/src/utils/app/folders';
+import { addGeneratedFolderId, generateNextName, getFolderFromId, getFoldersFromIds, getNextDefaultName, getParentFolderIdsFromEntityId, getParentFolderIdsFromFolderId, updateMovedEntityId, updateMovedFolderId } from '@/src/utils/app/folders';
 import { getConversationRootId } from '@/src/utils/app/id';
-import {
-  mergeMessages,
-  parseStreamMessages,
-} from '@/src/utils/app/merge-streams';
+import { mergeMessages, parseStreamMessages } from '@/src/utils/app/merge-streams';
 import { isSmallScreen } from '@/src/utils/app/mobile';
 import { updateSystemPromptInMessages } from '@/src/utils/app/overlay';
 import { filterUnfinishedStages } from '@/src/utils/app/stages';
 import { translate } from '@/src/utils/app/translation';
 import { ApiUtils } from '@/src/utils/server/api';
 
-import {
-  ChatBody,
-  Conversation,
-  Message,
-  MessageSettings,
-  Playback,
-  RateBody,
-  Role,
-} from '@/src/types/chat';
+
+
+import { ChatBody, Conversation, Message, MessageSettings, Playback, RateBody, Role } from '@/src/types/chat';
 import { EntityType, FeatureType, UploadStatus } from '@/src/types/common';
 import { FolderType } from '@/src/types/folder';
 import { MigrationStorageKeys, StorageType } from '@/src/types/storage';
 import { AppEpic } from '@/src/types/store';
 
+
+
 import { SettingsSelectors } from '@/src/store/settings/settings.reducers';
 
+
+
 import { resetShareEntity } from '@/src/constants/chat';
-import {
-  DEFAULT_CONVERSATION_NAME,
-  DEFAULT_SYSTEM_PROMPT,
-  DEFAULT_TEMPERATURE,
-} from '@/src/constants/default-ui-settings';
+import { DEFAULT_CONVERSATION_NAME, DEFAULT_SYSTEM_PROMPT, DEFAULT_TEMPERATURE } from '@/src/constants/default-ui-settings';
 import { errorsMessages } from '@/src/constants/errors';
 import { defaultReplay } from '@/src/constants/replay';
+
+
 
 import { AddonsActions } from '../addons/addons.reducers';
 import { ModelsActions, ModelsSelectors } from '../models/models.reducers';
 import { OverlaySelectors } from '../overlay/overlay.reducers';
 import { UIActions, UISelectors } from '../ui/ui.reducers';
-import {
-  ConversationsActions,
-  ConversationsSelectors,
-} from './conversations.reducers';
+import { ConversationsActions, ConversationsSelectors } from './conversations.reducers';
+
+
 
 import orderBy from 'lodash-es/orderBy';
 import uniq from 'lodash-es/uniq';
+
 
 const initEpic: AppEpic = (action$) =>
   action$.pipe(
@@ -882,11 +831,17 @@ const migrateConversationsIfRequiredEpic: AppEpic = (action$, state$) => {
           return EMPTY;
         }
 
-        const sortedConversations = orderBy(
-          notMigratedConversations,
-          [(c) => c.lastActivityDate === null, (c) => c.lastActivityDate],
-          ['asc'],
+        const conversationsWithoutDate = notMigratedConversations.filter(
+          (c) => !c.lastActivityDate,
         );
+        const conversationsWithDate = notMigratedConversations.filter(
+          (c) => c.lastActivityDate,
+        );
+        const sortedConversations = [
+          ...conversationsWithoutDate,
+          ...orderBy(conversationsWithDate, (c) => c.lastActivityDate, ['asc']),
+        ];
+
         const preparedConversations = getPreparedConversations({
           conversations: sortedConversations,
           conversationsFolders,

--- a/apps/chat/src/store/conversations/conversations.epics.ts
+++ b/apps/chat/src/store/conversations/conversations.epics.ts
@@ -890,7 +890,7 @@ const migrateConversationsIfRequiredEpic: AppEpic = (action$, state$) => {
         );
         const sortedConversations = [
           ...conversationsWithoutDate,
-          ...orderBy(conversationsWithDate, (c) => c.lastActivityDate, ['asc']),
+          ...orderBy(conversationsWithDate, (c) => c.lastActivityDate),
         ];
 
         const preparedConversations = getPreparedConversations({

--- a/apps/chat/src/types/chat.ts
+++ b/apps/chat/src/types/chat.ts
@@ -130,3 +130,8 @@ export interface ConversationInfo extends ShareEntity {
   isPlayback?: boolean;
   isReplay?: boolean;
 }
+
+export interface PrepareNameOptions {
+  forRenaming: boolean;
+  replaceWithSpacesForRenaming: boolean;
+}

--- a/apps/chat/src/utils/app/clean.ts
+++ b/apps/chat/src/utils/app/clean.ts
@@ -89,7 +89,7 @@ export const cleanConversation = (
     replay: conversation.replay,
     selectedAddons: conversation.selectedAddons ?? [],
     assistantModelId,
-    lastActivityDate: conversation.lastActivityDate || Date.now(),
+    lastActivityDate: conversation.lastActivityDate || 0,
     isNameChanged: conversation.isNameChanged,
     ...(conversation.playback && {
       playback: conversation.playback,

--- a/apps/chat/src/utils/app/common.ts
+++ b/apps/chat/src/utils/app/common.ts
@@ -97,9 +97,20 @@ export const updateEntitiesFoldersAndIds = (
 
 export const trimEndDots = (str: string) => trimEnd(str, '. \t\r\n');
 
-export const prepareEntityName = (name: string, forRenaming = false) => {
-  const clearName = forRenaming
-    ? name.replace(notAllowedSymbolsRegex, '').trim()
+export const prepareEntityName = (
+  name: string,
+  options?: Partial<{
+    forRenaming: boolean;
+    replaceWithSpacesForRenaming: boolean;
+  }>,
+) => {
+  const clearName = options?.forRenaming
+    ? name
+        .replace(
+          notAllowedSymbolsRegex,
+          options?.replaceWithSpacesForRenaming ? ' ' : '',
+        )
+        .trim()
     : name
         .replace(/\r\n|\r/gm, '\n')
         .split('\n')
@@ -111,5 +122,5 @@ export const prepareEntityName = (name: string, forRenaming = false) => {
       ? substring(clearName, 0, MAX_ENTITY_LENGTH)
       : clearName;
 
-  return !forRenaming ? trimEndDots(result) : result.trim();
+  return !(options?.forRenaming ?? false) ? trimEndDots(result) : result.trim();
 };

--- a/apps/chat/src/utils/app/common.ts
+++ b/apps/chat/src/utils/app/common.ts
@@ -122,5 +122,5 @@ export const prepareEntityName = (
       ? substring(clearName, 0, MAX_ENTITY_LENGTH)
       : clearName;
 
-  return !(options?.forRenaming ?? false) ? trimEndDots(result) : result.trim();
+  return !options?.forRenaming ? trimEndDots(result) : result.trim();
 };

--- a/apps/chat/src/utils/app/common.ts
+++ b/apps/chat/src/utils/app/common.ts
@@ -1,6 +1,7 @@
 import { notAllowedSymbolsRegex } from '@/src/utils/app/file';
 import { getFoldersFromIds } from '@/src/utils/app/folders';
 
+import { PrepareNameOptions } from '@/src/types/chat';
 import { Entity, ShareEntity } from '@/src/types/common';
 import { FolderInterface, FolderType } from '@/src/types/folder';
 
@@ -99,10 +100,7 @@ export const trimEndDots = (str: string) => trimEnd(str, '. \t\r\n');
 
 export const prepareEntityName = (
   name: string,
-  options?: Partial<{
-    forRenaming: boolean;
-    replaceWithSpacesForRenaming: boolean;
-  }>,
+  options?: Partial<PrepareNameOptions>,
 ) => {
   const clearName = options?.forRenaming
     ? name

--- a/apps/chat/src/utils/app/data/prompt-service.ts
+++ b/apps/chat/src/utils/app/data/prompt-service.ts
@@ -63,7 +63,9 @@ export const getPreparedPrompts = ({
   addRoot?: boolean;
 }) =>
   prompts.map((prompt) => {
-    const { path } = getPathToFolderById(folders, prompt.folderId, true);
+    const { path } = getPathToFolderById(folders, prompt.folderId, {
+      forRenaming: false,
+    });
     const newName = prepareEntityName(prompt.name);
 
     return {
@@ -84,7 +86,9 @@ export const getImportPreparedPrompts = ({
   folders: FolderInterface[];
 }) =>
   prompts.map((prompt) => {
-    const { path } = getPathToFolderById(folders, prompt.folderId, true);
+    const { path } = getPathToFolderById(folders, prompt.folderId, {
+      forRenaming: false,
+    });
     const newName = prepareEntityName(prompt.name);
 
     const folderId = isRootPromptId(path)

--- a/apps/chat/src/utils/app/data/prompt-service.ts
+++ b/apps/chat/src/utils/app/data/prompt-service.ts
@@ -64,9 +64,13 @@ export const getPreparedPrompts = ({
 }) =>
   prompts.map((prompt) => {
     const { path } = getPathToFolderById(folders, prompt.folderId, {
-      forRenaming: false,
+      forRenaming: true,
+      replaceWithSpacesForRenaming: true,
     });
-    const newName = prepareEntityName(prompt.name);
+    const newName = prepareEntityName(prompt.name, {
+      forRenaming: true,
+      replaceWithSpacesForRenaming: true,
+    });
 
     return {
       ...prompt,

--- a/apps/chat/src/utils/app/data/storages/api-storage.ts
+++ b/apps/chat/src/utils/app/data/storages/api-storage.ts
@@ -152,7 +152,7 @@ export class ApiStorage implements DialStorage {
     return from(conversations).pipe(
       concatMap((conv) =>
         this.getConversations(conv.folderId).pipe(
-          switchMap((apiConversations) =>
+          concatMap((apiConversations) =>
             this.tryCreateEntity(
               conv,
               [...conversations, ...apiConversations],

--- a/apps/chat/src/utils/app/data/storages/api/conversation-api-storage.ts
+++ b/apps/chat/src/utils/app/data/storages/api/conversation-api-storage.ts
@@ -94,13 +94,15 @@ export const getPreparedConversations = ({
   addRoot?: boolean;
 }) =>
   conversations.map((conv) => {
-    const { path } = getPathToFolderById(
-      conversationsFolders,
-      conv.folderId,
-      true,
-    );
+    const { path } = getPathToFolderById(conversationsFolders, conv.folderId, {
+      forRenaming: true,
+      replaceWithSpacesForRenaming: true,
+    });
 
-    const newName = prepareEntityName(conv.name, true);
+    const newName = prepareEntityName(conv.name, {
+      forRenaming: true,
+      replaceWithSpacesForRenaming: true,
+    });
 
     return {
       ...conv,
@@ -122,11 +124,9 @@ export const getImportPreparedConversations = ({
   conversationsFolders: FolderInterface[];
 }) =>
   conversations.map((conv) => {
-    const { path } = getPathToFolderById(
-      conversationsFolders,
-      conv.folderId,
-      true,
-    );
+    const { path } = getPathToFolderById(conversationsFolders, conv.folderId, {
+      forRenaming: false,
+    });
 
     const newName = prepareEntityName(conv.name);
     const rootId = isRootConversationsId(path) ? path : getConversationRootId();

--- a/apps/chat/src/utils/app/data/storages/api/conversation-api-storage.ts
+++ b/apps/chat/src/utils/app/data/storages/api/conversation-api-storage.ts
@@ -100,7 +100,7 @@ export const getPreparedConversations = ({
       true,
     );
 
-    const newName = prepareEntityName(conv.name);
+    const newName = prepareEntityName(conv.name, true);
 
     return {
       ...conv,

--- a/apps/chat/src/utils/app/folders.ts
+++ b/apps/chat/src/utils/app/folders.ts
@@ -192,7 +192,10 @@ export const getFolderIdByPath = (path: string, folders: FolderInterface[]) => {
 export const getPathToFolderById = (
   folders: FolderInterface[],
   starterId: string | undefined,
-  prepareNames = false,
+  prepareNames?: {
+    forRenaming?: boolean;
+    replaceWithSpacesForRenaming?: boolean;
+  },
 ) => {
   const path: string[] = [];
   const createPath = (folderId: string) => {
@@ -201,7 +204,7 @@ export const getPathToFolderById = (
 
     path.unshift(
       prepareNames
-        ? prepareEntityName(folder.name) || DEFAULT_FOLDER_NAME
+        ? prepareEntityName(folder.name, prepareNames) || DEFAULT_FOLDER_NAME
         : folder.name,
     );
 

--- a/apps/chat/src/utils/app/folders.ts
+++ b/apps/chat/src/utils/app/folders.ts
@@ -5,7 +5,7 @@ import {
   notAllowedSymbolsRegex,
 } from '@/src/utils/app/file';
 
-import { Conversation } from '@/src/types/chat';
+import { Conversation, PrepareNameOptions } from '@/src/types/chat';
 import {
   Entity,
   PartialBy,
@@ -192,11 +192,7 @@ export const getFolderIdByPath = (path: string, folders: FolderInterface[]) => {
 export const getPathToFolderById = (
   folders: FolderInterface[],
   starterId: string | undefined,
-  options?: Partial<{
-    prepareNames: boolean;
-    forRenaming: boolean;
-    replaceWithSpacesForRenaming: boolean;
-  }>,
+  options?: Partial<PrepareNameOptions & { prepareNames: boolean }>,
 ) => {
   const path: string[] = [];
   const createPath = (folderId: string) => {

--- a/apps/chat/src/utils/app/folders.ts
+++ b/apps/chat/src/utils/app/folders.ts
@@ -192,10 +192,11 @@ export const getFolderIdByPath = (path: string, folders: FolderInterface[]) => {
 export const getPathToFolderById = (
   folders: FolderInterface[],
   starterId: string | undefined,
-  prepareNames?: {
-    forRenaming?: boolean;
-    replaceWithSpacesForRenaming?: boolean;
-  },
+  options?: Partial<{
+    prepareNames: boolean;
+    forRenaming: boolean;
+    replaceWithSpacesForRenaming: boolean;
+  }>,
 ) => {
   const path: string[] = [];
   const createPath = (folderId: string) => {
@@ -203,8 +204,8 @@ export const getPathToFolderById = (
     if (!folder) return;
 
     path.unshift(
-      prepareNames
-        ? prepareEntityName(folder.name, prepareNames) || DEFAULT_FOLDER_NAME
+      options?.prepareNames
+        ? prepareEntityName(folder.name, options) || DEFAULT_FOLDER_NAME
         : folder.name,
     );
 


### PR DESCRIPTION
**Description:**

Fix conversations migration. Migrate conversations without a last activity date before conversations with the last activity date.

Issues:

- https://github.com/epam/ai-dial-chat/issues/1106

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
