### PR TITLE
fix(chat): fix 'duplicate the conversation to be able to edit' button (Issue #1166)

### DIFF
--- a/apps/chat/src/components/Chat/ChatExternalControls.tsx
+++ b/apps/chat/src/components/Chat/ChatExternalControls.tsx
@@ -19,9 +19,7 @@ export default function ChatExternalControls({ conversations }: Props) {
 
   const handleDuplicate = useCallback(() => {
     conversations.forEach((conv) => {
-      if (conv.sharedWithMe) {
-        dispatch(ConversationsActions.duplicateConversation(conv));
-      }
+      dispatch(ConversationsActions.duplicateConversation(conv));
     });
   }, [conversations, dispatch]);
 


### PR DESCRIPTION
**Description:**

Fix 'duplicate the conversation to be able to edit' button

Issues:

- https://github.com/epam/ai-dial-chat/issues/1166

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
