### PR TITLE
fix(chat): update tooltip for shared entities with incorrect names (Issue #1123

### DIFF
--- a/apps/chat/src/components/Chatbar/Conversation.tsx
+++ b/apps/chat/src/components/Chatbar/Conversation.tsx
@@ -81,6 +81,7 @@ export function ConversationView({
   const modelsMap = useAppSelector(ModelsSelectors.selectModelsMap);
   const isNameInvalid = isEntityNameInvalid(conversation.name);
   const isInvalidPath = hasInvalidNameInPath(conversation.folderId);
+  const isNameOrPathInvalid = isNameInvalid || isInvalidPath;
   const isExternal = useAppSelector((state) =>
     isEntityOrParentsExternal(state, conversation, FeatureType.Chat),
   );
@@ -115,14 +116,16 @@ export function ConversationView({
         )}
       </ShareIcon>
       <div
-        className="relative max-h-5 flex-1 truncate whitespace-pre break-all text-left"
+        className={classNames(
+          'relative max-h-5 flex-1 truncate whitespace-pre break-all text-left',
+        )}
         data-qa="conversation-name"
       >
         <Tooltip
           tooltip={t(
             getEntityNameError(isNameInvalid, isInvalidPath, isExternal),
           )}
-          hideTooltip={!isNameInvalid && !isInvalidPath}
+          hideTooltip={!isNameOrPathInvalid}
           triggerClassName="block max-h-5 flex-1 truncate whitespace-pre break-all text-left"
         >
           {conversation.name}

--- a/apps/chat/src/components/Chatbar/Conversation.tsx
+++ b/apps/chat/src/components/Chatbar/Conversation.tsx
@@ -24,6 +24,7 @@ import {
   prepareEntityName,
   trimEndDots,
 } from '@/src/utils/app/common';
+import { getEntityNameError } from '@/src/utils/app/errors';
 import { constructPath, notAllowedSymbolsRegex } from '@/src/utils/app/file';
 import { getNextDefaultName } from '@/src/utils/app/folders';
 import { getConversationRootId } from '@/src/utils/app/id';
@@ -50,7 +51,6 @@ import { ShareActions } from '@/src/store/share/share.reducers';
 import { UIActions } from '@/src/store/ui/ui.reducers';
 
 import { DEFAULT_FOLDER_NAME } from '@/src/constants/default-ui-settings';
-import { errorsMessages } from '@/src/constants/errors';
 
 import SidebarActionButton from '@/src/components/Buttons/SidebarActionButton';
 import { PlaybackIcon } from '@/src/components/Chat/Playback/PlaybackIcon';
@@ -81,6 +81,9 @@ export function ConversationView({
   const modelsMap = useAppSelector(ModelsSelectors.selectModelsMap);
   const isNameInvalid = isEntityNameInvalid(conversation.name);
   const isInvalidPath = hasInvalidNameInPath(conversation.folderId);
+  const isExternal = useAppSelector((state) =>
+    isEntityOrParentsExternal(state, conversation, FeatureType.Chat),
+  );
 
   return (
     <>
@@ -117,9 +120,7 @@ export function ConversationView({
       >
         <Tooltip
           tooltip={t(
-            isNameInvalid
-              ? errorsMessages.entityNameInvalid
-              : errorsMessages.entityPathInvalid,
+            getEntityNameError(isNameInvalid, isInvalidPath, isExternal),
           )}
           hideTooltip={!isNameInvalid && !isInvalidPath}
           triggerClassName="block max-h-5 flex-1 truncate whitespace-pre break-all text-left"

--- a/apps/chat/src/components/Chatbar/Conversation.tsx
+++ b/apps/chat/src/components/Chatbar/Conversation.tsx
@@ -116,9 +116,7 @@ export function ConversationView({
         )}
       </ShareIcon>
       <div
-        className={classNames(
-          'relative max-h-5 flex-1 truncate whitespace-pre break-all text-left',
-        )}
+        className="relative max-h-5 flex-1 truncate whitespace-pre break-all text-left"
         data-qa="conversation-name"
       >
         <Tooltip

--- a/apps/chat/src/components/Folder/Folder.tsx
+++ b/apps/chat/src/components/Folder/Folder.tsx
@@ -161,6 +161,7 @@ const Folder = <T extends ConversationInfo | PromptInfo | DialFile>({
   );
   const isNameInvalid = isEntityNameInvalid(currentFolder.name);
   const isInvalidPath = hasInvalidNameInPath(currentFolder.folderId);
+  const isNameOrPathInvalid = isNameInvalid || isInvalidPath;
 
   useEffect(() => {
     // only if search term was changed after first render
@@ -688,7 +689,7 @@ const Folder = <T extends ConversationInfo | PromptInfo | DialFile>({
             onClick={() => {
               onClickFolder(currentFolder.id);
             }}
-            draggable={!!handleDrop && !isExternal && !isNameInvalid}
+            draggable={!!handleDrop && !isNameOrPathInvalid}
             onDragStart={(e) => handleDragStart(e, currentFolder)}
             onDragOver={(e) => {
               if (!isExternal && hasDragEventAnyData(e, featureType)) {
@@ -714,21 +715,24 @@ const Folder = <T extends ConversationInfo | PromptInfo | DialFile>({
               </ShareIcon>
             )}
             <div
-              className="relative max-h-5 flex-1 truncate break-all text-left group-hover/button:pr-5"
+              className={classNames(
+                'relative max-h-5 flex-1 truncate break-all text-left group-hover/button:pr-5',
+                isNameOrPathInvalid && 'text-secondary',
+              )}
               data-qa="folder-name"
             >
               <Tooltip
                 tooltip={t(
                   getEntityNameError(isNameInvalid, isInvalidPath, isExternal),
                 )}
-                hideTooltip={!isNameInvalid && !isInvalidPath}
+                hideTooltip={!isNameOrPathInvalid}
                 triggerClassName={classNames(
-                  'block max-h-5 flex-1 truncate break-all text-left',
+                  'max-h-5 flex-1 truncate break-all text-left',
                   highlightTemporaryFolders &&
                     (currentFolder.temporary
                       ? 'text-primary'
                       : 'text-secondary'),
-                  isNameInvalid
+                  isNameOrPathInvalid
                     ? 'text-secondary'
                     : highlightedFolders?.includes(currentFolder.id) &&
                         featureType

--- a/apps/chat/src/components/Folder/Folder.tsx
+++ b/apps/chat/src/components/Folder/Folder.tsx
@@ -27,6 +27,7 @@ import {
   prepareEntityName,
   trimEndDots,
 } from '@/src/utils/app/common';
+import { getEntityNameError } from '@/src/utils/app/errors';
 import { notAllowedSymbolsRegex } from '@/src/utils/app/file';
 import {
   getChildAndCurrentFoldersIdsById,
@@ -55,8 +56,6 @@ import { useAppDispatch, useAppSelector } from '@/src/store/hooks';
 import { SettingsSelectors } from '@/src/store/settings/settings.reducers';
 import { ShareActions } from '@/src/store/share/share.reducers';
 import { UIActions } from '@/src/store/ui/ui.reducers';
-
-import { errorsMessages } from '@/src/constants/errors';
 
 import SidebarActionButton from '@/src/components/Buttons/SidebarActionButton';
 import CaretIconComponent from '@/src/components/Common/CaretIconComponent';
@@ -720,9 +719,7 @@ const Folder = <T extends ConversationInfo | PromptInfo | DialFile>({
             >
               <Tooltip
                 tooltip={t(
-                  isNameInvalid
-                    ? errorsMessages.entityNameInvalid
-                    : errorsMessages.entityPathInvalid,
+                  getEntityNameError(isNameInvalid, isInvalidPath, isExternal),
                 )}
                 hideTooltip={!isNameInvalid && !isInvalidPath}
                 triggerClassName={classNames(

--- a/apps/chat/src/components/Folder/Folder.tsx
+++ b/apps/chat/src/components/Folder/Folder.tsx
@@ -689,7 +689,7 @@ const Folder = <T extends ConversationInfo | PromptInfo | DialFile>({
             onClick={() => {
               onClickFolder(currentFolder.id);
             }}
-            draggable={!!handleDrop && !isNameOrPathInvalid}
+            draggable={!!handleDrop && !isExternal && !isNameOrPathInvalid}
             onDragStart={(e) => handleDragStart(e, currentFolder)}
             onDragOver={(e) => {
               if (!isExternal && hasDragEventAnyData(e, featureType)) {

--- a/apps/chat/src/components/Promptbar/components/Prompt.tsx
+++ b/apps/chat/src/components/Promptbar/components/Prompt.tsx
@@ -83,6 +83,7 @@ export const PromptComponent = ({ item: prompt, level }: Props) => {
   );
   const isNameInvalid = isEntityNameInvalid(prompt.name);
   const isInvalidPath = hasInvalidNameInPath(prompt.folderId);
+  const isNameOrPathInvalid = isNameInvalid || isInvalidPath;
   const allPrompts = useAppSelector(PromptsSelectors.selectPrompts);
   const { showModal, isModalPreviewMode } = useAppSelector(
     PromptsSelectors.selectIsEditModalOpen,
@@ -303,7 +304,7 @@ export const PromptComponent = ({ item: prompt, level }: Props) => {
           className={classNames('flex size-full items-center gap-2', {
             'pr-6 xl:pr-0': !isDeleting && !isRenaming && isSelected,
           })}
-          draggable={!isExternal && !isNameInvalid && !isInvalidPath}
+          draggable={!isExternal && !isNameOrPathInvalid}
           onDragStart={(e) => handleDragStart(e, prompt)}
         >
           <ShareIcon
@@ -319,10 +320,10 @@ export const PromptComponent = ({ item: prompt, level }: Props) => {
               tooltip={t(
                 getEntityNameError(isNameInvalid, isInvalidPath, isExternal),
               )}
-              hideTooltip={!isNameInvalid && !isInvalidPath}
+              hideTooltip={!isNameOrPathInvalid}
               triggerClassName={classNames(
                 'block max-h-5 flex-1 truncate whitespace-pre break-all text-left',
-                (isNameInvalid || isInvalidPath) && 'text-secondary',
+                isNameOrPathInvalid && 'text-secondary',
               )}
             >
               {prompt.name}

--- a/apps/chat/src/components/Promptbar/components/Prompt.tsx
+++ b/apps/chat/src/components/Promptbar/components/Prompt.tsx
@@ -18,6 +18,7 @@ import {
   isEntityNameInvalid,
   isEntityNameOnSameLevelUnique,
 } from '@/src/utils/app/common';
+import { getEntityNameError } from '@/src/utils/app/errors';
 import { constructPath } from '@/src/utils/app/file';
 import { getNextDefaultName } from '@/src/utils/app/folders';
 import { getPromptRootId } from '@/src/utils/app/id';
@@ -43,7 +44,6 @@ import { UIActions } from '@/src/store/ui/ui.reducers';
 
 import { stopBubbling } from '@/src/constants/chat';
 import { DEFAULT_FOLDER_NAME } from '@/src/constants/default-ui-settings';
-import { errorsMessages } from '@/src/constants/errors';
 
 import ItemContextMenu from '@/src/components/Common/ItemContextMenu';
 import { MoveToFolderMobileModal } from '@/src/components/Common/MoveToFolderMobileModal';
@@ -317,9 +317,7 @@ export const PromptComponent = ({ item: prompt, level }: Props) => {
           <div className="relative max-h-5 flex-1 truncate whitespace-pre break-all text-left">
             <Tooltip
               tooltip={t(
-                isNameInvalid
-                  ? errorsMessages.entityNameInvalid
-                  : errorsMessages.entityPathInvalid,
+                getEntityNameError(isNameInvalid, isInvalidPath, isExternal),
               )}
               hideTooltip={!isNameInvalid && !isInvalidPath}
               triggerClassName={classNames(

--- a/apps/chat/src/constants/errors.ts
+++ b/apps/chat/src/constants/errors.ts
@@ -40,4 +40,6 @@ export const errorsMessages = {
     'You made a request with an unavailable or nonexistent entity type',
   entityNameInvalid: 'The name is invalid. Please, rename it',
   entityPathInvalid: 'The parent folder name is invalid. Please, rename it',
+  entityNameInvalidExternal: 'The name is invalid',
+  entityPathInvalidExternal: 'The parent folder name is invalid',
 };

--- a/apps/chat/src/utils/app/errors.ts
+++ b/apps/chat/src/utils/app/errors.ts
@@ -1,0 +1,18 @@
+import { errorsMessages } from '@/src/constants/errors';
+
+export const getEntityNameError = (
+  isNameInvalid: boolean,
+  isPathInvalid: boolean,
+  isExternal: boolean,
+) => {
+  if (isNameInvalid) {
+    return isExternal
+      ? errorsMessages.entityNameInvalidExternal
+      : errorsMessages.entityNameInvalid;
+  } else if (isPathInvalid) {
+    return isExternal
+      ? errorsMessages.entityPathInvalidExternal
+      : errorsMessages.entityPathInvalid;
+  }
+  return '';
+};


### PR DESCRIPTION
**Description:**

update tooltip for shared entities with incorrect names

Issues:

- Issue #1123

**UI changes**
![image](https://github.com/epam/ai-dial-chat/assets/20163971/2e08d2ee-943b-42f6-9639-8047f1c72c3e)

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
