### PR TITLE
fix(chat): truncate long prompt names (Issue #1790)

### DIFF
--- a/apps/chat/src/components/Chat/ChatInput/PromptList.tsx
+++ b/apps/chat/src/components/Chat/ChatInput/PromptList.tsx
@@ -64,7 +64,7 @@ export const PromptList: FC<Props> = ({
         <li
           key={prompt.id}
           className={classNames(
-            'cursor-pointer px-3 py-2',
+            'cursor-pointer truncate px-3 py-2',
             index === activePromptIndex && 'bg-accent-primary-alpha',
           )}
           onClick={(e) => {


### PR DESCRIPTION
**Description:**
truncate long prompt names

Issues:

- Issue #1790

**UI changes**

![image](https://github.com/user-attachments/assets/5d055f69-aad1-467b-8fed-1e73588a1a9b)

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
