### PR TITLE
chore(chat): use `HTTPMethod` enum instead of strings

### DIFF
--- a/apps/chat/src/pages/api/[entitytype]/[...slug].ts
+++ b/apps/chat/src/pages/api/[entitytype]/[...slug].ts
@@ -10,6 +10,7 @@ import { ServerUtils } from '@/src/utils/server/server';
 
 import { ApiKeys } from '@/src/types/common';
 import { DialAIError } from '@/src/types/error';
+import { HTTPMethod } from '@/src/types/http';
 
 import { errorsMessages } from '@/src/constants/errors';
 
@@ -59,13 +60,13 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
   const token = await getToken({ req });
 
   try {
-    if (req.method === 'GET') {
+    if (req.method === HTTPMethod.GET) {
       return await handleGetRequest(req, token, res);
-    } else if (req.method === 'PUT') {
+    } else if (req.method === HTTPMethod.PUT) {
       return await handlePutRequest(req, token, res);
-    } else if (req.method === 'POST') {
+    } else if (req.method === HTTPMethod.POST) {
       return await handlePutRequest(req, token, res, { ifNoneMatch: '*' });
-    } else if (req.method === 'DELETE') {
+    } else if (req.method === HTTPMethod.DELETE) {
       return await handleDeleteRequest(req, token, res);
     }
     return res.status(405).json({ error: 'Method not allowed' });
@@ -102,7 +103,7 @@ async function handlePutRequest(
   const readable = Readable.from(req);
   const url = getEntityUrlFromSlugs(process.env.DIAL_API_HOST, req);
   const proxyRes = await fetch(url, {
-    method: 'PUT',
+    method: HTTPMethod.PUT,
     headers: {
       ...getApiHeaders({
         jwt: token?.access_token as string,
@@ -170,7 +171,7 @@ async function handleDeleteRequest(
 ) {
   const url = getEntityUrlFromSlugs(process.env.DIAL_API_HOST, req);
   const proxyRes = await fetch(url, {
-    method: 'DELETE',
+    method: HTTPMethod.DELETE,
     headers: getApiHeaders({ jwt: token?.access_token as string }),
   });
 

--- a/apps/chat/src/pages/api/publication/approve.ts
+++ b/apps/chat/src/pages/api/publication/approve.ts
@@ -8,6 +8,7 @@ import { logger } from '@/src/utils/server/logger';
 import { ServerUtils } from '@/src/utils/server/server';
 
 import { DialAIError } from '@/src/types/error';
+import { HTTPMethod } from '@/src/types/http';
 
 import { errorsMessages } from '@/src/constants/errors';
 
@@ -29,7 +30,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
     const proxyRes = await fetch(
       `${process.env.DIAL_API_HOST}/v1/ops/publication/approve`,
       {
-        method: 'POST',
+        method: HTTPMethod.POST,
         headers: getApiHeaders({ jwt: token?.access_token as string }),
         body: JSON.stringify(req.body),
       },

--- a/apps/chat/src/pages/api/publication/create.ts
+++ b/apps/chat/src/pages/api/publication/create.ts
@@ -8,6 +8,7 @@ import { logger } from '@/src/utils/server/logger';
 import { ServerUtils } from '@/src/utils/server/server';
 
 import { DialAIError } from '@/src/types/error';
+import { HTTPMethod } from '@/src/types/http';
 
 import { errorsMessages } from '@/src/constants/errors';
 
@@ -29,7 +30,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
     const proxyRes = await fetch(
       `${process.env.DIAL_API_HOST}/v1/ops/publication/create`,
       {
-        method: 'POST',
+        method: HTTPMethod.POST,
         headers: getApiHeaders({ jwt: token?.access_token as string }),
         body: JSON.stringify(req.body),
       },

--- a/apps/chat/src/pages/api/publication/delete.ts
+++ b/apps/chat/src/pages/api/publication/delete.ts
@@ -7,6 +7,7 @@ import { getApiHeaders } from '@/src/utils/server/get-headers';
 import { logger } from '@/src/utils/server/logger';
 
 import { DialAIError } from '@/src/types/error';
+import { HTTPMethod } from '@/src/types/http';
 
 import { errorsMessages } from '@/src/constants/errors';
 
@@ -28,7 +29,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
     const proxyRes = await fetch(
       `${process.env.DIAL_API_HOST}/v1/ops/publication/delete`,
       {
-        method: 'POST',
+        method: HTTPMethod.POST,
         headers: getApiHeaders({ jwt: token?.access_token as string }),
         body: JSON.stringify(req.body),
       },

--- a/apps/chat/src/pages/api/publication/details.ts
+++ b/apps/chat/src/pages/api/publication/details.ts
@@ -7,6 +7,7 @@ import { getApiHeaders } from '@/src/utils/server/get-headers';
 import { logger } from '@/src/utils/server/logger';
 
 import { DialAIError } from '@/src/types/error';
+import { HTTPMethod } from '@/src/types/http';
 
 import { errorsMessages } from '@/src/constants/errors';
 
@@ -28,7 +29,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
     const proxyRes = await fetch(
       `${process.env.DIAL_API_HOST}/v1/ops/publication/get`,
       {
-        method: 'POST',
+        method: HTTPMethod.POST,
         headers: getApiHeaders({ jwt: token?.access_token as string }),
         body: JSON.stringify(req.body),
       },

--- a/apps/chat/src/pages/api/publication/listing.ts
+++ b/apps/chat/src/pages/api/publication/listing.ts
@@ -7,6 +7,7 @@ import { getApiHeaders } from '@/src/utils/server/get-headers';
 import { logger } from '@/src/utils/server/logger';
 
 import { DialAIError } from '@/src/types/error';
+import { HTTPMethod } from '@/src/types/http';
 
 import { errorsMessages } from '@/src/constants/errors';
 
@@ -28,7 +29,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
     const proxyRes = await fetch(
       `${process.env.DIAL_API_HOST}/v1/ops/publication/list`,
       {
-        method: 'POST',
+        method: HTTPMethod.POST,
         headers: getApiHeaders({ jwt: token?.access_token as string }),
         body: JSON.stringify(req.body),
       },

--- a/apps/chat/src/pages/api/publication/reject.ts
+++ b/apps/chat/src/pages/api/publication/reject.ts
@@ -7,6 +7,7 @@ import { getApiHeaders } from '@/src/utils/server/get-headers';
 import { logger } from '@/src/utils/server/logger';
 
 import { DialAIError } from '@/src/types/error';
+import { HTTPMethod } from '@/src/types/http';
 
 import { errorsMessages } from '@/src/constants/errors';
 
@@ -28,7 +29,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
     const proxyRes = await fetch(
       `${process.env.DIAL_API_HOST}/v1/ops/publication/reject`,
       {
-        method: 'POST',
+        method: HTTPMethod.POST,
         headers: getApiHeaders({ jwt: token?.access_token as string }),
         body: JSON.stringify(req.body),
       },

--- a/apps/chat/src/pages/api/publication/resourceListing.ts
+++ b/apps/chat/src/pages/api/publication/resourceListing.ts
@@ -7,6 +7,7 @@ import { getApiHeaders } from '@/src/utils/server/get-headers';
 import { logger } from '@/src/utils/server/logger';
 
 import { DialAIError } from '@/src/types/error';
+import { HTTPMethod } from '@/src/types/http';
 
 import { errorsMessages } from '@/src/constants/errors';
 
@@ -28,7 +29,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
     const proxyRes = await fetch(
       `${process.env.DIAL_API_HOST}/v1/ops/publication/resource/list`,
       {
-        method: 'POST',
+        method: HTTPMethod.POST,
         headers: getApiHeaders({ jwt: token?.access_token as string }),
         body: JSON.stringify(req.body),
       },

--- a/apps/chat/src/pages/api/publication/rulesList.ts
+++ b/apps/chat/src/pages/api/publication/rulesList.ts
@@ -8,13 +8,13 @@ import { logger } from '@/src/utils/server/logger';
 import { ServerUtils } from '@/src/utils/server/server';
 
 import { DialAIError } from '@/src/types/error';
+import { HTTPMethod } from '@/src/types/http';
 
 import { errorsMessages } from '@/src/constants/errors';
 
 import { authOptions } from '@/src/pages/api/auth/[...nextauth]';
 
 import fetch from 'node-fetch';
-import { HTTPMethod } from '@/src/types/http';
 
 const handler = async (req: NextApiRequest, res: NextApiResponse) => {
   const session = await getServerSession(req, res, authOptions);

--- a/apps/chat/src/pages/api/publication/rulesList.ts
+++ b/apps/chat/src/pages/api/publication/rulesList.ts
@@ -14,6 +14,7 @@ import { errorsMessages } from '@/src/constants/errors';
 import { authOptions } from '@/src/pages/api/auth/[...nextauth]';
 
 import fetch from 'node-fetch';
+import { HTTPMethod } from '@/src/types/http';
 
 const handler = async (req: NextApiRequest, res: NextApiResponse) => {
   const session = await getServerSession(req, res, authOptions);
@@ -29,7 +30,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
     const proxyRes = await fetch(
       `${process.env.DIAL_API_HOST}/v1/ops/publication/rule/list`,
       {
-        method: 'POST',
+        method: HTTPMethod.POST,
         headers: getApiHeaders({ jwt: token?.access_token as string }),
         body: JSON.stringify(req.body),
       },

--- a/apps/chat/src/pages/api/rate.ts
+++ b/apps/chat/src/pages/api/rate.ts
@@ -8,6 +8,7 @@ import { getSortedEntities } from '@/src/utils/server/get-sorted-entities';
 import { logger } from '@/src/utils/server/logger';
 
 import { RateBody } from '../../types/chat';
+import { HTTPMethod } from '@/src/types/http';
 
 import { DIAL_API_HOST } from '@/src/constants/default-server-settings';
 import { errorsMessages } from '@/src/constants/errors';
@@ -45,7 +46,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
         jwt: token?.access_token as string,
         jobTitle: token?.jobTitle as string,
       }),
-      method: 'POST',
+      method: HTTPMethod.POST,
       body: JSON.stringify({
         rate: value,
         responseId,

--- a/apps/chat/src/pages/api/report-issue.ts
+++ b/apps/chat/src/pages/api/report-issue.ts
@@ -4,6 +4,8 @@ import { getServerSession } from 'next-auth/next';
 import { validateServerSession } from '@/src/utils/auth/session';
 import { logger } from '@/src/utils/server/logger';
 
+import { HTTPMethod } from '@/src/types/http';
+
 import { errorsMessages } from '@/src/constants/errors';
 
 import { authOptions } from './auth/[...nextauth]';
@@ -28,7 +30,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
   const response = await fetch(
     `${process.env.AZURE_FUNCTIONS_API_HOST}/api/issue?code=${process.env.REPORT_ISSUE_CODE}`,
     {
-      method: 'POST',
+      method: HTTPMethod.POST,
       headers: {
         'Content-Type': 'application/json',
       },

--- a/apps/chat/src/pages/api/request-api-key.ts
+++ b/apps/chat/src/pages/api/request-api-key.ts
@@ -4,6 +4,8 @@ import { getServerSession } from 'next-auth/next';
 import { validateServerSession } from '@/src/utils/auth/session';
 import { logger } from '@/src/utils/server/logger';
 
+import { HTTPMethod } from '@/src/types/http';
+
 import { errorsMessages } from '@/src/constants/errors';
 
 import { authOptions } from './auth/[...nextauth]';
@@ -31,7 +33,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
   const response = await fetch(
     `${process.env.AZURE_FUNCTIONS_API_HOST}/api/request?code=${process.env.REQUEST_API_KEY_CODE}`,
     {
-      method: 'POST',
+      method: HTTPMethod.POST,
       headers: {
         'Content-Type': 'application/json',
       },

--- a/apps/chat/src/pages/api/share/accept.ts
+++ b/apps/chat/src/pages/api/share/accept.ts
@@ -7,6 +7,7 @@ import { getApiHeaders } from '@/src/utils/server/get-headers';
 import { logger } from '@/src/utils/server/logger';
 
 import { DialAIError } from '@/src/types/error';
+import { HTTPMethod } from '@/src/types/http';
 
 import { errorsMessages } from '@/src/constants/errors';
 
@@ -30,7 +31,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
     const proxyRes = await fetch(
       `${process.env.DIAL_API_HOST}/v1/invitations/${invitationId}?accept=true`,
       {
-        method: 'GET',
+        method: HTTPMethod.GET,
         headers: getApiHeaders({ jwt: token?.access_token as string }),
       },
     );

--- a/apps/chat/src/pages/api/share/create.ts
+++ b/apps/chat/src/pages/api/share/create.ts
@@ -7,6 +7,7 @@ import { getApiHeaders } from '@/src/utils/server/get-headers';
 import { logger } from '@/src/utils/server/logger';
 
 import { DialAIError } from '@/src/types/error';
+import { HTTPMethod } from '@/src/types/http';
 import { ShareRequestModel } from '@/src/types/share';
 
 import { errorsMessages } from '@/src/constants/errors';
@@ -31,7 +32,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
     const proxyRes = await fetch(
       `${process.env.DIAL_API_HOST}/v1/ops/resource/share/create`,
       {
-        method: 'POST',
+        method: HTTPMethod.POST,
         headers: getApiHeaders({ jwt: token?.access_token as string }),
         body: JSON.stringify(body),
       },

--- a/apps/chat/src/pages/api/share/details.ts
+++ b/apps/chat/src/pages/api/share/details.ts
@@ -7,6 +7,7 @@ import { getApiHeaders } from '@/src/utils/server/get-headers';
 import { logger } from '@/src/utils/server/logger';
 
 import { DialAIError } from '@/src/types/error';
+import { HTTPMethod } from '@/src/types/http';
 
 import { errorsMessages } from '@/src/constants/errors';
 
@@ -30,7 +31,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
     const proxyRes = await fetch(
       `${process.env.DIAL_API_HOST}/v1/invitations/${invitationId}`,
       {
-        method: 'GET',
+        method: HTTPMethod.GET,
         headers: getApiHeaders({ jwt: token?.access_token as string }),
       },
     );

--- a/apps/chat/src/pages/api/share/discard.ts
+++ b/apps/chat/src/pages/api/share/discard.ts
@@ -7,6 +7,7 @@ import { getApiHeaders } from '@/src/utils/server/get-headers';
 import { logger } from '@/src/utils/server/logger';
 
 import { DialAIError } from '@/src/types/error';
+import { HTTPMethod } from '@/src/types/http';
 
 import { errorsMessages } from '@/src/constants/errors';
 
@@ -28,7 +29,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
     const proxyRes = await fetch(
       `${process.env.DIAL_API_HOST}/v1/ops/resource/share/discard`,
       {
-        method: 'POST',
+        method: HTTPMethod.POST,
         headers: getApiHeaders({ jwt: token?.access_token as string }),
         body: JSON.stringify(req.body),
       },

--- a/apps/chat/src/pages/api/share/listing.ts
+++ b/apps/chat/src/pages/api/share/listing.ts
@@ -7,6 +7,7 @@ import { getApiHeaders } from '@/src/utils/server/get-headers';
 import { logger } from '@/src/utils/server/logger';
 
 import { DialAIError } from '@/src/types/error';
+import { HTTPMethod } from '@/src/types/http';
 
 import { errorsMessages } from '@/src/constants/errors';
 
@@ -28,7 +29,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
     const proxyRes = await fetch(
       `${process.env.DIAL_API_HOST}/v1/ops/resource/share/list`,
       {
-        method: 'POST',
+        method: HTTPMethod.POST,
         headers: getApiHeaders({ jwt: token?.access_token as string }),
         body: JSON.stringify(req.body),
       },

--- a/apps/chat/src/pages/api/share/revoke.ts
+++ b/apps/chat/src/pages/api/share/revoke.ts
@@ -7,6 +7,7 @@ import { getApiHeaders } from '@/src/utils/server/get-headers';
 import { logger } from '@/src/utils/server/logger';
 
 import { DialAIError } from '@/src/types/error';
+import { HTTPMethod } from '@/src/types/http';
 
 import { errorsMessages } from '@/src/constants/errors';
 
@@ -28,7 +29,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
     const proxyRes = await fetch(
       `${process.env.DIAL_API_HOST}/v1/ops/resource/share/revoke`,
       {
-        method: 'POST',
+        method: HTTPMethod.POST,
         headers: getApiHeaders({ jwt: token?.access_token as string }),
         body: JSON.stringify(req.body),
       },

--- a/apps/chat/src/pages/api/themes/image/[name].ts
+++ b/apps/chat/src/pages/api/themes/image/[name].ts
@@ -3,6 +3,7 @@ import { NextApiRequest, NextApiResponse } from 'next';
 import { isAbsoluteUrl } from '@/src/utils/app/file';
 import { logger } from '@/src/utils/server/logger';
 
+import { HTTPMethod } from '@/src/types/http';
 import { ThemesConfig } from '@/src/types/themes';
 
 import { errorsMessages } from '@/src/constants/errors';
@@ -73,7 +74,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
     const response = await fetch(
       `${process.env.THEMES_CONFIG_HOST}/config.json`,
       {
-        method: 'GET',
+        method: HTTPMethod.GET,
         headers: {
           'Content-Type': 'application/json',
         },

--- a/apps/chat/src/pages/api/themes/listing.ts
+++ b/apps/chat/src/pages/api/themes/listing.ts
@@ -2,6 +2,7 @@ import { NextApiRequest, NextApiResponse } from 'next';
 
 import { logger } from '@/src/utils/server/logger';
 
+import { HTTPMethod } from '@/src/types/http';
 import { Theme, ThemesConfig } from '@/src/types/themes';
 
 import { errorsMessages } from '@/src/constants/errors';
@@ -31,7 +32,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
   const response = await fetch(
     `${process.env.THEMES_CONFIG_HOST}/config.json`,
     {
-      method: 'GET',
+      method: HTTPMethod.GET,
       headers: {
         'Content-Type': 'application/json',
       },

--- a/apps/chat/src/pages/api/themes/styles.ts
+++ b/apps/chat/src/pages/api/themes/styles.ts
@@ -4,6 +4,7 @@ import { isAbsoluteUrl } from '@/src/utils/app/file';
 import { getThemeIconUrl } from '@/src/utils/app/themes';
 import { logger } from '@/src/utils/server/logger';
 
+import { HTTPMethod } from '@/src/types/http';
 import { ThemesConfig } from '@/src/types/themes';
 
 import { errorsMessages } from '@/src/constants/errors';
@@ -99,7 +100,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
   const response = await fetch(
     `${process.env.THEMES_CONFIG_HOST}/config.json`,
     {
-      method: 'GET',
+      method: HTTPMethod.GET,
       headers: {
         'Content-Type': 'application/json',
       },

--- a/apps/chat/src/store/conversations/conversations.epics.ts
+++ b/apps/chat/src/store/conversations/conversations.epics.ts
@@ -85,6 +85,7 @@ import {
 } from '@/src/types/chat';
 import { EntityType, FeatureType, UploadStatus } from '@/src/types/common';
 import { FolderType } from '@/src/types/folder';
+import { HTTPMethod } from '@/src/types/http';
 import { AppEpic } from '@/src/types/store';
 
 import { SettingsSelectors } from '@/src/store/settings/settings.reducers';
@@ -996,7 +997,7 @@ const rateMessageEpic: AppEpic = (action$, state$) =>
       };
 
       return fromFetch('api/rate', {
-        method: 'POST',
+        method: HTTPMethod.POST,
         headers: {
           'Content-Type': 'application/json',
         },
@@ -1347,7 +1348,7 @@ const streamMessageEpic: AppEpic = (action$, state$) =>
       let message = payload.message;
       return from(
         fetch('api/chat', {
-          method: 'POST',
+          method: HTTPMethod.POST,
           headers: {
             'Content-Type': 'application/json',
           },

--- a/apps/chat/src/store/service/service.epics.ts
+++ b/apps/chat/src/store/service/service.epics.ts
@@ -5,6 +5,7 @@ import { combineEpics } from 'redux-observable';
 import { translate } from '@/src/utils/app/translation';
 import { ApiUtils } from '@/src/utils/server/api';
 
+import { HTTPMethod } from '@/src/types/http';
 import { AppEpic } from '@/src/types/store';
 
 import { errorsMessages } from '@/src/constants/errors';
@@ -19,7 +20,7 @@ const reportIssueEpic: AppEpic = (action$) =>
       const controller = new AbortController();
 
       return ApiUtils.request('api/report-issue', {
-        method: 'POST',
+        method: HTTPMethod.POST,
         headers: {
           'Content-Type': 'application/json',
         },
@@ -61,7 +62,7 @@ const requestApiKeyEpic: AppEpic = (action$) =>
       const controller = new AbortController();
 
       return ApiUtils.request('api/request-api-key', {
-        method: 'POST',
+        method: HTTPMethod.POST,
         headers: {
           'Content-Type': 'application/json',
         },

--- a/apps/chat/src/types/http.ts
+++ b/apps/chat/src/types/http.ts
@@ -1,0 +1,11 @@
+export enum HTTPMethod {
+  CONNECT = 'CONNECT',
+  DELETE = 'DELETE',
+  GET = 'GET',
+  HEAD = 'HEAD',
+  OPTIONS = 'OPTIONS',
+  PATCH = 'PATCH',
+  POST = 'POST',
+  PUT = 'PUT',
+  TRACE = 'TRACE',
+}

--- a/apps/chat/src/utils/app/data/bucket-service.ts
+++ b/apps/chat/src/utils/app/data/bucket-service.ts
@@ -1,12 +1,14 @@
 import { Observable } from 'rxjs';
 
+import { HTTPMethod } from '@/src/types/http';
+
 import { ApiUtils } from '../../server/api';
 
 export class BucketService {
   private static bucket: string;
   public static requestBucket(): Observable<{ bucket: string }> {
     return ApiUtils.request('api/bucket', {
-      method: 'GET',
+      method: HTTPMethod.GET,
       headers: {
         'Content-Type': 'application/json',
       },

--- a/apps/chat/src/utils/app/data/file-service.ts
+++ b/apps/chat/src/utils/app/data/file-service.ts
@@ -8,6 +8,7 @@ import {
   FileFolderInterface,
 } from '@/src/types/files';
 import { FolderType } from '@/src/types/folder';
+import { HTTPMethod } from '@/src/types/http';
 
 import { ApiUtils } from '../../server/api';
 import { constructPath } from '../file';
@@ -25,7 +26,7 @@ export class FileService {
 
     return ApiUtils.requestOld({
       url: `api/${resultPath}`,
-      method: 'POST',
+      method: HTTPMethod.POST,
       async: true,
       body: formData,
     }).pipe(
@@ -132,7 +133,7 @@ export class FileService {
 
   public static deleteFile(filePath: string): Observable<void> {
     return ApiUtils.request(`api/${ApiUtils.encodeApiUrl(filePath)}`, {
-      method: 'DELETE',
+      method: HTTPMethod.DELETE,
     });
   }
 

--- a/apps/chat/src/utils/app/data/publication-service.ts
+++ b/apps/chat/src/utils/app/data/publication-service.ts
@@ -5,6 +5,7 @@ import {
   BackendResourceType,
   FeatureType,
 } from '@/src/types/common';
+import { HTTPMethod } from '@/src/types/http';
 import {
   Publication,
   PublicationInfo,
@@ -28,14 +29,14 @@ export class PublicationService {
     publicationData: PublicationRequestModel,
   ): Observable<Publication> {
     return ApiUtils.request('api/publication/create', {
-      method: 'POST',
+      method: HTTPMethod.POST,
       body: JSON.stringify(publicationData),
     });
   }
 
   public static publicationList(): Observable<PublicationInfo[]> {
     return ApiUtils.request('api/publication/listing', {
-      method: 'POST',
+      method: HTTPMethod.POST,
       body: JSON.stringify({
         url: 'publications/public/',
       }),
@@ -55,7 +56,7 @@ export class PublicationService {
 
   public static getPublication(url: string): Observable<Publication> {
     return ApiUtils.request('api/publication/details', {
-      method: 'POST',
+      method: HTTPMethod.POST,
       body: JSON.stringify({ url: ApiUtils.encodeApiUrl(url) }),
     }).pipe(
       map((publication: Publication) => {
@@ -128,21 +129,21 @@ export class PublicationService {
     resourceTypes: BackendResourceType[],
   ): Observable<PublishedByMeItem[]> {
     return ApiUtils.request('api/publication/resourceListing', {
-      method: 'POST',
+      method: HTTPMethod.POST,
       body: JSON.stringify({ resourceTypes }),
     });
   }
 
   public static approvePublication(url: string): Observable<Publication> {
     return ApiUtils.request('api/publication/approve', {
-      method: 'POST',
+      method: HTTPMethod.POST,
       body: JSON.stringify({ url: ApiUtils.encodeApiUrl(url) }),
     });
   }
 
   public static rejectPublication(url: string): Observable<Publication> {
     return ApiUtils.request('api/publication/reject', {
-      method: 'POST',
+      method: HTTPMethod.POST,
       body: JSON.stringify({ url: ApiUtils.encodeApiUrl(url) }),
     });
   }
@@ -151,7 +152,7 @@ export class PublicationService {
     path: string,
   ): Observable<Record<string, PublicationRule[]>> {
     return ApiUtils.request('api/publication/rulesList', {
-      method: 'POST',
+      method: HTTPMethod.POST,
       body: JSON.stringify({
         url: `${ApiUtils.encodeApiUrl(
           path ? constructPath(PUBLIC_URL_PREFIX, path) : PUBLIC_URL_PREFIX,

--- a/apps/chat/src/utils/app/data/share-service.ts
+++ b/apps/chat/src/utils/app/data/share-service.ts
@@ -11,6 +11,7 @@ import {
   BackendResourceType,
 } from '@/src/types/common';
 import { FolderInterface } from '@/src/types/folder';
+import { HTTPMethod } from '@/src/types/http';
 import { PromptInfo } from '@/src/types/prompt';
 import {
   InvitationDetails,
@@ -31,7 +32,7 @@ export class ShareService {
     shareData: ShareRequestModel,
   ): Observable<ShareByLinkResponseModel> {
     return ApiUtils.request('api/share/create', {
-      method: 'POST',
+      method: HTTPMethod.POST,
       body: JSON.stringify(shareData),
     });
   }
@@ -40,7 +41,7 @@ export class ShareService {
     shareAcceptData: ShareAcceptRequestModel,
   ): Observable<void> {
     return ApiUtils.request('api/share/accept', {
-      method: 'POST',
+      method: HTTPMethod.POST,
       body: JSON.stringify(shareAcceptData),
     });
   }
@@ -49,14 +50,14 @@ export class ShareService {
     shareAcceptData: ShareAcceptRequestModel,
   ): Observable<InvitationDetails> {
     return ApiUtils.request('api/share/details', {
-      method: 'POST',
+      method: HTTPMethod.POST,
       body: JSON.stringify(shareAcceptData),
     });
   }
 
   public static shareRevoke(resourceUrls: string[]): Observable<void> {
     return ApiUtils.request('api/share/revoke', {
-      method: 'POST',
+      method: HTTPMethod.POST,
       body: JSON.stringify({
         resources: resourceUrls.map((url) => ({ url })),
       } as ShareRevokeRequestModel),
@@ -65,7 +66,7 @@ export class ShareService {
 
   public static shareDiscard(resourceUrls: string[]): Observable<void> {
     return ApiUtils.request('api/share/discard', {
-      method: 'POST',
+      method: HTTPMethod.POST,
       body: JSON.stringify({
         resources: resourceUrls.map((url) => ({ url })),
       } as ShareRevokeRequestModel),
@@ -79,7 +80,7 @@ export class ShareService {
     folders: FolderInterface[];
   }> {
     return ApiUtils.request('api/share/listing', {
-      method: 'POST',
+      method: HTTPMethod.POST,
       body: JSON.stringify(sharedListingData),
     }).pipe(
       map((resp: { resources: BackendDataEntity[] }) => {

--- a/apps/chat/src/utils/app/data/storages/api/api-entity-storage.ts
+++ b/apps/chat/src/utils/app/data/storages/api/api-entity-storage.ts
@@ -11,6 +11,7 @@ import {
   UploadStatus,
 } from '@/src/types/common';
 import { FolderInterface, FoldersAndEntities } from '@/src/types/folder';
+import { HTTPMethod } from '@/src/types/http';
 import { EntityStorage } from '@/src/types/storage';
 
 import { constructPath } from '../../../file';
@@ -143,7 +144,7 @@ export abstract class ApiEntityStorage<
   createEntity(entity: TEntity): Observable<TEntityInfo> {
     try {
       return ApiUtils.request(this.getEntityUrl(entity), {
-        method: 'POST',
+        method: HTTPMethod.POST,
         headers: {
           'Content-Type': 'application/json',
         },
@@ -157,7 +158,7 @@ export abstract class ApiEntityStorage<
   updateEntity(entity: TEntity): Observable<void> {
     try {
       return ApiUtils.request(this.getEntityUrl(entity), {
-        method: 'PUT',
+        method: HTTPMethod.PUT,
         headers: {
           'Content-Type': 'application/json',
         },
@@ -171,7 +172,7 @@ export abstract class ApiEntityStorage<
   deleteEntity(info: TEntityInfo): Observable<void> {
     try {
       return ApiUtils.request(this.getEntityUrl(info), {
-        method: 'DELETE',
+        method: HTTPMethod.DELETE,
         headers: {
           'Content-Type': 'application/json',
         },

--- a/apps/chat/src/utils/server/api.ts
+++ b/apps/chat/src/utils/server/api.ts
@@ -4,6 +4,7 @@ import { fromFetch } from 'rxjs/fetch';
 import { ServerUtils } from '@/src/utils/server/server';
 
 import { Conversation, ConversationInfo } from '@/src/types/chat';
+import { HTTPMethod } from '@/src/types/http';
 import { PromptInfo } from '@/src/types/prompt';
 
 import { EMPTY_MODEL_ID } from '@/src/constants/default-ui-settings';
@@ -130,7 +131,7 @@ export class ApiUtils {
     body,
   }: {
     url: string | URL;
-    method: string;
+    method: HTTPMethod;
     async: boolean;
     body: XMLHttpRequestBodyInit | Document | null | undefined;
   }): Observable<{ percent?: number; result?: unknown }> {

--- a/apps/chat/src/utils/server/index.ts
+++ b/apps/chat/src/utils/server/index.ts
@@ -1,6 +1,7 @@
 import { Message } from '@/src/types/chat';
 import { EntityType } from '@/src/types/common';
 import { DialAIError } from '@/src/types/error';
+import { HTTPMethod } from '@/src/types/http';
 import { DialAIEntityModel } from '@/src/types/models';
 
 import {
@@ -103,7 +104,7 @@ export const OpenAIStream = async ({
 
     res = await fetch(url, {
       headers: requestHeaders,
-      method: 'POST',
+      method: HTTPMethod.POST,
       body,
     });
 


### PR DESCRIPTION
**Description:**

use `HTTPMethod` enum instead of strings
![image](https://github.com/user-attachments/assets/4c8cc434-eee2-4724-a67e-17ae62457234)


**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
