### PR TITLE
fix(chat): name duplicated attached file from empty prefix (Issue #1234)

### DIFF
--- a/apps/chat/src/utils/app/zip-import-export.ts
+++ b/apps/chat/src/utils/app/zip-import-export.ts
@@ -214,7 +214,7 @@ export const updateAttachmentsNames = ({
       existingFiles.length &&
       existingFiles.some(({ name }) => name === attachment.name)
     ) {
-      const newName = getNextFileName(attachment.name, existingFiles);
+      const newName = getNextFileName(attachment.name, existingFiles, 0, true);
 
       const updatedAttachment = { ...attachment, name: newName };
 


### PR DESCRIPTION
**Description:**

Name the duplicated attached files for imported conversations from the empty prefix.

Issues:

- Issue #1234 

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
