### PR TITLE
fix(chat): fix large right padding (Issue #1601)

### DIFF
--- a/apps/chat/src/components/Chat/Publish/PublishWizard.tsx
+++ b/apps/chat/src/components/Chat/Publish/PublishWizard.tsx
@@ -338,7 +338,7 @@ export function PublishModal({
       onClose={onClose}
       initialFocus={nameInputRef}
     >
-      <div className="flex flex-col divide-y divide-tertiary overflow-y-auto">
+      <div className="flex w-full flex-col divide-y divide-tertiary overflow-y-auto">
         <h4 className="truncate px-3 py-4 pr-10 text-base font-semibold md:px-4">
           <span className="w-full text-center">
             <Tooltip


### PR DESCRIPTION
**Description:**

paddings on request form should comply with

Issues:

- Issue #1601 

**UI changes**

Before:
<img width="873" alt="Снимок экрана 2024-06-18 в 14 45 43" src="https://github.com/epam/ai-dial-chat/assets/82438895/90490db5-7e55-4479-a1e2-82d1305a9c35">

After:
<img width="1130" alt="Снимок экрана 2024-06-18 в 14 45 57" src="https://github.com/epam/ai-dial-chat/assets/82438895/5731446c-aba8-4db7-b0f2-f581e21beeac">

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
