### PR TITLE
fix(chat): add error message and border if dot at the end of prompt name appears while renaming (Issue #1103)

### DIFF
--- a/apps/chat/src/components/Chat/Migration/MigrationFailedModal.tsx
+++ b/apps/chat/src/components/Chat/Migration/MigrationFailedModal.tsx
@@ -302,7 +302,7 @@ export const MigrationFailedWindow = ({
                   <wbr />
                   /
                   <wbr />
-                  {t('prompts')}
+                  {t('prompts. ')}
                 </>
               )}
               {t('All discarded items will be ')}

--- a/apps/chat/src/components/Common/EmptyRequiredInputMessage.tsx
+++ b/apps/chat/src/components/Common/EmptyRequiredInputMessage.tsx
@@ -8,21 +8,24 @@ interface Props {
   text?: string;
   useDisplay?: boolean;
   className?: string;
+  isShown?: boolean;
 }
 
 const EmptyRequiredInputMessage = ({
   text = 'Please fill in all required fields',
   useDisplay = false,
   className,
+  isShown,
 }: Props) => {
   const { t } = useTranslation(Translation.Settings);
   return (
     <div
       className={classNames(
         'text-xxs text-error peer-invalid:peer-[.submitted]:mb-4',
-        useDisplay
-          ? 'hidden peer-invalid:peer-[.submitted]:block'
-          : 'invisible peer-invalid:peer-[.submitted]:visible',
+        useDisplay && 'hidden peer-invalid:peer-[.submitted]:block',
+        !useDisplay &&
+          !isShown &&
+          'invisible peer-invalid:peer-[.submitted]:visible',
         className,
       )}
     >

--- a/apps/chat/src/components/Promptbar/components/PromptModal.tsx
+++ b/apps/chat/src/components/Promptbar/components/PromptModal.tsx
@@ -60,6 +60,7 @@ export const PromptModal: FC<Props> = ({ isOpen, onClose, onUpdatePrompt }) => {
   const [content, setContent] = useState(selectedPrompt?.content || '');
   const [isConfirmDialog, setIsConfirmDialog] = useState(false);
   const [submitted, setSubmitted] = useState(false);
+  const [isDotError, setIsDotError] = useState(false);
 
   const nameInputRef = useRef<HTMLInputElement>(null);
   const descriptionInputRef = useRef<HTMLTextAreaElement>(null);
@@ -71,7 +72,9 @@ export const PromptModal: FC<Props> = ({ isOpen, onClose, onUpdatePrompt }) => {
   }, [onClose]);
 
   const nameOnChangeHandler = (e: ChangeEvent<HTMLInputElement>) => {
-    setName(e.target.value.replaceAll(notAllowedSymbolsRegex, ''));
+    const newName = e.target.value.replaceAll(notAllowedSymbolsRegex, '');
+    setIsDotError(newName.trim().at(-1) === '.');
+    setName(newName);
   };
 
   const nameOnBlurHandler = (e: FocusEvent<HTMLInputElement>) => {
@@ -220,7 +223,11 @@ export const PromptModal: FC<Props> = ({ isOpen, onClose, onUpdatePrompt }) => {
             <input
               ref={nameInputRef}
               name="promptName"
-              className={inputClassName}
+              className={classNames(
+                isDotError &&
+                  'border-error hover:border-error focus:border-error',
+                inputClassName,
+              )}
               placeholder={t('A name for your prompt.') || ''}
               value={name}
               required
@@ -229,7 +236,14 @@ export const PromptModal: FC<Props> = ({ isOpen, onClose, onUpdatePrompt }) => {
               onChange={nameOnChangeHandler}
               data-qa="prompt-name"
             />
-            <EmptyRequiredInputMessage />
+            <EmptyRequiredInputMessage
+              isShown={isDotError}
+              text={
+                (isDotError
+                  ? t('Using a dot at the end of a name is not permitted.')
+                  : t('Please fill in all required fields')) || ''
+              }
+            />
           </div>
 
           <div className="mb-4">

--- a/apps/chat/src/components/Promptbar/components/PromptModal.tsx
+++ b/apps/chat/src/components/Promptbar/components/PromptModal.tsx
@@ -73,7 +73,7 @@ export const PromptModal: FC<Props> = ({ isOpen, onClose, onUpdatePrompt }) => {
 
   const nameOnChangeHandler = (e: ChangeEvent<HTMLInputElement>) => {
     const newName = e.target.value.replaceAll(notAllowedSymbolsRegex, '');
-    setIsDotError(newName.trim().at(-1) === '.');
+    setIsDotError(doesHaveDotsInTheEnd(newName));
     setName(newName);
   };
 


### PR DESCRIPTION
**Description:**

Add error message and border if dot at the end of prompt name appears while renaming

Issues:

- https://github.com/epam/ai-dial-chat/issues/1103

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
