### PR TITLE
fix(chat): fix replay flag check on extracting attachments from conversation (Issue #1824)

### DIFF
--- a/apps/chat/src/utils/app/folders.ts
+++ b/apps/chat/src/utils/app/folders.ts
@@ -383,10 +383,12 @@ export const getConversationAttachmentWithPath = <
   folders: FolderInterface[],
 ): DialFile[] => {
   const { path } = getPathToFolderById(folders, conversation.folderId);
+  const isReplay =
+    'replay' in conversation ? conversation?.replay?.isReplay : false;
   const attachments =
     'messages' in conversation
       ? (
-          conversation.replay?.replayUserMessagesStack ||
+          (isReplay && conversation.replay?.replayUserMessagesStack) ||
           conversation.playback?.messagesStack ||
           conversation.messages
         ).flatMap((message) => {


### PR DESCRIPTION
**Description:**

While extracting attachments from conversation there was no checking if the conversation is exported or imported in replay mode, now it checks isReplay flag.

Issues:

- Issue #1824 

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
