### PR TITLE
fix:  "Chat Settings" button is not disabled during model response in "Compare" mode (Issue #1923)

### DIFF
--- a/apps/chat/src/components/Chat/ChatHeader.tsx
+++ b/apps/chat/src/components/Chat/ChatHeader.tsx
@@ -80,6 +80,15 @@ export const ChatHeader = ({
     ConversationsSelectors.selectAreSelectedConversationsExternal,
   );
 
+  const selectedConversations = useAppSelector(
+    ConversationsSelectors.selectSelectedConversations,
+  );
+
+  const isMessageStreaming = useMemo(
+    () => selectedConversations.some((conv) => conv.isMessageStreaming),
+    [selectedConversations],
+  );
+
   const selectedAddons = useMemo(
     () => getSelectedAddons(conversation.selectedAddons, addonsMap, model),
     [conversation, model, addonsMap],
@@ -254,7 +263,7 @@ export const ChatHeader = ({
                   className="cursor-pointer text-secondary hover:text-accent-primary disabled:cursor-not-allowed disabled:text-controls-disable"
                   onClick={() => setShowSettings(!isShowSettings)}
                   data-qa="conversation-setting"
-                  disabled={conversation.isMessageStreaming}
+                  disabled={isMessageStreaming}
                 >
                   <IconSettings size={iconSize} />
                 </button>
@@ -282,9 +291,9 @@ export const ChatHeader = ({
                 tooltip={t('Delete conversation from compare mode')}
               >
                 <button
-                  className="cursor-pointer text-secondary hover:text-accent-primary disabled:cursor-not-allowed"
+                  className="cursor-pointer text-secondary hover:text-accent-primary disabled:cursor-not-allowed disabled:text-controls-disable"
                   onClick={() => onUnselectConversation(conversation.id)}
-                  disabled={conversation.isMessageStreaming}
+                  disabled={isMessageStreaming}
                   data-qa="delete-from-compare"
                 >
                   <IconX size={18} />


### PR DESCRIPTION
**Description:**

- Fixed:  "Chat Settings" and 'x' buttons is not disabled during model response  in "Compare" mode. Buttons now disabled until both responses are received.

Issues:

- Issue #1923 


**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
