### PR TITLE
fix(chat): hide copy and download buttons for code block and table if last message is being generating (Issue #1085)

### DIFF
--- a/apps/chat/src/components/Markdown/ChatMDComponent.tsx
+++ b/apps/chat/src/components/Markdown/ChatMDComponent.tsx
@@ -55,6 +55,7 @@ export const getMDComponents = (
           language={(match && match[1]) || ''}
           value={String(children).replace(/\n$/, '')}
           isInner={isInner}
+          isLastMessageStreaming={isShowResponseLoader}
           {...props}
         />
       ) : (
@@ -63,7 +64,11 @@ export const getMDComponents = (
         </code>
       );
     },
-    table: Table,
+    table({ children }) {
+      return (
+        <Table isLastMessageStreaming={isShowResponseLoader}>{children}</Table>
+      );
+    },
     th({ children }) {
       return (
         <th className="break-words border border-tertiary bg-layer-4 px-3 py-1 text-sm text-secondary">

--- a/apps/chat/src/components/Markdown/CodeBlock.tsx
+++ b/apps/chat/src/components/Markdown/CodeBlock.tsx
@@ -21,117 +21,122 @@ import Tooltip from '../Common/Tooltip';
 interface Props {
   language: string;
   value: string;
-  isInner?: boolean;
+  isInner: boolean;
+  isLastMessageStreaming: boolean;
 }
 const codeBlockTheme: Record<string, Record<string, CSSProperties>> = {
   dark: oneDark,
   light: oneLight,
 };
 
-export const CodeBlock: FC<Props> = memo(({ language, value, isInner }) => {
-  const { t } = useTranslation(Translation.Markdown);
-  const [isCopied, setIsCopied] = useState<boolean>(false);
+export const CodeBlock: FC<Props> = memo(
+  ({ language, value, isInner, isLastMessageStreaming }) => {
+    const { t } = useTranslation(Translation.Markdown);
+    const [isCopied, setIsCopied] = useState<boolean>(false);
 
-  const theme = useAppSelector(UISelectors.selectThemeState);
+    const theme = useAppSelector(UISelectors.selectThemeState);
 
-  const copyToClipboard = useCallback(() => {
-    if (!navigator.clipboard || !navigator.clipboard.writeText) {
-      return;
-    }
+    const copyToClipboard = useCallback(() => {
+      if (!navigator.clipboard || !navigator.clipboard.writeText) {
+        return;
+      }
 
-    navigator.clipboard.writeText(value).then(() => {
-      setIsCopied(true);
+      navigator.clipboard.writeText(value).then(() => {
+        setIsCopied(true);
 
-      setTimeout(() => {
-        setIsCopied(false);
-      }, 2000);
-    });
-  }, [value]);
+        setTimeout(() => {
+          setIsCopied(false);
+        }, 2000);
+      });
+    }, [value]);
 
-  const downloadAsFile = useCallback(() => {
-    const fileExtension = programmingLanguages[language] || '.txt';
-    const suggestedFileName = `ai-chat-code${fileExtension}`;
-    const fileName = window.prompt(
-      t('Enter file name') || '',
-      suggestedFileName,
-    );
+    const downloadAsFile = useCallback(() => {
+      const fileExtension = programmingLanguages[language] || '.txt';
+      const suggestedFileName = `ai-chat-code${fileExtension}`;
+      const fileName = window.prompt(
+        t('Enter file name') || '',
+        suggestedFileName,
+      );
 
-    if (!fileName) {
-      // user pressed cancel on prompt
-      return;
-    }
+      if (!fileName) {
+        // user pressed cancel on prompt
+        return;
+      }
 
-    const blob = new Blob([value], { type: 'text/plain' });
-    const url = URL.createObjectURL(blob);
-    const link = document.createElement('a');
-    link.download = fileName;
-    link.href = url;
-    link.style.display = 'none';
-    document.body.appendChild(link);
-    link.click();
-    document.body.removeChild(link);
-    URL.revokeObjectURL(url);
-  }, [language, t, value]);
+      const blob = new Blob([value], { type: 'text/plain' });
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.download = fileName;
+      link.href = url;
+      link.style.display = 'none';
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      URL.revokeObjectURL(url);
+    }, [language, t, value]);
 
-  return (
-    <div
-      className={`codeblock relative overflow-hidden rounded border border-secondary font text-sm text-primary`}
-    >
+    return (
       <div
-        className={`flex items-center justify-between border-b border-secondary p-3 ${
-          isInner ? 'bg-layer-3' : 'bg-layer-1'
-        }`}
+        className={`codeblock relative overflow-hidden rounded border border-secondary font text-sm text-primary`}
       >
-        <span className="lowercase">{language}</span>
+        <div
+          className={`flex items-center justify-between border-b border-secondary p-3 ${
+            isInner ? 'bg-layer-3' : 'bg-layer-1'
+          }`}
+        >
+          <span className="lowercase">{language}</span>
 
-        <div className="flex items-center gap-3 text-secondary">
-          <button
-            className="flex items-center [&:not(:disabled)]:hover:text-accent-primary"
-            onClick={copyToClipboard}
-            disabled={isCopied}
-          >
-            {isCopied ? (
-              <Tooltip tooltip={t('Copied!')}>
-                <IconCheck size={18} />
+          {!isLastMessageStreaming && (
+            <div className="flex items-center gap-3 text-secondary">
+              <button
+                className="flex items-center [&:not(:disabled)]:hover:text-accent-primary"
+                onClick={copyToClipboard}
+                disabled={isCopied}
+              >
+                {isCopied ? (
+                  <Tooltip tooltip={t('Copied!')}>
+                    <IconCheck size={18} />
+                  </Tooltip>
+                ) : (
+                  <Tooltip isTriggerClickable tooltip={t('Copy code')}>
+                    <IconCopy size={18} />
+                  </Tooltip>
+                )}
+              </button>
+              <Tooltip isTriggerClickable tooltip={t('Download')}>
+                <button
+                  className="flex items-center rounded bg-none hover:text-accent-primary"
+                  onClick={downloadAsFile}
+                >
+                  <Download width={18} height={18} />
+                </button>
               </Tooltip>
-            ) : (
-              <Tooltip isTriggerClickable tooltip={t('Copy code')}>
-                <IconCopy size={18} />
-              </Tooltip>
-            )}
-          </button>
-          <Tooltip isTriggerClickable tooltip={t('Download')}>
-            <button
-              className="flex items-center rounded bg-none hover:text-accent-primary"
-              onClick={downloadAsFile}
-            >
-              <Download width={18} height={18} />
-            </button>
-          </Tooltip>
+            </div>
+          )}
         </div>
-      </div>
 
-      <SyntaxHighlighter
-        language={language}
-        style={codeBlockTheme[theme] || oneDark}
-        customStyle={{
-          margin: 0,
-          borderRadius: 0,
-          fontSize: 14,
-          padding: 12,
-          letterSpacing: 0,
-          fontFamily: 'var(--font-inter)',
-        }}
-        className={`${isInner ? '!bg-layer-3' : '!bg-layer-1'}`}
-        codeTagProps={{
-          style: {
+        <SyntaxHighlighter
+          language={language}
+          style={codeBlockTheme[theme] || oneDark}
+          customStyle={{
+            margin: 0,
+            borderRadius: 0,
+            fontSize: 14,
+            padding: 12,
+            letterSpacing: 0,
             fontFamily: 'var(--font-inter)',
-          },
-        }}
-      >
-        {value}
-      </SyntaxHighlighter>
-    </div>
-  );
-});
+          }}
+          className={`${isInner ? '!bg-layer-3' : '!bg-layer-1'}`}
+          codeTagProps={{
+            style: {
+              fontFamily: 'var(--font-inter)',
+            },
+          }}
+        >
+          {value}
+        </SyntaxHighlighter>
+      </div>
+    );
+  },
+);
 CodeBlock.displayName = 'CodeBlock';

--- a/apps/chat/src/components/Markdown/Table.tsx
+++ b/apps/chat/src/components/Markdown/Table.tsx
@@ -5,14 +5,7 @@ import {
   IconTxt,
   TablerIconsProps,
 } from '@tabler/icons-react';
-import React, {
-  FC,
-  ReactNode,
-  useCallback,
-  useEffect,
-  useRef,
-  useState,
-} from 'react';
+import { FC, ReactNode, useCallback, useEffect, useRef, useState } from 'react';
 
 import { CopyTableType } from '@/src/types/chat';
 
@@ -40,9 +33,10 @@ const CopyIcon = ({ Icon, onClick, copied }: CopyIconProps) => {
 
 interface Props {
   children: ReactNode[];
+  isLastMessageStreaming: boolean;
 }
 
-export const Table = ({ children }: Props) => {
+export const Table = ({ children, isLastMessageStreaming }: Props) => {
   const tableRef = useRef<HTMLTableElement | null>(null);
 
   const [copiedType, setCopiedType] = useState<CopyTableType | undefined>(
@@ -145,23 +139,25 @@ export const Table = ({ children }: Props) => {
 
   return (
     <div className="mt-7 max-w-full overflow-auto">
-      <div className="flex max-w-full justify-end gap-2 bg-layer-3 px-2 py-1">
-        <CopyIcon
-          Icon={IconCsv}
-          onClick={copyTableToCSV}
-          copied={CopyTableType.CSV === copiedType}
-        />
-        <CopyIcon
-          Icon={IconTxt}
-          onClick={copyTableToTXT}
-          copied={CopyTableType.TXT === copiedType}
-        />
-        <CopyIcon
-          Icon={IconMarkdown}
-          onClick={copyTableToMD}
-          copied={CopyTableType.MD === copiedType}
-        />
-      </div>
+      {!isLastMessageStreaming && (
+        <div className="flex max-w-full justify-end gap-2 bg-layer-3 px-2 py-1">
+          <CopyIcon
+            Icon={IconCsv}
+            onClick={copyTableToCSV}
+            copied={CopyTableType.CSV === copiedType}
+          />
+          <CopyIcon
+            Icon={IconTxt}
+            onClick={copyTableToTXT}
+            copied={CopyTableType.TXT === copiedType}
+          />
+          <CopyIcon
+            Icon={IconMarkdown}
+            onClick={copyTableToMD}
+            copied={CopyTableType.MD === copiedType}
+          />
+        </div>
+      )}
       <table
         ref={tableRef}
         className="mt-0 border-collapse border border-tertiary px-3 py-1 text-sm"


### PR DESCRIPTION
**Description:**

hide copy and download buttons for code block and table if last message is being generating

Issues:

- Issue #1085

**UI changes**

![image](https://github.com/epam/ai-dial-chat/assets/20163971/23901c86-b8c8-4d0d-9fee-3f2fcc035f2a)

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
