### PR TITLE
fix(chat): fix no data view in files manager (Issue #1977)

### DIFF
--- a/apps/chat/src/components/Files/FileManagerModal.tsx
+++ b/apps/chat/src/components/Files/FileManagerModal.tsx
@@ -58,7 +58,6 @@ interface FilesSectionProps {
   dataQa: string;
   children: ReactNode;
   files: DialFile[];
-  searchQuery: string;
   folders: FolderInterface[];
 }
 
@@ -67,13 +66,13 @@ const FilesSectionWrapper = ({
   dataQa,
   folders,
   files,
-  searchQuery,
   children,
 }: FilesSectionProps) => {
   const { handleToggle, isExpanded } = useSectionToggle(name, FeatureType.File);
 
   const isNothingExists = folders.length === 0 && files.length === 0;
-  const isNoEntitiesFound = searchQuery !== '' && isNothingExists;
+
+  if (isNothingExists) return null;
 
   return (
     <CollapsibleSection
@@ -86,17 +85,7 @@ const FilesSectionWrapper = ({
     >
       <div className="flex flex-col overflow-auto" data-qa="all-files">
         <div className="flex grow flex-col gap-0.5 overflow-auto">
-          {isNoEntitiesFound ? (
-            <div className="my-10">
-              <NoResultsFound />
-            </div>
-          ) : isNothingExists ? (
-            <div className="my-10">
-              <NoData />
-            </div>
-          ) : (
-            children
-          )}
+          {children}
         </div>
       </div>
     </CollapsibleSection>
@@ -258,6 +247,14 @@ export const FileManagerModal = ({
   }, [allowedTypesArray, allowedTypesLabel, t]);
 
   const showSpinner = folders.length === 0 && areFoldersLoading;
+
+  const isNothingExists =
+    !myRootFolders.length &&
+    !myRootFiles.length &&
+    !organizationRootFolders.length &&
+    !organizationRootFiles.length;
+
+  const showNoResult = searchQuery !== '' && isNothingExists;
 
   useEffect(() => {
     if (isOpen) {
@@ -617,12 +614,16 @@ export const FileManagerModal = ({
               className="flex min-h-[350px] flex-col divide-y divide-tertiary overflow-auto"
               data-qa="all-files"
             >
+              {(isNothingExists || showNoResult) && (
+                <div className="flex grow flex-col justify-center">
+                  {showNoResult ? <NoResultsFound /> : <NoData />}
+                </div>
+              )}
               <FilesSectionWrapper
                 name={t('Organization')}
                 dataQa="organization-files"
                 folders={organizationRootFolders}
                 files={organizationRootFiles}
-                searchQuery={searchQuery}
               >
                 <div className="flex flex-col gap-1 overflow-auto">
                   {organizationRootFolders.map((folder) => {
@@ -695,7 +696,6 @@ export const FileManagerModal = ({
                 dataQa="all-files"
                 folders={myRootFolders}
                 files={myRootFiles}
-                searchQuery={searchQuery}
               >
                 <div className="flex flex-col gap-1 overflow-auto">
                   {myRootFolders.map((folder) => {


### PR DESCRIPTION
**Description:**

- remove no result and no data view from filesSectionWrapper
- add no result and no data view for all files in file manager modal

Issues:

- Issue #1977 

**UI changes**

<img width="528" alt="Снимок экрана 2024-08-29 в 20 34 30" src="https://github.com/user-attachments/assets/7b968c45-9e2f-40c5-b40b-bb1b0eee5f53">

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
