### PR TITLE
fix(chat): hide folder checkboxes in Manage attachments (Issue #1665)

### DIFF
--- a/apps/chat/src/components/Chatbar/ChatbarSettings.tsx
+++ b/apps/chat/src/components/Chatbar/ChatbarSettings.tsx
@@ -180,6 +180,7 @@ export const ChatbarSettings = () => {
           }}
           headerLabel={t('Manage attachments')}
           forceShowSelectCheckBox
+          forceHideSelectFolders
           showTooltip
         />
       )}

--- a/apps/chat/src/components/Files/FileManagerModal.tsx
+++ b/apps/chat/src/components/Files/FileManagerModal.tsx
@@ -272,7 +272,7 @@ export const FileManagerModal = ({
               .slice(0, -2)
               .map((fid) => `${fid}/`);
             if (
-              selectedFolderIds.some((fid) => parentFolderIds.includes(fid))
+              selectedFolderIds.some((fid) => parentFolderIds.includes(fid)) // selected now
             ) {
               setSelectedFilesIds((oldFileIds) =>
                 !canAttachFiles
@@ -288,11 +288,14 @@ export const FileManagerModal = ({
                     ),
               );
               setSelectedFolderIds((oldFolderIds) => {
+                const parentSelectedFolderIds = selectedFolderIds.filter(
+                  (fid) => parentFolderIds.includes(fid),
+                );
                 return oldFolderIds
                   .concat(
                     folders
                       .filter((folder) =>
-                        parentFolderIds.some((parentId) =>
+                        parentSelectedFolderIds.some((parentId) =>
                           folder.id.startsWith(parentId),
                         ),
                       )

--- a/apps/chat/src/components/Files/FileManagerModal.tsx
+++ b/apps/chat/src/components/Files/FileManagerModal.tsx
@@ -51,6 +51,7 @@ interface Props {
   customUploadButtonLabel?: string;
   onClose: (result: boolean | string[]) => void;
   forceShowSelectCheckBox?: boolean;
+  forceHideSelectFolders?: boolean;
   showTooltip?: boolean;
 }
 
@@ -64,6 +65,7 @@ export const FileManagerModal = ({
   customUploadButtonLabel,
   maximumAttachmentsAmount = 0,
   forceShowSelectCheckBox,
+  forceHideSelectFolders,
   onClose,
   showTooltip,
 }: Props) => {
@@ -86,9 +88,9 @@ export const FileManagerModal = ({
   const canAttachFiles = useAppSelector(
     ConversationsSelectors.selectCanAttachFile,
   );
-  const canAttachFolders = useAppSelector(
-    ConversationsSelectors.selectCanAttachFolders,
-  );
+  const canAttachFolders =
+    useAppSelector(ConversationsSelectors.selectCanAttachFolders) &&
+    !forceHideSelectFolders;
   const allowedTypesArray = useMemo(
     () => (!canAttachFiles && canAttachFolders ? ['*/*'] : allowedTypes),
     [allowedTypes, canAttachFiles, canAttachFolders],


### PR DESCRIPTION
**Description:**

- hide folder checkboxes in Manage attachments
- fix unselect child folder

Issues:

- Issue #1665

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
