### PR TITLE
fix: hide folder caret  when it is empty (Issue #1484)

### DIFF
--- a/apps/chat/src/components/Files/FileManagerModal.tsx
+++ b/apps/chat/src/components/Files/FileManagerModal.tsx
@@ -538,7 +538,6 @@ export const FileManagerModal = ({
                               highlightedFolders={highlightFolderIds}
                               isInitialRenameEnabled
                               newAddedFolderId={newFolderId}
-                              displayCaretAlways
                               loadingFolderIds={loadingFolderIds}
                               openedFoldersIds={openedFoldersIds}
                               allItems={filteredFiles}


### PR DESCRIPTION
**Description:**

- Hide folder caret when it is empty -  removed `displayCaretAlways` property.

Issues:

- Issue #1484 

**UI changes**

![image](https://github.com/epam/ai-dial-chat/assets/143205282/66df3311-f42e-45ce-b7dd-613dd881e685)

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
