### PR TITLE
fix(chat): fix export button color for prompt preview mode and add truncating to publish modal (Issues #1327, #1464)

### DIFF
--- a/apps/chat/src/components/Chat/Publish/PublishWizard.tsx
+++ b/apps/chat/src/components/Chat/Publish/PublishWizard.tsx
@@ -347,9 +347,19 @@ export function PublishModal({
       initialFocus={nameInputRef}
     >
       <div className="flex h-full flex-col divide-y divide-tertiary">
-        <h4 className="p-4 pr-10 text-base font-semibold">
-          <span className="line-clamp-2 whitespace-pre break-words text-center">
-            {`${t('Publication request for')}: ${entity.name.trim()}`}
+        <h4 className="truncate p-4 pr-10 text-base font-semibold">
+          <span className="w-full text-center">
+            <Tooltip
+              contentClassName="max-w-[400px] break-words"
+              tooltip={entity.name.trim()}
+            >
+              <div
+                className="line-clamp-2 w-full break-words"
+                data-qa="modal-entity-name"
+              >
+                {`${t('Publication request for')}: ${entity.name.trim()}`}
+              </div>
+            </Tooltip>
           </span>
         </h4>
         <div className="flex min-h-0 grow flex-col divide-y divide-tertiary overflow-y-auto md:flex-row md:divide-x md:divide-y-0">

--- a/apps/chat/src/components/Chat/Publish/PublishWizard.tsx
+++ b/apps/chat/src/components/Chat/Publish/PublishWizard.tsx
@@ -354,7 +354,7 @@ export function PublishModal({
               tooltip={entity.name.trim()}
             >
               <div
-                className="line-clamp-2 w-full break-words"
+                className="w-full truncate break-words"
                 data-qa="modal-entity-name"
               >
                 {`${t('Publication request for')}: ${entity.name.trim()}`}

--- a/apps/chat/src/components/Common/ReplaceConfirmationModal/Components.tsx
+++ b/apps/chat/src/components/Common/ReplaceConfirmationModal/Components.tsx
@@ -145,6 +145,7 @@ const ConversationView = ({ item: conversation }: ConversationViewProps) => {
       />
       <Tooltip
         tooltip={conversation.name}
+        contentClassName="max-w-[400px]"
         triggerClassName="truncate text-center w-full"
       >
         <div className="truncate whitespace-pre break-all text-left">
@@ -192,6 +193,7 @@ const PromptView = ({ item: prompt }: PromptViewProps) => {
       <IconBulb size={18} className="text-secondary" />
       <Tooltip
         tooltip={prompt.name}
+        contentClassName="max-w-[400px]"
         triggerClassName="truncate text-center w-full"
       >
         <div className="truncate whitespace-pre break-all text-left">
@@ -239,6 +241,7 @@ const FileView = ({ item: file }: FileViewProps) => {
       <IconFile size={18} className="text-secondary" />
       <Tooltip
         tooltip={file.name}
+        contentClassName="max-w-[400px]"
         triggerClassName="truncate text-center w-full"
       >
         <div className="truncate whitespace-pre break-all text-left">

--- a/apps/chat/src/components/Promptbar/components/PreviewPromptModal.tsx
+++ b/apps/chat/src/components/Promptbar/components/PreviewPromptModal.tsx
@@ -57,7 +57,7 @@ export const PreviewPromptModal = ({
             }),
           );
         }}
-        className="flex cursor-pointer items-center justify-center rounded p-[5px] text-secondary hover:bg-accent-tertiary-alpha hover:text-accent-tertiary"
+        className="flex cursor-pointer items-center justify-center rounded p-[5px] text-secondary hover:bg-accent-primary-alpha hover:text-accent-primary"
       >
         <IconFileArrowRight size={24} strokeWidth="1.5" />
       </button>
@@ -123,7 +123,7 @@ export const PreviewPromptModal = ({
                     >
                       <button
                         onClick={onDelete}
-                        className="flex cursor-pointer items-center justify-center rounded p-[5px] text-secondary hover:bg-accent-tertiary-alpha hover:text-accent-tertiary"
+                        className="flex cursor-pointer items-center justify-center rounded p-[5px] text-secondary hover:bg-accent-primary-alpha hover:text-accent-primary"
                       >
                         <IconTrashX size={24} strokeWidth="1.5" />
                       </button>


### PR DESCRIPTION
**Description:**

fix export button color for prompt preview mode and add truncating to publish modal

Issues:

- #1327
- #1464 

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
