### PR TITLE
fix(chat): fix request api key fields reset (Issue #1524)

### DIFF
--- a/apps/chat/src/components/Chat/RequestApiKeyDialog.tsx
+++ b/apps/chat/src/components/Chat/RequestApiKeyDialog.tsx
@@ -142,7 +142,7 @@ export const RequestAPIKeyDialog: FC<Props> = ({ isOpen, onClose }) => {
 
   useEffect(() => {
     if (isSuccessfullySent) {
-      dispatch(ServiceActions.resetIsSuccessfullySent);
+      dispatch(ServiceActions.resetIsSuccessfullySent());
 
       setScenario('');
       setBusinessJustification('');


### PR DESCRIPTION
**Description:**

fix request api key fields reset

Issues:

- #1524

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
