### PR TITLE
fix(chat): disable context menu for attachment/table/code block buttons (Issue #1156)

### DIFF
--- a/apps/chat/src/components/Chat/MessageAttachment.tsx
+++ b/apps/chat/src/components/Chat/MessageAttachment.tsx
@@ -202,6 +202,7 @@ export const MessageAttachment = ({ attachment, isInner }: Props) => {
 
   return (
     <div
+      data-no-context-menu
       className={classNames(
         'rounded bg-layer-3 px-1 py-2',
         isExpanded && 'col-span-1 col-start-1 sm:col-span-2 md:col-span-3',

--- a/apps/chat/src/components/Markdown/CodeBlock.tsx
+++ b/apps/chat/src/components/Markdown/CodeBlock.tsx
@@ -24,6 +24,7 @@ interface Props {
   isInner: boolean;
   isLastMessageStreaming: boolean;
 }
+
 const codeBlockTheme: Record<string, Record<string, CSSProperties>> = {
   dark: oneDark,
   light: oneLight,
@@ -87,7 +88,10 @@ export const CodeBlock: FC<Props> = memo(
           <span className="lowercase">{language}</span>
 
           {!isLastMessageStreaming && (
-            <div className="flex items-center gap-3 text-secondary">
+            <div
+              data-no-context-menu
+              className="flex items-center gap-3 text-secondary"
+            >
               <button
                 className="flex items-center [&:not(:disabled)]:hover:text-accent-primary"
                 onClick={copyToClipboard}

--- a/apps/chat/src/components/Markdown/Table.tsx
+++ b/apps/chat/src/components/Markdown/Table.tsx
@@ -7,7 +7,12 @@ import {
 } from '@tabler/icons-react';
 import { FC, ReactNode, useCallback, useEffect, useRef, useState } from 'react';
 
+import { useTranslation } from 'next-i18next';
+
 import { CopyTableType } from '@/src/types/chat';
+import { Translation } from '@/src/types/translation';
+
+import Tooltip from '@/src/components/Common/Tooltip';
 
 interface CopyIconProps {
   Icon: FC<TablerIconsProps>;
@@ -37,6 +42,8 @@ interface Props {
 }
 
 export const Table = ({ children, isLastMessageStreaming }: Props) => {
+  const { t } = useTranslation(Translation.Chat);
+
   const tableRef = useRef<HTMLTableElement | null>(null);
 
   const [copiedType, setCopiedType] = useState<CopyTableType | undefined>(
@@ -140,22 +147,30 @@ export const Table = ({ children, isLastMessageStreaming }: Props) => {
   return (
     <div className="mt-7 max-w-full overflow-auto">
       {!isLastMessageStreaming && (
-        <div className="flex max-w-full justify-end gap-2 bg-layer-3 px-2 py-1">
-          <CopyIcon
-            Icon={IconCsv}
-            onClick={copyTableToCSV}
-            copied={CopyTableType.CSV === copiedType}
-          />
-          <CopyIcon
-            Icon={IconTxt}
-            onClick={copyTableToTXT}
-            copied={CopyTableType.TXT === copiedType}
-          />
-          <CopyIcon
-            Icon={IconMarkdown}
-            onClick={copyTableToMD}
-            copied={CopyTableType.MD === copiedType}
-          />
+        <div className="flex max-w-full justify-end bg-layer-3 px-2 py-1">
+          <div data-no-context-menu className="flex gap-2">
+            <Tooltip placement="top" tooltip={t('Copy as CSV')}>
+              <CopyIcon
+                Icon={IconCsv}
+                onClick={copyTableToCSV}
+                copied={CopyTableType.CSV === copiedType}
+              />
+            </Tooltip>
+            <Tooltip placement="top" tooltip={t('Copy as TXT')}>
+              <CopyIcon
+                Icon={IconTxt}
+                onClick={copyTableToTXT}
+                copied={CopyTableType.TXT === copiedType}
+              />
+            </Tooltip>
+            <Tooltip placement="top" tooltip={t('Copy as MD')}>
+              <CopyIcon
+                Icon={IconMarkdown}
+                onClick={copyTableToMD}
+                copied={CopyTableType.MD === copiedType}
+              />
+            </Tooltip>
+          </div>
         </div>
       )}
       <table


### PR DESCRIPTION
**Description:**

Disable context menu for attachment/table/code block buttons

Issues:

- https://github.com/epam/ai-dial-chat/issues/1156

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
