### PR TITLE
fix(chat): fix MD tables bg color and add escaping for CSV copying (Issues #1295, #1302)

### DIFF
--- a/apps/chat/src/components/Markdown/ChatMDComponent.tsx
+++ b/apps/chat/src/components/Markdown/ChatMDComponent.tsx
@@ -78,7 +78,7 @@ export const getMDComponents = (
     },
     td({ children }) {
       return (
-        <td className="break-words border border-tertiary px-3 py-1 text-sm">
+        <td className="break-words border border-tertiary bg-layer-3 px-3 py-1 text-sm">
           {children}
         </td>
       );

--- a/apps/chat/src/components/Markdown/Table.tsx
+++ b/apps/chat/src/components/Markdown/Table.tsx
@@ -133,7 +133,9 @@ export const Table = ({ children, isLastMessageStreaming }: Props) => {
       withCopyToClipboard(CopyTableType.CSV, (table) => {
         const csv = Array.from(table.rows).map((row) => {
           const rowArray = Array.from(row.cells).map((cell) =>
-            cell.textContent ? `"${cell.textContent.replace(/"/g, '""')}"` : '',
+            cell.textContent?.trim()
+              ? `"${cell.textContent.trim().replace(/"/g, '""')}"`
+              : '',
           );
 
           return rowArray.join(',');

--- a/apps/chat/src/components/Markdown/Table.tsx
+++ b/apps/chat/src/components/Markdown/Table.tsx
@@ -133,7 +133,7 @@ export const Table = ({ children, isLastMessageStreaming }: Props) => {
       withCopyToClipboard(CopyTableType.CSV, (table) => {
         const csv = Array.from(table.rows).map((row) => {
           const rowArray = Array.from(row.cells).map((cell) =>
-            cell.textContent ? cell.textContent.trim() : '',
+            cell.textContent ? `"${cell.textContent.replace(/"/g, '""')}"` : '',
           );
 
           return rowArray.join(',');


### PR DESCRIPTION
**Description:**

Fix MD tables bg color
Add escaping for csv

Issues:

- #1295 
- #1302 

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
