### PR TITLE
fix(chat): fix folders selection if search term isn't empty (Issue #1837)

### DIFF
--- a/apps/chat/src/store/conversations/conversations.epics.ts
+++ b/apps/chat/src/store/conversations/conversations.epics.ts
@@ -69,9 +69,11 @@ import {
 } from '@/src/utils/app/merge-streams';
 import { isSmallScreen } from '@/src/utils/app/mobile';
 import { updateSystemPromptInMessages } from '@/src/utils/app/overlay';
+import { doesEntityContainSearchTerm } from '@/src/utils/app/search';
 import { isEntityOrParentsExternal } from '@/src/utils/app/share';
 import { filterUnfinishedStages } from '@/src/utils/app/stages';
 import { translate } from '@/src/utils/app/translation';
+import { parseConversationApiKey } from '@/src/utils/server/api';
 
 import {
   ChatBody,
@@ -82,7 +84,12 @@ import {
   RateBody,
   Role,
 } from '@/src/types/chat';
-import { EntityType, FeatureType, UploadStatus } from '@/src/types/common';
+import {
+  EntityType,
+  FeatureType,
+  ShareEntity,
+  UploadStatus,
+} from '@/src/types/common';
 import { FolderType } from '@/src/types/folder';
 import { AppEpic } from '@/src/types/store';
 
@@ -2663,16 +2670,31 @@ const deleteChosenConversationsEpic: AppEpic = (action$, state$) =>
       const chosenFolderIds = ConversationsSelectors.selectChosenFolderIds(
         state$.value,
       );
-      const conversationIds = ConversationsSelectors.selectConversations(
+      const searchTerm = ConversationsSelectors.selectSearchTerm(state$.value);
+      const conversations = ConversationsSelectors.selectConversations(
         state$.value,
-      ).map((conv) => conv.id);
+      );
+      const conversationIds = conversations.map((conv) => conv.id);
       const folders = ConversationsSelectors.selectFolders(state$.value);
       const deletedConversationIds = uniq([
-        ...chosenConversationIds,
-        ...conversationIds.filter((id) =>
-          chosenFolderIds.some((folderId) => id.startsWith(folderId)),
+        ...chosenConversationIds.filter((id) =>
+          doesEntityContainSearchTerm(
+            parseConversationApiKey(id) as unknown as ShareEntity,
+            searchTerm,
+          ),
+        ),
+        ...conversationIds.filter(
+          (id) =>
+            chosenFolderIds.some((folderId) => id.startsWith(folderId)) &&
+            doesEntityContainSearchTerm(
+              parseConversationApiKey(id) as unknown as ShareEntity,
+              searchTerm,
+            ),
         ),
       ]);
+      const filteredConversations = conversations.filter(
+        (conv) => !deletedConversationIds.includes(conv.id),
+      );
 
       if (conversationIds.length) {
         actions.push(
@@ -2688,8 +2710,8 @@ const deleteChosenConversationsEpic: AppEpic = (action$, state$) =>
         of(
           ConversationsActions.setFolders({
             folders: folders.filter((folder) =>
-              chosenFolderIds.every(
-                (id) => !folder.id.startsWith(id) && `${folder.id}/` !== id,
+              filteredConversations.some((conv) =>
+                conv.id.startsWith(`${folder.id}/`),
               ),
             ),
           }),

--- a/apps/chat/src/store/conversations/conversations.reducers.ts
+++ b/apps/chat/src/store/conversations/conversations.reducers.ts
@@ -794,14 +794,15 @@ export const conversationsSlice = createSlice({
               (convId: string) => convId !== conversationId,
             ),
             ...state.conversations
-              .map((conv) => conv.id)
               .filter(
-                (convId) =>
-                  convId !== conversationId &&
+                (conv) =>
+                  conv.id !== conversationId &&
                   parentFolderIds.some((parentId) =>
-                    convId.startsWith(parentId),
-                  ),
-              ),
+                    conv.id.startsWith(parentId),
+                  ) &&
+                  doesEntityContainSearchTerm(conv, state.searchTerm),
+              )
+              .map((conv) => conv.id),
           ]);
         } else {
           state.chosenConversationIds = state.chosenConversationIds.filter(
@@ -836,7 +837,10 @@ export const conversationsSlice = createSlice({
       state,
       {
         payload: { folderId, isChosen },
-      }: PayloadAction<{ folderId: string; isChosen: boolean }>,
+      }: PayloadAction<{
+        folderId: string;
+        isChosen: boolean;
+      }>,
     ) => {
       if (isChosen) {
         const parentFolderIds = state.chosenFolderIds.filter(
@@ -861,12 +865,14 @@ export const conversationsSlice = createSlice({
             (convId: string) => !convId.startsWith(folderId),
           ),
           ...state.conversations
-            .map((conv) => conv.id)
             .filter(
-              (convId) =>
-                !convId.startsWith(folderId) &&
-                parentFolderIds.some((parentId) => convId.startsWith(parentId)),
-            ),
+              (conv) =>
+                !conv.id.startsWith(folderId) &&
+                parentFolderIds.some((parentId) =>
+                  conv.id.startsWith(parentId),
+                ),
+            )
+            .map((c) => c.id),
         ]);
       } else {
         state.chosenConversationIds = state.chosenConversationIds.filter(

--- a/apps/chat/src/store/conversations/conversations.selectors.ts
+++ b/apps/chat/src/store/conversations/conversations.selectors.ts
@@ -786,9 +786,28 @@ export const selectAllChosenFolderIds = createSelector(
   (state, folders) => {
     return folders
       .map((folder) => `${folder.id}/`)
-      .filter((folderId) =>
-        state.chosenFolderIds.some((chosenId) => folderId.startsWith(chosenId)),
-      );
+      .filter((folderId) => {
+        const filteredConversations = state.conversations.filter(
+          (conv) =>
+            doesEntityContainSearchTerm(conv, state.searchTerm) &&
+            conv.id.startsWith(folderId) &&
+            !isEntityOrParentsExternal(
+              { conversations: state },
+              conv,
+              FeatureType.Chat,
+            ),
+        );
+
+        return (
+          state.chosenFolderIds.some((chosenId) =>
+            folderId.startsWith(chosenId),
+          ) ||
+          (filteredConversations.length &&
+            filteredConversations.every((conv) =>
+              state.chosenConversationIds.includes(conv.id),
+            ))
+        );
+      });
   },
 );
 

--- a/apps/chat/src/store/prompts/prompts.reducers.ts
+++ b/apps/chat/src/store/prompts/prompts.reducers.ts
@@ -431,12 +431,16 @@ export const promptsSlice = createSlice({
               (convId: string) => convId !== promptId,
             ),
             ...state.prompts
-              .map((prompt) => prompt.id)
+
               .filter(
-                (prId) =>
-                  prId !== promptId &&
-                  parentFolderIds.some((parentId) => prId.startsWith(parentId)),
-              ),
+                (prompt) =>
+                  prompt.id !== promptId &&
+                  parentFolderIds.some((parentId) =>
+                    prompt.id.startsWith(parentId),
+                  ) &&
+                  doesEntityContainSearchTerm(prompt, state.searchTerm),
+              )
+              .map((prompt) => prompt.id),
           ]);
         } else {
           state.chosenPromptIds = state.chosenPromptIds.filter(


### PR DESCRIPTION
**Description:**

fix folders selection if search term isn't empty

Issues:

- #1837

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
