### PR TITLE
fix(chat): fix collapsing folders on import (Issue #1958)

### DIFF
--- a/apps/chat/src/store/import-export/importExport.epics.ts
+++ b/apps/chat/src/store/import-export/importExport.epics.ts
@@ -524,7 +524,6 @@ const uploadImportedConversationsEpic: AppEpic = (action$, state$) =>
                   UIActions.setOpenedFoldersIds({
                     openedFolderIds: uniq([
                       ...uploadedConversationsFoldersIds,
-                      ...conversationsFolders.map((folder) => folder.id),
                       ...openedFolderIds,
                     ]),
                     featureType: FeatureType.Chat,
@@ -590,6 +589,13 @@ const uploadImportedPromptsEpic: AppEpic = (action$, state$) =>
                 ),
                 FolderType.Prompt,
               );
+              const uploadedPrompsFolderIds = uniq(
+                itemsToUpload.map((prompt) => prompt.folderId),
+              );
+              const openedFolderIds = UISelectors.selectOpenedFoldersIds(
+                state$.value,
+                FeatureType.Prompt,
+              );
 
               const isShowReplaceDialog =
                 ImportExportSelectors.selectIsShowReplaceDialog(state$.value);
@@ -599,6 +605,15 @@ const uploadImportedPromptsEpic: AppEpic = (action$, state$) =>
                   PromptsActions.importPromptsSuccess({
                     prompts: promptsListing,
                     folders: promptsFolders,
+                  }),
+                ),
+                of(
+                  UIActions.setOpenedFoldersIds({
+                    openedFolderIds: uniq([
+                      ...uploadedPrompsFolderIds,
+                      ...openedFolderIds,
+                    ]),
+                    featureType: FeatureType.Prompt,
                   }),
                 ),
                 iif(


### PR DESCRIPTION
**Description:**

- fix collapsing all folders on conversation import
- fix collapsing folders on prompt import

Issues:

- Issue #1958 

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
