### PR TITLE
fix(chat): add nested folders loading for change path dialog (Issue #1429)

### DIFF
--- a/apps/chat/src/components/Chat/ChangePathDialog.tsx
+++ b/apps/chat/src/components/Chat/ChangePathDialog.tsx
@@ -71,9 +71,7 @@ export const ChangePathDialog = ({
   const folders = useAppSelector((state) =>
     selectors.selectTemporaryAndFilteredFolders(state, searchQuery),
   );
-  const loadingFolderIds = useAppSelector(
-    ConversationsSelectors.selectLoadingFolderIds,
-  );
+  const loadingFolderIds = useAppSelector(selectors.selectLoadingFolderIds);
 
   useEffect(() => {
     if (!isOpen) {

--- a/apps/chat/src/components/Chat/ChangePathDialog.tsx
+++ b/apps/chat/src/components/Chat/ChangePathDialog.tsx
@@ -71,6 +71,9 @@ export const ChangePathDialog = ({
   const folders = useAppSelector((state) =>
     selectors.selectTemporaryAndFilteredFolders(state, searchQuery),
   );
+  const loadingFolderIds = useAppSelector(
+    ConversationsSelectors.selectLoadingFolderIds,
+  );
 
   useEffect(() => {
     if (!isOpen) {
@@ -93,7 +96,23 @@ export const ChangePathDialog = ({
         setIsAllFoldersOpened((value) => !value);
         setOpenedFoldersIds([]);
         setSelectedFolderId(folderId);
+
         return;
+      }
+
+      if (
+        type === SharingType.Conversation ||
+        type === SharingType.ConversationFolder
+      ) {
+        dispatch(
+          ConversationsActions.uploadConversationsWithFolders({
+            ids: [folderId],
+          }),
+        );
+      } else {
+        dispatch(
+          PromptsActions.uploadChildPromptsWithFolders({ ids: [folderId] }),
+        );
       }
 
       if (openedFoldersIds.includes(folderId)) {
@@ -108,7 +127,7 @@ export const ChangePathDialog = ({
         setOpenedFoldersIds(openedFoldersIds.concat(folderId));
       }
     },
-    [folders, openedFoldersIds],
+    [dispatch, folders, openedFoldersIds, type],
   );
 
   const handleFolderSelect = useCallback(
@@ -205,6 +224,7 @@ export const ChangePathDialog = ({
                 ? FeatureType.Chat
                 : FeatureType.Prompt,
             isSidePanelFolder: false,
+            loadingFolderIds,
           }}
           handleFolderSelect={handleFolderSelect}
           isAllEntitiesOpened={isAllFoldersOpened}


### PR DESCRIPTION
**Description:**

add nested folders loading for change path dialog

Issues:

- #1429

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
