### PR TITLE
fix(chat): fix Markdown-inline images encoded as Data URLs (Issue #1518)

### DIFF
--- a/apps/chat/src/components/Chat/Publish/PublishWizard.tsx
+++ b/apps/chat/src/components/Chat/Publish/PublishWizard.tsx
@@ -372,7 +372,7 @@ export function PublishModal({
                       contentClassName="sm:max-w-[400px] max-w-[250px] break-all"
                       triggerClassName="truncate whitespace-pre"
                     >
-                      {constructPath(t(PUBLISHING_FOLDER_NAME), path)}
+                      {constructPath(PUBLISHING_FOLDER_NAME, path)}
                     </Tooltip>
                     <span className="text-accent-primary">{t('Change')}</span>
                   </div>

--- a/apps/chat/src/components/Folder/Folder.tsx
+++ b/apps/chat/src/components/Folder/Folder.tsx
@@ -1052,6 +1052,7 @@ const Folder = <T extends ConversationInfo | PromptInfo | DialFile>({
                     withBorderHighlight={withBorderHighlight}
                     itemComponentClassNames={itemComponentClassNames}
                     canAttachFolders={canAttachFolders}
+                    isSidePanelFolder={isSidePanelFolder}
                   />
                 </Fragment>
               );

--- a/apps/chat/src/utils/app/attachments.ts
+++ b/apps/chat/src/utils/app/attachments.ts
@@ -4,9 +4,17 @@ export const getMappedAttachmentUrl = (url: string | undefined) => {
   if (!url) {
     return undefined;
   }
-  return url.startsWith('data:') ||
-    url.startsWith('//') ||
-    url.startsWith('http')
+  const urlLower = url.toLowerCase();
+  return [
+    'data:',
+    '//',
+    'http://',
+    'https://',
+    'file://',
+    'ftp://',
+    'mailto:',
+    'telnet://',
+  ].some((prefix) => urlLower.startsWith(prefix))
     ? url
     : `api/${url}`;
 };

--- a/apps/chat/src/utils/app/attachments.ts
+++ b/apps/chat/src/utils/app/attachments.ts
@@ -4,7 +4,11 @@ export const getMappedAttachmentUrl = (url: string | undefined) => {
   if (!url) {
     return undefined;
   }
-  return url.startsWith('//') || url.startsWith('http') ? url : `api/${url}`;
+  return url.startsWith('data:') ||
+    url.startsWith('//') ||
+    url.startsWith('http')
+    ? url
+    : `api/${url}`;
 };
 
 export const getMappedAttachment = (attachment: Attachment): Attachment => {


### PR DESCRIPTION
**Description:**

 fix Markdown-inline images encoded as Data URLs

Issues:

- Issue #1518 

**UI changes**

![image](https://github.com/epam/ai-dial-chat/assets/20163971/96de8794-a353-4cf5-8b93-a630e70c6978)

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
