### PR TITLE
fix(chat): disable chatbar menu and conversation settings (Issue #1835, #1368)

### DIFF
--- a/apps/chat/src/components/Chat/ChatHeader.tsx
+++ b/apps/chat/src/components/Chat/ChatHeader.tsx
@@ -251,9 +251,10 @@ export const ChatHeader = ({
             {isShowModelSelect && !isConversationInvalid && (
               <Tooltip isTriggerClickable tooltip={t('Conversation settings')}>
                 <button
-                  className="cursor-pointer text-secondary hover:text-accent-primary"
+                  className="cursor-pointer text-secondary hover:text-accent-primary disabled:cursor-not-allowed disabled:text-controls-disable"
                   onClick={() => setShowSettings(!isShowSettings)}
                   data-qa="conversation-setting"
+                  disabled={conversation.isMessageStreaming}
                 >
                   <IconSettings size={iconSize} />
                 </button>

--- a/apps/chat/src/components/Chatbar/ChatFolders.tsx
+++ b/apps/chat/src/components/Chatbar/ChatFolders.tsx
@@ -231,13 +231,15 @@ const ChatFolderTemplate = ({
     [conversations, dispatch, partialChosenFolderIds, selectedConversations],
   );
 
+  const shouldDenyDrop = isExternal || isSelectMode || isConversationsStreaming;
+
   return (
     <>
       <BetweenFoldersLine
         level={0}
         onDrop={onDropBetweenFolders}
         featureType={FeatureType.Chat}
-        denyDrop={isExternal || isSelectMode || isConversationsStreaming}
+        denyDrop={shouldDenyDrop}
       />
       <Folder
         maxDepth={MAX_CONVERSATION_AND_PROMPT_FOLDERS_DEPTH}
@@ -251,7 +253,7 @@ const ChatFolderTemplate = ({
         allFoldersWithoutFilters={allFolders}
         highlightedFolders={highlightedFolders}
         openedFoldersIds={openedFoldersIds}
-        handleDrop={!isConversationsStreaming ? handleDrop : undefined}
+        handleDrop={!shouldDenyDrop ? handleDrop : undefined}
         onRenameFolder={handleFolderRename}
         onDeleteFolder={handleFolderDelete}
         onClickFolder={handleFolderClick}
@@ -269,7 +271,7 @@ const ChatFolderTemplate = ({
           level={0}
           onDrop={onDropBetweenFolders}
           featureType={FeatureType.Chat}
-          denyDrop={isExternal || isSelectMode || isConversationsStreaming}
+          denyDrop={shouldDenyDrop}
         />
       )}
     </>

--- a/apps/chat/src/components/Chatbar/ChatFolders.tsx
+++ b/apps/chat/src/components/Chatbar/ChatFolders.tsx
@@ -99,6 +99,9 @@ const ChatFolderTemplate = ({
   const isSelectMode = useAppSelector(
     ConversationsSelectors.selectIsSelectMode,
   );
+  const isConversationsStreaming = useAppSelector(
+    ConversationsSelectors.selectIsConversationsStreaming,
+  );
   const { fullyChosenFolderIds, partialChosenFolderIds } = useAppSelector(
     (state) =>
       ConversationsSelectors.selectChosenFolderIds(state, conversations),
@@ -234,7 +237,7 @@ const ChatFolderTemplate = ({
         level={0}
         onDrop={onDropBetweenFolders}
         featureType={FeatureType.Chat}
-        denyDrop={isExternal || isSelectMode}
+        denyDrop={isExternal || isSelectMode || isConversationsStreaming}
       />
       <Folder
         maxDepth={MAX_CONVERSATION_AND_PROMPT_FOLDERS_DEPTH}
@@ -248,7 +251,7 @@ const ChatFolderTemplate = ({
         allFoldersWithoutFilters={allFolders}
         highlightedFolders={highlightedFolders}
         openedFoldersIds={openedFoldersIds}
-        handleDrop={handleDrop}
+        handleDrop={!isConversationsStreaming ? handleDrop : undefined}
         onRenameFolder={handleFolderRename}
         onDeleteFolder={handleFolderDelete}
         onClickFolder={handleFolderClick}
@@ -266,7 +269,7 @@ const ChatFolderTemplate = ({
           level={0}
           onDrop={onDropBetweenFolders}
           featureType={FeatureType.Chat}
-          denyDrop={isExternal || isSelectMode}
+          denyDrop={isExternal || isSelectMode || isConversationsStreaming}
         />
       )}
     </>

--- a/apps/chat/src/components/Chatbar/ChatbarSettings.tsx
+++ b/apps/chat/src/components/Chatbar/ChatbarSettings.tsx
@@ -100,6 +100,7 @@ export const ChatbarSettings = () => {
         onClick: () => {
           dispatch(ConversationsActions.setAllChosenConversations());
         },
+        disabled: isStreaming,
       },
       {
         name: t('Unselect all'),
@@ -109,6 +110,7 @@ export const ChatbarSettings = () => {
           dispatch(ConversationsActions.resetChosenConversations());
         },
         display: isSelectMode,
+        disabled: isStreaming,
       },
       {
         name: t('Create new folder'),
@@ -122,6 +124,7 @@ export const ChatbarSettings = () => {
           );
         },
         display: !isSelectMode,
+        disabled: isStreaming,
       },
       {
         name: t('Import conversations'),
@@ -139,6 +142,7 @@ export const ChatbarSettings = () => {
         dataQa: 'import',
         CustomTriggerRenderer: Import,
         display: !isSelectMode,
+        disabled: isStreaming,
       },
       {
         name: t('Export conversations without attachments'),
@@ -149,6 +153,7 @@ export const ChatbarSettings = () => {
         onClick: () => {
           dispatch(ImportExportActions.exportConversations());
         },
+        disabled: isStreaming,
       },
       {
         name: t(`Delete ${deleteTerm} conversations`),
@@ -158,6 +163,7 @@ export const ChatbarSettings = () => {
         onClick: () => {
           setIsClearModalOpen(true);
         },
+        disabled: isStreaming,
       },
       {
         name: t('Compare mode'),

--- a/apps/chat/src/components/Chatbar/Conversation.tsx
+++ b/apps/chat/src/components/Chatbar/Conversation.tsx
@@ -258,6 +258,9 @@ export const ConversationComponent = ({
   const isSelectMode = useAppSelector(
     ConversationsSelectors.selectIsSelectMode,
   );
+  const isConversationsStreaming = useAppSelector(
+    ConversationsSelectors.selectIsConversationsStreaming,
+  );
   const chosenConversationIds = useAppSelector(
     ConversationsSelectors.selectSelectedItems,
   );
@@ -366,7 +369,12 @@ export const ConversationComponent = ({
 
   const handleDragStart = useCallback(
     (e: DragEvent<HTMLButtonElement>, conversation: ConversationInfo) => {
-      if (e.dataTransfer && !isExternal && !isSelectMode) {
+      if (
+        e.dataTransfer &&
+        !isExternal &&
+        !isSelectMode &&
+        !isConversationsStreaming
+      ) {
         e.dataTransfer.setDragImage(getDragImage(), 0, 0);
         e.dataTransfer.setData(
           MoveType.Conversation,
@@ -374,7 +382,7 @@ export const ConversationComponent = ({
         );
       }
     },
-    [isExternal, isSelectMode],
+    [isConversationsStreaming, isExternal, isSelectMode],
   );
 
   const handleDelete = useCallback(() => {
@@ -703,7 +711,12 @@ export const ConversationComponent = ({
             }
           }}
           disabled={messageIsStreaming || (isSelectMode && isExternal)}
-          draggable={!isExternal && !isNameOrPathInvalid && !isSelectMode}
+          draggable={
+            !isExternal &&
+            !isNameOrPathInvalid &&
+            !isSelectMode &&
+            !isConversationsStreaming
+          }
           onDragStart={(e) => handleDragStart(e, conversation)}
           ref={buttonRef}
           data-qa={isSelected ? 'selected' : null}

--- a/apps/chat/src/components/Common/SidebarMenu.tsx
+++ b/apps/chat/src/components/Common/SidebarMenu.tsx
@@ -26,7 +26,7 @@ export function SidebarMenuItemRenderer(props: MenuItemRendererProps) {
   const item = (
     <button
       className={classNames(
-        'flex cursor-pointer items-center justify-center rounded p-[5px] hover:bg-accent-primary-alpha hover:text-accent-primary disabled:cursor-not-allowed',
+        'flex cursor-pointer items-center justify-center rounded p-[5px] disabled:cursor-not-allowed [&:not(:disabled)]:hover:bg-accent-primary-alpha [&:not(:disabled)]:hover:text-accent-primary',
         className,
       )}
       onClick={!childMenuItems ? onClick : undefined}


### PR DESCRIPTION
**Description:**

- disable chatbar menu and conversation settings during message generation
- disable drag & drop in conversation panel during message generation

Issues:

- Issue #1835 
- Issue #1368 

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
