### PR TITLE
fix(chat): Fix long list outdise (Issue #1446)

### DIFF
--- a/apps/chat/src/pages/index.tsx
+++ b/apps/chat/src/pages/index.tsx
@@ -235,7 +235,7 @@ export default function Home({ initialState }: HomeProps) {
                   <Chatbar />
                 )}
 
-                <div className="flex min-w-0 grow flex-col">
+                <div className="flex min-w-0 grow flex-col overflow-y-auto">
                   <AnnouncementsBanner />
                   <Chat />
 


### PR DESCRIPTION
**Description:**

Long list of chats/files is displayed outside the publish request details form
When the message “Welcome to [AI Dial](about:blank)! ..." the middle column descends below the side columns

Issues:

- Issue #1446 

**UI changes**

Before:
<img width="880" alt="Снимок экрана 2024-06-03 в 13 07 43" src="https://github.com/epam/ai-dial-chat/assets/82438895/4f1dc66b-5ea9-4432-afe8-350c710a5bb9">
<img width="1510" alt="Снимок экрана 2024-06-05 в 20 47 00" src="https://github.com/epam/ai-dial-chat/assets/82438895/cf2106df-ecca-4dfb-8137-cccd94df2c4d">

After:
<img width="823" alt="Снимок экрана 2024-06-03 в 13 08 09" src="https://github.com/epam/ai-dial-chat/assets/82438895/8d680de2-3f0f-4875-80fd-928caf7c618f">
<img width="1512" alt="Снимок экрана 2024-06-05 в 20 46 09" src="https://github.com/epam/ai-dial-chat/assets/82438895/ba897e43-b38b-466b-9dbb-d836f23cff8f">


**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
