### PR TITLE
feat(overlay): improve ready to interact event and add conversation loaded event (Issue #1578)

### DIFF
--- a/apps/chat/src/store/overlay/overlay.epics.ts
+++ b/apps/chat/src/store/overlay/overlay.epics.ts
@@ -58,7 +58,7 @@ import {
   overlayAppName,
   validateFeature,
 } from '@epam/ai-dial-shared';
-import isEqual from 'lodash-es';
+import isEqual from 'lodash-es/isEqual';
 
 export const postMessageMapperEpic: AppEpic = (_, state$) =>
   typeof window === 'object'

--- a/apps/chat/src/store/overlay/overlay.reducers.ts
+++ b/apps/chat/src/store/overlay/overlay.reducers.ts
@@ -28,6 +28,7 @@ interface OverlayState {
 
   systemPrompt: string | null;
 
+  readyToInteractSent: boolean;
   optionsReceived?: boolean;
 }
 
@@ -35,6 +36,7 @@ const initialState: OverlayState = {
   hostDomain: '*',
 
   systemPrompt: null,
+  readyToInteractSent: false,
 };
 
 export const overlaySlice = createSlice({
@@ -85,6 +87,10 @@ export const overlaySlice = createSlice({
         requestParams: PostMessageRequestParams;
       }>,
     ) => state,
+    checkReadyToInteract: (state) => state,
+    sendReadyToInteract: (state) => {
+      state.readyToInteractSent = true;
+    },
   },
 });
 
@@ -102,10 +108,15 @@ const selectOptionsReceived = createSelector([rootSelector], (state) => {
   return state.optionsReceived;
 });
 
+const selectReadyToInteractSent = createSelector([rootSelector], (state) => {
+  return state.readyToInteractSent;
+});
+
 export const OverlaySelectors = {
   selectHostDomain,
   selectOverlaySystemPrompt,
   selectOptionsReceived,
+  selectReadyToInteractSent,
 };
 
 export const OverlayActions = overlaySlice.actions;

--- a/libs/overlay/src/index.ts
+++ b/libs/overlay/src/index.ts
@@ -1,4 +1,9 @@
 export * from './lib/ChatOverlay';
 export * from './lib/ChatOverlayManager';
 
-export { Feature, type ChatOverlayOptions } from '@epam/ai-dial-shared';
+export {
+  Feature,
+  type ChatOverlayOptions,
+  overlayAppName,
+  OverlayEvents,
+} from '@epam/ai-dial-shared';

--- a/libs/overlay/src/lib/ChatOverlay.ts
+++ b/libs/overlay/src/lib/ChatOverlay.ts
@@ -206,7 +206,6 @@ export class ChatOverlay {
 
   /**
    * Callback to post message event, contains mapping event to this.requests, mapping event to this.subscriptions
-   * If event.data.type === '@DIAL_OVERLAY/READY' means that DIAL ready to receive message -> this.iframeInteraction.complete()
    * @param event {MessageEvent} post message event
    */
   protected process = (event: MessageEvent<OverlayRequest>): void => {

--- a/libs/shared/src/constants/overlay.ts
+++ b/libs/shared/src/constants/overlay.ts
@@ -8,10 +8,37 @@ export enum OverlayRequests {
 }
 
 export enum OverlayEvents {
+  /**
+   * Chat dispatch this event when starting initializing (loading models, requesting conversations, etc.)
+   *
+   * *Dispatched only once*
+   */
   initReady = 'INIT_READY',
+  /**
+   * Chat dispatch this event when models loaded or login needed - needed to receive and set initial chat options
+   *
+   * *Dispatched only once*
+   */
   ready = 'READY',
+  /**
+   * Chat dispatch this event when previous ready events sent and selected conversation loaded
+   *
+   * *Dispatched only once*
+   */
   readyToInteract = 'READY_TO_INTERACT',
+  /**
+   * Chat dispatch this event when selected conversation loaded
+   *
+   * *Dispatched once before ready to interact event and on all conversation full reloads (renaming, changing model, etc.)*
+   */
+  selectedConversationLoaded = 'SELECTED_CONVERSATION_LOADED',
+  /**
+   * Chat dispatch this event when user send message to assistant
+   */
   gptStartGenerating = 'GPT_START_GENERATING',
+  /**
+   * Chat dispatch this event when user end receiving message from assistant
+   */
   gptEndGenerating = 'GPT_END_GENERATING',
 }
 


### PR DESCRIPTION
**Description:**

Previously ready to interact called right after models loaded and overlay settings set, but we should also wait for conversation loaded, because we cannot get all needed info from it (like messages and their state)
Currently ready to interact event sent once after conversation loaded and if it's not sent before
Also added conversation loaded event for cases when we are switching conversation and need to tell about this to host

Issues:

- Issue #1578

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
