### PR TITLE
fix(chat): reset new folder after renaming (Issue #1340)

### DIFF
--- a/apps/chat/src/components/Folder/Folder.tsx
+++ b/apps/chat/src/components/Folder/Folder.tsx
@@ -56,6 +56,7 @@ import { PromptInfo } from '@/src/types/prompt';
 import { SharingType } from '@/src/types/share';
 import { Translation } from '@/src/types/translation';
 
+import { FilesActions } from '@/src/store/files/files.reducers';
 import { useAppDispatch, useAppSelector } from '@/src/store/hooks';
 import { SettingsSelectors } from '@/src/store/settings/settings.reducers';
 import { ShareActions } from '@/src/store/share/share.reducers';
@@ -288,6 +289,12 @@ const Folder = <T extends ConversationInfo | PromptInfo | DialFile>({
   const dismiss = useDismiss(context);
   const { getFloatingProps } = useInteractions([dismiss]);
 
+  const handleNewFolderRename = useCallback(() => {
+    if (newAddedFolderId === currentFolder.id) {
+      dispatch(FilesActions.resetNewFolderId());
+    }
+  }, [newAddedFolderId, dispatch, currentFolder]);
+
   const handleRename = useCallback(() => {
     if (!onRenameFolder) {
       return;
@@ -338,6 +345,9 @@ const Folder = <T extends ConversationInfo | PromptInfo | DialFile>({
     if (newName && newName !== currentFolder.name) {
       onRenameFolder(newName, currentFolder.id);
     }
+
+    handleNewFolderRename();
+
     setRenameValue('');
     setIsRenaming(false);
     setIsContextMenu(false);
@@ -347,6 +357,7 @@ const Folder = <T extends ConversationInfo | PromptInfo | DialFile>({
     skipFolderRenameValidation,
     currentFolder,
     allFoldersWithoutFilters,
+    handleNewFolderRename,
     dispatch,
     t,
   ]);
@@ -917,6 +928,7 @@ const Folder = <T extends ConversationInfo | PromptInfo | DialFile>({
               handleClick={(e) => {
                 e.stopPropagation();
                 setIsRenaming(false);
+                handleNewFolderRename();
               }}
             >
               <IconX


### PR DESCRIPTION
**Description:**

Reset new folder after renaming 

Issues:

- Issue #1340 

**UI changes**

<Please, provide Screenshots or Figma links>

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
