### PR TITLE
fix(chat): fix modal scrolling (Issue #1194)

### DIFF
--- a/apps/chat/src/components/Common/ReplaceConfirmationModal/ReplaceConfirmationModal.tsx
+++ b/apps/chat/src/components/Common/ReplaceConfirmationModal/ReplaceConfirmationModal.tsx
@@ -302,7 +302,7 @@ export const ReplaceConfirmationModal = ({ isOpen }: Props) => {
       dismissProps={{ outsidePressEvent: 'mousedown' }}
     >
       <div className="flex h-full flex-col justify-between gap-2 sm:gap-4">
-        <div className="flex h-[90%] flex-col gap-4 md:p-6">
+        <div className="flex min-h-[80%] flex-col gap-4 md:p-6">
           <div className="flex h-fit flex-col gap-2">
             <h2 className="text-base font-semibold">
               {t('Some items failed to import due to duplicate names')}
@@ -314,7 +314,7 @@ export const ReplaceConfirmationModal = ({ isOpen }: Props) => {
             </p>
           </div>
 
-          <div className="flex h-[90%] min-h-[150px] flex-col sm:h-[92%]">
+          <div className="flex h-[90%] min-h-[100px] flex-col sm:h-[92%]">
             <div className="flex h-fit flex-row items-center justify-between overflow-y-scroll border-b-[1px] border-tertiary pb-1 pl-3 sm:pb-3">
               <span>{t('All items')}</span>
               <ReplaceSelector

--- a/apps/chat/src/components/Promptbar/components/PromptModal.tsx
+++ b/apps/chat/src/components/Promptbar/components/PromptModal.tsx
@@ -179,7 +179,7 @@ export const PromptModal: FC<Props> = ({ isOpen, onClose, onUpdatePrompt }) => {
     setContent(selectedPrompt?.content || '');
   }, [selectedPrompt]);
 
-  const inputClassName = classNames('input-form', 'peer', {
+  const inputClassName = classNames('input-form', 'mx-0', 'peer', {
     'input-invalid': submitted,
     submitted: submitted,
   });
@@ -194,7 +194,7 @@ export const PromptModal: FC<Props> = ({ isOpen, onClose, onUpdatePrompt }) => {
   return (
     <Modal
       portalId="theme-main"
-      containerClassName="inline-block w-full overflow-y-auto px-3 py-4 align-bottom transition-all md:p-6 xl:max-h-[800px] xl:max-w-[720px] 2xl:max-w-[1000px]"
+      containerClassName="flex flex-col gap-4 inline-block w-full overflow-y-auto px-3 py-4 align-bottom transition-all md:p-6 xl:max-h-[800px] xl:max-w-[720px] 2xl:max-w-[1000px]"
       dataQa="prompt-modal"
       state={
         isOpen
@@ -203,7 +203,6 @@ export const PromptModal: FC<Props> = ({ isOpen, onClose, onUpdatePrompt }) => {
             : ModalState.OPENED
           : ModalState.CLOSED
       }
-      heading={t('Edit prompt')}
       onClose={handleClose}
       onKeyDownOverlay={(e) => {
         if (selectedPrompt && !saveDisabled) handleEnter(e, selectedPrompt);
@@ -212,85 +211,90 @@ export const PromptModal: FC<Props> = ({ isOpen, onClose, onUpdatePrompt }) => {
     >
       {selectedPrompt ? (
         <>
-          <div className="mb-4">
-            <label
-              className="mb-1 flex text-xs text-secondary"
-              htmlFor="promptName"
-            >
-              {t('Name')}
-              <span className="ml-1 inline text-accent-primary">*</span>
-            </label>
-            <input
-              ref={nameInputRef}
-              name="promptName"
-              className={classNames(
-                isDotError &&
-                  'border-error hover:border-error focus:border-error',
-                inputClassName,
-              )}
-              placeholder={t('A name for your prompt.') || ''}
-              value={name}
-              required
-              type="text"
-              onBlur={nameOnBlurHandler}
-              onChange={nameOnChangeHandler}
-              data-qa="prompt-name"
-            />
-            <EmptyRequiredInputMessage
-              isShown={isDotError}
-              text={
-                (isDotError
-                  ? t('Using a dot at the end of a name is not permitted.')
-                  : t('Please fill in all required fields')) || ''
-              }
-            />
+          <div className="flex justify-between">
+            <h2 className="text-base font-semibold">{t('Edit prompt')}</h2>
           </div>
+          <div className="flex flex-col gap-2 overflow-y-auto">
+            <div className="mb-4">
+              <label
+                className="mb-1 flex text-xs text-secondary"
+                htmlFor="promptName"
+              >
+                {t('Name')}
+                <span className="ml-1 inline text-accent-primary">*</span>
+              </label>
+              <input
+                ref={nameInputRef}
+                name="promptName"
+                className={classNames(
+                  isDotError &&
+                    'border-error hover:border-error focus:border-error',
+                  inputClassName,
+                )}
+                placeholder={t('A name for your prompt.') || ''}
+                value={name}
+                required
+                type="text"
+                onBlur={nameOnBlurHandler}
+                onChange={nameOnChangeHandler}
+                data-qa="prompt-name"
+              />
+              <EmptyRequiredInputMessage
+                isShown={isDotError}
+                text={
+                  (isDotError
+                    ? t('Using a dot at the end of a name is not permitted.')
+                    : t('Please fill in all required fields')) || ''
+                }
+              />
+            </div>
 
-          <div className="mb-4">
-            <label
-              className="mb-1 flex text-xs text-secondary"
-              htmlFor="description"
-            >
-              {t('Description')}
-            </label>
-            <textarea
-              ref={descriptionInputRef}
-              name="description"
-              className={inputClassName}
-              style={{ resize: 'none' }}
-              placeholder={t('A description for your prompt.') || ''}
-              value={description}
-              onChange={descriptionOnChangeHandler}
-              rows={3}
-              data-qa="prompt-descr"
-            />
-          </div>
-          <div className="mb-5">
-            <label
-              className="mb-1 flex text-xs text-secondary"
-              htmlFor="content"
-            >
-              {t('Prompt')}
-              <span className="ml-1 inline text-accent-primary">*</span>
-            </label>
-            <textarea
-              ref={contentInputRef}
-              name="content"
-              className={inputClassName}
-              style={{ resize: 'none' }}
-              placeholder={
-                t(
-                  'Prompt content. Use {{}} to denote a variable. Ex: {{name}} is a {{adjective}} {{noun}}',
-                ) || ''
-              }
-              value={content}
-              onChange={contentOnChangeHandler}
-              onBlur={contentOnBlurHandler}
-              rows={10}
-              data-qa="prompt-value"
-              required
-            />
-            <EmptyRequiredInputMessage />
+            <div className="mb-4">
+              <label
+                className="mb-1 flex text-xs text-secondary"
+                htmlFor="description"
+              >
+                {t('Description')}
+              </label>
+              <textarea
+                ref={descriptionInputRef}
+                name="description"
+                className={inputClassName}
+                style={{ resize: 'none' }}
+                placeholder={t('A description for your prompt.') || ''}
+                value={description}
+                onChange={descriptionOnChangeHandler}
+                rows={3}
+                data-qa="prompt-descr"
+              />
+            </div>
+            <div className="mb-5">
+              <label
+                className="mb-1 flex text-xs text-secondary"
+                htmlFor="content"
+              >
+                {t('Prompt')}
+                <span className="ml-1 inline text-accent-primary">*</span>
+              </label>
+              <textarea
+                ref={contentInputRef}
+                name="content"
+                className={inputClassName}
+                style={{ resize: 'none' }}
+                placeholder={
+                  t(
+                    'Prompt content. Use {{}} to denote a variable. Ex: {{name}} is a {{adjective}} {{noun}}',
+                  ) || ''
+                }
+                value={content}
+                onChange={contentOnChangeHandler}
+                onBlur={contentOnBlurHandler}
+                rows={10}
+                data-qa="prompt-value"
+                required
+              />
+              <EmptyRequiredInputMessage />
+            </div>
           </div>
           <div className="flex justify-end">
             <Tooltip


### PR DESCRIPTION
**Description:**

Some modals have flexible height, for example Edit prompt, and user has to scroll to see it's header and buttons at the bottom. On mobile devices it's rather inconvenient.

Expected: need to make header and buttons to be always on the pop-ups, scroll should be applied between header and buttons.

Issues 
- #1194  

**UI changes**

https://www.figma.com/design/lwL5jneveZczAj5RLcLFH2/DIAL-Chat?node-id=3322-9978&t=Ks1O6UOv7zgljSxP-0

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
