### PR TITLE
fix(chat): change folder hover color (Issue #1338)

### DIFF
--- a/apps/chat/src/components/Common/SelectFolder/SelectFolderFooter.tsx
+++ b/apps/chat/src/components/Common/SelectFolder/SelectFolderFooter.tsx
@@ -22,11 +22,7 @@ export const SelectFolderFooter = ({
           onClick={handleNewFolder}
           className="flex size-[34px] items-center justify-center rounded text-secondary hover:bg-accent-primary-alpha hover:text-accent-primary"
         >
-          <FolderPlus
-            height={24}
-            width={24}
-            className="text-secondary hover:text-accent-primary"
-          />
+          <FolderPlus height={24} width={24} />
         </button>
       </div>
       <div>


### PR DESCRIPTION
**Description:**

There is one position when hover over Select Folder icon, background is changed (ok), but folder icon is not blue

Issues:

- #1338 

**UI changes**

Before:
<img width="554" alt="Снимок экрана 2024-05-16 в 20 26 01" src="https://github.com/epam/ai-dial-chat/assets/82438895/426686f3-b333-4e76-88c8-00bca40d94ca">

After:
<img width="116" alt="Снимок экрана 2024-05-16 в 20 26 30" src="https://github.com/epam/ai-dial-chat/assets/82438895/65dc1e17-f7c8-4db6-826e-c6692f7b2dd5">

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
