### PR TITLE
fix(chat): fix replacement attachment type after import (Issue #1759)

### DIFF
--- a/apps/chat/src/utils/app/import-export.ts
+++ b/apps/chat/src/utils/app/import-export.ts
@@ -310,10 +310,7 @@ export const updateAttachment = ({
       constructPath(newAttachmentFile.absolutePath, newAttachmentFile.name),
     );
 
-  const newType =
-    oldAttachment.type === PLOTLY_CONTENT_TYPE
-      ? oldAttachment.type ?? newAttachmentFile.contentType
-      : newAttachmentFile.contentType ?? oldAttachment.type;
+  const newType = oldAttachment.type ?? newAttachmentFile.contentType;
 
   const newTitle =
     oldAttachment.type === PLOTLY_CONTENT_TYPE


### PR DESCRIPTION
**Description:**

fix replacement attachment type after import

Issues:

- Issue #1759 

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
