### PR TITLE
fix(chat): fix import/export for Replay-conversations (Issue #1451)

### DIFF
--- a/apps/chat/src/utils/app/folders.ts
+++ b/apps/chat/src/utils/app/folders.ts
@@ -388,9 +388,13 @@ export const getConversationAttachmentWithPath = <
   const attachments =
     'messages' in conversation
       ? (
-          (isReplay && conversation.replay?.replayUserMessagesStack) ||
           conversation.playback?.messagesStack ||
-          conversation.messages
+          (isReplay && conversation.replay?.replayUserMessagesStack
+            ? [
+                ...conversation.replay.replayUserMessagesStack,
+                ...conversation.messages,
+              ]
+            : conversation.messages)
         ).flatMap((message) => {
           const messageAttachments: Attachment[] =
             message.custom_content?.attachments || [];

--- a/apps/chat/src/utils/app/import-export.ts
+++ b/apps/chat/src/utils/app/import-export.ts
@@ -332,7 +332,7 @@ export const updateAttachment = ({
     ...oldAttachment,
     title: newTitle,
     type: newType,
-    url: newAttachmentUrl,
+    url: encodedNewAttachmentUrl,
     reference_url: newReferenceUrl,
   };
   return updatedAttachment;


### PR DESCRIPTION
**Description:**

fix import/export for Replay-conversations

Issues:

- Issue #1451 

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
