### PR TITLE
fix(chat): fix importing prompts with duplicates & new ones (Issue #1892)

### DIFF
--- a/apps/chat/src/store/import-export/importExport.epics.ts
+++ b/apps/chat/src/store/import-export/importExport.epics.ts
@@ -430,29 +430,25 @@ const importPromptsEpic: AppEpic = (action$) =>
             },
           );
 
-          if (!existedImportNamesPrompts.length) {
-            return of(
-              ImportExportActions.uploadImportedPrompts({
-                itemsToUpload: nonExistedImportNamesPrompts,
-              }),
-            );
-          }
-
-          if (!nonExistedImportNamesPrompts.length) {
-            return of(
-              ImportExportActions.showReplaceDialog({
-                duplicatedItems: existedImportNamesPrompts,
-                featureType: FeatureType.Prompt,
-              }),
-            );
-          }
-
           return concat(
-            of(
-              ImportExportActions.showReplaceDialog({
-                duplicatedItems: existedImportNamesPrompts,
-                featureType: FeatureType.Prompt,
-              }),
+            iif(
+              () => !!existedImportNamesPrompts.length,
+              of(
+                ImportExportActions.showReplaceDialog({
+                  duplicatedItems: existedImportNamesPrompts,
+                  featureType: FeatureType.Prompt,
+                }),
+              ),
+              EMPTY,
+            ),
+            iif(
+              () => !!nonExistedImportNamesPrompts.length,
+              of(
+                ImportExportActions.uploadImportedPrompts({
+                  itemsToUpload: nonExistedImportNamesPrompts,
+                }),
+              ),
+              EMPTY,
             ),
           );
         }),
@@ -597,7 +593,6 @@ const uploadImportedPromptsEpic: AppEpic = (action$, state$) =>
                     folders: promptsFolders,
                   }),
                 ),
-
                 iif(
                   () => !isShowReplaceDialog,
                   concat(
@@ -1392,7 +1387,6 @@ const resetStateEpic: AppEpic = (action$) =>
         ImportExportActions.importFail.match(action) ||
         ImportExportActions.importStop.match(action) ||
         ImportExportActions.importPromptsFail.match(action) ||
-        PromptsActions.importPromptsSuccess.match(action) ||
         PromptsActions.initFoldersAndPromptsSuccess.match(action),
     ),
     switchMap(() => {


### PR DESCRIPTION
**Description:**

- fix import prompts logic to handle duplicates and new propts together

Issues:

- Issue #1892 

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
