### PR TITLE
feat(chat): add possibility to duplicate own chats and prompts (Issue #1137)

### DIFF
--- a/apps/chat-e2e/src/testData/expectedConstants.ts
+++ b/apps/chat-e2e/src/testData/expectedConstants.ts
@@ -92,6 +92,7 @@ export enum MenuOptions {
   rename = 'Rename',
   edit = 'Edit',
   compare = 'Compare',
+  duplicate = 'Duplicate',
   replay = 'Replay',
   playback = 'Playback',
   export = 'Export',

--- a/apps/chat-e2e/src/tests/chatBarConversation.test.ts
+++ b/apps/chat-e2e/src/tests/chatBarConversation.test.ts
@@ -295,6 +295,7 @@ dialTest(
       .toEqual([
         MenuOptions.rename,
         MenuOptions.compare,
+        MenuOptions.duplicate,
         MenuOptions.moveTo,
         MenuOptions.delete,
       ]);
@@ -331,6 +332,7 @@ dialTest(
       .toEqual([
         MenuOptions.rename,
         MenuOptions.compare,
+        MenuOptions.duplicate,
         MenuOptions.replay,
         MenuOptions.playback,
         MenuOptions.export,

--- a/apps/chat-e2e/src/tests/prompts.test.ts
+++ b/apps/chat-e2e/src/tests/prompts.test.ts
@@ -305,6 +305,7 @@ dialTest(
       .soft(menuOptions, ExpectedMessages.contextMenuOptionsValid)
       .toEqual([
         MenuOptions.edit,
+        MenuOptions.duplicate,
         MenuOptions.export,
         MenuOptions.moveTo,
         MenuOptions.share,

--- a/apps/chat/src/components/Common/ItemContextMenu.tsx
+++ b/apps/chat/src/components/Common/ItemContextMenu.tsx
@@ -128,7 +128,7 @@ export default function ItemContextMenu({
       },
       {
         name: t('Duplicate'),
-        display: !!onDuplicate && isExternal,
+        display: !!onDuplicate,
         dataQa: 'duplicate',
         Icon: IconCopy,
         onClick: onDuplicate,


### PR DESCRIPTION
**Description:**

Add possibility to duplicate own chats and prompts 

Issues:

- https://github.com/epam/ai-dial-chat/issues/1137

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
