### PR TITLE
fix(chat): fix publication request text (Issue #1483)

### DIFF
--- a/apps/chat/src/components/Chat/Publish/HandlePublication.tsx
+++ b/apps/chat/src/components/Chat/Publish/HandlePublication.tsx
@@ -380,7 +380,7 @@ export function HandlePublication({ publication }: Props) {
             className="text-accent-primary"
             onClick={handlePublicationReview}
           >
-            {t('Go to a publication review...')}
+            {t('Go to a review...')}
           </button>
           <div>
             <button


### PR DESCRIPTION
**Description:**

Button Reject is displayed under Approve button
Approve/Reject buttons and "Go to publication view" link aligned to middle
"Go to publication view" displayed in 2 lines

Issues:

- Issue #1483 

**UI changes**

Before:
<img width="568" alt="Снимок экрана 2024-06-21 в 14 04 29" src="https://github.com/epam/ai-dial-chat/assets/82438895/7a8b0e84-9229-44ff-a949-1af2c7513567">

After:
<img width="364" alt="Снимок экрана 2024-06-21 в 14 17 12" src="https://github.com/epam/ai-dial-chat/assets/82438895/28dc262a-7433-4085-94b0-808e111887e2">

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
