### PR TITLE
fix(chat): hide share icon when mouse hover on the file (Issue #1169)

### DIFF
--- a/apps/chat/src/components/Common/ShareIcon.tsx
+++ b/apps/chat/src/components/Common/ShareIcon.tsx
@@ -22,6 +22,7 @@ interface ShareIconProps extends ShareInterface {
   children: ReactNode | ReactNode[];
   featureType: FeatureType;
   isInvalid?: boolean;
+  containerClassName?: string;
 }
 
 export default function ShareIcon({
@@ -32,6 +33,7 @@ export default function ShareIcon({
   children,
   featureType,
   isInvalid,
+  containerClassName,
 }: ShareIconProps) {
   const { t } = useTranslation(Translation.SideBar);
   const isSharingEnabled = useAppSelector((state) =>
@@ -40,7 +42,11 @@ export default function ShareIcon({
   const isPublishingEnabled = useAppSelector((state) =>
     SettingsSelectors.isPublishingEnabled(state, featureType),
   );
-  const containerClass = classNames('relative', isInvalid && 'text-secondary');
+  const containerClass = classNames(
+    'relative',
+    isInvalid && 'text-secondary',
+    containerClassName,
+  );
 
   if (
     (!isSharingEnabled || !isShared) &&

--- a/apps/chat/src/components/Files/FileItem.tsx
+++ b/apps/chat/src/components/Files/FileItem.tsx
@@ -118,6 +118,10 @@ export const FileItem = ({
           {!isSelected && item.status !== UploadStatus.FAILED ? (
             <ShareIcon
               {...item}
+              containerClassName={classNames(
+                item.status !== UploadStatus.LOADING &&
+                  'group-hover/file-item:hidden',
+              )}
               featureType={FeatureType.Chat}
               isHighlighted={isSelected}
             >


### PR DESCRIPTION
**Description:**

* Add additional property `containerClassName` to the `ShareIcon` component.
* Add additional class to hide share icon when hover on file.

Issues:

- Issue #1169

**UI changes**

![image](https://github.com/epam/ai-dial-chat/assets/143205282/c3eae837-29c3-455c-805d-1b9a6204d407)

On hover:
![image](https://github.com/epam/ai-dial-chat/assets/143205282/a5748126-87c6-4920-aed5-e204fdc7fdf9)


**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
