### PR TITLE
fix(chat): fix cutting conversation name if named from attachment link (Issue #1313)

### DIFF
--- a/apps/chat/src/utils/app/common.ts
+++ b/apps/chat/src/utils/app/common.ts
@@ -140,11 +140,17 @@ export const prepareEntityName = (
     clearName.length > MAX_ENTITY_LENGTH
       ? substring(clearName, 0, MAX_ENTITY_LENGTH)
       : clearName;
+
+  const newResult =
+    result.length > MAX_ENTITY_LENGTH
+      ? result.substring(0, MAX_ENTITY_LENGTH)
+      : result;
   console.log(result);
+  console.log('newResult', newResult);
   console.log('condition', clearName.length > MAX_ENTITY_LENGTH);
   console.log('MAX_ENTITY_LENGTH', MAX_ENTITY_LENGTH);
   console.log('substring', substring(clearName, 0, MAX_ENTITY_LENGTH));
   return !options?.forRenaming || options?.trimEndDotsRequired
-    ? trimEndDots(result)
-    : result.trim();
+    ? trimEndDots(newResult)
+    : newResult.trim();
 };

--- a/apps/chat/src/utils/app/common.ts
+++ b/apps/chat/src/utils/app/common.ts
@@ -134,12 +134,12 @@ export const prepareEntityName = (
         .split('\n')
         .map((s) => s.replace(notAllowedSymbolsRegex, ' ').trim())
         .filter(Boolean)[0] ?? '';
-
+  console.log(clearName);
   const result =
     clearName.length > MAX_ENTITY_LENGTH
       ? substring(clearName, 0, MAX_ENTITY_LENGTH)
       : clearName;
-
+  console.log(result);
   return !options?.forRenaming || options?.trimEndDotsRequired
     ? trimEndDots(result)
     : result.trim();

--- a/apps/chat/src/utils/app/common.ts
+++ b/apps/chat/src/utils/app/common.ts
@@ -12,7 +12,7 @@ import merge from 'lodash-es/merge';
 import trimEnd from 'lodash-es/trimEnd';
 import uniq from 'lodash-es/uniq';
 import values from 'lodash-es/values';
-import { substring } from 'stringz';
+import { length, substring } from 'stringz';
 
 /**
  * Combine entities. If there are the same ids then will be used entity from entities1 i.e. first in array
@@ -134,12 +134,11 @@ export const prepareEntityName = (
         .split('\n')
         .map((s) => s.replace(notAllowedSymbolsRegex, ' ').trim())
         .filter(Boolean)[0] ?? '';
-
   const result =
     clearName.length > MAX_ENTITY_LENGTH
-      ? substring(clearName, 0, MAX_ENTITY_LENGTH ?? 160)
+      ? substring(clearName, 0, 160)
       : clearName;
-
+  console.log(result);
   return !options?.forRenaming || options?.trimEndDotsRequired
     ? trimEndDots(result)
     : result.trim();

--- a/apps/chat/src/utils/app/common.ts
+++ b/apps/chat/src/utils/app/common.ts
@@ -135,22 +135,12 @@ export const prepareEntityName = (
         .map((s) => s.replace(notAllowedSymbolsRegex, ' ').trim())
         .filter(Boolean)[0] ?? '';
 
-  console.log(clearName);
   const result =
     clearName.length > MAX_ENTITY_LENGTH
-      ? substring(clearName, 0, MAX_ENTITY_LENGTH)
+      ? substring(clearName, 0, MAX_ENTITY_LENGTH ?? 160)
       : clearName;
 
-  const newResult =
-    result.length > MAX_ENTITY_LENGTH
-      ? result.substring(0, MAX_ENTITY_LENGTH)
-      : result;
-  console.log(result);
-  console.log('newResult', newResult);
-  console.log('condition', clearName.length > MAX_ENTITY_LENGTH);
-  console.log('MAX_ENTITY_LENGTH', MAX_ENTITY_LENGTH);
-  console.log('substring', substring(clearName, 0, MAX_ENTITY_LENGTH));
   return !options?.forRenaming || options?.trimEndDotsRequired
-    ? trimEndDots(newResult)
-    : newResult.trim();
+    ? trimEndDots(result)
+    : result.trim();
 };

--- a/apps/chat/src/utils/app/common.ts
+++ b/apps/chat/src/utils/app/common.ts
@@ -12,7 +12,7 @@ import merge from 'lodash-es/merge';
 import trimEnd from 'lodash-es/trimEnd';
 import uniq from 'lodash-es/uniq';
 import values from 'lodash-es/values';
-import { length, substring } from 'stringz';
+import { substring } from 'stringz';
 
 /**
  * Combine entities. If there are the same ids then will be used entity from entities1 i.e. first in array
@@ -136,10 +136,15 @@ export const prepareEntityName = (
         .filter(Boolean)[0] ?? '';
   const result =
     clearName.length > MAX_ENTITY_LENGTH
-      ? substring(clearName, 0, 160)
+      ? substring(clearName, 0, MAX_ENTITY_LENGTH)
       : clearName;
-  console.log(result);
+
+  const additionalCuttedResult =
+    result.length > MAX_ENTITY_LENGTH
+      ? result.substring(0, MAX_ENTITY_LENGTH)
+      : result;
+
   return !options?.forRenaming || options?.trimEndDotsRequired
-    ? trimEndDots(result)
-    : result.trim();
+    ? trimEndDots(additionalCuttedResult)
+    : additionalCuttedResult.trim();
 };

--- a/apps/chat/src/utils/app/common.ts
+++ b/apps/chat/src/utils/app/common.ts
@@ -134,12 +134,16 @@ export const prepareEntityName = (
         .split('\n')
         .map((s) => s.replace(notAllowedSymbolsRegex, ' ').trim())
         .filter(Boolean)[0] ?? '';
+
   console.log(clearName);
   const result =
     clearName.length > MAX_ENTITY_LENGTH
       ? substring(clearName, 0, MAX_ENTITY_LENGTH)
       : clearName;
   console.log(result);
+  console.log('condition', clearName.length > MAX_ENTITY_LENGTH);
+  console.log('MAX_ENTITY_LENGTH', MAX_ENTITY_LENGTH);
+  console.log('substring', substring(clearName, 0, MAX_ENTITY_LENGTH));
   return !options?.forRenaming || options?.trimEndDotsRequired
     ? trimEndDots(result)
     : result.trim();


### PR DESCRIPTION
**Description:**

- Fixed cutting conversation name if named from attachment link. Added additional check.

Issues:

- Issue #1313 


**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
