### PR TITLE
fix(chat): change button color depending on mode (Issue #1284)

### DIFF
--- a/apps/chat/src/components/Files/PreUploadModal.tsx
+++ b/apps/chat/src/components/Files/PreUploadModal.tsx
@@ -454,7 +454,7 @@ export const PreUploadDialog = ({
         </label>
 
         <button
-          className="button button-primary"
+          className="button button-secondary"
           onClick={handleUpload}
           disabled={selectedFiles.length === 0}
           data-qa="upload"

--- a/apps/chat/src/components/Files/PreUploadModal.tsx
+++ b/apps/chat/src/components/Files/PreUploadModal.tsx
@@ -454,7 +454,7 @@ export const PreUploadDialog = ({
         </label>
 
         <button
-          className="button button-secondary"
+          className="button button-primary"
           onClick={handleUpload}
           disabled={selectedFiles.length === 0}
           data-qa="upload"

--- a/apps/chat/src/styles/globals.css
+++ b/apps/chat/src/styles/globals.css
@@ -109,6 +109,10 @@ pre:has(div.codeblock) {
     @apply text-controls-permanent;
   }
 
+  .button.button-primary:disabled {
+    @apply text-controls-disable;
+  }
+
   .button.button-primary:not(:disabled) {
     @apply bg-controls-accent hover:bg-controls-accent-hover;
   }


### PR DESCRIPTION
**Description:**

Need to change button color depending on mode

Issues:

- Issue #1284 

**UI changes**

Before:
<img width="612" alt="Снимок экрана 2024-05-22 в 17 03 04" src="https://github.com/epam/ai-dial-chat/assets/82438895/4dfc55ea-35d9-4040-b525-43920ce8bb0e">

After:
<img width="434" alt="Снимок экрана 2024-05-22 в 17 03 43" src="https://github.com/epam/ai-dial-chat/assets/82438895/8209c61d-0d2a-4adf-9809-cedd10a206f0">
<img width="437" alt="Снимок экрана 2024-05-22 в 17 04 20" src="https://github.com/epam/ai-dial-chat/assets/82438895/b9ef2704-2e33-4e18-88ad-2e6abb91fd7a">

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
