### PR TITLE
fix(chat): fix temporary prompt folders displaying (Issue #1724)

### DIFF
--- a/apps/chat/src/store/prompts/prompts.selectors.ts
+++ b/apps/chat/src/store/prompts/prompts.selectors.ts
@@ -304,7 +304,10 @@ export const selectTemporaryAndPublishedFolders = createSelector(
       ...temporaryFolders,
     ].filter((folder) => doesEntityContainSearchTerm(folder, searchTerm));
 
-    return getParentAndChildFolders(sortByName(allFolders), filteredFolders);
+    return getParentAndChildFolders(
+      sortByName([...allFolders, ...temporaryFolders]),
+      filteredFolders,
+    );
   },
 );
 


### PR DESCRIPTION
**Description:**

fix temporary prompt folders displaying

Issues:

- Issue #1724 

**Related**
- #1725 

**UI changes**

![image](https://github.com/epam/ai-dial-chat/assets/20163971/bc731234-6203-42f2-a63d-65671b1517af)

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
