### PR TITLE
fix: fix Manage attachments impossible to download or delete files, no text about supported types and max size (Issue #1443)

### DIFF
--- a/apps/chat/src/components/Chatbar/ChatbarSettings.tsx
+++ b/apps/chat/src/components/Chatbar/ChatbarSettings.tsx
@@ -179,6 +179,7 @@ export const ChatbarSettings = () => {
             setIsSelectFilesDialogOpened(false);
           }}
           headerLabel={t('Manage attachments')}
+          forceShowSelectCheckBox
         />
       )}
 

--- a/apps/chat/src/components/Files/FileItem.tsx
+++ b/apps/chat/src/components/Files/FileItem.tsx
@@ -56,7 +56,7 @@ export const FileItem = ({
 
   const [isContextMenu, setIsContextMenu] = useState(false);
   const [isSelected, setIsSelected] = useState(false);
-  const [isHighligted, setIsHighlighted] = useState(false);
+  const [isHighlighted, setIsHighlighted] = useState(false);
   const [isUnshareConfirmOpened, setIsUnshareConfirmOpened] = useState(false);
 
   const canAttachFiles = !!additionalItemData?.canAttachFiles;
@@ -116,7 +116,7 @@ export const FileItem = ({
     <div
       className={classNames(
         'group/file-item flex justify-between gap-3 rounded px-3 py-1.5 hover:bg-accent-primary-alpha',
-        (isHighligted || isContextMenu) && 'bg-accent-primary-alpha',
+        (isHighlighted || isContextMenu) && 'bg-accent-primary-alpha',
       )}
       style={{
         paddingLeft: `${1.005 + level * 1.5}rem`,

--- a/apps/chat/src/components/Files/FileManagerModal.tsx
+++ b/apps/chat/src/components/Files/FileManagerModal.tsx
@@ -50,6 +50,7 @@ interface Props {
   customButtonLabel?: string;
   customUploadButtonLabel?: string;
   onClose: (result: boolean | string[]) => void;
+  forceShowSelectCheckBox?: boolean;
 }
 
 export const FileManagerModal = ({
@@ -61,6 +62,7 @@ export const FileManagerModal = ({
   customButtonLabel,
   customUploadButtonLabel,
   maximumAttachmentsAmount = 0,
+  forceShowSelectCheckBox,
   onClose,
 }: Props) => {
   const dispatch = useAppDispatch();
@@ -446,7 +448,7 @@ export const FileManagerModal = ({
             {headerLabel}
           </h2>
         </div>
-        {canAttachFiles && (
+        {(canAttachFiles || forceShowSelectCheckBox) && (
           <p id={descriptionId} data-qa="supported-attributes">
             {t(
               'Max file size up to 512 Mb. Supported types: {{allowedExtensions}}.',
@@ -538,7 +540,8 @@ export const FileManagerModal = ({
                               additionalItemData={{
                                 selectedFilesIds,
                                 selectedFolderIds,
-                                canAttachFiles,
+                                canAttachFiles:
+                                  canAttachFiles || forceShowSelectCheckBox,
                               }}
                               itemComponent={FileItem}
                               onClickFolder={handleFolderSelect}
@@ -566,7 +569,8 @@ export const FileManagerModal = ({
                               additionalItemData={{
                                 selectedFolderIds,
                                 selectedFilesIds,
-                                canAttachFiles,
+                                canAttachFiles:
+                                  canAttachFiles || forceShowSelectCheckBox,
                               }}
                               onEvent={handleItemCallback}
                             />

--- a/apps/chat/src/components/Settings/CustomLogoSelect.tsx
+++ b/apps/chat/src/components/Settings/CustomLogoSelect.tsx
@@ -67,6 +67,7 @@ export const CustomLogoSelect = ({
           headerLabel={t('Select custom logo')}
           customButtonLabel={t('Select file') as string}
           customUploadButtonLabel={t('Upload files') as string}
+          forceShowSelectCheckBox
         />
       )}
     </div>


### PR DESCRIPTION
**Description:**

- Fixed possibility to download or delete files on Manage attachments and Select custom logo screens.
- Fixed to show text about supported types and max size.

Issues:

- Issue #1443 

**UI changes**


**Manage attachments screen:**
![image](https://github.com/epam/ai-dial-chat/assets/143205282/faa90a64-7235-41ca-a824-62c02c32e986)

**Select custom logo:**
![image](https://github.com/epam/ai-dial-chat/assets/143205282/652a2c7e-cb30-4e50-852f-de5b8177a8ae)

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
