### PR TITLE
fix(chat): reuse isAbsoluteUrl logic (Issue #1518)

### DIFF
--- a/apps/chat/src/pages/api/themes/image.ts
+++ b/apps/chat/src/pages/api/themes/image.ts
@@ -1,6 +1,6 @@
 import { NextApiRequest, NextApiResponse } from 'next';
 
-import { isAbsoluteUrl } from '@/src/utils/app/attachments';
+import { isAbsoluteUrl } from '@/src/utils/app/file';
 import { logger } from '@/src/utils/server/logger';
 
 import { ThemesConfig } from '@/src/types/themes';

--- a/apps/chat/src/pages/api/themes/image.ts
+++ b/apps/chat/src/pages/api/themes/image.ts
@@ -1,5 +1,6 @@
 import { NextApiRequest, NextApiResponse } from 'next';
 
+import { isAbsoluteUrl } from '@/src/utils/app/attachments';
 import { logger } from '@/src/utils/server/logger';
 
 import { ThemesConfig } from '@/src/types/themes';
@@ -33,7 +34,7 @@ const getImage = async (
   }
 
   let finalUrl = imageUrl;
-  if (!finalUrl.startsWith('http') && !finalUrl.startsWith('//')) {
+  if (!isAbsoluteUrl(finalUrl)) {
     finalUrl = `${process.env.THEMES_CONFIG_HOST}/${finalUrl}`;
   }
   const response = await fetch(finalUrl);

--- a/apps/chat/src/pages/api/themes/styles.ts
+++ b/apps/chat/src/pages/api/themes/styles.ts
@@ -1,6 +1,6 @@
 import { NextApiRequest, NextApiResponse } from 'next';
 
-import { isAbsoluteUrl } from '@/src/utils/app/attachments';
+import { isAbsoluteUrl } from '@/src/utils/app/file';
 import { logger } from '@/src/utils/server/logger';
 
 import { ThemesConfig } from '@/src/types/themes';

--- a/apps/chat/src/pages/api/themes/styles.ts
+++ b/apps/chat/src/pages/api/themes/styles.ts
@@ -1,5 +1,6 @@
 import { NextApiRequest, NextApiResponse } from 'next';
 
+import { isAbsoluteUrl } from '@/src/utils/app/attachments';
 import { logger } from '@/src/utils/server/logger';
 
 import { ThemesConfig } from '@/src/types/themes';
@@ -46,7 +47,7 @@ function generateUrlsCssVariables(
       return;
     }
     let compiledValue = value;
-    if (!value.startsWith('http') && !value.startsWith('//')) {
+    if (!isAbsoluteUrl(value)) {
       compiledValue = `${process.env.THEMES_CONFIG_HOST}/${value}`;
     }
     cssContent += `--${cssEscape(variable)}: url('${compiledValue}');\n`;

--- a/apps/chat/src/utils/app/__tests__/file.test.ts
+++ b/apps/chat/src/utils/app/__tests__/file.test.ts
@@ -1,12 +1,13 @@
 import { isAbsoluteUrl } from '../file';
 
-describe.skip('File utility methods', () => {
+describe('File utility methods', () => {
   it.each([
     ['http://test.com'],
     ['https://test.com'],
     ['ftp://test.com'],
     ['file://test.com'],
     ['data:some_data'],
+    ['//abc/cde'],
   ])('isAbsoluteUrl (%s, %s, %s, %s) returns true', (url) => {
     expect(isAbsoluteUrl(url)).toBe(true);
   });

--- a/apps/chat/src/utils/app/__tests__/file.test.ts
+++ b/apps/chat/src/utils/app/__tests__/file.test.ts
@@ -1,0 +1,20 @@
+import { isAbsoluteUrl } from '../file';
+
+describe.skip('File utility methods', () => {
+  it.each([
+    ['http://test.com'],
+    ['https://test.com'],
+    ['ftp://test.com'],
+    ['file://test.com'],
+    ['data:some_data'],
+  ])('isAbsoluteUrl (%s, %s, %s, %s) returns true', (url) => {
+    expect(isAbsoluteUrl(url)).toBe(true);
+  });
+
+  it.each([['/test/test1'], ['abc'], ['abc/cde'], ['1/2/3']])(
+    'isAbsoluteUrl (%s, %s, %s, %s) returns false',
+    (url) => {
+      expect(isAbsoluteUrl(url)).toBe(false);
+    },
+  );
+});

--- a/apps/chat/src/utils/app/attachments.ts
+++ b/apps/chat/src/utils/app/attachments.ts
@@ -1,18 +1,6 @@
-import { Attachment } from '@/src/types/chat';
+import { isAbsoluteUrl } from '@/src/utils/app/file';
 
-export const isAbsoluteUrl = (url: string): boolean => {
-  const urlLower = url.toLowerCase();
-  return [
-    'data:',
-    '//',
-    'http://',
-    'https://',
-    'file://',
-    'ftp://',
-    'mailto:',
-    'telnet://',
-  ].some((prefix) => urlLower.startsWith(prefix));
-};
+import { Attachment } from '@/src/types/chat';
 
 export const getMappedAttachmentUrl = (url: string | undefined) => {
   if (!url) {

--- a/apps/chat/src/utils/app/attachments.ts
+++ b/apps/chat/src/utils/app/attachments.ts
@@ -1,9 +1,6 @@
 import { Attachment } from '@/src/types/chat';
 
-export const getMappedAttachmentUrl = (url: string | undefined) => {
-  if (!url) {
-    return undefined;
-  }
+export const isAbsoluteUrl = (url: string): boolean => {
   const urlLower = url.toLowerCase();
   return [
     'data:',
@@ -14,9 +11,14 @@ export const getMappedAttachmentUrl = (url: string | undefined) => {
     'ftp://',
     'mailto:',
     'telnet://',
-  ].some((prefix) => urlLower.startsWith(prefix))
-    ? url
-    : `api/${url}`;
+  ].some((prefix) => urlLower.startsWith(prefix));
+};
+
+export const getMappedAttachmentUrl = (url: string | undefined) => {
+  if (!url) {
+    return undefined;
+  }
+  return isAbsoluteUrl(url) ? url : `api/${url}`;
 };
 
 export const getMappedAttachment = (attachment: Attachment): Attachment => {

--- a/apps/chat/src/utils/app/clean.ts
+++ b/apps/chat/src/utils/app/clean.ts
@@ -1,3 +1,5 @@
+import { isAbsoluteUrl } from '@/src/utils/app/file';
+
 import {
   Attachment,
   Conversation,
@@ -15,7 +17,6 @@ import {
   FALLBACK_MODEL_ID,
 } from '@/src/constants/default-ui-settings';
 
-import { isAbsoluteUrl } from './attachments';
 import { prepareEntityName } from './common';
 import { constructPath } from './file';
 import { getConversationRootId } from './id';

--- a/apps/chat/src/utils/app/clean.ts
+++ b/apps/chat/src/utils/app/clean.ts
@@ -15,17 +15,17 @@ import {
   FALLBACK_MODEL_ID,
 } from '@/src/constants/default-ui-settings';
 
+import { isAbsoluteUrl } from './attachments';
 import { prepareEntityName } from './common';
 import { constructPath } from './file';
 import { getConversationRootId } from './id';
-import { isAbsoluteUrl } from './attachments';
 
 const migrateAttachmentUrls = (attachment: Attachment): Attachment => {
   const getNewAttachmentUrl = (url: string | undefined): string | undefined =>
     url &&
     !url.startsWith('metadata') &&
     !url.startsWith('files') &&
-    !isAbsoluteUrl(url) &&
+    !isAbsoluteUrl(url)
       ? constructPath('files', url)
       : url;
 

--- a/apps/chat/src/utils/app/clean.ts
+++ b/apps/chat/src/utils/app/clean.ts
@@ -18,14 +18,14 @@ import {
 import { prepareEntityName } from './common';
 import { constructPath } from './file';
 import { getConversationRootId } from './id';
+import { isAbsoluteUrl } from './attachments';
 
 const migrateAttachmentUrls = (attachment: Attachment): Attachment => {
   const getNewAttachmentUrl = (url: string | undefined): string | undefined =>
     url &&
     !url.startsWith('metadata') &&
     !url.startsWith('files') &&
-    !url.startsWith('http') &&
-    !url.startsWith('//')
+    !isAbsoluteUrl(url) &&
       ? constructPath('files', url)
       : url;
 

--- a/apps/chat/src/utils/app/file.ts
+++ b/apps/chat/src/utils/app/file.ts
@@ -8,6 +8,7 @@ import { FolderInterface, FolderType } from '@/src/types/folder';
 import { FOLDER_ATTACHMENT_CONTENT_TYPE } from '@/src/constants/folders';
 
 import { ApiUtils } from '../server/api';
+import { isAbsoluteUrl } from './attachments';
 import { doesHaveDotsInTheEnd } from './common';
 import { getPathToFolderById } from './folders';
 import { isFolderId } from './id';
@@ -172,8 +173,7 @@ const parseAttachmentUrl = (url: string) => {
   };
 };
 
-export const isAttachmentLink = (url: string): boolean =>
-  url.startsWith('http') || url.startsWith('//');
+export const isAttachmentLink = (url: string): boolean => isAbsoluteUrl(url);
 
 export const getDialFilesFromAttachments = (
   attachments: Attachment[] | undefined,

--- a/apps/chat/src/utils/app/file.ts
+++ b/apps/chat/src/utils/app/file.ts
@@ -8,7 +8,6 @@ import { FolderInterface, FolderType } from '@/src/types/folder';
 import { FOLDER_ATTACHMENT_CONTENT_TYPE } from '@/src/constants/folders';
 
 import { ApiUtils } from '../server/api';
-import { isAbsoluteUrl } from './attachments';
 import { doesHaveDotsInTheEnd } from './common';
 import { getPathToFolderById } from './folders';
 import { isFolderId } from './id';
@@ -416,3 +415,17 @@ export const getNextFileName = (
 
 export const prepareFileName = (filename: string) =>
   `${getFileNameWithoutExtension(filename)}${getFileNameExtension(filename)}`;
+
+export const isAbsoluteUrl = (url: string): boolean => {
+  const urlLower = url.toLowerCase();
+  return [
+    'data:',
+    '//',
+    'http://',
+    'https://',
+    'file://',
+    'ftp://',
+    'mailto:',
+    'telnet://',
+  ].some((prefix) => urlLower.startsWith(prefix));
+};


### PR DESCRIPTION
**Description:**

reuse isAbsoluteUrl logic

Related to:

- Issue #1518 
- Issue #1158 

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
