### PR TITLE
fix(chat): fix prompt displaying with long or multiline text (Issue #1792)

### DIFF
--- a/apps/chat/src/components/Chat/ChatInput/PromptVariablesDialog.tsx
+++ b/apps/chat/src/components/Chat/ChatInput/PromptVariablesDialog.tsx
@@ -25,6 +25,7 @@ import { Translation } from '@/src/types/translation';
 import { PROMPT_VARIABLE_REGEX } from '@/src/constants/folders';
 
 import EmptyRequiredInputMessage from '../../Common/EmptyRequiredInputMessage';
+import Tooltip from '../../Common/Tooltip';
 
 interface Props {
   prompt: Prompt;
@@ -147,15 +148,20 @@ export const PromptVariablesDialog: FC<Props> = ({
         data-qa="variable-modal"
         onSubmit={handleSubmit}
       >
-        <div
-          className="mb-4 whitespace-pre text-base font-bold"
-          data-qa="variable-prompt-name"
+        <Tooltip
+          tooltip={prompt.name}
+          contentClassName="sm:max-w-[400px] max-w-[250px] break-all"
+          triggerClassName="mb-4 truncate whitespace-pre text-base font-bold block"
+          dataQa="variable-prompt-name"
         >
           {prompt.name}
-        </div>
+        </Tooltip>
 
         {prompt.description && (
-          <div className="mb-5 italic" data-qa="variable-prompt-descr">
+          <div
+            className="mb-5 whitespace-pre-wrap italic"
+            data-qa="variable-prompt-descr"
+          >
             {prompt.description}
           </div>
         )}
@@ -172,7 +178,7 @@ export const PromptVariablesDialog: FC<Props> = ({
         {updatedVariables.map((variable, index) => (
           <div className="mb-4" key={variable.key}>
             <div className="mb-1 flex text-xs text-secondary">
-              {variable.key}
+              <span className="break-all">{variable.key}</span>
               <span className="ml-1 inline text-accent-primary">*</span>
             </div>
 

--- a/apps/chat/src/components/Chat/ChatInput/ReplayVariables.tsx
+++ b/apps/chat/src/components/Chat/ChatInput/ReplayVariables.tsx
@@ -89,7 +89,8 @@ const ReplayVariablesDialog = () => {
     content: replaceDefaultValuesFromContent(activeMessage.content, template),
     id: '',
     folderId: '',
-    name: '',
+    name: 'Please, enter variables for template:',
+    description: template,
   };
 
   return (

--- a/apps/chat/src/components/Chat/ChatInput/ReplayVariables.tsx
+++ b/apps/chat/src/components/Chat/ChatInput/ReplayVariables.tsx
@@ -1,8 +1,11 @@
 import { useCallback, useEffect, useRef } from 'react';
 
+import { useTranslation } from 'next-i18next';
+
 import { replaceDefaultValuesFromContent } from '@/src/utils/app/prompts';
 
 import { Prompt } from '@/src/types/prompt';
+import { Translation } from '@/src/types/translation';
 
 import {
   ConversationsActions,
@@ -27,9 +30,14 @@ export const ReplayVariables = () => {
 };
 
 const ReplayVariablesDialog = () => {
+  const { t } = useTranslation(Translation.Chat);
   const dispatch = useAppDispatch();
   const conversation = useAppSelector(
     ConversationsSelectors.selectFirstSelectedConversation,
+  );
+
+  const isReplayRequiresVariables = useAppSelector(
+    ConversationsSelectors.selectIsReplayRequiresVariables,
   );
 
   const activeMessage =
@@ -43,8 +51,10 @@ const ReplayVariablesDialog = () => {
 
   const onCloseRef = useRef<() => void>();
   useEffect(() => {
-    onCloseRef.current = handleClose;
-  }, [handleClose]);
+    if (isReplayRequiresVariables) {
+      onCloseRef.current = handleClose;
+    }
+  }, [handleClose, isReplayRequiresVariables]);
 
   const handleContentApply = useCallback(
     (newContent: string) => {
@@ -98,7 +108,7 @@ const ReplayVariablesDialog = () => {
     content: replaceDefaultValuesFromContent(activeMessage.content, template),
     id: '',
     folderId: '',
-    name: 'Please, enter variables for template:',
+    name: t('Please, enter variables for template:'),
     description: template,
   };
 

--- a/apps/chat/src/components/Chat/ChatInput/ReplayVariables.tsx
+++ b/apps/chat/src/components/Chat/ChatInput/ReplayVariables.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 
 import { replaceDefaultValuesFromContent } from '@/src/utils/app/prompts';
 
@@ -36,6 +36,15 @@ const ReplayVariablesDialog = () => {
     conversation?.replay?.replayUserMessagesStack?.[
       conversation?.replay?.activeReplayIndex ?? 0
     ];
+
+  const handleClose = useCallback(() => {
+    dispatch(ConversationsActions.setIsReplayRequiresVariables(false));
+  }, [dispatch]);
+
+  const onCloseRef = useRef<() => void>();
+  useEffect(() => {
+    onCloseRef.current = handleClose;
+  }, [handleClose]);
 
   const handleContentApply = useCallback(
     (newContent: string) => {
@@ -94,6 +103,10 @@ const ReplayVariablesDialog = () => {
   };
 
   return (
-    <PromptVariablesDialog prompt={prompt} onSubmit={handleContentApply} />
+    <PromptVariablesDialog
+      prompt={prompt}
+      onSubmit={handleContentApply}
+      onClose={onCloseRef.current}
+    />
   );
 };

--- a/apps/chat/src/components/Common/Tooltip.tsx
+++ b/apps/chat/src/components/Common/Tooltip.tsx
@@ -221,6 +221,7 @@ interface TooltipOptions extends TooltipContainerOptions {
   children: ReactNode;
   triggerClassName?: string;
   contentClassName?: string;
+  dataQa?: string;
 }
 
 export default function Tooltip({
@@ -229,13 +230,16 @@ export default function Tooltip({
   children,
   triggerClassName,
   contentClassName,
+  dataQa,
   ...tooltipProps
 }: TooltipOptions) {
   if (hideTooltip || !tooltip)
     return <span className={triggerClassName}>{children}</span>;
   return (
     <TooltipContainer {...tooltipProps}>
-      <TooltipTrigger className={triggerClassName}>{children}</TooltipTrigger>
+      <TooltipTrigger className={triggerClassName} data-qa={dataQa}>
+        {children}
+      </TooltipTrigger>
       <TooltipContent className={contentClassName}>{tooltip}</TooltipContent>
     </TooltipContainer>
   );

--- a/apps/chat/src/utils/app/prompts.ts
+++ b/apps/chat/src/utils/app/prompts.ts
@@ -39,7 +39,7 @@ export const parseVariablesFromContent = (
   while ((match = PROMPT_VARIABLE_REGEX.exec(content)) !== null) {
     foundVariables.push({
       name: match[1],
-      defaultValue: match[2]?.slice(1) ?? '',
+      defaultValue: match[2]?.slice(1).trim() ?? '',
     });
   }
 


### PR DESCRIPTION
**Description:**

- fix prompt displaying with long or multiline text
- allow to close the replay variables dialog
- add title and description for the replay variables dialog

Issues:

- Issue #1792

**UI changes**

![image](https://github.com/user-attachments/assets/de29d5cf-9c85-4777-8046-da7f1e44a893)
![image](https://github.com/user-attachments/assets/06440e76-1fe5-4cb0-9c3f-440d8350e810)


**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
