### PR TITLE
fix: highlight resize trigger while resizing in tablet mode (Issue #1911)

### DIFF
--- a/apps/chat/src/components/Sidebar/Sidebar.tsx
+++ b/apps/chat/src/components/Sidebar/Sidebar.tsx
@@ -105,7 +105,7 @@ const Sidebar = <T,>({
 
   const resizeTriggerColor = classNames(
     'xl:bg-accent-primary xl:text-accent-primary',
-    isResizing ? 'bg-accent-primary text-accent-primary' : '',
+    isResizing ? 'md:bg-accent-primary md:text-accent-primary' : '',
   );
 
   const resizeTriggerClassName = classNames(

--- a/apps/chat/src/components/Sidebar/Sidebar.tsx
+++ b/apps/chat/src/components/Sidebar/Sidebar.tsx
@@ -103,15 +103,11 @@ const Sidebar = <T,>({
     [isLeftSidebar],
   );
 
-  const resizeTriggerColor = classNames(
-    'xl:bg-accent-primary xl:text-accent-primary',
-    isResizing ? 'md:bg-accent-primary md:text-accent-primary' : '',
-  );
-
   const resizeTriggerClassName = classNames(
-    'invisible h-full w-0.5 bg-layer-3 text-secondary group-hover:visible md:visible',
-    resizeTriggerColor,
-    isResizing ? 'xl:visible' : 'xl:invisible',
+    'invisible h-full w-0.5 group-hover:visible md:visible xl:bg-accent-primary xl:text-accent-primary',
+    isResizing
+      ? 'bg-accent-primary text-accent-primary xl:visible'
+      : 'bg-layer-3 text-secondary xl:invisible',
   );
 
   const sidebarWidth = useMemo(


### PR DESCRIPTION
**Description:**

- Fixed highlight resize trigger while resizing for the tablet mode.

Issues:

- Issue #1911 


**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
