### PR TITLE
fix(chat): fix settings field widths (Issue #1893)

### DIFF
--- a/apps/chat/src/components/Settings/CustomLogoSelect.tsx
+++ b/apps/chat/src/components/Settings/CustomLogoSelect.tsx
@@ -32,7 +32,7 @@ export const CustomLogoSelect = ({
   return (
     <div className="flex items-center gap-5">
       <div className="basis-1/3 md:basis-1/4">{t('Custom logo')}</div>
-      <div className="flex h-[38px] max-w-[331px] grow  items-center gap-8 overflow-hidden rounded border border-primary px-3 focus-within:border-accent-primary focus:border-accent-primary">
+      <div className="flex h-[38px] grow basis-2/3 items-center gap-8 overflow-hidden rounded border border-primary px-3 focus-within:border-accent-primary focus:border-accent-primary md:basis-3/4">
         <div
           className={classNames(
             'block w-full max-w-full truncate',

--- a/apps/chat/src/components/Settings/ThemeSelect.tsx
+++ b/apps/chat/src/components/Settings/ThemeSelect.tsx
@@ -48,7 +48,7 @@ export const ThemeSelect = ({
     <div className="flex items-center gap-5">
       <div className="basis-1/3 md:basis-1/4">{t('Theme')}</div>
       <div
-        className="h-[38px] grow rounded border border-primary focus-within:border-accent-primary focus:border-accent-primary"
+        className="h-[38px] grow basis-2/3 rounded border border-primary focus-within:border-accent-primary focus:border-accent-primary md:basis-3/4"
         data-qa="theme"
       >
         <Menu


### PR DESCRIPTION
**Description:**

fix settings field widths

Issues:

- Issue #1893

**UI changes**
![image](https://github.com/user-attachments/assets/6487347e-d35c-48ed-8913-b00edfc9df83)

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
