### PR TITLE
fix(chat): fix opening two prompt dialogs for unpublish request (Issue #1515)

### DIFF
--- a/apps/chat/src/components/Chat/Publish/ApproveRequiredSection.tsx
+++ b/apps/chat/src/components/Chat/Publish/ApproveRequiredSection.tsx
@@ -109,8 +109,8 @@ const PublicationItem = ({ publication, featureType }: PublicationProps) => {
           </div>
         </div>
       </div>
-      {isOpen && publication.resources && (
-        <ResourcesComponent resources={publication.resources} />
+      {publication.resources && (
+        <ResourcesComponent resources={publication.resources} isOpen={isOpen} />
       )}
     </div>
   );

--- a/apps/chat/src/components/Chat/Publish/HandlePublication.tsx
+++ b/apps/chat/src/components/Chat/Publish/HandlePublication.tsx
@@ -163,6 +163,7 @@ export function HandlePublication({ publication }: Props) {
           promptId: promptsToReviewIds.length
             ? promptsToReviewIds[0].reviewUrl
             : reviewedPromptsIds[0].reviewUrl,
+          isPublicationResource: true,
         }),
       );
       dispatch(

--- a/apps/chat/src/components/Chat/Publish/HandlePublication.tsx
+++ b/apps/chat/src/components/Chat/Publish/HandlePublication.tsx
@@ -345,6 +345,7 @@ export function HandlePublication({ publication }: Props) {
                       <Component
                         resources={publication.resources}
                         forViewOnly
+                        isOpen
                       />
                     </CollapsibleSection>
                   ),

--- a/apps/chat/src/components/Chat/Publish/HandlePublication.tsx
+++ b/apps/chat/src/components/Chat/Publish/HandlePublication.tsx
@@ -345,7 +345,6 @@ export function HandlePublication({ publication }: Props) {
                       <Component
                         resources={publication.resources}
                         forViewOnly
-                        isOpen
                       />
                     </CollapsibleSection>
                   ),

--- a/apps/chat/src/components/Chat/Publish/PublicationChatControls.tsx
+++ b/apps/chat/src/components/Chat/Publish/PublicationChatControls.tsx
@@ -65,6 +65,7 @@ export function PublicationControlsView<
         dispatch(
           PromptsActions.setSelectedPrompt({
             promptId: resourcesToReview[publicationIdx + offset].reviewUrl,
+            isPublicationResource: true,
           }),
         );
       }

--- a/apps/chat/src/components/Chat/Publish/PublicationResources.tsx
+++ b/apps/chat/src/components/Chat/Publish/PublicationResources.tsx
@@ -58,6 +58,9 @@ export const PromptPublicationResources = ({
     PromptsSelectors.selectSelectedPromptFoldersIds,
   );
   const allFolders = useAppSelector(PromptsSelectors.selectFolders);
+  const { isSelectedPublicationResource } = useAppSelector(
+    PromptsSelectors.selectSelectedPromptId,
+  );
 
   const resourceUrls = useMemo(
     () => resources.map((r) => r.reviewUrl),
@@ -122,7 +125,11 @@ export const PromptPublicationResources = ({
               }
             }}
             featureType={FeatureType.Prompt}
-            highlightedFolders={forViewOnly ? undefined : highlightedFolders}
+            highlightedFolders={
+              !isSelectedPublicationResource || forViewOnly
+                ? undefined
+                : highlightedFolders
+            }
             folderClassName={classNames(forViewOnly && 'h-[38px]')}
             itemComponentClassNames={classNames(
               forViewOnly && 'cursor-pointer',

--- a/apps/chat/src/components/Chat/Publish/PublicationResources.tsx
+++ b/apps/chat/src/components/Chat/Publish/PublicationResources.tsx
@@ -125,6 +125,7 @@ export const PromptPublicationResources = ({
             itemComponentClassNames={classNames(
               forViewOnly && 'cursor-pointer',
             )}
+            additionalItemData={{ isPublicationResource: true }}
           />
         );
       })}
@@ -137,7 +138,12 @@ export const PromptPublicationResources = ({
             level={0}
           />
         ) : (
-          <PromptComponent key={p.id} item={p} level={1} />
+          <PromptComponent
+            key={p.id}
+            item={p}
+            level={1}
+            additionalItemData={{ isPublicationResource: true }}
+          />
         ),
       )}
     </>

--- a/apps/chat/src/components/Chat/Publish/PublicationResources.tsx
+++ b/apps/chat/src/components/Chat/Publish/PublicationResources.tsx
@@ -38,14 +38,14 @@ interface PublicationResources {
   resources: PublicationResource[];
   forViewOnly?: boolean;
   rootFolder?: ShareEntity;
-  isOpen: boolean;
+  isOpen?: boolean;
 }
 
 export const PromptPublicationResources = ({
   resources,
   forViewOnly,
   rootFolder,
-  isOpen,
+  isOpen = true,
 }: PublicationResources) => {
   const dispatch = useAppDispatch();
 
@@ -156,7 +156,7 @@ export const ConversationPublicationResources = ({
   resources,
   forViewOnly,
   rootFolder,
-  isOpen,
+  isOpen = true,
 }: PublicationResources) => {
   const dispatch = useAppDispatch();
 
@@ -265,6 +265,7 @@ export const FilePublicationResources = ({
   resources,
   forViewOnly,
   uploadedFiles,
+  isOpen = true,
 }: PublicationResources & { uploadedFiles?: DialFile[] }) => {
   const dispatch = useAppDispatch();
 
@@ -308,7 +309,7 @@ export const FilePublicationResources = ({
   }, [allFolders, resources]);
 
   return (
-    <>
+    <div className={classNames(!isOpen && 'hidden')}>
       {rootFolders.filter(Boolean).map((f) => {
         return (
           <Folder
@@ -349,6 +350,6 @@ export const FilePublicationResources = ({
           <FileItem key={f.id} item={f} level={1} />
         ),
       )}
-    </>
+    </div>
   );
 };

--- a/apps/chat/src/components/Chat/Publish/PublicationResources.tsx
+++ b/apps/chat/src/components/Chat/Publish/PublicationResources.tsx
@@ -38,12 +38,14 @@ interface PublicationResources {
   resources: PublicationResource[];
   forViewOnly?: boolean;
   rootFolder?: ShareEntity;
+  isOpen: boolean;
 }
 
 export const PromptPublicationResources = ({
   resources,
   forViewOnly,
   rootFolder,
+  isOpen,
 }: PublicationResources) => {
   const dispatch = useAppDispatch();
 
@@ -90,7 +92,7 @@ export const PromptPublicationResources = ({
   }, [allFolders, resources, rootFolder]);
 
   return (
-    <>
+    <div className={classNames(!isOpen && 'hidden')}>
       {rootFolders.filter(Boolean).map((f) => {
         return (
           <Folder
@@ -146,7 +148,7 @@ export const PromptPublicationResources = ({
           />
         ),
       )}
-    </>
+    </div>
   );
 };
 
@@ -154,6 +156,7 @@ export const ConversationPublicationResources = ({
   resources,
   forViewOnly,
   rootFolder,
+  isOpen,
 }: PublicationResources) => {
   const dispatch = useAppDispatch();
 
@@ -202,7 +205,7 @@ export const ConversationPublicationResources = ({
   }, [allFolders, resources, rootFolder]);
 
   return (
-    <>
+    <div className={classNames(!isOpen && 'hidden')}>
       {rootFolders.filter(Boolean).map((f) => {
         return (
           <Folder
@@ -254,7 +257,7 @@ export const ConversationPublicationResources = ({
           <ConversationComponent key={c.id} item={c} level={1} />
         ),
       )}
-    </>
+    </div>
   );
 };
 

--- a/apps/chat/src/components/Promptbar/components/Prompt.tsx
+++ b/apps/chat/src/components/Promptbar/components/Prompt.tsx
@@ -60,9 +60,14 @@ import { PreviewPromptModal } from './PreviewPromptModal';
 interface Props {
   item: PromptInfo;
   level?: number;
+  additionalItemData?: Record<string, unknown>;
 }
 
-export const PromptComponent = ({ item: prompt, level }: Props) => {
+export const PromptComponent = ({
+  item: prompt,
+  level,
+  additionalItemData,
+}: Props) => {
   const dispatch = useAppDispatch();
 
   const { t } = useTranslation(Translation.Chat);
@@ -75,10 +80,12 @@ export const PromptComponent = ({ item: prompt, level }: Props) => {
       true,
     ),
   );
-  const selectedPromptId = useAppSelector(
+  const { selectedPromptId, isPublicationResource } = useAppSelector(
     PromptsSelectors.selectSelectedPromptId,
   );
-  const isSelected = selectedPromptId === prompt.id;
+  const isSelected =
+    selectedPromptId === prompt.id &&
+    !!additionalItemData?.isPublicationResource === isPublicationResource;
 
   const isExternal = useAppSelector((state) =>
     isEntityOrParentsExternal(state, prompt, FeatureType.Prompt),
@@ -379,23 +386,29 @@ export const PromptComponent = ({ item: prompt, level }: Props) => {
             />
           )}
         </div>
-        {showModal && isSelected && isModalPreviewMode && (
-          <PreviewPromptModal
-            prompt={prompt}
-            isOpen
-            isPublicationPreview={!!resourceToReview}
-            onClose={handleClose}
-            onDuplicate={
-              !resourceToReview
-                ? (e) => {
-                    handleDuplicate(e);
-                    handleClose();
-                  }
-                : undefined
-            }
-            onDelete={!resourceToReview ? () => setIsDeleting(true) : undefined}
-          />
-        )}
+        {showModal &&
+          isSelected &&
+          isModalPreviewMode &&
+          !!additionalItemData?.isPublicationResource ===
+            isPublicationResource && (
+            <PreviewPromptModal
+              prompt={prompt}
+              isOpen
+              isPublicationPreview={!!resourceToReview}
+              onClose={handleClose}
+              onDuplicate={
+                !resourceToReview
+                  ? (e) => {
+                      handleDuplicate(e);
+                      handleClose();
+                    }
+                  : undefined
+              }
+              onDelete={
+                !resourceToReview ? () => setIsDeleting(true) : undefined
+              }
+            />
+          )}
       </div>
 
       {isPublishing && (

--- a/apps/chat/src/components/Promptbar/components/Prompt.tsx
+++ b/apps/chat/src/components/Promptbar/components/Prompt.tsx
@@ -198,11 +198,16 @@ export const PromptComponent = ({
       e.stopPropagation();
       e.preventDefault();
       setIsRenaming(true);
-      dispatch(PromptsActions.setSelectedPrompt({ promptId: prompt.id }));
+      dispatch(
+        PromptsActions.setSelectedPrompt({
+          promptId: prompt.id,
+          isPublicationResource: !!additionalItemData?.isPublicationResource,
+        }),
+      );
       dispatch(PromptsActions.uploadPrompt({ promptId: prompt.id }));
       dispatch(PromptsActions.setIsEditModalOpen({ isOpen: true, isPreview }));
     },
-    [dispatch, prompt.id],
+    [additionalItemData?.isPublicationResource, dispatch, prompt.id],
   );
 
   const handleExportPrompt = useCallback(

--- a/apps/chat/src/components/Promptbar/components/Prompt.tsx
+++ b/apps/chat/src/components/Promptbar/components/Prompt.tsx
@@ -83,10 +83,10 @@ export const PromptComponent = ({
   const { selectedPromptId, isSelectedPublicationResource } = useAppSelector(
     PromptsSelectors.selectSelectedPromptId,
   );
+  const isPublicationResource = !!additionalItemData?.isPublicationResource;
   const isSelected =
     selectedPromptId === prompt.id &&
-    !!additionalItemData?.isPublicationResource ===
-      isSelectedPublicationResource;
+    isPublicationResource === isSelectedPublicationResource;
 
   const isExternal = useAppSelector((state) =>
     isEntityOrParentsExternal(state, prompt, FeatureType.Prompt),
@@ -201,13 +201,13 @@ export const PromptComponent = ({
       dispatch(
         PromptsActions.setSelectedPrompt({
           promptId: prompt.id,
-          isPublicationResource: !!additionalItemData?.isPublicationResource,
+          isPublicationResource,
         }),
       );
       dispatch(PromptsActions.uploadPrompt({ promptId: prompt.id }));
       dispatch(PromptsActions.setIsEditModalOpen({ isOpen: true, isPreview }));
     },
-    [additionalItemData?.isPublicationResource, dispatch, prompt.id],
+    [dispatch, isPublicationResource, prompt.id],
   );
 
   const handleExportPrompt = useCallback(
@@ -395,8 +395,7 @@ export const PromptComponent = ({
         {showModal &&
           isSelected &&
           isModalPreviewMode &&
-          !!additionalItemData?.isPublicationResource ===
-            isSelectedPublicationResource && (
+          isPublicationResource === isSelectedPublicationResource && (
             <PreviewPromptModal
               prompt={prompt}
               isOpen

--- a/apps/chat/src/components/Promptbar/components/Prompt.tsx
+++ b/apps/chat/src/components/Promptbar/components/Prompt.tsx
@@ -80,12 +80,13 @@ export const PromptComponent = ({
       true,
     ),
   );
-  const { selectedPromptId, isPublicationResource } = useAppSelector(
+  const { selectedPromptId, isSelectedPublicationResource } = useAppSelector(
     PromptsSelectors.selectSelectedPromptId,
   );
   const isSelected =
     selectedPromptId === prompt.id &&
-    !!additionalItemData?.isPublicationResource === isPublicationResource;
+    !!additionalItemData?.isPublicationResource ===
+      isSelectedPublicationResource;
 
   const isExternal = useAppSelector((state) =>
     isEntityOrParentsExternal(state, prompt, FeatureType.Prompt),
@@ -390,7 +391,7 @@ export const PromptComponent = ({
           isSelected &&
           isModalPreviewMode &&
           !!additionalItemData?.isPublicationResource ===
-            isPublicationResource && (
+            isSelectedPublicationResource && (
             <PreviewPromptModal
               prompt={prompt}
               isOpen

--- a/apps/chat/src/components/Promptbar/components/Prompt.tsx
+++ b/apps/chat/src/components/Promptbar/components/Prompt.tsx
@@ -392,28 +392,23 @@ export const PromptComponent = ({
             />
           )}
         </div>
-        {showModal &&
-          isSelected &&
-          isModalPreviewMode &&
-          isPublicationResource === isSelectedPublicationResource && (
-            <PreviewPromptModal
-              prompt={prompt}
-              isOpen
-              isPublicationPreview={!!resourceToReview}
-              onClose={handleClose}
-              onDuplicate={
-                !resourceToReview
-                  ? (e) => {
-                      handleDuplicate(e);
-                      handleClose();
-                    }
-                  : undefined
-              }
-              onDelete={
-                !resourceToReview ? () => setIsDeleting(true) : undefined
-              }
-            />
-          )}
+        {showModal && isSelected && isModalPreviewMode && (
+          <PreviewPromptModal
+            prompt={prompt}
+            isOpen
+            isPublicationPreview={!!resourceToReview}
+            onClose={handleClose}
+            onDuplicate={
+              !resourceToReview
+                ? (e) => {
+                    handleDuplicate(e);
+                    handleClose();
+                  }
+                : undefined
+            }
+            onDelete={!resourceToReview ? () => setIsDeleting(true) : undefined}
+          />
+        )}
       </div>
 
       {isPublishing && (

--- a/apps/chat/src/components/Promptbar/components/PromptFolders.tsx
+++ b/apps/chat/src/components/Promptbar/components/PromptFolders.tsx
@@ -249,7 +249,7 @@ export const PromptSection = ({
   const selectedFoldersIds = useAppSelector(
     PromptsSelectors.selectSelectedPromptFoldersIds,
   );
-  const { selectedPromptId, isPublicationResource } = useAppSelector(
+  const { selectedPromptId, isSelectedPublicationResource } = useAppSelector(
     PromptsSelectors.selectSelectedPromptId,
   );
 
@@ -264,7 +264,7 @@ export const PromptSection = ({
     const shouldBeHighlighted =
       rootFolders.some((folder) => selectedFoldersIds.includes(folder.id)) ||
       (!!displayRootFiles &&
-        !isPublicationResource &&
+        !isSelectedPublicationResource &&
         rootPrompts.some(({ id }) => selectedPromptId === id));
     if (isSectionHighlighted !== shouldBeHighlighted) {
       setIsSectionHighlighted(shouldBeHighlighted);
@@ -276,7 +276,7 @@ export const PromptSection = ({
     selectedPromptId,
     selectedFoldersIds,
     rootPrompts,
-    isPublicationResource,
+    isSelectedPublicationResource,
   ]);
 
   if (

--- a/apps/chat/src/components/Promptbar/components/PromptFolders.tsx
+++ b/apps/chat/src/components/Promptbar/components/PromptFolders.tsx
@@ -262,10 +262,10 @@ export const PromptSection = ({
 
   useEffect(() => {
     const shouldBeHighlighted =
-      rootFolders.some((folder) => selectedFoldersIds.includes(folder.id)) ||
-      (!!displayRootFiles &&
-        !isSelectedPublicationResource &&
-        rootPrompts.some(({ id }) => selectedPromptId === id));
+      !isSelectedPublicationResource &&
+      (rootFolders.some((folder) => selectedFoldersIds.includes(folder.id)) ||
+        (!!displayRootFiles &&
+          rootPrompts.some(({ id }) => selectedPromptId === id)));
     if (isSectionHighlighted !== shouldBeHighlighted) {
       setIsSectionHighlighted(shouldBeHighlighted);
     }

--- a/apps/chat/src/components/Promptbar/components/PromptFolders.tsx
+++ b/apps/chat/src/components/Promptbar/components/PromptFolders.tsx
@@ -249,7 +249,7 @@ export const PromptSection = ({
   const selectedFoldersIds = useAppSelector(
     PromptsSelectors.selectSelectedPromptFoldersIds,
   );
-  const selectSelectedPromptId = useAppSelector(
+  const { selectedPromptId, isPublicationResource } = useAppSelector(
     PromptsSelectors.selectSelectedPromptId,
   );
 
@@ -264,7 +264,8 @@ export const PromptSection = ({
     const shouldBeHighlighted =
       rootFolders.some((folder) => selectedFoldersIds.includes(folder.id)) ||
       (!!displayRootFiles &&
-        rootPrompts.some(({ id }) => selectSelectedPromptId === id));
+        !isPublicationResource &&
+        rootPrompts.some(({ id }) => selectedPromptId === id));
     if (isSectionHighlighted !== shouldBeHighlighted) {
       setIsSectionHighlighted(shouldBeHighlighted);
     }
@@ -272,9 +273,10 @@ export const PromptSection = ({
     displayRootFiles,
     rootFolders,
     isSectionHighlighted,
-    selectSelectedPromptId,
+    selectedPromptId,
     selectedFoldersIds,
     rootPrompts,
+    isPublicationResource,
   ]);
 
   if (

--- a/apps/chat/src/components/Promptbar/components/PromptFolders.tsx
+++ b/apps/chat/src/components/Promptbar/components/PromptFolders.tsx
@@ -48,6 +48,7 @@ interface promptFolderProps {
   isLast: boolean;
   filters: EntityFilters;
   includeEmpty: boolean;
+  allowHighlight?: boolean;
 }
 
 const PromptFolderTemplate = ({
@@ -55,6 +56,7 @@ const PromptFolderTemplate = ({
   isLast,
   filters,
   includeEmpty = false,
+  allowHighlight = true,
 }: promptFolderProps) => {
   const { t } = useTranslation(Translation.SideBar);
 
@@ -184,7 +186,7 @@ const PromptFolderTemplate = ({
         allFolders={promptFolders}
         allFoldersWithoutFilters={allFolders}
         loadingFolderIds={loadingFolderIds}
-        highlightedFolders={highlightedFolders}
+        highlightedFolders={allowHighlight ? highlightedFolders : []}
         openedFoldersIds={openedFoldersIds}
         handleDrop={handleDrop}
         onRenameFolder={(name, folderId) => {
@@ -303,6 +305,7 @@ export const PromptSection = ({
             isLast={index === arr.length - 1}
             filters={{ searchFilter: filters.searchFilter }}
             includeEmpty={showEmptyFolders}
+            allowHighlight={!isSelectedPublicationResource}
           />
         ))}
       </div>

--- a/apps/chat/src/store/prompts/prompts.reducers.ts
+++ b/apps/chat/src/store/prompts/prompts.reducers.ts
@@ -30,6 +30,7 @@ const initialState: PromptsState = {
   searchTerm: '',
   searchFilters: SearchFilters.None,
   selectedPromptId: undefined,
+  isSelectedPromptPublicationResource: false,
   isEditModalOpen: false,
   isModalPreviewMode: false,
   newAddedFolderId: undefined,
@@ -326,9 +327,16 @@ export const promptsSlice = createSlice({
     },
     setSelectedPrompt: (
       state,
-      { payload }: PayloadAction<{ promptId: string | undefined }>,
+      {
+        payload,
+      }: PayloadAction<{
+        promptId: string | undefined;
+        isPublicationResource?: boolean;
+      }>,
     ) => {
       state.selectedPromptId = payload.promptId;
+      state.isSelectedPromptPublicationResource =
+        !!payload.isPublicationResource;
       state.isPromptLoading = !!payload.promptId;
     },
     uploadPrompt: (state, _action: PayloadAction<{ promptId: string }>) => {

--- a/apps/chat/src/store/prompts/prompts.selectors.ts
+++ b/apps/chat/src/store/prompts/prompts.selectors.ts
@@ -177,13 +177,16 @@ export const selectIsEditModalOpen = createSelector([rootSelector], (state) => {
 export const selectSelectedPromptId = createSelector(
   [rootSelector],
   (state) => {
-    return state.selectedPromptId;
+    return {
+      selectedPromptId: state.selectedPromptId,
+      isPublicationResource: state.isSelectedPromptPublicationResource,
+    };
   },
 );
 
 export const selectSelectedPrompt = createSelector(
   [selectPrompts, selectSelectedPromptId],
-  (prompts, selectedPromptId): Prompt | undefined => {
+  (prompts, { selectedPromptId }): Prompt | undefined => {
     if (!selectedPromptId) {
       return undefined;
     }

--- a/apps/chat/src/store/prompts/prompts.selectors.ts
+++ b/apps/chat/src/store/prompts/prompts.selectors.ts
@@ -179,7 +179,7 @@ export const selectSelectedPromptId = createSelector(
   (state) => {
     return {
       selectedPromptId: state.selectedPromptId,
-      isPublicationResource: state.isSelectedPromptPublicationResource,
+      isSelectedPublicationResource: state.isSelectedPromptPublicationResource,
     };
   },
 );

--- a/apps/chat/src/store/prompts/prompts.types.ts
+++ b/apps/chat/src/store/prompts/prompts.types.ts
@@ -9,6 +9,7 @@ export interface PromptsState {
   searchTerm: string;
   searchFilters: SearchFilters;
   selectedPromptId: string | undefined;
+  isSelectedPromptPublicationResource: boolean;
   isEditModalOpen: boolean;
   isModalPreviewMode: boolean;
   newAddedFolderId?: string;


### PR DESCRIPTION
**Description:**

fix opening two prompt dialogs for unpublish request

Issues:

- Issue #1515

**UI changes**

![image](https://github.com/epam/ai-dial-chat/assets/20163971/ff1908e6-c663-453d-992d-4afd96989440)

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
