### PR TITLE
fix(chat): remove empty folders from the publish request dialog and hide the publish button for folders containing only 'replay' chats (Issue #1504)

### DIFF
--- a/apps/chat/src/components/Chat/Publish/PublicationResources.tsx
+++ b/apps/chat/src/components/Chat/Publish/PublicationResources.tsx
@@ -1,12 +1,9 @@
-import { useMemo } from 'react';
-
 import classNames from 'classnames';
 
-import { isRootId } from '@/src/utils/app/id';
+import { usePublicationResources } from '@/src/hooks/usePublicationResources';
 
 import { FeatureType, ShareEntity, UploadStatus } from '@/src/types/common';
 import { DialFile } from '@/src/types/files';
-import { FolderInterface } from '@/src/types/folder';
 import { PublicationResource } from '@/src/types/publication';
 
 import {
@@ -31,8 +28,6 @@ import {
 } from '../../Common/ReplaceConfirmationModal/Components';
 import { FileItem } from '../../Files/FileItem';
 import Folder from '../../Folder/Folder';
-
-import uniqBy from 'lodash-es/uniqBy';
 
 interface PublicationResources {
   resources: PublicationResource[];
@@ -62,37 +57,8 @@ export const PromptPublicationResources = ({
     PromptsSelectors.selectSelectedPromptId,
   );
 
-  const resourceUrls = useMemo(
-    () => resources.map((r) => r.reviewUrl),
-    [resources],
-  );
-  const promptsToDisplay = useMemo(() => {
-    return prompts.filter(
-      (c) => c.folderId.split('/').length === 2 && resourceUrls.includes(c.id),
-    );
-  }, [prompts, resourceUrls]);
-  const folderPromptsToDisplay = useMemo(() => {
-    return prompts.filter(
-      (c) => c.folderId.split('/').length !== 2 && resourceUrls.includes(c.id),
-    );
-  }, [prompts, resourceUrls]);
-  const rootFolders = useMemo(() => {
-    if (rootFolder) return allFolders.filter((f) => f.id === rootFolder.id);
-
-    const folders = resources.map((resource) => {
-      const relevantFolders = allFolders.filter((folder) =>
-        resource.reviewUrl
-          ? resource.reviewUrl.startsWith(folder.id)
-          : resource.targetUrl.startsWith(folder.id),
-      );
-
-      return relevantFolders.find((folder) => isRootId(folder.folderId));
-    });
-
-    const existingFolders = folders.filter(Boolean) as FolderInterface[];
-
-    return uniqBy(existingFolders, 'id');
-  }, [allFolders, resources, rootFolder]);
+  const { rootFolders, itemsToDisplay, folderItemsToDisplay } =
+    usePublicationResources(allFolders, resources, prompts, rootFolder);
 
   return (
     <div className={classNames(!isOpen && 'hidden')}>
@@ -104,12 +70,16 @@ export const PromptPublicationResources = ({
             level={forViewOnly ? 0 : 1}
             key={f.id}
             currentFolder={f}
-            allFolders={allFolders}
+            allFolders={allFolders.filter((f) =>
+              folderItemsToDisplay.some((item) =>
+                item.id.startsWith(`${f.id}/`),
+              ),
+            )}
             searchTerm={forViewOnly ? '' : searchTerm}
             openedFoldersIds={
               forViewOnly ? allFolders.map((f) => f.id) : openedFoldersIds
             }
-            allItems={folderPromptsToDisplay}
+            allItems={folderItemsToDisplay}
             itemComponent={forViewOnly ? PromptsRow : PromptComponent}
             onClickFolder={(folderId: string) => {
               if (forViewOnly) return;
@@ -138,7 +108,7 @@ export const PromptPublicationResources = ({
           />
         );
       })}
-      {promptsToDisplay.map((p) =>
+      {itemsToDisplay.map((p) =>
         forViewOnly ? (
           <PromptsRow
             itemComponentClassNames="cursor-pointer"
@@ -179,37 +149,8 @@ export const ConversationPublicationResources = ({
     ConversationsSelectors.selectSelectedConversationsFoldersIds,
   );
 
-  const resourceUrls = useMemo(
-    () => resources.map((r) => r.reviewUrl),
-    [resources],
-  );
-  const conversationsToDisplay = useMemo(() => {
-    return conversations.filter(
-      (c) => c.folderId.split('/').length === 2 && resourceUrls.includes(c.id),
-    );
-  }, [conversations, resourceUrls]);
-  const folderConversationsToDisplay = useMemo(() => {
-    return conversations.filter(
-      (c) => c.folderId.split('/').length !== 2 && resourceUrls.includes(c.id),
-    );
-  }, [conversations, resourceUrls]);
-  const rootFolders = useMemo(() => {
-    if (rootFolder) return allFolders.filter((f) => f.id === rootFolder.id);
-
-    const folders = resources.map((resource) => {
-      const relevantFolders = allFolders.filter((folder) =>
-        resource.reviewUrl
-          ? resource.reviewUrl.startsWith(folder.id)
-          : resource.targetUrl.startsWith(folder.id),
-      );
-
-      return relevantFolders.find((folder) => isRootId(folder.folderId));
-    });
-
-    const existingFolders = folders.filter(Boolean) as FolderInterface[];
-
-    return uniqBy(existingFolders, 'id');
-  }, [allFolders, resources, rootFolder]);
+  const { rootFolders, itemsToDisplay, folderItemsToDisplay } =
+    usePublicationResources(allFolders, resources, conversations, rootFolder);
 
   return (
     <div className={classNames(!isOpen && 'hidden')}>
@@ -221,12 +162,16 @@ export const ConversationPublicationResources = ({
             level={forViewOnly ? 0 : 1}
             key={f.id}
             currentFolder={f}
-            allFolders={allFolders}
+            allFolders={allFolders.filter((f) =>
+              folderItemsToDisplay.some((item) =>
+                item.id.startsWith(`${f.id}/`),
+              ),
+            )}
             searchTerm={forViewOnly ? '' : searchTerm}
             openedFoldersIds={
               forViewOnly ? allFolders.map((f) => f.id) : openedFoldersIds
             }
-            allItems={folderConversationsToDisplay}
+            allItems={folderItemsToDisplay}
             itemComponent={
               forViewOnly ? ConversationRow : ConversationComponent
             }
@@ -252,7 +197,7 @@ export const ConversationPublicationResources = ({
           />
         );
       })}
-      {conversationsToDisplay.map((c) =>
+      {itemsToDisplay.map((c) =>
         forViewOnly ? (
           <ConversationRow
             itemComponentClassNames="cursor-pointer"
@@ -271,49 +216,23 @@ export const ConversationPublicationResources = ({
 export const FilePublicationResources = ({
   resources,
   forViewOnly,
+  // TODO: get rid of uploaded files in https://github.com/epam/ai-dial-chat/issues/1502
   uploadedFiles,
   isOpen = true,
-}: PublicationResources & { uploadedFiles?: DialFile[] }) => {
+}: PublicationResources & { uploadedFiles: DialFile[] }) => {
   const dispatch = useAppDispatch();
 
   const openedFoldersIds = useAppSelector((state) =>
-    UISelectors.selectOpenedFoldersIds(state, FeatureType.Chat),
+    UISelectors.selectOpenedFoldersIds(state, FeatureType.File),
   );
   const files = useAppSelector(FilesSelectors.selectFiles);
   const allFolders = useAppSelector(FilesSelectors.selectFolders);
 
-  const resourceUrls = useMemo(
-    () => resources.map((r) => r.reviewUrl),
-    [resources],
+  const { rootFolders, folderItemsToDisplay } = usePublicationResources(
+    allFolders,
+    resources,
+    files,
   );
-  const filesToDisplay = useMemo(() => {
-    return uploadedFiles
-      ? uploadedFiles
-      : files.filter(
-          (f) =>
-            f.folderId.split('/').length === 2 && resourceUrls.includes(f.id),
-        );
-  }, [files, uploadedFiles, resourceUrls]);
-  const folderFilesToDisplay = useMemo(() => {
-    return files.filter(
-      (c) => c.folderId.split('/').length !== 2 && resourceUrls.includes(c.id),
-    );
-  }, [files, resourceUrls]);
-  const rootFolders = useMemo(() => {
-    const folders = resources.map((resource) => {
-      const relevantFolders = allFolders.filter((folder) =>
-        resource.reviewUrl
-          ? resource.reviewUrl.startsWith(folder.id)
-          : resource.targetUrl.startsWith(folder.id),
-      );
-
-      return relevantFolders.find((folder) => isRootId(folder.folderId));
-    });
-
-    const existingFolders = folders.filter(Boolean) as FolderInterface[];
-
-    return uniqBy(existingFolders, 'id');
-  }, [allFolders, resources]);
 
   return (
     <div className={classNames(!isOpen && 'hidden')}>
@@ -326,12 +245,16 @@ export const FilePublicationResources = ({
             level={forViewOnly ? 0 : 1}
             key={f.id}
             currentFolder={f}
-            allFolders={allFolders}
+            allFolders={allFolders.filter((f) =>
+              folderItemsToDisplay.some((item) =>
+                item.id.startsWith(`${f.id}/`),
+              ),
+            )}
             searchTerm={''}
             openedFoldersIds={
               forViewOnly ? allFolders.map((f) => f.id) : openedFoldersIds
             }
-            allItems={folderFilesToDisplay}
+            allItems={folderItemsToDisplay}
             itemComponent={forViewOnly ? FilesRow : FileItem}
             onClickFolder={(folderId: string) => {
               if (forViewOnly) return;
@@ -345,7 +268,7 @@ export const FilePublicationResources = ({
           />
         );
       })}
-      {filesToDisplay.map((f) =>
+      {uploadedFiles.map((f) =>
         forViewOnly ? (
           <FilesRow
             itemComponentClassNames="cursor-pointer"

--- a/apps/chat/src/components/Chat/Publish/PublicationResources.tsx
+++ b/apps/chat/src/components/Chat/Publish/PublicationResources.tsx
@@ -219,7 +219,7 @@ export const FilePublicationResources = ({
   // TODO: get rid of uploaded files in https://github.com/epam/ai-dial-chat/issues/1502
   uploadedFiles,
   isOpen = true,
-}: PublicationResources & { uploadedFiles: DialFile[] }) => {
+}: PublicationResources & { uploadedFiles?: DialFile[] }) => {
   const dispatch = useAppDispatch();
 
   const openedFoldersIds = useAppSelector((state) =>
@@ -228,11 +228,8 @@ export const FilePublicationResources = ({
   const files = useAppSelector(FilesSelectors.selectFiles);
   const allFolders = useAppSelector(FilesSelectors.selectFolders);
 
-  const { rootFolders, folderItemsToDisplay } = usePublicationResources(
-    allFolders,
-    resources,
-    files,
-  );
+  const { rootFolders, itemsToDisplay, folderItemsToDisplay } =
+    usePublicationResources(allFolders, resources, files);
 
   return (
     <div className={classNames(!isOpen && 'hidden')}>
@@ -268,7 +265,7 @@ export const FilePublicationResources = ({
           />
         );
       })}
-      {uploadedFiles.map((f) =>
+      {(uploadedFiles ?? itemsToDisplay).map((f) =>
         forViewOnly ? (
           <FilesRow
             itemComponentClassNames="cursor-pointer"

--- a/apps/chat/src/components/Folder/Folder.tsx
+++ b/apps/chat/src/components/Folder/Folder.tsx
@@ -969,11 +969,10 @@ const Folder = <T extends ConversationInfo | PromptInfo | DialFile>({
                     onShare={handleShare}
                     onUnshare={handleUnshare}
                     onPublish={
-                      (featureType === FeatureType.Chat &&
-                        !allChildItems.every(
-                          (item) => (item as ConversationInfo).isReplay,
-                        )) ||
-                      featureType !== FeatureType.Chat
+                      featureType !== FeatureType.Chat ||
+                      !allChildItems.every(
+                        (item) => (item as ConversationInfo).isReplay,
+                      )
                         ? handleOpenPublishing
                         : undefined
                     }

--- a/apps/chat/src/components/Folder/Folder.tsx
+++ b/apps/chat/src/components/Folder/Folder.tsx
@@ -968,7 +968,15 @@ const Folder = <T extends ConversationInfo | PromptInfo | DialFile>({
                     onAddFolder={onAddFolder && onAdd}
                     onShare={handleShare}
                     onUnshare={handleUnshare}
-                    onPublish={handleOpenPublishing}
+                    onPublish={
+                      (featureType === FeatureType.Chat &&
+                        !allChildItems.every(
+                          (item) => (item as ConversationInfo).isReplay,
+                        )) ||
+                      featureType !== FeatureType.Chat
+                        ? handleOpenPublishing
+                        : undefined
+                    }
                     onUnpublish={handleOpenUnpublishing}
                     onPublishUpdate={handleOpenPublishing}
                     onOpenChange={setIsContextMenu}

--- a/apps/chat/src/hooks/usePublicationResources.ts
+++ b/apps/chat/src/hooks/usePublicationResources.ts
@@ -1,0 +1,59 @@
+import { useMemo } from 'react';
+
+import { isRootId } from '../utils/app/id';
+
+import { ConversationInfo } from '../types/chat';
+import { ShareEntity } from '../types/common';
+import { DialFile } from '../types/files';
+import { FolderInterface } from '../types/folder';
+import { PromptInfo } from '../types/prompt';
+import { PublicationResource } from '../types/publication';
+
+import uniqBy from 'lodash-es/uniqBy';
+
+export const usePublicationResources = <
+  T extends PromptInfo | ConversationInfo | DialFile,
+>(
+  allFolders: FolderInterface[],
+  resources: PublicationResource[],
+  items: T[],
+  rootFolder?: ShareEntity,
+) => {
+  const resourceUrls = useMemo(
+    () => resources.map((r) => r.reviewUrl),
+    [resources],
+  );
+  const itemsToDisplay = useMemo(() => {
+    return items.filter(
+      (item) =>
+        item.folderId.split('/').length === 2 && resourceUrls.includes(item.id),
+    );
+  }, [items, resourceUrls]);
+  const folderItemsToDisplay = useMemo(() => {
+    return items.filter(
+      (item) =>
+        item.folderId.split('/').length !== 2 && resourceUrls.includes(item.id),
+    );
+  }, [items, resourceUrls]);
+  const rootFolders = useMemo(() => {
+    if (rootFolder) return allFolders.filter((f) => f.id === rootFolder.id);
+
+    const folders = resources.map((resource) => {
+      const relevantFolders = allFolders.filter((folder) =>
+        resource.reviewUrl.startsWith(folder.id),
+      );
+
+      return relevantFolders.find((folder) => isRootId(folder.folderId));
+    });
+
+    const existingFolders = folders.filter(Boolean) as FolderInterface[];
+
+    return uniqBy(existingFolders, 'id');
+  }, [allFolders, resources, rootFolder]);
+
+  return {
+    itemsToDisplay,
+    folderItemsToDisplay,
+    rootFolders,
+  };
+};


### PR DESCRIPTION
**Description:**

remove empty folders from the publish request dialog and disabling the publish button for folders containing only 'replay' chats

Issues:

- #1504 

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
