### PR TITLE
fix(chat): open chat/prompt from root shared folder (Issue #1202, #1250)

### DIFF
--- a/apps/chat/src/store/conversations/conversations.epics.ts
+++ b/apps/chat/src/store/conversations/conversations.epics.ts
@@ -2323,6 +2323,10 @@ const uploadConversationsWithFoldersRecursiveEpic: AppEpic = (
               FeatureType.Chat,
             );
 
+            const rootConversationId = conversations.toSorted(
+              (a, b) => a.folderId.length - b.folderId.length,
+            )[0].id;
+
             actions.push(
               concat(
                 of(
@@ -2340,7 +2344,7 @@ const uploadConversationsWithFoldersRecursiveEpic: AppEpic = (
                 ),
                 of(
                   ConversationsActions.selectConversations({
-                    conversationIds: [conversations[0]?.id],
+                    conversationIds: [rootConversationId],
                   }),
                 ),
                 of(

--- a/apps/chat/src/store/conversations/conversations.epics.ts
+++ b/apps/chat/src/store/conversations/conversations.epics.ts
@@ -2323,7 +2323,7 @@ const uploadConversationsWithFoldersRecursiveEpic: AppEpic = (
               FeatureType.Chat,
             );
 
-            const rootConversationId = conversations.toSorted(
+            const topLevelConversationId = conversations.toSorted(
               (a, b) => a.folderId.length - b.folderId.length,
             )[0].id;
 
@@ -2344,7 +2344,7 @@ const uploadConversationsWithFoldersRecursiveEpic: AppEpic = (
                 ),
                 of(
                   ConversationsActions.selectConversations({
-                    conversationIds: [rootConversationId],
+                    conversationIds: [topLevelConversationId],
                   }),
                 ),
                 of(

--- a/apps/chat/src/store/prompts/prompts.epics.ts
+++ b/apps/chat/src/store/prompts/prompts.epics.ts
@@ -586,6 +586,10 @@ const uploadPromptsWithFoldersRecursiveEpic: AppEpic = (action$, state$) =>
               FeatureType.Prompt,
             );
 
+            const rootPromptId = prompts.toSorted(
+              (a, b) => a.folderId.length - b.folderId.length,
+            )[0].id;
+
             actions.push(
               concat(
                 of(
@@ -599,10 +603,10 @@ const uploadPromptsWithFoldersRecursiveEpic: AppEpic = (action$, state$) =>
                     prompts,
                   }),
                 ),
-                of(PromptsActions.uploadPrompt({ promptId: prompts[0]?.id })),
+                of(PromptsActions.uploadPrompt({ promptId: rootPromptId })),
                 of(
                   PromptsActions.setSelectedPrompt({
-                    promptId: prompts[0]?.id,
+                    promptId: rootPromptId,
                   }),
                 ),
                 of(

--- a/apps/chat/src/store/prompts/prompts.epics.ts
+++ b/apps/chat/src/store/prompts/prompts.epics.ts
@@ -586,7 +586,7 @@ const uploadPromptsWithFoldersRecursiveEpic: AppEpic = (action$, state$) =>
               FeatureType.Prompt,
             );
 
-            const rootPromptId = prompts.toSorted(
+            const topLevelPromptId = prompts.toSorted(
               (a, b) => a.folderId.length - b.folderId.length,
             )[0].id;
 
@@ -603,10 +603,10 @@ const uploadPromptsWithFoldersRecursiveEpic: AppEpic = (action$, state$) =>
                     prompts,
                   }),
                 ),
-                of(PromptsActions.uploadPrompt({ promptId: rootPromptId })),
+                of(PromptsActions.uploadPrompt({ promptId: topLevelPromptId })),
                 of(
                   PromptsActions.setSelectedPrompt({
-                    promptId: rootPromptId,
+                    promptId: topLevelPromptId,
                   }),
                 ),
                 of(


### PR DESCRIPTION
**Description:**

Open the conversation/prompt from the root folder when a folder with nested folders has been shared.

Issues:

- Issue #1202 
- Issue #1250 

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
