### PR TITLE
fix: Duplicated attachment import fails if the replace option is chosen. (Issue #1952)

### DIFF
--- a/apps/chat/src/store/import-export/importExport.epics.ts
+++ b/apps/chat/src/store/import-export/importExport.epics.ts
@@ -76,6 +76,7 @@ import { Conversation, Message } from '@/src/types/chat';
 import { FeatureType, UploadStatus } from '@/src/types/common';
 import { DialFile } from '@/src/types/files';
 import { FolderType } from '@/src/types/folder';
+import { HTTPMethod } from '@/src/types/http';
 import { LatestExportFormat, ReplaceOptions } from '@/src/types/import-export';
 import { Prompt } from '@/src/types/prompt';
 import { AppEpic } from '@/src/types/store';
@@ -1185,10 +1186,17 @@ const uploadConversationAttachmentsEpic: AppEpic = (action$, state$) =>
               attachment.name,
             );
 
+            const httpMethod =
+              attachmentsToReplace?.length &&
+              attachmentsToReplace.includes(attachment)
+                ? HTTPMethod.PUT
+                : undefined;
+
             return FileService.sendFile(
               formData,
               attachment.relativePath,
               attachment.name,
+              httpMethod,
             ).pipe(
               filter(
                 ({ percent, result }) =>

--- a/apps/chat/src/utils/app/data/file-service.ts
+++ b/apps/chat/src/utils/app/data/file-service.ts
@@ -19,6 +19,7 @@ export class FileService {
     formData: FormData,
     relativePath: string | undefined,
     fileName: string,
+    httpMethod?: HTTPMethod,
   ): Observable<{ percent?: number; result?: DialFile }> {
     const resultPath = ApiUtils.encodeApiUrl(
       constructPath(getFileRootId(), relativePath, fileName),
@@ -26,7 +27,7 @@ export class FileService {
 
     return ApiUtils.requestOld({
       url: `api/${resultPath}`,
-      method: HTTPMethod.POST,
+      method: httpMethod ? httpMethod : HTTPMethod.POST,
       async: true,
       body: formData,
     }).pipe(


### PR DESCRIPTION

**Description:**

- Fixed duplicated attachment import fails if the replace option is chosen. Use PUT method for this action.

Issues:

- Issue #1952 


**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
