### PR TITLE
fix(chat): fix first falsy request on creating conversation with postfix (Issue #1905)

### DIFF
--- a/apps/chat/src/store/import-export/importExport.epics.ts
+++ b/apps/chat/src/store/import-export/importExport.epics.ts
@@ -27,6 +27,7 @@ import {
   filterOnlyMyEntities,
   isImportEntityNameOnSameLevelUnique,
 } from '@/src/utils/app/common';
+import { regenerateConversationId } from '@/src/utils/app/conversation';
 import { BucketService } from '@/src/utils/app/data/bucket-service';
 import { ConversationService } from '@/src/utils/app/data/conversation-service';
 import { FileService } from '@/src/utils/app/data/file-service';
@@ -42,6 +43,7 @@ import { getOrUploadPrompt } from '@/src/utils/app/data/storages/api/prompt-api-
 import { BrowserStorage } from '@/src/utils/app/data/storages/browser-storage';
 import { constructPath } from '@/src/utils/app/file';
 import {
+  generateNextName,
   getConversationAttachmentWithPath,
   getFoldersFromIds,
   getParentFolderIdsFromFolderId,
@@ -82,6 +84,7 @@ import {
   PromptsSelectors,
 } from '@/src/store/prompts/prompts.reducers';
 
+import { DEFAULT_CONVERSATION_NAME } from '@/src/constants/default-ui-settings';
 import { errorsMessages } from '@/src/constants/errors';
 import { successMessages } from '@/src/constants/successMessages';
 
@@ -634,6 +637,9 @@ const continueDuplicatedImportEpic: AppEpic = (action$, state$) =>
       if (featureType === FeatureType.Chat) {
         const duplicatedConversations =
           ImportExportSelectors.selectDuplicatedConversations(state$.value);
+        const conversations = ConversationsSelectors.selectConversations(
+          state$.value,
+        );
 
         const conversationsToPostfix: Conversation[] = [];
         const conversationsToReplace: Conversation[] = [];
@@ -641,7 +647,21 @@ const continueDuplicatedImportEpic: AppEpic = (action$, state$) =>
           if (
             payload.mappedActions[conversation.id] === ReplaceOptions.Postfix
           ) {
-            conversationsToPostfix.push(conversation);
+            const siblingConversations = conversations.filter(
+              (conv) => conv.folderId === conversation.folderId,
+            );
+            const newName = generateNextName(
+              DEFAULT_CONVERSATION_NAME,
+              conversation.name,
+              siblingConversations,
+            );
+
+            conversationsToPostfix.push(
+              regenerateConversationId({
+                ...conversation,
+                name: newName,
+              }),
+            );
           }
 
           if (


### PR DESCRIPTION
**Description:**

- create new name and regenerate conversation id before api call

Issues:

- Issue #1905 

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
