### PR TITLE
fix(chat): not reset selection for publication when view prompt (Issue #1978)

### DIFF
--- a/apps/chat/src/components/Promptbar/components/Prompt.tsx
+++ b/apps/chat/src/components/Promptbar/components/Prompt.tsx
@@ -223,11 +223,13 @@ export const PromptComponent = ({
           isApproveRequiredResource,
         }),
       );
-      dispatch(
-        PublicationActions.selectPublication(
-          additionalItemData?.publicationUrl ?? null,
-        ),
-      );
+      if (additionalItemData?.publicationUrl) {
+        dispatch(
+          PublicationActions.selectPublication(
+            additionalItemData?.publicationUrl,
+          ),
+        );
+      }
       dispatch(PromptsActions.uploadPrompt({ promptId: prompt.id }));
       dispatch(PromptsActions.setIsEditModalOpen({ isOpen: true, isPreview }));
     },


### PR DESCRIPTION
**Description:**

do not reset selection for publication when view prompt

Issues:

- Issue #1978

**UI changes**

![image](https://github.com/user-attachments/assets/8670273a-d832-4be1-9a13-4438d692995c)

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
