### PR TITLE
fix(chat): change tooltip showing place (Issue #109)

### DIFF
--- a/apps/chat/src/components/Chat/Addons.tsx
+++ b/apps/chat/src/components/Chat/Addons.tsx
@@ -69,6 +69,7 @@ const Addon = ({
           }
           triggerClassName="flex shrink-0"
           contentClassName="max-w-[220px]"
+          placement="top"
         >
           {template}
         </Tooltip>

--- a/apps/chat/src/components/Chatbar/ModelIcon.tsx
+++ b/apps/chat/src/components/Chatbar/ModelIcon.tsx
@@ -76,7 +76,6 @@ export const ModelIcon = ({
       hideTooltip={isCustomTooltip}
       tooltip={entity ? getOpenAIEntityFullName(entity) : entityId}
       triggerClassName="flex shrink-0 relative"
-      placement="top"
     >
       <ModelIconTemplate
         entity={entity}

--- a/apps/chat/src/components/Chatbar/ModelIcon.tsx
+++ b/apps/chat/src/components/Chatbar/ModelIcon.tsx
@@ -76,6 +76,7 @@ export const ModelIcon = ({
       hideTooltip={isCustomTooltip}
       tooltip={entity ? getOpenAIEntityFullName(entity) : entityId}
       triggerClassName="flex shrink-0 relative"
+      placement="top"
     >
       <ModelIconTemplate
         entity={entity}


### PR DESCRIPTION
**Description:**

Need to show one of the tooltips above the addon and another below the addon name.

Issues:

- Issue #109 

**UI changes**

Before: 
<img width="322" alt="Снимок экрана 2024-05-23 в 12 16 35" src="https://github.com/epam/ai-dial-chat/assets/82438895/f9553458-6eba-4cae-88cc-e9d796a36c8e">

After:
<img width="225" alt="Снимок экрана 2024-05-23 в 14 33 12" src="https://github.com/epam/ai-dial-chat/assets/82438895/3ee8f6c3-bd47-4db9-8620-12bb01baffab">

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
