### PR TITLE
fix(chat): check assistant model id only for "assistant" type (Issue #1179)

### DIFF
--- a/apps/chat/src/components/Chat/Chat.tsx
+++ b/apps/chat/src/components/Chat/Chat.tsx
@@ -148,9 +148,14 @@ export const ChatView = memo(() => {
             );
           }
 
+          const model = models.find(({ id }) => id === conv.model.id);
+
           return (
             !modelIds.includes(conv.model.id) ||
-            (conv.assistantModelId && !modelIds.includes(conv.assistantModelId))
+            (model &&
+              model.type === EntityType.Assistant &&
+              conv.assistantModelId &&
+              !modelIds.includes(conv.assistantModelId))
           );
         }));
     if (isNotAllowedModel) {


### PR DESCRIPTION
**Description:**

check assistant model id only for "assistant" type

Issues:

- Issue #1179

**UI changes**

![image](https://github.com/epam/ai-dial-chat/assets/20163971/86a4214b-09bb-42e8-86a2-23b511aa9059)

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
