### PR TITLE
feat(chat-e2e): removed gpt-4-0314 model

### DIFF
--- a/apps/chat-e2e/src/testData/expectedConstants.ts
+++ b/apps/chat-e2e/src/testData/expectedConstants.ts
@@ -254,7 +254,6 @@ export enum ModelIds {
   GPT_3_5_TURBO_16K = 'gpt-35-turbo-16k',
   GPT_3_5_TURBO_0125 = 'gpt-35-turbo-0125',
   GPT_4 = 'gpt-4',
-  GPT_4_0314 = 'gpt-4-0314',
   GPT_4_0613 = 'gpt-4-0613',
   GPT_4_1106_PREVIEW = 'gpt-4-1106-preview',
   GPT_4_0125_PREVIEW = 'gpt-4-0125-preview',

--- a/apps/chat-e2e/src/tests/chatApi/arithmeticRequest.test.ts
+++ b/apps/chat-e2e/src/tests/chatApi/arithmeticRequest.test.ts
@@ -13,7 +13,6 @@ const modelsForArithmeticRequest: {
   { modelId: ModelIds.GPT_3_5_TURBO_16K, isSysPromptAllowed: true },
   { modelId: ModelIds.GPT_3_5_TURBO_0125, isSysPromptAllowed: true },
   { modelId: ModelIds.GPT_3_5_TURBO_1106, isSysPromptAllowed: true },
-  { modelId: ModelIds.GPT_4_0314, isSysPromptAllowed: true },
   { modelId: ModelIds.GPT_4, isSysPromptAllowed: true },
   { modelId: ModelIds.GPT_4_1106_PREVIEW, isSysPromptAllowed: true },
   { modelId: ModelIds.GPT_4_0125_PREVIEW, isSysPromptAllowed: true },


### PR DESCRIPTION
Removing `gpt-4-0314` since it's going to be deprecated soon and is already missing in review-env configuration.