### PR TITLE
feat(chat-e2e): removed gpt-4-0314 from models list

### DIFF
--- a/apps/chat-e2e/src/testData/expectedConstants.ts
+++ b/apps/chat-e2e/src/testData/expectedConstants.ts
@@ -254,7 +254,6 @@ export enum ModelIds {
   GPT_3_5_TURBO_16K = 'gpt-35-turbo-16k',
   GPT_3_5_TURBO_0125 = 'gpt-35-turbo-0125',
   GPT_4 = 'gpt-4',
-  GPT_4_0314 = 'gpt-4-0314',
   GPT_4_0613 = 'gpt-4-0613',
   GPT_4_1106_PREVIEW = 'gpt-4-1106-preview',
   GPT_4_0125_PREVIEW = 'gpt-4-0125-preview',

--- a/apps/chat-e2e/src/tests/chatApi/arithmeticRequest.test.ts
+++ b/apps/chat-e2e/src/tests/chatApi/arithmeticRequest.test.ts
@@ -13,7 +13,6 @@ const modelsForArithmeticRequest: {
   { modelId: ModelIds.GPT_3_5_TURBO_16K, isSysPromptAllowed: true },
   { modelId: ModelIds.GPT_3_5_TURBO_0125, isSysPromptAllowed: true },
   { modelId: ModelIds.GPT_3_5_TURBO_1106, isSysPromptAllowed: true },
-  { modelId: ModelIds.GPT_4_0314, isSysPromptAllowed: true },
   { modelId: ModelIds.GPT_4, isSysPromptAllowed: true },
   { modelId: ModelIds.GPT_4_1106_PREVIEW, isSysPromptAllowed: true },
   { modelId: ModelIds.GPT_4_0125_PREVIEW, isSysPromptAllowed: true },


### PR DESCRIPTION
**Description:**

removed gpt-4-0314 from models list

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
