### PR TITLE
fix(chat): fix folders order and no attachments label in publish modal (Issue #1844, #1856)

### DIFF
--- a/apps/chat/src/components/Chat/ChangePathDialog.tsx
+++ b/apps/chat/src/components/Chat/ChangePathDialog.tsx
@@ -8,6 +8,7 @@ import {
   getFolderIdFromEntityId,
   getNextDefaultName,
   getPathToFolderById,
+  sortByName,
   validateFolderRenaming,
 } from '@/src/utils/app/folders';
 
@@ -86,7 +87,7 @@ export const ChangePathDialog = ({
   const loadingFolderIds = useAppSelector(selectors.selectLoadingFolderIds);
 
   const folders = useMemo(
-    () => [...conversationFolders, ...promptFolders],
+    () => sortByName([...conversationFolders, ...promptFolders]),
     [conversationFolders, promptFolders],
   );
 

--- a/apps/chat/src/components/Chat/Publish/PublicationItemsList.tsx
+++ b/apps/chat/src/components/Chat/Publish/PublicationItemsList.tsx
@@ -198,7 +198,9 @@ export function PublicationItemsList({
               ))
             ) : (
               <p className="pl-3.5 text-secondary">
-                {type === SharingType.Conversation
+                {type === SharingType.Conversation ||
+                (type === SharingType.ConversationFolder &&
+                  entities.length === 1)
                   ? t("This conversation doesn't contain any files")
                   : t("These conversations don't contain any files")}
               </p>


### PR DESCRIPTION
**Description:**

In publish modal:
- sort folders alphabetically by name
- fix no attachments label of single conversation folder

Issues:

- Issue #1844 
- Issue #1856 

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
