### PR TITLE
fix(chat): fix expanding folders logic for "go to review" (Issue #1979)

### DIFF
--- a/apps/chat/src/components/Chat/Publish/PublicationHandler.tsx
+++ b/apps/chat/src/components/Chat/Publish/PublicationHandler.tsx
@@ -240,9 +240,9 @@ export function PublicationHandler({ publication }: Props) {
       const conversationPaths = uniq(
         [...conversationsToReviewIds, ...reviewedConversationsIds].flatMap(
           (p) =>
-            getParentFolderIdsFromEntityId(
-              getFolderIdFromEntityId(p.reviewUrl),
-            ).filter((id) => id !== p.reviewUrl),
+            getParentFolderIdsFromEntityId(getFolderIdFromEntityId(p.reviewUrl))
+              .filter((id) => id !== p.reviewUrl)
+              .map((id) => `${publication.url}${id}`),
         ),
       );
 
@@ -257,9 +257,9 @@ export function PublicationHandler({ publication }: Props) {
 
       const promptPaths = uniq(
         [...promptsToReviewIds, ...reviewedPromptsIds].flatMap((p) =>
-          getParentFolderIdsFromEntityId(
-            getFolderIdFromEntityId(p.reviewUrl),
-          ).filter((id) => id !== p.reviewUrl),
+          getParentFolderIdsFromEntityId(getFolderIdFromEntityId(p.reviewUrl))
+            .filter((id) => id !== p.reviewUrl)
+            .map((id) => `${publication.url}${id}`),
         ),
       );
 


### PR DESCRIPTION
**Description:**

fix expanding folders logic for "go to review"

Issues:

- Issue #1979 

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
