### PR TITLE
fix(chat): fix prompts select mode in search mode (Issue #1874)

### DIFF
--- a/apps/chat/src/store/prompts/prompts.reducers.ts
+++ b/apps/chat/src/store/prompts/prompts.reducers.ts
@@ -431,6 +431,9 @@ export const promptsSlice = createSlice({
               (convId: string) => convId !== promptId,
             ),
             ...state.prompts
+              .filter((prompt) =>
+                doesEntityContainSearchTerm(prompt, state.searchTerm),
+              )
               .map((prompt) => prompt.id)
               .filter(
                 (prId) =>
@@ -452,14 +455,18 @@ export const promptsSlice = createSlice({
             .filter(
               (folderId) =>
                 promptId.startsWith(folderId) &&
-                !state.prompts.some(
-                  (prompt) =>
-                    prompt.id.startsWith(folderId) &&
-                    !state.chosenPromptIds.includes(prompt.id) &&
-                    !state.chosenFolderIds.some((chosenFolderId) =>
-                      prompt.id.startsWith(chosenFolderId),
-                    ),
-                ),
+                !state.prompts
+                  .filter((prompt) =>
+                    doesEntityContainSearchTerm(prompt, state.searchTerm),
+                  )
+                  .some(
+                    (prompt) =>
+                      prompt.id.startsWith(folderId) &&
+                      !state.chosenPromptIds.includes(prompt.id) &&
+                      !state.chosenFolderIds.some((chosenFolderId) =>
+                        prompt.id.startsWith(chosenFolderId),
+                      ),
+                  ),
             ),
         ]);
       }


### PR DESCRIPTION
**Description:**

- fix checkboxes behaviour in search mode
- fix delete selected prompts behaviour in search mode

Issues:

- Issue #1874 

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
