### PR TITLE
fix(chat): fix regenerate button after last message error (Issue #1118)

### DIFF
--- a/apps/chat/src/components/Chat/Chat.tsx
+++ b/apps/chat/src/components/Chat/Chat.tsx
@@ -237,14 +237,12 @@ export const ChatView = memo(() => {
       ? mergedMessages[mergedMessages.length - 1]
       : [];
 
-    if (!messageIsStreaming) {
-      const isErrorInSomeLastMessage = lastMergedMessages.some(
-        (mergedStr: [Conversation, Message, number]) =>
-          !!mergedStr[1].errorMessage,
-      );
-      setIsLastMessageError(isErrorInSomeLastMessage);
-    }
-  }, [mergedMessages, messageIsStreaming]);
+    const isErrorInSomeLastMessage = lastMergedMessages.some(
+      (mergedStr: [Conversation, Message, number]) =>
+        !!mergedStr[1].errorMessage,
+    );
+    setIsLastMessageError(isErrorInSomeLastMessage);
+  }, [mergedMessages]);
 
   useEffect(() => {
     const observer = new IntersectionObserver(


### PR DESCRIPTION
**Description:**

Fix regenerate button after last message error

Issues:

- https://github.com/epam/ai-dial-chat/issues/1118

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
