### PR TITLE
feat(chat): add option to unpublish app, add apps filter for publish request modal, hide caret icon if publication resource types don't contain prompt or conversation (Issues #1940, #2006, #2031)

### DIFF
--- a/apps/chat/src/components/Chat/ModelList.tsx
+++ b/apps/chat/src/components/Chat/ModelList.tsx
@@ -326,7 +326,7 @@ export const ModelList = ({
   const [currentEntity, setCurrentEntity] = useState<DialAIEntityModel>();
   const [publishAction, setPublishAction] = useState<
     PublishActions | undefined
-  >(undefined);
+  >();
   const recentModelsIds = useAppSelector(ModelsSelectors.selectRecentModelsIds);
 
   const entityForPublish: ShareEntity | null = currentEntity

--- a/apps/chat/src/components/Chat/ModelList.tsx
+++ b/apps/chat/src/components/Chat/ModelList.tsx
@@ -61,7 +61,7 @@ interface ModelGroupProps {
   isReplayAsIs?: boolean;
   handleChangeCurrentEntity: (model: DialAIEntityModel) => void;
   openApplicationModal?: () => void;
-  handlePublish: () => void;
+  handlePublish: (action: PublishActions) => void;
   handleOpenDeleteConfirmModal: () => void;
   handleEdit: (currentEntityId: string) => void;
 }
@@ -142,7 +142,7 @@ const ModelGroup = ({
         onClick: (e: React.MouseEvent) => {
           e.stopPropagation();
           handleChangeCurrentEntity(currentEntity);
-          handlePublish();
+          handlePublish(PublishActions.ADD);
         },
       },
       {
@@ -150,7 +150,11 @@ const ModelGroup = ({
         dataQa: 'unpublish',
         display: isPublishedEntity,
         Icon: UnpublishIcon,
-        // onClick: () => console.log('unpublish'),
+        onClick: (e: React.MouseEvent) => {
+          e.stopPropagation();
+          handleChangeCurrentEntity(currentEntity);
+          handlePublish(PublishActions.DELETE);
+        },
       },
       {
         name: t('Delete'),
@@ -319,7 +323,9 @@ export const ModelList = ({
   const [modalIsOpen, setModalIsOpen] = useState(false);
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const [currentEntity, setCurrentEntity] = useState<DialAIEntityModel>();
-  const [isPublishing, setIsPublishing] = useState(false);
+  const [publishAction, setPublishAction] = useState<
+    PublishActions | undefined
+  >(undefined);
   const recentModelsIds = useAppSelector(ModelsSelectors.selectRecentModelsIds);
 
   const entityForPublish: ShareEntity | null = currentEntity
@@ -342,16 +348,16 @@ export const ModelList = ({
     [dispatch, handleOpenApplicationModal],
   );
 
-  const handleOpenDeleteConfirmModal = () => {
+  const handleOpenDeleteConfirmModal = useCallback(() => {
     setIsDeleteModalOpen(true);
-  };
+  }, []);
 
-  const handlePublish = () => {
-    setIsPublishing(true);
-  };
+  const handlePublish = useCallback((action: PublishActions) => {
+    setPublishAction(action);
+  }, []);
 
   const handlePublishClose = () => {
-    setIsPublishing(false);
+    setPublishAction(undefined);
   };
 
   const handleDelete = useCallback(() => {
@@ -451,16 +457,13 @@ export const ModelList = ({
           isEdit
         />
       )}
-      {entityForPublish && entityForPublish.id && (
+      {publishAction && entityForPublish && entityForPublish.id && (
         <PublishModal
           entity={entityForPublish}
           type={SharingType.Application}
-          isOpen={isPublishing}
+          isOpen={!!publishAction}
           onClose={handlePublishClose}
-          publishAction={
-            PublishActions.ADD
-            // isPublishing ? PublishActions.ADD : PublishActions.DELETE
-          }
+          publishAction={publishAction}
         />
       )}
     </div>

--- a/apps/chat/src/components/Chat/ModelList.tsx
+++ b/apps/chat/src/components/Chat/ModelList.tsx
@@ -324,9 +324,7 @@ export const ModelList = ({
   const [modalIsOpen, setModalIsOpen] = useState(false);
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const [currentEntity, setCurrentEntity] = useState<DialAIEntityModel>();
-  const [publishAction, setPublishAction] = useState<
-    PublishActions | undefined
-  >();
+  const [publishAction, setPublishAction] = useState<PublishActions>();
   const recentModelsIds = useAppSelector(ModelsSelectors.selectRecentModelsIds);
 
   const entityForPublish: ShareEntity | null = currentEntity

--- a/apps/chat/src/components/Chat/Publish/ApproveRequiredSection.tsx
+++ b/apps/chat/src/components/Chat/Publish/ApproveRequiredSection.tsx
@@ -36,6 +36,8 @@ interface PublicationProps {
   featureTypes: FeatureType[];
 }
 
+const featureTypesWithCaretIcon = [FeatureType.Chat, FeatureType.Prompt];
+
 const PublicationItem = ({ publication, featureTypes }: PublicationProps) => {
   const dispatch = useAppDispatch();
 
@@ -72,6 +74,12 @@ const PublicationItem = ({ publication, featureTypes }: PublicationProps) => {
     );
   }, [dispatch, publication]);
 
+  const showCaretIcon = featureTypesWithCaretIcon.some((type) =>
+    publication.resourceTypes.includes(
+      EnumMapper.getBackendResourceTypeByFeatureType(type),
+    ),
+  );
+
   const ResourcesComponent = featureTypes.includes(FeatureType.Chat)
     ? ConversationPublicationResources
     : featureTypes.includes(FeatureType.Prompt)
@@ -91,7 +99,7 @@ const PublicationItem = ({ publication, featureTypes }: PublicationProps) => {
         )}
       >
         <div className="group/button flex size-full cursor-pointer items-center gap-1 py-2 pr-3">
-          <CaretIconComponent isOpen={isOpen} />
+          <CaretIconComponent hidden={!showCaretIcon} isOpen={isOpen} />
           <div className="relative">
             <IconClipboard className="text-secondary" width={18} height={18} />
             {(!itemsToReview

--- a/apps/chat/src/components/Chat/Publish/PublicationResources.tsx
+++ b/apps/chat/src/components/Chat/Publish/PublicationResources.tsx
@@ -1,4 +1,5 @@
 import { IconDownload } from '@tabler/icons-react';
+import { useMemo } from 'react';
 
 import classNames from 'classnames';
 
@@ -319,14 +320,23 @@ export const FilePublicationResources = ({
 
 export const ApplicationPublicationResources = ({
   isOpen = true,
+  resources,
 }: PublicationResources) => {
   const publishRequestModels = useAppSelector(
     ModelsSelectors.selectPublishRequestModels,
   );
 
+  const filteredApps = useMemo(() => {
+    const resourcesIds = resources.map((resource) => resource.reviewUrl);
+
+    return publishRequestModels.filter((model) =>
+      resourcesIds.includes(model.id),
+    );
+  }, [publishRequestModels, resources]);
+
   return (
     <div className={classNames(!isOpen && 'hidden')}>
-      {publishRequestModels.map((application) => (
+      {filteredApps.map((application) => (
         <ApplicationRow item={application} key={application.id} />
       ))}
     </div>

--- a/apps/chat/src/components/Chat/Publish/ReviewApplicationDialogView.tsx
+++ b/apps/chat/src/components/Chat/Publish/ReviewApplicationDialogView.tsx
@@ -1,3 +1,5 @@
+import { Fragment } from 'react';
+
 import { useTranslation } from 'next-i18next';
 
 import { getFolderIdFromEntityId } from '@/src/utils/app/folders';
@@ -74,10 +76,10 @@ export function ReviewApplicationDialogView() {
                   <br />
                   {Object.entries(application?.features || {}).map(
                     ([key, value]) => (
-                      <>
+                      <Fragment key={key}>
                         <span>{key}</span> <span>{value}</span>
                         <br />
-                      </>
+                      </Fragment>
                     ),
                   )}
                 </pre>

--- a/apps/chat/src/store/models/models.reducers.ts
+++ b/apps/chat/src/store/models/models.reducers.ts
@@ -3,7 +3,11 @@ import { PayloadAction, createSelector, createSlice } from '@reduxjs/toolkit';
 import { combineEntities } from '@/src/utils/app/common';
 import { translate } from '@/src/utils/app/translation';
 
-import { EntityType, UploadStatus } from '@/src/types/common';
+import {
+  EntityPublicationInfo,
+  EntityType,
+  UploadStatus,
+} from '@/src/types/common';
 import { ErrorMessage } from '@/src/types/error';
 import { DialAIEntityModel, ModelsMap } from '@/src/types/models';
 
@@ -21,7 +25,10 @@ export interface ModelsState {
   models: DialAIEntityModel[];
   modelsMap: ModelsMap;
   recentModelsIds: string[];
-  publishRequestModels: (DialAIEntityModel & { folderId: string })[];
+  publishRequestModels: (DialAIEntityModel & {
+    folderId: string;
+    publicationInfo: EntityPublicationInfo;
+  })[];
   publishedApplicationIds: string[];
 }
 
@@ -189,7 +196,10 @@ export const modelsSlice = createSlice({
       {
         payload,
       }: PayloadAction<{
-        models: (DialAIEntityModel & { folderId: string })[];
+        models: (DialAIEntityModel & {
+          folderId: string;
+          publicationInfo: EntityPublicationInfo;
+        })[];
       }>,
     ) => {
       state.publishRequestModels = combineEntities(

--- a/apps/chat/src/store/publication/publication.epics.ts
+++ b/apps/chat/src/store/publication/publication.epics.ts
@@ -62,7 +62,7 @@ import {
   ConversationsSelectors,
 } from '../conversations/conversations.reducers';
 import { FilesActions } from '../files/files.reducers';
-import { ModelsActions } from '../models/models.reducers';
+import { ModelsActions, ModelsSelectors } from '../models/models.reducers';
 import { PromptsActions, PromptsSelectors } from '../prompts/prompts.reducers';
 import { UIActions } from '../ui/ui.reducers';
 import {
@@ -146,7 +146,7 @@ const uploadPublicationsFailEpic: AppEpic = (action$) =>
     ),
   );
 
-const uploadPublicationEpic: AppEpic = (action$) =>
+const uploadPublicationEpic: AppEpic = (action$, state$) =>
   action$.pipe(
     filter(PublicationActions.uploadPublication.match),
     switchMap(({ payload }) =>
@@ -348,6 +348,8 @@ const uploadPublicationEpic: AppEpic = (action$) =>
             );
 
             if (applicationResources.length) {
+              const allModels = ModelsSelectors.selectModels(state$.value);
+
               actions.push(
                 of(
                   ModelsActions.addPublishRequestModels({
@@ -363,9 +365,14 @@ const uploadPublicationEpic: AppEpic = (action$) =>
                         reference: r.reviewUrl,
                         type: EntityType.Application,
                         folderId: getFolderIdFromEntityId(r.reviewUrl),
-                        // publicationInfo: {
-                        //   action: r.action,
-                        // },
+                        publicationInfo: {
+                          action: r.action,
+                          isNotExist:
+                            r.action === PublishActions.DELETE &&
+                            !allModels.some(
+                              (model) => model.id === r.reviewUrl,
+                            ),
+                        },
                       };
                     }),
                   }),

--- a/apps/chat/src/store/publication/publication.selectors.ts
+++ b/apps/chat/src/store/publication/publication.selectors.ts
@@ -8,7 +8,6 @@ import { FolderInterface } from '@/src/types/folder';
 import { Publication, PublicationResource } from '@/src/types/publication';
 
 import { RootState } from '../index';
-
 import { PublicationState } from './publication.reducers';
 
 const rootSelector = (state: RootState): PublicationState => state.publication;

--- a/apps/chat/src/store/publication/publication.selectors.ts
+++ b/apps/chat/src/store/publication/publication.selectors.ts
@@ -6,15 +6,9 @@ import { EnumMapper } from '@/src/utils/app/mappers';
 import { FeatureType, ShareEntity, UploadStatus } from '@/src/types/common';
 import { Publication, PublicationResource } from '@/src/types/publication';
 
-import {
-  selectFolders as selectConversationFolders,
-  selectConversations,
-} from '../conversations/conversations.selectors';
+import { selectFolders as selectConversationFolders } from '../conversations/conversations.selectors';
 import { RootState } from '../index';
-import {
-  selectFolders as selectPromptFolders,
-  selectPrompts,
-} from '../prompts/prompts.selectors';
+import { selectFolders as selectPromptFolders } from '../prompts/prompts.selectors';
 import { PublicationState } from './publication.reducers';
 
 const rootSelector = (state: RootState): PublicationState => state.publication;
@@ -186,15 +180,6 @@ export const selectChosenFolderIds = createSelector(
       );
 
     return { partialChosenFolderIds, fullyChosenFolderIds };
-  },
-);
-
-export const selectNonExistentEntities = createSelector(
-  [selectConversations, selectPrompts],
-  (conversations, prompts) => {
-    return [...conversations, ...prompts].filter(
-      (entity) => entity.publicationInfo?.isNotExist,
-    );
   },
 );
 


### PR DESCRIPTION
**Description:**

add option to unpublish app
add apps filter for publish request modal
hide caret icon if publication resource types don't contain prompt or conversation

Issues:

- #1940 
- #2006 
- #2031 

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
