### PR TITLE
feat(chat): add tooltips for files and folders (Issue #1227)

### DIFF
--- a/apps/chat-e2e/src/ui/webElements/folders.ts
+++ b/apps/chat-e2e/src/ui/webElements/folders.ts
@@ -44,7 +44,7 @@ export class Folders extends BaseElement {
 
   public getFolderByName(name: string, index?: number) {
     return this.getChildElementBySelector(
-      SideBarSelectors.folderName,
+      SideBarSelectors.folder,
     ).getElementLocatorByText(name, index);
   }
 

--- a/apps/chat-e2e/src/ui/webElements/folders.ts
+++ b/apps/chat-e2e/src/ui/webElements/folders.ts
@@ -44,7 +44,7 @@ export class Folders extends BaseElement {
 
   public getFolderByName(name: string, index?: number) {
     return this.getChildElementBySelector(
-      SideBarSelectors.folder,
+      SideBarSelectors.folderName,
     ).getElementLocatorByText(name, index);
   }
 

--- a/apps/chat/src/components/Files/FileItem.tsx
+++ b/apps/chat/src/components/Files/FileItem.tsx
@@ -181,16 +181,22 @@ export const FileItem = ({
               </div>
             )}
         </div>
-        <span
-          className={classNames(
-            'block max-w-full truncate whitespace-pre',
-            item.status === UploadStatus.FAILED && 'text-error',
-            isSelected && 'text-accent-primary',
-          )}
-          data-qa="attached-file-name"
+        <Tooltip
+          tooltip={item.name}
+          triggerClassName="block max-h-5 flex-1 truncate whitespace-pre text-left"
+          contentClassName="sm:max-w-[400px] max-w-[250px] break-all"
         >
-          {item.name}
-        </span>
+          <span
+            className={classNames(
+              'block max-w-full truncate whitespace-pre',
+              item.status === UploadStatus.FAILED && 'text-error',
+              isSelected && 'text-accent-primary',
+            )}
+            data-qa="attached-file-name"
+          >
+            {item.name}
+          </span>
+        </Tooltip>
       </div>
 
       <div className="flex items-center gap-2">

--- a/apps/chat/src/components/Folder/Folder.tsx
+++ b/apps/chat/src/components/Folder/Folder.tsx
@@ -722,6 +722,13 @@ const Folder = <T extends ConversationInfo | PromptInfo | DialFile>({
             onClickFolder(currentFolder.id);
           }
         }}
+        draggable={!!handleDrop && !isExternal && !isNameOrPathInvalid}
+        onDragStart={(e) => handleDragStart(e, currentFolder)}
+        onDragOver={(e) => {
+          if (!isExternal && hasDragEventAnyData(e, featureType)) {
+            e.preventDefault();
+          }
+        }}
       >
         {isRenaming ? (
           <div
@@ -801,13 +808,6 @@ const Folder = <T extends ConversationInfo | PromptInfo | DialFile>({
             className="group/folder-item flex max-w-full items-center gap-1 py-2 pr-3"
             style={{
               paddingLeft: `${level * 24}px`,
-            }}
-            draggable={!!handleDrop && !isExternal && !isNameOrPathInvalid}
-            onDragStart={(e) => handleDragStart(e, currentFolder)}
-            onDragOver={(e) => {
-              if (!isExternal && hasDragEventAnyData(e, featureType)) {
-                e.preventDefault();
-              }
             }}
           >
             <CaretIconComponent

--- a/apps/chat/src/components/Folder/Folder.tsx
+++ b/apps/chat/src/components/Folder/Folder.tsx
@@ -704,13 +704,24 @@ const Folder = <T extends ConversationInfo | PromptInfo | DialFile>({
     >
       <div
         className={classNames(
-          'group/folder-item group relative flex h-[30px] items-center rounded border-l-2 hover:bg-accent-primary-alpha',
+          'group/button group/folder-item group relative flex h-[30px] cursor-pointer items-center rounded border-l-2 hover:bg-accent-primary-alpha',
           !withBorderHighlight && 'border-transparent',
           isHighlighted ? 'bg-accent-primary-alpha' : 'border-transparent',
           isHighlighted && withBorderHighlight && 'border-accent-primary',
           folderClassName,
         )}
         data-qa="folder"
+        onClick={(e) => {
+          if (
+            onClickFolder &&
+            !hasParentWithAttribute(
+              e.target as HTMLDivElement,
+              'data-item-checkbox',
+            )
+          ) {
+            onClickFolder(currentFolder.id);
+          }
+        }}
       >
         {isRenaming ? (
           <div
@@ -787,20 +798,9 @@ const Folder = <T extends ConversationInfo | PromptInfo | DialFile>({
           </div>
         ) : (
           <div
-            className="group/button group/folder-item flex size-full cursor-pointer items-center gap-1 py-2 pr-3"
+            className="group/folder-item flex max-w-full items-center gap-1 py-2 pr-3"
             style={{
               paddingLeft: `${level * 24}px`,
-            }}
-            onClick={(e) => {
-              if (
-                onClickFolder &&
-                !hasParentWithAttribute(
-                  e.target as HTMLDivElement,
-                  'data-item-checkbox',
-                )
-              ) {
-                onClickFolder(currentFolder.id);
-              }
             }}
             draggable={!!handleDrop && !isExternal && !isNameOrPathInvalid}
             onDragStart={(e) => handleDragStart(e, currentFolder)}
@@ -868,18 +868,26 @@ const Folder = <T extends ConversationInfo | PromptInfo | DialFile>({
             )}
             <div
               className={classNames(
-                'relative max-h-5 flex-1 truncate break-all text-left group-hover/button:pr-5',
+                'relative max-h-5 flex-1 truncate text-left group-hover/button:pr-5',
                 isNameOrPathInvalid && 'text-secondary',
               )}
               data-qa="folder-name"
             >
               <Tooltip
-                tooltip={t(
-                  getEntityNameError(isNameInvalid, isInvalidPath, isExternal),
-                )}
-                hideTooltip={!isNameOrPathInvalid}
+                tooltip={
+                  featureType === 'file' && !isNameOrPathInvalid
+                    ? currentFolder.name
+                    : t(
+                        getEntityNameError(
+                          isNameInvalid,
+                          isInvalidPath,
+                          isExternal,
+                        ),
+                      )
+                }
+                contentClassName="sm:max-w-[400px] max-w-[250px] break-all"
                 triggerClassName={classNames(
-                  'max-h-5 flex-1 truncate whitespace-pre break-all text-left',
+                  'block max-h-5 flex-1 truncate whitespace-pre break-all text-left',
                   highlightTemporaryFolders &&
                     (currentFolder.temporary
                       ? 'text-primary'


### PR DESCRIPTION
**Description:**

In manage attachments, chats and prompts for files and folder need to add a tooltip that will show the full name.

Issues:

- Issue #1227 

**UI changes**

<img width="524" alt="Снимок экрана 2024-05-30 в 00 05 29" src="https://github.com/epam/ai-dial-chat/assets/82438895/79515053-cc26-4ed9-9114-d57cd1a59c95">
<img width="518" alt="Снимок экрана 2024-05-30 в 00 05 41" src="https://github.com/epam/ai-dial-chat/assets/82438895/7b7c606e-21de-409a-bf65-4455c033270a">
<img width="517" alt="Снимок экрана 2024-05-30 в 00 05 50" src="https://github.com/epam/ai-dial-chat/assets/82438895/759409fe-a0ef-407e-bb0d-959588c00cc8">
<img width="532" alt="wwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwww" src="https://github.com/epam/ai-dial-chat/assets/82438895/35e4d747-9be7-4f7f-a04e-27647d389973">

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
