### PR TITLE
fix(chat): disallow double quotes in entity names (Issue #1622)

### DIFF
--- a/apps/chat-e2e/src/testData/expectedConstants.ts
+++ b/apps/chat-e2e/src/testData/expectedConstants.ts
@@ -110,18 +110,18 @@ export const ExpectedConstants = {
     `Conversation with name "${name}" already exists in this folder.`,
   duplicatedConversationRootNameErrorMessage: (name: string) =>
     `Conversation with name "${name}" already exists at the root.`,
-  prohibitedNameSymbols: `=,:;{}/%&`,
+  prohibitedNameSymbols: `=,:;{}/%&"`,
   // eslint-disable-next-line no-irregular-whitespace
   controlChars: `\b\t\f`,
   attachedFileError: (filename: string) =>
     `You've trying to upload files with incorrect type: ${filename}`,
   allowedSpecialSymbolsInName: "Test (`~!@#$^*-_+[]'|<>.?)",
-  winAllowedSpecialSymbolsInName: "Test (`~!@#$^_-_+[]'___.__)",
+  winAllowedSpecialSymbolsInName: "Test (`~!@#$^_-_+[]'___._)",
   duplicatedFilenameError: (filename: string) =>
     `Files which you trying to upload already presented in selected folder. Please rename or delete them from uploading files list: ${filename}`,
   sameFilenamesError: (filename: string) =>
     `Files which you trying to upload have same names. Please rename or delete them from uploading files list: ${filename}`,
-  restrictedNameChars: ':;,=/{}%&\\',
+  restrictedNameChars: ':;,=/{}%&\\"',
   notAllowedFilenameError: (filename: string) =>
     `The symbols ${ExpectedConstants.restrictedNameChars} are not allowed in file name. Please rename or delete them from uploading files list: ${filename}`,
   endDotFilenameError: (filename: string) =>

--- a/apps/chat-e2e/src/testData/expectedConstants.ts
+++ b/apps/chat-e2e/src/testData/expectedConstants.ts
@@ -115,7 +115,7 @@ export const ExpectedConstants = {
   controlChars: `\b\t\f`,
   attachedFileError: (filename: string) =>
     `You've trying to upload files with incorrect type: ${filename}`,
-  allowedSpecialSymbolsInName: 'Test (`~!@#$^*-_+[]\'|<>.?")',
+  allowedSpecialSymbolsInName: "Test (`~!@#$^*-_+[]'|<>.?)",
   winAllowedSpecialSymbolsInName: "Test (`~!@#$^_-_+[]'___.__)",
   duplicatedFilenameError: (filename: string) =>
     `Files which you trying to upload already presented in selected folder. Please rename or delete them from uploading files list: ${filename}`,

--- a/apps/chat-e2e/src/tests/chatBarConversation.test.ts
+++ b/apps/chat-e2e/src/tests/chatBarConversation.test.ts
@@ -354,7 +354,7 @@ dialTest(
       'EPMRTC-1276',
     );
     let editInputContainer: EditInput;
-    const specialSymbolsName = `(\`~!@#$^*-_+[]'|<>.?")`;
+    const specialSymbolsName = `(\`~!@#$^*-_+[]'|<>.?)`;
     const newNameWithEndDot = 'updated folder name.';
 
     await dialTest.step(

--- a/apps/chat-e2e/src/tests/chatBarConversation.test.ts
+++ b/apps/chat-e2e/src/tests/chatBarConversation.test.ts
@@ -67,7 +67,7 @@ dialTest(
       async () => {
         await expect
           .soft(
-            await chatMessages.getChatMessage(1),
+            chatMessages.getChatMessage(1),
             ExpectedMessages.messageContentIsValid,
           )
           .toHaveText(messageToSend);
@@ -1372,8 +1372,8 @@ dialTest(
     setTestIds,
   }) => {
     setTestIds('EPMRTC-2958');
-    const updatedRequest = `Chat"${ExpectedConstants.prohibitedNameSymbols}name.....`;
-    const expectedConversationName = `Chat"${' '.repeat(ExpectedConstants.prohibitedNameSymbols.length)}name`;
+    const updatedRequest = `Chat${ExpectedConstants.prohibitedNameSymbols}name.....`;
+    const expectedConversationName = `Chat${' '.repeat(ExpectedConstants.prohibitedNameSymbols.length)}name`;
     let conversation: Conversation;
 
     await dialTest.step('Prepare new conversation', async () => {

--- a/apps/chat-e2e/src/tests/chatBarFolderConversation.test.ts
+++ b/apps/chat-e2e/src/tests/chatBarFolderConversation.test.ts
@@ -587,7 +587,7 @@ dialTest(
     setTestIds,
   }) => {
     setTestIds('EPMRTC-1277');
-    const specialSymbols = `(\`~!@#$^*-_+[]'|<>.?")`;
+    const specialSymbols = `(\`~!@#$^*-_+[]'|<>.?)`;
 
     await dialTest.step(
       'Create a new folder and rename to name with special symbols',

--- a/apps/chat-e2e/src/tests/prompts.test.ts
+++ b/apps/chat-e2e/src/tests/prompts.test.ts
@@ -437,7 +437,7 @@ dialTest(
     setTestIds,
   }) => {
     setTestIds('EPMRTC-955', 'EPMRTC-1278');
-    const nameWithSpecialSymbols = '!@$^()_[]"\'.<>-`~';
+    const nameWithSpecialSymbols = "!@$^()_[]'.<>-`~";
     const prompt = promptData.prepareDefaultPrompt();
     await dataInjector.createPrompts([prompt]);
 

--- a/apps/chat-e2e/src/tests/selectUploadFolder.test.ts
+++ b/apps/chat-e2e/src/tests/selectUploadFolder.test.ts
@@ -33,7 +33,7 @@ dialTest(
       'EPMRTC-3237',
       'EPMRTC-3238',
     );
-    const updatedFolderName = 'New folder 1    (`~!@#$^*-_+[]\'|<>.?")';
+    const updatedFolderName = "New folder 1    (`~!@#$^*-_+[]'|<>.?)";
 
     await dialTest.step(
       'Open "Upload from device" modal through chat side bar clip icon and click on "Change" link',

--- a/apps/chat-e2e/src/ui/webElements/chat.ts
+++ b/apps/chat-e2e/src/ui/webElements/chat.ts
@@ -185,12 +185,16 @@ export class Chat extends BaseElement {
   }
 
   public waitForRequestSent(userRequest: string | undefined) {
-    return userRequest
-      ? this.page.waitForRequest(
-          (request) =>
+    return userRequest !== undefined
+      ? this.page.waitForRequest((request) => {
+          const escapedRequestData = userRequest.includes('"')
+            ? userRequest.replaceAll('"', '\\"')
+            : userRequest;
+          return (
             request.url().includes(API.chatHost) &&
-            request.postData()!.includes(userRequest),
-        )
+            request.postData()!.includes(escapedRequestData)
+          );
+        })
       : this.page.waitForRequest(API.chatHost);
   }
 

--- a/apps/chat-e2e/src/ui/webElements/uploadFromDeviceModal.ts
+++ b/apps/chat-e2e/src/ui/webElements/uploadFromDeviceModal.ts
@@ -63,9 +63,12 @@ export class UploadFromDeviceModal extends BaseElement {
     const dotIndex = filename.lastIndexOf('.');
     let filenameValue =
       dotIndex !== -1 ? filename.substring(0, dotIndex) : filename;
-    if (filename.includes('\\')) {
-      filenameValue = filenameValue.replaceAll('\\', '\\\\');
-    }
+    const charsToEscape = ['\\', '"'];
+    charsToEscape.forEach((char) => {
+      if (filename.includes(char)) {
+        filenameValue = filenameValue.replaceAll(char, `\\${char}`);
+      }
+    });
     const inputValue = new BaseElement(
       this.page,
       `[${Attributes.value} = "${filenameValue}"]`,

--- a/apps/chat/src/utils/app/file.ts
+++ b/apps/chat/src/utils/app/file.ts
@@ -141,7 +141,7 @@ export const getFilesWithInvalidFileType = (
     ? []
     : files.filter((file) => !isAllowedMimeType(allowedFileTypes, file.type));
 };
-export const notAllowedSymbols = ':;,=/{}%&\\';
+export const notAllowedSymbols = ':;,=/{}%&\\"';
 export const notAllowedSymbolsRegex = new RegExp(
   `[${escapeRegExp(notAllowedSymbols)}]|(\r\n|\n|\r|\t)|[\x00-\x1F]`,
   'gm',


### PR DESCRIPTION
**Description:**

disallow double quotes in entity names

Issues:

- Issue #1622

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
