### PR TITLE
fix(chat): fix publication files download icon, hide 'go to a review' button if request contains only files, add file section to publication request if there no files to publish (Issues #1839, #1745)

### DIFF
--- a/apps/chat/src/components/Chat/Publish/PublicationHandler.tsx
+++ b/apps/chat/src/components/Chat/Publish/PublicationHandler.tsx
@@ -3,6 +3,8 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { useTranslation } from 'next-i18next';
 
+import classNames from 'classnames';
+
 import {
   getFolderIdFromEntityId,
   getParentFolderIdsFromEntityId,
@@ -301,6 +303,9 @@ export function PublicationHandler({ publication }: Props) {
   const invalidEntities = nonExistentEntities.filter((entity) =>
     publication.resources.some((r) => r.reviewUrl === entity.id),
   );
+  const isOnlyFilesPublication = publication.resources.every((resource) =>
+    isFileId(resource.reviewUrl),
+  );
 
   return (
     <div className="flex size-full flex-col items-center overflow-y-auto p-0 md:px-5 md:pt-5">
@@ -425,7 +430,12 @@ export function PublicationHandler({ publication }: Props) {
             </div>
           </div>
         </div>
-        <div className="flex w-full items-center justify-between gap-5 rounded-t bg-layer-2 px-3 py-4 md:px-4">
+        <div
+          className={classNames(
+            'flex w-full items-center gap-5 rounded-t bg-layer-2 px-3 py-4 md:px-4',
+            isOnlyFilesPublication ? 'justify-end' : 'justify-between',
+          )}
+        >
           {invalidEntities.length ? (
             <div className="flex items-center gap-3">
               <IconExclamationCircle
@@ -449,14 +459,16 @@ export function PublicationHandler({ publication }: Props) {
               </p>
             </div>
           ) : (
-            <button
-              className="text-accent-primary"
-              onClick={handlePublicationReview}
-            >
-              {resourcesToReview.some((r) => r.reviewed)
-                ? t('Continue review...')
-                : t('Go to a review...')}
-            </button>
+            !isOnlyFilesPublication && (
+              <button
+                className="text-accent-primary"
+                onClick={handlePublicationReview}
+              >
+                {resourcesToReview.some((r) => r.reviewed)
+                  ? t('Continue review...')
+                  : t('Go to a review...')}
+              </button>
+            )
           )}
           <div className="flex gap-3">
             <button

--- a/apps/chat/src/components/Chat/Publish/PublicationItemsList.tsx
+++ b/apps/chat/src/components/Chat/Publish/PublicationItemsList.tsx
@@ -1,8 +1,12 @@
+import { IconDownload } from '@tabler/icons-react';
 import { useCallback, useEffect } from 'react';
 
 import { useTranslation } from 'next-i18next';
 
 import classNames from 'classnames';
+
+import { constructPath } from '@/src/utils/app/file';
+import { ApiUtils } from '@/src/utils/server/api';
 
 import { ConversationInfo } from '@/src/types/chat';
 import { Entity, FeatureType } from '@/src/types/common';
@@ -93,94 +97,114 @@ export function PublicationItemsList({
     >
       {(type === SharingType.Conversation ||
         type === SharingType.ConversationFolder) && (
-        <CollapsibleSection
-          togglerClassName="!text-sm !text-primary"
-          name={t('Conversations')}
-          openByDefault
-          className="!pl-0"
-          dataQa="conversations-to-send-request"
-        >
-          {type === SharingType.Conversation ? (
-            <ConversationRow
-              onSelect={handleSelect}
-              itemComponentClassNames={classNames(
-                'group/conversation-item cursor-pointer',
-                publishAction === PublishActions.DELETE && 'text-error',
-              )}
-              item={entity as ConversationInfo}
-              level={0}
-              isChosen={chosenItemsIds.some((id) => id === entity.id)}
-            />
-          ) : (
-            <Folder
-              noCaretIcon
-              level={0}
-              currentFolder={entity as FolderInterface}
-              allFolders={conversationFolders.filter((f) =>
-                entities.some((item) => item.id.startsWith(`${f.id}/`)),
-              )}
-              searchTerm={''}
-              openedFoldersIds={conversationFolders.map((f) => f.id)}
-              onSelectFolder={(folderId) => {
-                handleSelect(
-                  entities
-                    .filter(
-                      (e) =>
-                        e.id.startsWith(folderId) &&
-                        (!partialChosenFolderIds.includes(folderId) ||
-                          !chosenItemsIds.includes(e.id)),
-                    )
-                    .map((e) => e.id),
-                );
-              }}
-              allItems={entities}
-              itemComponent={({ item, ...props }) => (
-                <ConversationRow
-                  {...props}
-                  item={item as ConversationInfo}
-                  onSelect={handleSelect}
-                  isChosen={chosenItemsIds.some((id) => id === item.id)}
-                />
-              )}
-              featureType={FeatureType.Chat}
-              folderClassName="h-[38px]"
-              itemComponentClassNames={classNames(
-                'group/conversation-item cursor-pointer',
-                publishAction === PublishActions.DELETE && 'text-error',
-              )}
-              additionalItemData={{
-                partialSelectedFolderIds: partialChosenFolderIds,
-                selectedFolderIds: fullyChosenFolderIds,
-              }}
-              showTooltip
-              canSelectFolders
-              isSelectAlwaysVisible
-            />
-          )}
-        </CollapsibleSection>
-      )}
-      {!!files.length && (
-        <CollapsibleSection
-          togglerClassName="!text-sm !text-primary"
-          name={t('Files')}
-          openByDefault
-          dataQa="files-to-send-request"
-          className="!pl-0"
-        >
-          {files.map((f) => (
-            <FilesRow
-              itemComponentClassNames={classNames(
-                'group/file-item cursor-pointer',
-                publishAction === PublishActions.DELETE && 'text-error',
-              )}
-              key={f.id}
-              item={f}
-              level={0}
-              onSelect={handleSelect}
-              isChosen={chosenItemsIds.some((id) => id === f.id)}
-            />
-          ))}
-        </CollapsibleSection>
+        <>
+          <CollapsibleSection
+            togglerClassName="!text-sm !text-primary"
+            name={t('Conversations')}
+            openByDefault
+            className="!pl-0"
+            dataQa="conversations-to-send-request"
+          >
+            {type === SharingType.Conversation ? (
+              <ConversationRow
+                onSelect={handleSelect}
+                itemComponentClassNames={classNames(
+                  'group/conversation-item cursor-pointer',
+                  publishAction === PublishActions.DELETE && 'text-error',
+                )}
+                item={entity as ConversationInfo}
+                level={0}
+                isChosen={chosenItemsIds.some((id) => id === entity.id)}
+              />
+            ) : (
+              <Folder
+                noCaretIcon
+                level={0}
+                currentFolder={entity as FolderInterface}
+                allFolders={conversationFolders.filter((f) =>
+                  entities.some((item) => item.id.startsWith(`${f.id}/`)),
+                )}
+                searchTerm={''}
+                openedFoldersIds={conversationFolders.map((f) => f.id)}
+                onSelectFolder={(folderId) => {
+                  handleSelect(
+                    entities
+                      .filter(
+                        (e) =>
+                          e.id.startsWith(folderId) &&
+                          (!partialChosenFolderIds.includes(folderId) ||
+                            !chosenItemsIds.includes(e.id)),
+                      )
+                      .map((e) => e.id),
+                  );
+                }}
+                allItems={entities}
+                itemComponent={({ item, ...props }) => (
+                  <ConversationRow
+                    {...props}
+                    item={item as ConversationInfo}
+                    onSelect={handleSelect}
+                    isChosen={chosenItemsIds.some((id) => id === item.id)}
+                  />
+                )}
+                featureType={FeatureType.Chat}
+                folderClassName="h-[38px]"
+                itemComponentClassNames={classNames(
+                  'group/conversation-item cursor-pointer',
+                  publishAction === PublishActions.DELETE && 'text-error',
+                )}
+                additionalItemData={{
+                  partialSelectedFolderIds: partialChosenFolderIds,
+                  selectedFolderIds: fullyChosenFolderIds,
+                }}
+                showTooltip
+                canSelectFolders
+                isSelectAlwaysVisible
+              />
+            )}
+          </CollapsibleSection>
+
+          <CollapsibleSection
+            togglerClassName="!text-sm !text-primary"
+            name={t('Files')}
+            openByDefault
+            dataQa="files-to-send-request"
+            className="!pl-0"
+          >
+            {files.length ? (
+              files.map((f) => (
+                <div key={f.id} className="flex items-center gap-2">
+                  <FilesRow
+                    itemComponentClassNames={classNames(
+                      'group/file-item w-full cursor-pointer truncate',
+                      publishAction === PublishActions.DELETE && 'text-error',
+                    )}
+                    key={f.id}
+                    item={f}
+                    level={0}
+                    onSelect={handleSelect}
+                    isChosen={chosenItemsIds.some((id) => id === f.id)}
+                  />
+                  <a
+                    download={f.name}
+                    href={constructPath('api', ApiUtils.encodeApiUrl(f.id))}
+                  >
+                    <IconDownload
+                      className="shrink-0 text-secondary hover:text-accent-primary"
+                      size={18}
+                    />
+                  </a>
+                </div>
+              ))
+            ) : (
+              <p className="pl-3.5 text-secondary">
+                {type === SharingType.Conversation
+                  ? t("This conversation doesn't contain any files")
+                  : t("These conversations don't contain any files")}
+              </p>
+            )}
+          </CollapsibleSection>
+        </>
       )}
       {(type === SharingType.Prompt || type === SharingType.PromptFolder) && (
         <CollapsibleSection

--- a/apps/chat/src/components/Chat/Publish/PublicationResources.tsx
+++ b/apps/chat/src/components/Chat/Publish/PublicationResources.tsx
@@ -257,7 +257,7 @@ export const FilePublicationResources = ({
                 <FilesRow
                   {...props}
                   itemComponentClassNames={classNames(
-                    'w-full',
+                    'w-full truncate',
                     props.itemComponentClassNames,
                   )}
                 />

--- a/apps/chat/src/components/Common/ReplaceConfirmationModal/Components.tsx
+++ b/apps/chat/src/components/Common/ReplaceConfirmationModal/Components.tsx
@@ -313,7 +313,7 @@ const FileView = ({ item: file, onSelect, isChosen }: FileViewProps) => {
   return (
     <FeatureContainer>
       {onSelect && (
-        <div className={'relative flex size-[18px] shrink-0'}>
+        <div className="relative flex size-[18px] shrink-0">
           <input
             className="checkbox peer size-[18px] bg-layer-3"
             type="checkbox"


### PR DESCRIPTION
**Description:**

- fix publication files download icon
- hide 'go to a review' button if request contains only files
- add file section to publication request if there no files to publish

Issues:

- #1745
- #1839 

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
