### PR TITLE
feat(chat): replace "show more" by "show previous" for stages and show last 3 stages by default (Issue 1820)

### DIFF
--- a/apps/chat-e2e/src/assertions/chatMessagesAssertion.ts
+++ b/apps/chat-e2e/src/assertions/chatMessagesAssertion.ts
@@ -27,8 +27,8 @@ export class ChatMessagesAssertion {
   ) {
     const button =
       label === 'more'
-        ? this.chatMessages.showMoreButton.getElementLocator()
-        : this.chatMessages.showLessButton.getElementLocator();
+        ? this.chatMessages.showPreviousButton.getElementLocator()
+        : this.chatMessages.hidePreviousButton.getElementLocator();
     expectedState === 'visible'
       ? await expect
           .soft(button, ExpectedMessages.buttonIsVisible)
@@ -44,8 +44,8 @@ export class ChatMessagesAssertion {
   ) {
     const button =
       label === 'more'
-        ? this.chatMessages.showMoreButton
-        : this.chatMessages.showLessButton;
+        ? this.chatMessages.showPreviousButton
+        : this.chatMessages.hidePreviousButton;
     const color = await button.getComputedStyleProperty(Styles.color);
     expect
       .soft(color[0], ExpectedMessages.elementColorIsValid)

--- a/apps/chat-e2e/src/tests/conversationWithStage.test.ts
+++ b/apps/chat-e2e/src/tests/conversationWithStage.test.ts
@@ -54,7 +54,7 @@ dialTest(
     await dialTest.step(
       'Click on "Show more" and verify all stages and "Show less" button are displayed',
       async () => {
-        await chatMessages.showMoreButton.click();
+        await chatMessages.showPreviousButton.click();
         await chatMessagesAssertion.assertMessageStagesCount(2, stagesCount);
         await chatMessagesAssertion.assertShowMoreLessButtonState(
           'less',
@@ -70,7 +70,7 @@ dialTest(
     await dialTest.step(
       'Click on "Show less" and verify 3 stages and "Show more" button are displayed',
       async () => {
-        await chatMessages.showLessButton.click();
+        await chatMessages.hidePreviousButton.click();
         await chatMessagesAssertion.assertMessageStagesCount(
           2,
           maxDisplayedStagesCount,

--- a/apps/chat-e2e/src/ui/selectors/chatSelectors.ts
+++ b/apps/chat-e2e/src/ui/selectors/chatSelectors.ts
@@ -143,8 +143,8 @@ export const ChatSelectors = {
   messageSpinner: '[data-qa="message-input-spinner"]',
   plotlyContainer: '.plot-container',
   maxWidth: '.max-w-none',
-  showMore: '[data-qa="show-more"]',
-  showLess: '[data-qa="show-less"]',
+  showPrevious: '[data-qa="show-previous"]',
+  hidePrevious: '[data-qa="hide-previous"]',
 };
 
 export const TableSelectors = {

--- a/apps/chat-e2e/src/ui/webElements/chatMessages.ts
+++ b/apps/chat-e2e/src/ui/webElements/chatMessages.ts
@@ -62,12 +62,12 @@ export class ChatMessages extends BaseElement {
       ChatSelectors.stageLoader,
     );
 
-  public showMoreButton = this.getChildElementBySelector(
-    ChatSelectors.showMore,
+  public showPreviousButton = this.getChildElementBySelector(
+    ChatSelectors.showPrevious,
   );
 
-  public showLessButton = this.getChildElementBySelector(
-    ChatSelectors.showLess,
+  public hidePreviousButton = this.getChildElementBySelector(
+    ChatSelectors.hidePrevious,
   );
 
   public async waitForResponseReceived() {

--- a/apps/chat/src/components/Chat/MessageStages.tsx
+++ b/apps/chat/src/components/Chat/MessageStages.tsx
@@ -15,35 +15,34 @@ export interface Props {
 const NUMBER_OF_VISIBLE_STAGES = 3;
 
 export const MessageStages = ({ stages }: Props) => {
-  const [showMore, setShowMore] = useState(false);
+  const [showPrevious, setShowPrevious] = useState(false);
 
   const displayedStages = stages.slice(
-    0,
-    showMore ? stages.length : NUMBER_OF_VISIBLE_STAGES,
+    showPrevious ? -stages.length : -NUMBER_OF_VISIBLE_STAGES,
   );
 
   return (
     <div data-no-context-menu className="flex flex-col gap-1">
-      {displayedStages.map((stage) => (
-        <MessageStage key={stage.index} stage={stage} />
-      ))}
       {stages.length > NUMBER_OF_VISIBLE_STAGES && (
         <button
-          onClick={() => setShowMore(!showMore)}
-          className="mt-2 flex leading-[18px] text-accent-primary"
-          data-qa={showMore ? 'show-less' : 'show-more'}
+          onClick={() => setShowPrevious(!showPrevious)}
+          className="mb-2 flex leading-[18px] text-accent-primary"
+          data-qa={showPrevious ? 'hide-previous' : 'show-previous'}
         >
-          {showMore ? 'Show less' : 'Show more'}
+          {showPrevious ? 'Hide previous' : 'Show previous'}
           <ChevronDown
             height={18}
             width={18}
             className={classNames(
               'ml-2 shrink-0 transition',
-              showMore && 'rotate-180',
+              !showPrevious && 'rotate-180',
             )}
           />
         </button>
       )}
+      {displayedStages.map((stage) => (
+        <MessageStage key={stage.index} stage={stage} />
+      ))}
     </div>
   );
 };


### PR DESCRIPTION
**Description:**

replace "show more" by "show previous" for stages and show last 3 stages by default

Issues:

- Issue #1820 

**UI changes**

![image](https://github.com/user-attachments/assets/8aaacbd9-b3f1-4d6d-af36-d14c03e49c77)
->
![image](https://github.com/user-attachments/assets/a9489a60-f018-4dd6-b1c6-c0b30f2bc78c)

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
