### PR TITLE
fix(chat): fix editing folder attachments and cutting entity names to 160 symbols (Issue #1313, #1665)

### DIFF
--- a/apps/chat/src/components/Chat/ChatMessage/ChatMessageContent.tsx
+++ b/apps/chat/src/components/Chat/ChatMessage/ChatMessageContent.tsx
@@ -16,6 +16,7 @@ import classNames from 'classnames';
 import { isEntityNameOrPathInvalid } from '@/src/utils/app/common';
 import {
   getDialFilesFromAttachments,
+  getDialFoldersFromAttachments,
   getDialLinksFromAttachments,
   getUserCustomContent,
 } from '@/src/utils/app/file';
@@ -145,7 +146,12 @@ export const ChatMessageContent = ({
   const codeDetection = (content: string) => content.match(codeRegEx);
 
   const mappedUserEditableAttachments = useMemo(() => {
-    return getDialFilesFromAttachments(message.custom_content?.attachments);
+    return [
+      ...(getDialFoldersFromAttachments(
+        message.custom_content?.attachments,
+      ) as unknown as Omit<DialFile, 'contentLength'>[]),
+      ...getDialFilesFromAttachments(message.custom_content?.attachments),
+    ];
   }, [message.custom_content?.attachments]);
   const mappedUserEditableAttachmentsIds = useMemo(() => {
     return mappedUserEditableAttachments.map(({ id }) => id);
@@ -181,16 +187,23 @@ export const ChatMessageContent = ({
       (id) => !mappedUserEditableAttachmentsIds.includes(id),
     );
     const newFiles = newIds
-      .map(
-        (id) =>
-          files.find((file) => file.id === id) ||
-          (canAttachFolders && folders.find((folder) => folder.id === id)),
-      )
+      .map((id) => files.find((file) => file.id === id))
       .filter(Boolean) as DialFile[];
+
+    const newFolders = newIds
+      .map(
+        (id) => canAttachFolders && folders.find((folder) => folder.id === id),
+      )
+      .filter(Boolean)
+      .map((folder) => ({
+        ...folder,
+        contentType: FOLDER_ATTACHMENT_CONTENT_TYPE,
+      })) as DialFile[];
 
     return mappedUserEditableAttachments
       .filter(({ id }) => newEditableAttachmentsIds.includes(id))
-      .concat(newFiles);
+      .concat(newFiles)
+      .concat(newFolders);
   }, [
     canAttachFolders,
     files,

--- a/apps/chat/src/components/Chatbar/ChatbarSettings.tsx
+++ b/apps/chat/src/components/Chatbar/ChatbarSettings.tsx
@@ -180,6 +180,7 @@ export const ChatbarSettings = () => {
           }}
           headerLabel={t('Manage attachments')}
           forceShowSelectCheckBox
+          forceHideSelectFolders
           showTooltip
         />
       )}

--- a/apps/chat/src/components/Files/FileManagerModal.tsx
+++ b/apps/chat/src/components/Files/FileManagerModal.tsx
@@ -103,10 +103,14 @@ export const FileManagerModal = ({
     useState(false);
   const [searchQuery, setSearchQuery] = useState('');
   const [selectedFilesIds, setSelectedFilesIds] = useState(
-    initialSelectedFilesIds.filter((id) => !isFolderId(id)),
+    canAttachFiles || forceShowSelectCheckBox
+      ? initialSelectedFilesIds.filter((id) => !isFolderId(id))
+      : [],
   );
   const [selectedFolderIds, setSelectedFolderIds] = useState(
-    initialSelectedFilesIds.filter((id) => isFolderId(id)),
+    canAttachFolders
+      ? initialSelectedFilesIds.filter((id) => isFolderId(id))
+      : [],
   );
   const [deletingFileIds, setDeletingFileIds] = useState<string[]>([]);
   const [deletingFolderIds, setDeletingFolderIds] = useState<string[]>([]);
@@ -384,9 +388,11 @@ export const FileManagerModal = ({
       selectedFiles: Required<Pick<DialFile, 'fileContent' | 'id' | 'name'>>[],
       folderPath: string | undefined,
     ) => {
-      setSelectedFilesIds((oldValues) =>
-        oldValues.concat(selectedFiles.map((f) => f.id)),
-      );
+      if (canAttachFiles || forceShowSelectCheckBox) {
+        setSelectedFilesIds((oldValues) =>
+          oldValues.concat(selectedFiles.map((f) => f.id)),
+        );
+      }
 
       selectedFiles.forEach((file) => {
         dispatch(
@@ -399,7 +405,7 @@ export const FileManagerModal = ({
         );
       });
     },
-    [dispatch],
+    [canAttachFiles, dispatch, forceShowSelectCheckBox],
   );
 
   const handleDeleteMultipleFiles = useCallback(() => {

--- a/apps/chat/src/components/Files/FileManagerModal.tsx
+++ b/apps/chat/src/components/Files/FileManagerModal.tsx
@@ -51,6 +51,7 @@ interface Props {
   customUploadButtonLabel?: string;
   onClose: (result: boolean | string[]) => void;
   forceShowSelectCheckBox?: boolean;
+  forceHideSelectFolders?: boolean;
   showTooltip?: boolean;
 }
 
@@ -64,6 +65,7 @@ export const FileManagerModal = ({
   customUploadButtonLabel,
   maximumAttachmentsAmount = 0,
   forceShowSelectCheckBox,
+  forceHideSelectFolders,
   onClose,
   showTooltip,
 }: Props) => {
@@ -86,9 +88,9 @@ export const FileManagerModal = ({
   const canAttachFiles = useAppSelector(
     ConversationsSelectors.selectCanAttachFile,
   );
-  const canAttachFolders = useAppSelector(
-    ConversationsSelectors.selectCanAttachFolders,
-  );
+  const canAttachFolders =
+    useAppSelector(ConversationsSelectors.selectCanAttachFolders) &&
+    !forceHideSelectFolders;
   const allowedTypesArray = useMemo(
     () => (!canAttachFiles && canAttachFolders ? ['*/*'] : allowedTypes),
     [allowedTypes, canAttachFiles, canAttachFolders],
@@ -270,7 +272,7 @@ export const FileManagerModal = ({
               .slice(0, -2)
               .map((fid) => `${fid}/`);
             if (
-              selectedFolderIds.some((fid) => parentFolderIds.includes(fid))
+              selectedFolderIds.some((fid) => parentFolderIds.includes(fid)) // selected now
             ) {
               setSelectedFilesIds((oldFileIds) =>
                 !canAttachFiles
@@ -286,11 +288,14 @@ export const FileManagerModal = ({
                     ),
               );
               setSelectedFolderIds((oldFolderIds) => {
+                const parentSelectedFolderIds = selectedFolderIds.filter(
+                  (fid) => parentFolderIds.includes(fid),
+                );
                 return oldFolderIds
                   .concat(
                     folders
                       .filter((folder) =>
-                        parentFolderIds.some((parentId) =>
+                        parentSelectedFolderIds.some((parentId) =>
                           folder.id.startsWith(parentId),
                         ),
                       )

--- a/apps/chat/src/types/files.ts
+++ b/apps/chat/src/types/files.ts
@@ -5,6 +5,8 @@ import {
   ShareEntity,
 } from '@/src/types/common';
 
+import { FOLDER_ATTACHMENT_CONTENT_TYPE } from '../constants/folders';
+
 import { FolderInterface } from './folder';
 
 export type ImageMIMEType = 'image/jpeg' | 'image/png' | string;
@@ -37,6 +39,10 @@ export type DialFile = Omit<
 export type FileFolderInterface = FolderInterface & {
   absolutePath?: string;
   relativePath?: string;
+};
+
+export type FileFolderAttachment = FileFolderInterface & {
+  contentType: typeof FOLDER_ATTACHMENT_CONTENT_TYPE;
 };
 
 export type Status = undefined | 'LOADING' | 'LOADED' | 'FAILED';

--- a/apps/chat/src/utils/app/common.ts
+++ b/apps/chat/src/utils/app/common.ts
@@ -134,13 +134,17 @@ export const prepareEntityName = (
         .split('\n')
         .map((s) => s.replace(notAllowedSymbolsRegex, ' ').trim())
         .filter(Boolean)[0] ?? '';
-
   const result =
     clearName.length > MAX_ENTITY_LENGTH
       ? substring(clearName, 0, MAX_ENTITY_LENGTH)
       : clearName;
 
+  const additionalCuttedResult =
+    result.length > MAX_ENTITY_LENGTH
+      ? result.substring(0, MAX_ENTITY_LENGTH)
+      : result;
+
   return !options?.forRenaming || options?.trimEndDotsRequired
-    ? trimEndDots(result)
-    : result.trim();
+    ? trimEndDots(additionalCuttedResult)
+    : additionalCuttedResult.trim();
 };

--- a/apps/chat/src/utils/app/file.ts
+++ b/apps/chat/src/utils/app/file.ts
@@ -2,7 +2,7 @@ import { TFunction } from 'next-i18next';
 
 import { Attachment, Conversation } from '@/src/types/chat';
 import { UploadStatus } from '@/src/types/common';
-import { DialFile, DialLink, FileFolderInterface } from '@/src/types/files';
+import { DialFile, DialLink, FileFolderAttachment } from '@/src/types/files';
 import { FolderInterface, FolderType } from '@/src/types/folder';
 
 import { FOLDER_ATTACHMENT_CONTENT_TYPE } from '@/src/constants/folders';
@@ -206,13 +206,13 @@ export const getDialFilesFromAttachments = (
 
 export const getDialFoldersFromAttachments = (
   attachments: Attachment[] | undefined,
-): FileFolderInterface[] => {
+): FileFolderAttachment[] => {
   if (!attachments) {
     return [];
   }
 
   return attachments
-    .map((attachment): FileFolderInterface | null => {
+    .map((attachment): FileFolderAttachment | null => {
       if (
         !attachment.url ||
         isAttachmentLink(attachment.url) ||
@@ -226,12 +226,13 @@ export const getDialFoldersFromAttachments = (
       return {
         id: attachment.url,
         type: FolderType.File,
+        contentType: FOLDER_ATTACHMENT_CONTENT_TYPE,
         name,
         folderId: absolutePath,
         absolutePath,
       };
     })
-    .filter(Boolean) as FileFolderInterface[];
+    .filter(Boolean) as FileFolderAttachment[];
 };
 
 export const getDialLinksFromAttachments = (


### PR DESCRIPTION
**Description:**

fix editing folder attachments and cutting entity names to 160 symbols

Issues:

- Issue #1313 
- Issue #1665 

**Related PRs**
- #1669 
- #1677 

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
