### PR TITLE
fix(chat): fix folders selection if search term isn't empty (Issue #1837)

### DIFF
--- a/apps/chat/src/components/Chatbar/ChatFolders.tsx
+++ b/apps/chat/src/components/Chatbar/ChatFolders.tsx
@@ -210,9 +210,15 @@ const ChatFolderTemplate = ({
   );
   const handleFolderSelect = useCallback(
     (folderId: string, isChosen: boolean) => {
-      dispatch(ConversationsActions.setChosenFolder({ folderId, isChosen }));
+      dispatch(
+        ConversationsActions.setChosenFolder({
+          folderId,
+          isChosen,
+          searchTerm,
+        }),
+      );
     },
-    [dispatch],
+    [dispatch, searchTerm],
   );
 
   return (

--- a/apps/chat/src/components/Chatbar/ChatFolders.tsx
+++ b/apps/chat/src/components/Chatbar/ChatFolders.tsx
@@ -210,15 +210,9 @@ const ChatFolderTemplate = ({
   );
   const handleFolderSelect = useCallback(
     (folderId: string, isChosen: boolean) => {
-      dispatch(
-        ConversationsActions.setChosenFolder({
-          folderId,
-          isChosen,
-          searchTerm,
-        }),
-      );
+      dispatch(ConversationsActions.setChosenFolder({ folderId, isChosen }));
     },
-    [dispatch, searchTerm],
+    [dispatch],
   );
 
   return (

--- a/apps/chat/src/store/conversations/conversations.epics.ts
+++ b/apps/chat/src/store/conversations/conversations.epics.ts
@@ -2685,7 +2685,7 @@ const deleteChosenConversationsEpic: AppEpic = (action$, state$) =>
         ),
       ]);
       const filteredConversations = conversations.filter(
-        (p) => !deletedConversationIds.includes(p.id),
+        (conv) => !deletedConversationIds.includes(conv.id),
       );
 
       if (conversationIds.length) {
@@ -2702,8 +2702,8 @@ const deleteChosenConversationsEpic: AppEpic = (action$, state$) =>
         of(
           ConversationsActions.setFolders({
             folders: folders.filter((folder) =>
-              filteredConversations.some((c) =>
-                c.id.startsWith(`${folder.id}/`),
+              filteredConversations.some((conv) =>
+                conv.id.startsWith(`${folder.id}/`),
               ),
             ),
           }),

--- a/apps/chat/src/store/conversations/conversations.epics.ts
+++ b/apps/chat/src/store/conversations/conversations.epics.ts
@@ -69,9 +69,11 @@ import {
 } from '@/src/utils/app/merge-streams';
 import { isSmallScreen } from '@/src/utils/app/mobile';
 import { updateSystemPromptInMessages } from '@/src/utils/app/overlay';
+import { doesEntityContainSearchTerm } from '@/src/utils/app/search';
 import { isEntityOrParentsExternal } from '@/src/utils/app/share';
 import { filterUnfinishedStages } from '@/src/utils/app/stages';
 import { translate } from '@/src/utils/app/translation';
+import { parseConversationApiKey } from '@/src/utils/server/api';
 
 import {
   ChatBody,
@@ -82,7 +84,12 @@ import {
   RateBody,
   Role,
 } from '@/src/types/chat';
-import { EntityType, FeatureType, UploadStatus } from '@/src/types/common';
+import {
+  EntityType,
+  FeatureType,
+  ShareEntity,
+  UploadStatus,
+} from '@/src/types/common';
 import { FolderType } from '@/src/types/folder';
 import { AppEpic } from '@/src/types/store';
 
@@ -2655,16 +2662,31 @@ const deleteChosenConversationsEpic: AppEpic = (action$, state$) =>
       const chosenFolderIds = ConversationsSelectors.selectChosenFolderIds(
         state$.value,
       );
-      const conversationIds = ConversationsSelectors.selectConversations(
+      const searchTerm = ConversationsSelectors.selectSearchTerm(state$.value);
+      const conversations = ConversationsSelectors.selectConversations(
         state$.value,
-      ).map((conv) => conv.id);
+      );
+      const conversationIds = conversations.map((conv) => conv.id);
       const folders = ConversationsSelectors.selectFolders(state$.value);
       const deletedConversationIds = uniq([
-        ...chosenConversationIds,
-        ...conversationIds.filter((id) =>
-          chosenFolderIds.some((folderId) => id.startsWith(folderId)),
+        ...chosenConversationIds.filter((id) =>
+          doesEntityContainSearchTerm(
+            parseConversationApiKey(id) as unknown as ShareEntity,
+            searchTerm,
+          ),
+        ),
+        ...conversationIds.filter(
+          (id) =>
+            chosenFolderIds.some((folderId) => id.startsWith(folderId)) &&
+            doesEntityContainSearchTerm(
+              parseConversationApiKey(id) as unknown as ShareEntity,
+              searchTerm,
+            ),
         ),
       ]);
+      const filteredConversations = conversations.filter(
+        (p) => !deletedConversationIds.includes(p.id),
+      );
 
       if (conversationIds.length) {
         actions.push(
@@ -2680,8 +2702,8 @@ const deleteChosenConversationsEpic: AppEpic = (action$, state$) =>
         of(
           ConversationsActions.setFolders({
             folders: folders.filter((folder) =>
-              chosenFolderIds.every(
-                (id) => !folder.id.startsWith(id) && `${folder.id}/` !== id,
+              filteredConversations.some((c) =>
+                c.id.startsWith(`${folder.id}/`),
               ),
             ),
           }),

--- a/apps/chat/src/store/conversations/conversations.reducers.ts
+++ b/apps/chat/src/store/conversations/conversations.reducers.ts
@@ -828,7 +828,6 @@ export const conversationsSlice = createSlice({
       }: PayloadAction<{
         folderId: string;
         isChosen: boolean;
-        searchTerm: string;
       }>,
     ) => {
       if (isChosen) {

--- a/apps/chat/src/store/conversations/conversations.reducers.ts
+++ b/apps/chat/src/store/conversations/conversations.reducers.ts
@@ -782,14 +782,15 @@ export const conversationsSlice = createSlice({
               (convId: string) => convId !== conversationId,
             ),
             ...state.conversations
-              .map((conv) => conv.id)
               .filter(
-                (convId) =>
-                  convId !== conversationId &&
+                (conv) =>
+                  conv.id !== conversationId &&
                   parentFolderIds.some((parentId) =>
-                    convId.startsWith(parentId),
-                  ),
-              ),
+                    conv.id.startsWith(parentId),
+                  ) &&
+                  doesEntityContainSearchTerm(conv, state.searchTerm),
+              )
+              .map((conv) => conv.id),
           ]);
         } else {
           state.chosenConversationIds = state.chosenConversationIds.filter(
@@ -824,7 +825,11 @@ export const conversationsSlice = createSlice({
       state,
       {
         payload: { folderId, isChosen },
-      }: PayloadAction<{ folderId: string; isChosen: boolean }>,
+      }: PayloadAction<{
+        folderId: string;
+        isChosen: boolean;
+        searchTerm: string;
+      }>,
     ) => {
       if (isChosen) {
         const parentFolderIds = state.chosenFolderIds.filter(
@@ -849,12 +854,14 @@ export const conversationsSlice = createSlice({
             (convId: string) => !convId.startsWith(folderId),
           ),
           ...state.conversations
-            .map((conv) => conv.id)
             .filter(
-              (convId) =>
-                !convId.startsWith(folderId) &&
-                parentFolderIds.some((parentId) => convId.startsWith(parentId)),
-            ),
+              (conv) =>
+                !conv.id.startsWith(folderId) &&
+                parentFolderIds.some((parentId) =>
+                  conv.id.startsWith(parentId),
+                ),
+            )
+            .map((c) => c.id),
         ]);
       } else {
         state.chosenConversationIds = state.chosenConversationIds.filter(

--- a/apps/chat/src/store/conversations/conversations.selectors.ts
+++ b/apps/chat/src/store/conversations/conversations.selectors.ts
@@ -768,7 +768,7 @@ export const selectAllChosenFolderIds = createSelector(
     return folders
       .map((folder) => `${folder.id}/`)
       .filter((folderId) => {
-        const filteredChats = state.conversations.filter(
+        const filteredConversations = state.conversations.filter(
           (conv) =>
             doesEntityContainSearchTerm(conv, state.searchTerm) &&
             conv.id.startsWith(folderId) &&
@@ -783,9 +783,9 @@ export const selectAllChosenFolderIds = createSelector(
           state.chosenFolderIds.some((chosenId) =>
             folderId.startsWith(chosenId),
           ) ||
-          (filteredChats.length &&
-            filteredChats.every((c) =>
-              state.chosenConversationIds.includes(c.id),
+          (filteredConversations.length &&
+            filteredConversations.every((conv) =>
+              state.chosenConversationIds.includes(conv.id),
             ))
         );
       });

--- a/apps/chat/src/store/conversations/conversations.selectors.ts
+++ b/apps/chat/src/store/conversations/conversations.selectors.ts
@@ -769,12 +769,12 @@ export const selectAllChosenFolderIds = createSelector(
       .map((folder) => `${folder.id}/`)
       .filter((folderId) => {
         const filteredChats = state.conversations.filter(
-          (c) =>
-            doesEntityContainSearchTerm(c, state.searchTerm) &&
-            c.id.startsWith(folderId) &&
+          (conv) =>
+            doesEntityContainSearchTerm(conv, state.searchTerm) &&
+            conv.id.startsWith(folderId) &&
             !isEntityOrParentsExternal(
               { conversations: state },
-              c,
+              conv,
               FeatureType.Chat,
             ),
         );

--- a/apps/chat/src/store/conversations/conversations.selectors.ts
+++ b/apps/chat/src/store/conversations/conversations.selectors.ts
@@ -767,9 +767,28 @@ export const selectAllChosenFolderIds = createSelector(
   (state, folders) => {
     return folders
       .map((folder) => `${folder.id}/`)
-      .filter((folderId) =>
-        state.chosenFolderIds.some((chosenId) => folderId.startsWith(chosenId)),
-      );
+      .filter((folderId) => {
+        const filteredChats = state.conversations.filter(
+          (c) =>
+            doesEntityContainSearchTerm(c, state.searchTerm) &&
+            c.id.startsWith(folderId) &&
+            !isEntityOrParentsExternal(
+              { conversations: state },
+              c,
+              FeatureType.Chat,
+            ),
+        );
+
+        return (
+          state.chosenFolderIds.some((chosenId) =>
+            folderId.startsWith(chosenId),
+          ) ||
+          (filteredChats.length &&
+            filteredChats.every((c) =>
+              state.chosenConversationIds.includes(c.id),
+            ))
+        );
+      });
   },
 );
 

--- a/apps/chat/src/store/prompts/prompts.epics.ts
+++ b/apps/chat/src/store/prompts/prompts.epics.ts
@@ -745,7 +745,7 @@ const deleteChosenPromptsEpic: AppEpic = (action$, state$) =>
         ),
       ]);
       const filteredPrompts = prompts.filter(
-        (p) => !deletedPromptIds.includes(p.id),
+        (prompt) => !deletedPromptIds.includes(prompt.id),
       );
 
       if (promptIds.length) {
@@ -762,7 +762,9 @@ const deleteChosenPromptsEpic: AppEpic = (action$, state$) =>
         of(
           PromptsActions.setFolders({
             folders: folders.filter((folder) =>
-              filteredPrompts.some((p) => p.id.startsWith(`${folder.id}/`)),
+              filteredPrompts.some((prompt) =>
+                prompt.id.startsWith(`${folder.id}/`),
+              ),
             ),
           }),
         ),

--- a/apps/chat/src/store/prompts/prompts.epics.ts
+++ b/apps/chat/src/store/prompts/prompts.epics.ts
@@ -40,11 +40,12 @@ import {
   getPromptInfoFromId,
   regeneratePromptId,
 } from '@/src/utils/app/prompts';
+import { doesEntityContainSearchTerm } from '@/src/utils/app/search';
 import { isEntityOrParentsExternal } from '@/src/utils/app/share';
 import { translate } from '@/src/utils/app/translation';
-import { getPromptApiKey } from '@/src/utils/server/api';
+import { getPromptApiKey, parsePromptApiKey } from '@/src/utils/server/api';
 
-import { FeatureType, UploadStatus } from '@/src/types/common';
+import { FeatureType, ShareEntity, UploadStatus } from '@/src/types/common';
 import { FolderType } from '@/src/types/folder';
 import { Prompt, PromptInfo } from '@/src/types/prompt';
 import { AppEpic } from '@/src/types/store';
@@ -723,16 +724,29 @@ const deleteChosenPromptsEpic: AppEpic = (action$, state$) =>
       const chosenFolderIds = PromptsSelectors.selectChosenFolderIds(
         state$.value,
       );
-      const promptIds = PromptsSelectors.selectPrompts(state$.value).map(
-        (prompt) => prompt.id,
-      );
+      const searchTerm = PromptsSelectors.selectSearchTerm(state$.value);
+      const prompts = PromptsSelectors.selectPrompts(state$.value);
+      const promptIds = prompts.map((prompt) => prompt.id);
       const folders = PromptsSelectors.selectFolders(state$.value);
       const deletedPromptIds = uniq([
-        ...chosenPromptIds,
-        ...promptIds.filter((id) =>
-          chosenFolderIds.some((folderId) => id.startsWith(folderId)),
+        ...chosenPromptIds.filter((id) =>
+          doesEntityContainSearchTerm(
+            parsePromptApiKey(id) as unknown as ShareEntity,
+            searchTerm,
+          ),
+        ),
+        ...promptIds.filter(
+          (id) =>
+            chosenFolderIds.some((folderId) => id.startsWith(folderId)) &&
+            doesEntityContainSearchTerm(
+              parsePromptApiKey(id) as unknown as ShareEntity,
+              searchTerm,
+            ),
         ),
       ]);
+      const filteredPrompts = prompts.filter(
+        (p) => !deletedPromptIds.includes(p.id),
+      );
 
       if (promptIds.length) {
         actions.push(
@@ -748,9 +762,7 @@ const deleteChosenPromptsEpic: AppEpic = (action$, state$) =>
         of(
           PromptsActions.setFolders({
             folders: folders.filter((folder) =>
-              chosenFolderIds.every(
-                (id) => !folder.id.startsWith(id) && `${folder.id}/` !== id,
-              ),
+              filteredPrompts.some((p) => p.id.startsWith(`${folder.id}/`)),
             ),
           }),
         ),

--- a/apps/chat/src/store/prompts/prompts.reducers.ts
+++ b/apps/chat/src/store/prompts/prompts.reducers.ts
@@ -433,12 +433,12 @@ export const promptsSlice = createSlice({
             ...state.prompts
 
               .filter(
-                (p) =>
-                  p.id !== promptId &&
+                (prompt) =>
+                  prompt.id !== promptId &&
                   parentFolderIds.some((parentId) =>
-                    p.id.startsWith(parentId),
+                    prompt.id.startsWith(parentId),
                   ) &&
-                  doesEntityContainSearchTerm(p, state.searchTerm),
+                  doesEntityContainSearchTerm(prompt, state.searchTerm),
               )
               .map((prompt) => prompt.id),
           ]);

--- a/apps/chat/src/store/prompts/prompts.reducers.ts
+++ b/apps/chat/src/store/prompts/prompts.reducers.ts
@@ -431,12 +431,16 @@ export const promptsSlice = createSlice({
               (convId: string) => convId !== promptId,
             ),
             ...state.prompts
-              .map((prompt) => prompt.id)
+
               .filter(
-                (prId) =>
-                  prId !== promptId &&
-                  parentFolderIds.some((parentId) => prId.startsWith(parentId)),
-              ),
+                (p) =>
+                  p.id !== promptId &&
+                  parentFolderIds.some((parentId) =>
+                    p.id.startsWith(parentId),
+                  ) &&
+                  doesEntityContainSearchTerm(p, state.searchTerm),
+              )
+              .map((prompt) => prompt.id),
           ]);
         } else {
           state.chosenPromptIds = state.chosenPromptIds.filter(

--- a/apps/chat/src/store/prompts/prompts.selectors.ts
+++ b/apps/chat/src/store/prompts/prompts.selectors.ts
@@ -423,12 +423,12 @@ export const selectAllChosenFolderIds = createSelector(
       .map((folder) => `${folder.id}/`)
       .filter((folderId) => {
         const filteredChats = state.prompts.filter(
-          (c) =>
-            doesEntityContainSearchTerm(c, state.searchTerm) &&
-            c.id.startsWith(folderId) &&
+          (prompt) =>
+            doesEntityContainSearchTerm(prompt, state.searchTerm) &&
+            prompt.id.startsWith(folderId) &&
             !isEntityOrParentsExternal(
               { prompts: state },
-              c,
+              prompt,
               FeatureType.Prompt,
             ),
         );

--- a/apps/chat/src/store/prompts/prompts.selectors.ts
+++ b/apps/chat/src/store/prompts/prompts.selectors.ts
@@ -422,7 +422,7 @@ export const selectAllChosenFolderIds = createSelector(
     return folders
       .map((folder) => `${folder.id}/`)
       .filter((folderId) => {
-        const filteredChats = state.prompts.filter(
+        const filteredPrompts = state.prompts.filter(
           (prompt) =>
             doesEntityContainSearchTerm(prompt, state.searchTerm) &&
             prompt.id.startsWith(folderId) &&
@@ -437,8 +437,10 @@ export const selectAllChosenFolderIds = createSelector(
           state.chosenFolderIds.some((chosenId) =>
             folderId.startsWith(chosenId),
           ) ||
-          (filteredChats.length &&
-            filteredChats.every((c) => state.chosenPromptIds.includes(c.id)))
+          (filteredPrompts.length &&
+            filteredPrompts.every((prompt) =>
+              state.chosenPromptIds.includes(prompt.id),
+            ))
         );
       });
   },


### PR DESCRIPTION
**Description:**

fix(chat): fix folders selection if search term isn't empty

Issues:

- #1837

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
