### PR TITLE
fix(chat): fix 'see chahges' button visibility while rules is loading and fix rules comparison (Issue #1640)

### DIFF
--- a/apps/chat/src/components/Chat/Publish/HandlePublication.tsx
+++ b/apps/chat/src/components/Chat/Publish/HandlePublication.tsx
@@ -43,18 +43,16 @@ interface FilterComponentProps {
   filteredRuleEntries: [string, PublicationRule[]][];
   newRules: PublicationRule[];
   publication: Publication;
+  isRulesLoading: boolean;
 }
 
 function FiltersComponent({
   filteredRuleEntries,
   newRules,
   publication,
+  isRulesLoading,
 }: FilterComponentProps) {
   const { t } = useTranslation(Translation.Chat);
-
-  const isRulesLoading = useAppSelector(
-    PublicationSelectors.selectIsRulesLoading,
-  );
 
   if (isRulesLoading) {
     return (
@@ -105,6 +103,9 @@ export function HandlePublication({ publication }: Props) {
   );
   const rules = useAppSelector((state) =>
     PublicationSelectors.selectRulesByPath(state, publication.targetFolder),
+  );
+  const isRulesLoading = useAppSelector(
+    PublicationSelectors.selectIsRulesLoading,
   );
 
   useEffect(() => {
@@ -319,22 +320,27 @@ export function HandlePublication({ publication }: Props) {
                 <h2 className="mb-4 flex items-center gap-2 text-sm">
                   <div className="flex w-full justify-between">
                     <p>{t('Allow access if all match')}</p>
-                    {!isEqual(
-                      publication.rules || [],
-                      rules[publication.targetFolder] || [],
-                    ) ? (
-                      <span
-                        onClick={() => setIsCompareModalOpened(true)}
-                        className="cursor-pointer text-accent-primary"
-                      >
-                        {t('See changes')}
-                      </span>
-                    ) : (
-                      <span className="text-secondary">{t('No changes')}</span>
-                    )}
+                    {!isRulesLoading &&
+                      (publication.rules &&
+                      !isEqual(
+                        publication.rules,
+                        rules[publication.targetFolder] || [],
+                      ) ? (
+                        <span
+                          onClick={() => setIsCompareModalOpened(true)}
+                          className="cursor-pointer text-accent-primary"
+                        >
+                          {t('See changes')}
+                        </span>
+                      ) : (
+                        <span className="text-secondary">
+                          {t('No changes')}
+                        </span>
+                      ))}
                   </div>
                 </h2>
                 <FiltersComponent
+                  isRulesLoading={isRulesLoading}
                   filteredRuleEntries={filteredRuleEntries}
                   newRules={newRules}
                   publication={publication}


### PR DESCRIPTION
**Description:**

- fix 'see chahges' button visibility while rules is loading
- fix rules comparison

Issues:

- #1640 

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
