### PR TITLE
fix(chat): disallow auto-select uploaded files if can't attach files (Issue #1665)

### DIFF
--- a/apps/chat/src/components/Files/FileManagerModal.tsx
+++ b/apps/chat/src/components/Files/FileManagerModal.tsx
@@ -103,7 +103,7 @@ export const FileManagerModal = ({
     useState(false);
   const [searchQuery, setSearchQuery] = useState('');
   const [selectedFilesIds, setSelectedFilesIds] = useState(
-    canAttachFiles
+    canAttachFiles || forceShowSelectCheckBox
       ? initialSelectedFilesIds.filter((id) => !isFolderId(id))
       : [],
   );
@@ -388,7 +388,7 @@ export const FileManagerModal = ({
       selectedFiles: Required<Pick<DialFile, 'fileContent' | 'id' | 'name'>>[],
       folderPath: string | undefined,
     ) => {
-      if (canAttachFiles) {
+      if (canAttachFiles || forceShowSelectCheckBox) {
         setSelectedFilesIds((oldValues) =>
           oldValues.concat(selectedFiles.map((f) => f.id)),
         );
@@ -405,7 +405,7 @@ export const FileManagerModal = ({
         );
       });
     },
-    [canAttachFiles, dispatch],
+    [canAttachFiles, dispatch, forceShowSelectCheckBox],
   );
 
   const handleDeleteMultipleFiles = useCallback(() => {

--- a/apps/chat/src/components/Files/FileManagerModal.tsx
+++ b/apps/chat/src/components/Files/FileManagerModal.tsx
@@ -103,10 +103,14 @@ export const FileManagerModal = ({
     useState(false);
   const [searchQuery, setSearchQuery] = useState('');
   const [selectedFilesIds, setSelectedFilesIds] = useState(
-    initialSelectedFilesIds.filter((id) => !isFolderId(id)),
+    canAttachFiles
+      ? initialSelectedFilesIds.filter((id) => !isFolderId(id))
+      : [],
   );
   const [selectedFolderIds, setSelectedFolderIds] = useState(
-    initialSelectedFilesIds.filter((id) => isFolderId(id)),
+    canAttachFolders
+      ? initialSelectedFilesIds.filter((id) => isFolderId(id))
+      : [],
   );
   const [deletingFileIds, setDeletingFileIds] = useState<string[]>([]);
   const [deletingFolderIds, setDeletingFolderIds] = useState<string[]>([]);
@@ -384,9 +388,11 @@ export const FileManagerModal = ({
       selectedFiles: Required<Pick<DialFile, 'fileContent' | 'id' | 'name'>>[],
       folderPath: string | undefined,
     ) => {
-      setSelectedFilesIds((oldValues) =>
-        oldValues.concat(selectedFiles.map((f) => f.id)),
-      );
+      if (canAttachFiles) {
+        setSelectedFilesIds((oldValues) =>
+          oldValues.concat(selectedFiles.map((f) => f.id)),
+        );
+      }
 
       selectedFiles.forEach((file) => {
         dispatch(

--- a/apps/chat/src/components/Files/FileManagerModal.tsx
+++ b/apps/chat/src/components/Files/FileManagerModal.tsx
@@ -405,7 +405,7 @@ export const FileManagerModal = ({
         );
       });
     },
-    [dispatch],
+    [canAttachFiles, dispatch],
   );
 
   const handleDeleteMultipleFiles = useCallback(() => {


### PR DESCRIPTION
**Description:**

disallow auto-select uploaded files if can't attach files

Issues:

- Issue #1665 

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
