### PR TITLE
feat(chat): Implement federated logout with custom session termination flow

### DIFF
--- a/apps/chat-e2e/src/tests/announcementBanner.test.ts
+++ b/apps/chat-e2e/src/tests/announcementBanner.test.ts
@@ -7,24 +7,29 @@ dialTest(
   'Banner is shown.\n' +
     'Banner text contains html link.\n' +
     "Banner doesn't appear if to close it",
-  async ({
-    dialHomePage,
-    conversationData,
-    dataInjector,
-    chatBar,
-    promptBar,
-    conversations,
-    banner,
-    header,
-    appContainer,
-    chatMessages,
-    accountSettings,
-    accountDropdownMenu,
-    confirmationDialog,
-    providerLogin,
-    setTestIds,
-  }) => {
+  async (
+    {
+      dialHomePage,
+      conversationData,
+      dataInjector,
+      chatBar,
+      promptBar,
+      conversations,
+      banner,
+      header,
+      appContainer,
+      chatMessages,
+      accountSettings,
+      accountDropdownMenu,
+      confirmationDialog,
+      providerLogin,
+      setTestIds,
+    },
+    testInfo,
+  ) => {
     setTestIds('EPMRTC-1576', 'EPMRTC-1580', 'EPMRTC-1577');
+    const username =
+      process.env.E2E_USERNAME!.split(',')[+process.env.TEST_PARALLEL_INDEX!];
     let conversation: Conversation;
     let chatBarBounding;
     let promptBarBounding;
@@ -148,6 +153,12 @@ dialTest(
         await accountDropdownMenu.selectMenuOption(AccountMenuOptions.logout);
         await confirmationDialog.confirm();
         await providerLogin.navigateToCredentialsPage();
+        await providerLogin.authProviderLogin(
+          testInfo,
+          username,
+          process.env.E2E_PASSWORD!,
+          false,
+        );
         await chatMessages.waitForState({ state: 'attached' });
         await expect
           .soft(banner.getElementLocator(), ExpectedMessages.bannerIsClosed)

--- a/apps/chat-e2e/src/ui/actions/providerLogin.ts
+++ b/apps/chat-e2e/src/ui/actions/providerLogin.ts
@@ -45,7 +45,7 @@ export abstract class ProviderLogin<T extends BasePage & LoginInterface> {
       : await this.loginPage.navigateToBaseUrl();
   }
 
-  protected async authProviderLogin(
+  public async authProviderLogin(
     testInfo: TestInfo,
     username: string,
     password: string,

--- a/apps/chat/src/components/Header/User/UserDesktop.tsx
+++ b/apps/chat/src/components/Header/User/UserDesktop.tsx
@@ -1,9 +1,11 @@
 /*eslint-disable @next/next/no-img-element*/
 import { IconSettings } from '@tabler/icons-react';
-import { signIn, signOut, useSession } from 'next-auth/react';
+import { signIn, useSession } from 'next-auth/react';
 import { useCallback, useState } from 'react';
 
 import { useTranslation } from 'next-i18next';
+
+import { customSignOut } from '@/src/utils/auth/signOut';
 
 import { Translation } from '@/src/types/translation';
 
@@ -25,9 +27,7 @@ export const UserDesktop = () => {
   const { data: session } = useSession();
   const dispatch = useAppDispatch();
   const handleLogout = useCallback(() => {
-    session
-      ? signOut({ redirect: true })
-      : signIn('azure-ad', { redirect: true });
+    session ? customSignOut() : signIn('azure-ad', { redirect: true });
   }, [session]);
 
   return (

--- a/apps/chat/src/components/Header/User/UserMobile.tsx
+++ b/apps/chat/src/components/Header/User/UserMobile.tsx
@@ -1,11 +1,13 @@
 /*eslint-disable @next/next/no-img-element*/
 import { IconSettings } from '@tabler/icons-react';
-import { signIn, signOut, useSession } from 'next-auth/react';
+import { signIn, useSession } from 'next-auth/react';
 import { useCallback, useState } from 'react';
 
 import { useTranslation } from 'next-i18next';
 
 import classNames from 'classnames';
+
+import { customSignOut } from '@/src/utils/auth/signOut';
 
 import { Translation } from '@/src/types/translation';
 
@@ -71,9 +73,7 @@ const Logout = () => {
     useState(false);
 
   const handleLogout = useCallback(() => {
-    session
-      ? signOut({ redirect: true })
-      : signIn('azure-ad', { redirect: true });
+    session ? customSignOut() : signIn('azure-ad', { redirect: true });
   }, [session]);
   return (
     <>

--- a/apps/chat/src/pages/api/auth/federated-logout.ts
+++ b/apps/chat/src/pages/api/auth/federated-logout.ts
@@ -1,0 +1,64 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+import { getToken } from 'next-auth/jwt';
+
+import NextClient from '@/src/utils/auth/nextauth-client';
+import { logger } from '@/src/utils/server/logger';
+
+const DEFAULT_LOGOUT_REDIRECT_URI =
+  process.env.NEXTAUTH_URL || 'http://localhost:3000/';
+
+/**
+ * Federated logout handler
+ *
+ * 1. Retrieves the user's authentication token via JWT.
+ * 2. Validates the presence and type of `providerId` in the token.
+ * 3. If the provider supports logout, generates a URL for session termination.
+ * 4. Returns the logout URL in JSON format or `null` if logout is not possible.
+ *
+ * @param req - HTTP request (NextApiRequest)
+ * @param res - HTTP response (NextApiResponse)
+ *
+ * @returns A JSON response with the logout URL or `null` in case of an error.
+ */
+const handler = async (
+  req: NextApiRequest,
+  res: NextApiResponse,
+): Promise<void> => {
+  try {
+    const token = await getToken({ req });
+
+    if (!token || typeof token.providerId !== 'string') {
+      logger.warn('Token is missing or providerId not found.');
+      res.status(200).json({ url: null });
+      return;
+    }
+
+    const client = NextClient.getClient(token.providerId);
+
+    if (!client) {
+      logger.warn(`Client for providerId ${token.providerId} not found.`);
+      res.status(200).json({ url: null });
+      return;
+    }
+
+    const url = client.endSessionUrl({
+      post_logout_redirect_uri: DEFAULT_LOGOUT_REDIRECT_URI,
+      id_token_hint: token.idToken as string,
+    });
+
+    if (!url) {
+      logger.warn(
+        `End session URL not found for providerId ${token.providerId}.`,
+      );
+      res.status(200).json({ url: null });
+      return;
+    }
+
+    res.status(200).json({ url });
+  } catch (error) {
+    logger.error('Error during federated logout:', error);
+    res.status(200).json({ url: null });
+  }
+};
+
+export default handler;

--- a/apps/chat/src/utils/auth/auth-callbacks.ts
+++ b/apps/chat/src/utils/auth/auth-callbacks.ts
@@ -176,6 +176,7 @@ export const callbacks: Partial<
         refreshToken: options.account.refresh_token,
         providerId: options.account.provider,
         userId: options.user.id,
+        idToken: options.account.id_token,
       };
     }
 

--- a/apps/chat/src/utils/auth/signOut.ts
+++ b/apps/chat/src/utils/auth/signOut.ts
@@ -1,5 +1,7 @@
 import { signOut } from 'next-auth/react';
 
+import { parseUrl } from 'next/dist/shared/lib/router/utils/parse-url';
+
 /**
  * Custom signOut function to handle federated logout.
  * - It first removes the session cookie using next-auth's signOut method.
@@ -16,7 +18,8 @@ export const customSignOut = async (): Promise<void> => {
     await signOut({ redirect: true });
 
     if (url) {
-      window.location.href = url;
+      const parsedUrl = parseUrl(url);
+      window.location.href = parsedUrl.href;
     }
   } catch (error) {
     await signOut({ redirect: true });

--- a/apps/chat/src/utils/auth/signOut.ts
+++ b/apps/chat/src/utils/auth/signOut.ts
@@ -1,0 +1,24 @@
+import { signOut } from 'next-auth/react';
+
+/**
+ * Custom signOut function to handle federated logout.
+ * - It first removes the session cookie using next-auth's signOut method.
+ * - Then, it checks for a federated logout URL by calling the backend API.
+ * - If a federated logout URL is returned, it redirects the user to the external identity provider for logout.
+ *
+ * @returns {Promise<void>}
+ */
+export const customSignOut = async (): Promise<void> => {
+  try {
+    const res = await fetch('/api/auth/federated-logout');
+    const { url }: { url: string | null } = await res.json();
+
+    await signOut({ redirect: true });
+
+    if (url) {
+      window.location.href = url;
+    }
+  } catch (error) {
+    await signOut({ redirect: true });
+  }
+};


### PR DESCRIPTION
**Description:**

Implemented federated logout functionality, allowing users to sign out both locally and from the external identity provider (IDP). The custom logout flow handles session termination and redirects to the federated logout endpoint when available.

Issues:


**UI changes**

No UI changes involved.

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [ ] the pull request name ends with `(Issue #12345)` (comma-separated list of issues)
- [x] I confirm that I do not share any confidential information like API keys or any other secrets and private URLs
