### PR TITLE
feat(chat): [Authorizatiton] Add option to do authorization in the same window (Issue #1737)

### DIFF
--- a/apps/chat/src/pages/index.tsx
+++ b/apps/chat/src/pages/index.tsx
@@ -98,6 +98,9 @@ export default function Home({ initialState }: HomeProps) {
   const isImportingExporting = useAppSelector(
     ImportExportSelectors.selectIsLoadingImportExport,
   );
+  const isSignInInSameWindow = useAppSelector(
+    SettingsSelectors.selectIsSignInInSameWindow,
+  );
 
   const isReplaceModalOpened = useAppSelector(
     ImportExportSelectors.selectIsShowReplaceDialog,
@@ -151,6 +154,7 @@ export default function Home({ initialState }: HomeProps) {
       (async () => {
         const authWindowLocation = new AuthWindowLocationLike(
           `api/auth/signin`,
+          isSignInInSameWindow,
         );
 
         await authWindowLocation.ready; // ready after redirects

--- a/apps/chat/src/store/overlay/overlay.epics.ts
+++ b/apps/chat/src/store/overlay/overlay.epics.ts
@@ -204,6 +204,7 @@ const setOverlayOptionsEpic: AppEpic = (action$, state$) =>
         enabledFeatures,
         signInOptions,
         overlayConversationId,
+        signInInSameWindow,
       }) => {
         const actions = [];
 
@@ -227,6 +228,12 @@ const setOverlayOptionsEpic: AppEpic = (action$, state$) =>
               `[Overlay](Theme) No such theme: ${theme}.\nTheme isn't set.`,
             );
           }
+        }
+
+        if (signInInSameWindow) {
+          actions.push(
+            of(SettingsActions.setIsSignInInSameWindow(signInInSameWindow)),
+          );
         }
 
         if (enabledFeatures) {

--- a/apps/chat/src/store/settings/settings.reducers.ts
+++ b/apps/chat/src/store/settings/settings.reducers.ts
@@ -29,6 +29,7 @@ export interface SettingsState {
   themesHostDefined: boolean;
   isolatedModelId?: string;
   customRenderers?: CustomVisualizer[];
+  isSignInInSameWindow?: boolean;
 }
 
 const initialState: SettingsState = {
@@ -130,6 +131,9 @@ export const settingsSlice = createSlice({
     },
     setOverlayConversationId: (state, { payload }: PayloadAction<string>) => {
       state.overlayConversationId = payload;
+    },
+    setIsSignInInSameWindow: (state, { payload }: PayloadAction<boolean>) => {
+      state.isSignInInSameWindow = payload;
     },
   },
 });
@@ -271,6 +275,10 @@ const selectOverlayConversationId = createSelector([rootSelector], (state) => {
   return state.overlayConversationId;
 });
 
+const selectIsSignInInSameWindow = createSelector([rootSelector], (state) => {
+  return state.isSignInInSameWindow;
+});
+
 export const SettingsActions = settingsSlice.actions;
 export const SettingsSelectors = {
   selectAppName,
@@ -295,4 +303,5 @@ export const SettingsSelectors = {
   selectIsCustomAttachmentType,
   selectPublicationFilters,
   selectOverlayConversationId,
+  selectIsSignInInSameWindow,
 };

--- a/apps/chat/src/utils/auth/auth-window-location-like.ts
+++ b/apps/chat/src/utils/auth/auth-window-location-like.ts
@@ -3,8 +3,11 @@ export class AuthWindowLocationLike {
   protected resolve: (() => void) | null = null;
   protected reject: (() => void) | null = null;
 
-  constructor(url: string) {
-    this.authWindow = window.open(url);
+  constructor(url: string, isSignInInSameWindow?: boolean) {
+    this.authWindow = window.open(
+      url,
+      isSignInInSameWindow ? '_self' : '_blank',
+    );
 
     if (this.authWindow == null) {
       this.reject?.();

--- a/libs/overlay/README.md
+++ b/libs/overlay/README.md
@@ -65,6 +65,8 @@ const run = async () => {
     loaderClass: 'overlay__loader',
     // optional, id of the conversation to be selected at the start
     overlayConversationId: 'some-conversation-id',
+    // optional, if DIAL should redirect to sign in in the same browser window
+    signInInSameWindow: false,
   });
 
   // overlay loaded application and ready to send and receive information from the application

--- a/libs/shared/src/types/overlay.ts
+++ b/libs/shared/src/types/overlay.ts
@@ -20,6 +20,7 @@ export interface ChatOverlayOptions {
   loaderInnerHTML?: string;
 
   signInOptions?: OverlaySignInOptions;
+  signInInSameWindow?: boolean;
 }
 
 interface OverlaySignInOptions {


### PR DESCRIPTION
feat: [Authorizatiton] Add option to do authorization in the same window (Issue #1737)

**Description:**

Added flag to force sign in to overlay be opened in the same window

Issues:

- Issue #1737

**UI changes**

None

**Checklist:**

- [X] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [X] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [X] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
