### PR TITLE
fix(chat): fix passing feature "allowResume" (Issue #1834)

### DIFF
--- a/apps/chat/src/types/models.ts
+++ b/apps/chat/src/types/models.ts
@@ -36,7 +36,7 @@ export interface CoreAIEntity<T = EntityType.Model> {
     system_prompt?: boolean;
     url_attachments?: boolean;
     folder_attachments?: boolean;
-    allowResume?: boolean;
+    allow_resume?: boolean;
   };
   tokenizer_model?: TokenizerModel;
 }

--- a/apps/chat/src/utils/server/get-sorted-entities.ts
+++ b/apps/chat/src/utils/server/get-sorted-entities.ts
@@ -170,7 +170,7 @@ export const getSortedEntities = async (token: JWT | null) => {
         truncatePrompt: entity.features.truncate_prompt ?? false,
         urlAttachments: entity.features.url_attachments ?? false,
         folderAttachments: entity.features.folder_attachments ?? false,
-        allowResume: entity.features.allowResume ?? true,
+        allowResume: entity.features.allow_resume ?? true,
       },
       inputAttachmentTypes: entity.input_attachment_types,
       maxInputAttachments: entity.max_input_attachments,


### PR DESCRIPTION
**Description:**

fix passing feature "allowResume"

Issues:

- Issue #1834 

**UI changes**

![image](https://github.com/user-attachments/assets/452718de-53d1-4b94-be5a-92bff15fd5f8)

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
