### PR TITLE
fix(chat): hide unpublish option from change path dialog (Issue #1501)

### DIFF
--- a/apps/chat/src/components/Chat/ChangePathDialog.tsx
+++ b/apps/chat/src/components/Chat/ChangePathDialog.tsx
@@ -204,6 +204,7 @@ export const ChangePathDialog = ({
               type === SharingType.ConversationFolder
                 ? FeatureType.Chat
                 : FeatureType.Prompt,
+            isSidePanelFolder: false,
           }}
           handleFolderSelect={handleFolderSelect}
           isAllEntitiesOpened={isAllFoldersOpened}

--- a/apps/chat/src/components/Chat/Publish/PublicationResources.tsx
+++ b/apps/chat/src/components/Chat/Publish/PublicationResources.tsx
@@ -95,6 +95,7 @@ export const PromptPublicationResources = ({
         return (
           <Folder
             readonly
+            isSidePanelFolder={false}
             noCaretIcon={!!forViewOnly}
             level={forViewOnly ? 0 : 1}
             key={f.id}

--- a/apps/chat/src/components/Chat/Publish/PublicationResources.tsx
+++ b/apps/chat/src/components/Chat/Publish/PublicationResources.tsx
@@ -95,7 +95,6 @@ export const PromptPublicationResources = ({
         return (
           <Folder
             readonly
-            isSidePanelFolder={false}
             noCaretIcon={!!forViewOnly}
             level={forViewOnly ? 0 : 1}
             key={f.id}

--- a/apps/chat/src/components/Chat/Publish/PublishAttachment.tsx
+++ b/apps/chat/src/components/Chat/Publish/PublishAttachment.tsx
@@ -139,7 +139,7 @@ export const PublishAttachment = ({
 
   if (!file) return null;
 
-  const fullPath = constructPath(t(PUBLISHING_FOLDER_NAME), file.relativePath);
+  const fullPath = constructPath(PUBLISHING_FOLDER_NAME, file.relativePath);
 
   const handleContextMenuOpen = (e: MouseEvent) => {
     if (isRenaming) {

--- a/apps/chat/src/components/Chat/Publish/PublishWizard.tsx
+++ b/apps/chat/src/components/Chat/Publish/PublishWizard.tsx
@@ -368,7 +368,7 @@ export function PublishModal({
                   onClick={handleFolderChange}
                 >
                   <span className="truncate">
-                    {constructPath(t(PUBLISHING_FOLDER_NAME), path)}
+                    {constructPath(PUBLISHING_FOLDER_NAME, path)}
                   </span>
                   <span className="text-accent-primary">{t('Change')}</span>
                 </button>

--- a/apps/chat/src/components/Chatbar/ChatFolders.tsx
+++ b/apps/chat/src/components/Chatbar/ChatFolders.tsx
@@ -358,7 +358,7 @@ export function ChatFolders() {
       [
         {
           hidden: !isPublishingEnabled || !isFilterEmpty,
-          name: t(PUBLISHING_FOLDER_NAME),
+          name: PUBLISHING_FOLDER_NAME,
           filters: PublishedWithMeFilter,
           displayRootFiles: true,
           dataQa: 'published-with-me',

--- a/apps/chat/src/components/Common/FolderContextMenu.tsx
+++ b/apps/chat/src/components/Common/FolderContextMenu.tsx
@@ -38,6 +38,7 @@ interface FolderContextMenuProps {
   featureType: FeatureType;
   isOpen?: boolean;
   isEmpty?: boolean;
+  isSidePanelFolder?: boolean;
   onDelete?: MouseEventHandler<unknown>;
   onRename?: MouseEventHandler<unknown>;
   onAddFolder?: MouseEventHandler;
@@ -65,6 +66,7 @@ export const FolderContextMenu = ({
   onUpload,
   isOpen,
   isEmpty,
+  isSidePanelFolder,
 }: FolderContextMenuProps) => {
   const { t } = useTranslation(Translation.SideBar);
 
@@ -146,7 +148,10 @@ export const FolderContextMenu = ({
         name: t('Unpublish'),
         dataQa: 'unpublish',
         display:
-          isPublishingEnabled && isItemPublic(folder.id) && !!onUnpublish,
+          isPublishingEnabled &&
+          isItemPublic(folder.id) &&
+          !!onUnpublish &&
+          isSidePanelFolder,
         Icon: UnpublishIcon,
         onClick: onUnpublish,
         disabled: disableAll,
@@ -199,8 +204,9 @@ export const FolderContextMenu = ({
       onUnshare,
       isPublishingEnabled,
       onPublish,
-      onUnpublish,
       onPublishUpdate,
+      onUnpublish,
+      isSidePanelFolder,
       onDelete,
       featureType,
       onAddFolder,

--- a/apps/chat/src/components/Common/SelectFolder/SelectFolderList.tsx
+++ b/apps/chat/src/components/Common/SelectFolder/SelectFolderList.tsx
@@ -86,6 +86,7 @@ export const SelectFolderList = <T extends Conversation | Prompt | DialFile>({
                 ) {
                   return null;
                 }
+
                 return (
                   <div className="relative" key={folder.id}>
                     <Folder

--- a/apps/chat/src/components/Files/SelectFolderModal.tsx
+++ b/apps/chat/src/components/Files/SelectFolderModal.tsx
@@ -127,6 +127,7 @@ export const SelectFolderModal = ({
             newAddedFolderId: newFolderId,
             loadingFolderIds: loadingFolderIds,
             featureType: FeatureType.File,
+            isSidePanelFolder: false,
           }}
           handleFolderSelect={handleFolderSelect}
           isAllEntitiesOpened={isAllFilesOpened}

--- a/apps/chat/src/components/Folder/Folder.tsx
+++ b/apps/chat/src/components/Folder/Folder.tsx
@@ -117,6 +117,7 @@ export interface FolderProps<T, P = unknown> {
   noCaretIcon?: boolean;
   itemComponentClassNames?: string;
   canAttachFolders?: boolean;
+  isSidePanelFolder?: boolean;
 }
 
 const Folder = <T extends ConversationInfo | PromptInfo | DialFile>({
@@ -152,6 +153,7 @@ const Folder = <T extends ConversationInfo | PromptInfo | DialFile>({
   noCaretIcon = false,
   itemComponentClassNames,
   canAttachFolders = false,
+  isSidePanelFolder = true,
 }: FolderProps<T>) => {
   const { t } = useTranslation(Translation.Chat);
   const dispatch = useAppDispatch();
@@ -970,6 +972,7 @@ const Folder = <T extends ConversationInfo | PromptInfo | DialFile>({
                     onUpload={onFileUpload && onUpload}
                     isOpen={isContextMenu}
                     isEmpty={!hasChildItemOnAnyLevel}
+                    isSidePanelFolder={isSidePanelFolder}
                   />
                 </div>
               )}

--- a/apps/chat/src/constants/folders.ts
+++ b/apps/chat/src/constants/folders.ts
@@ -1,6 +1,8 @@
+import { translate } from '../utils/app/translation';
+
 export const MAX_CONVERSATION_AND_PROMPT_FOLDERS_DEPTH = 3;
 
-export const PUBLISHING_FOLDER_NAME = 'Organization';
+export const PUBLISHING_FOLDER_NAME = translate('Organization');
 
 export const PUBLISHING_APPROVE_REQUIRED_NAME = 'Approve required';
 


### PR DESCRIPTION
**Description:**

hide unpublish option from change path dialog

Issues:

- #1501 

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
