### PR TITLE
fix(chat): change prompt button colors (Issue #1249)

### DIFF
--- a/apps/chat/src/components/Promptbar/components/PreviewPromptModal.tsx
+++ b/apps/chat/src/components/Promptbar/components/PreviewPromptModal.tsx
@@ -90,7 +90,7 @@ export const PreviewPromptModal = ({
                       }),
                     );
                   }}
-                  className="flex cursor-pointer items-center justify-center rounded p-[5px] hover:bg-accent-primary-alpha hover:text-accent-primary"
+                  className="flex cursor-pointer items-center justify-center rounded p-[5px] text-secondary hover:bg-accent-primary-alpha hover:text-accent-primary"
                 >
                   <IconFileArrowRight size={24} strokeWidth="1.5" />
                 </button>
@@ -102,14 +102,14 @@ export const PreviewPromptModal = ({
               >
                 <button
                   onClick={onDelete}
-                  className="flex cursor-pointer items-center justify-center rounded p-[5px] hover:bg-accent-primary-alpha hover:text-accent-primary"
+                  className="flex cursor-pointer items-center justify-center rounded p-[5px] text-secondary hover:bg-accent-primary-alpha hover:text-accent-primary"
                 >
                   <IconTrashX size={24} strokeWidth="1.5" />
                 </button>
               </Tooltip>
             </div>
             <button
-              className="button button-primary"
+              className="button button-secondary"
               data-qa="save-prompt"
               onClick={onDuplicate}
             >


### PR DESCRIPTION
**Description:**

Actual result
Buttons Export prompt and Delete prompt are black
Botton Duplicate prompt is blue and it seems that user have to duplicate prompt, as no other options

Expected result
Buttons Export prompt and Delete prompt should be in grey color
Botton Duplicate prompt should be white with black letters

Issues:

- #1249 

**UI changes**

Before:
<img width="814" alt="Снимок экрана 2024-05-16 в 19 31 56" src="https://github.com/epam/ai-dial-chat/assets/82438895/685affbd-b608-4d5f-b7b6-a4e1da53a0ef">

After:
<img width="726" alt="Снимок экрана 2024-05-16 в 19 32 33" src="https://github.com/epam/ai-dial-chat/assets/82438895/d39edbe7-b5a6-484e-afbf-abadad9b8fe6">

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
