### PR TITLE
fix(chat): use `model.reference` instead of `model.id` everywhere in `conversation.model.id`  (Error 412) (Issue #2080)

### DIFF
--- a/apps/chat/src/components/Chat/ModelList.tsx
+++ b/apps/chat/src/components/Chat/ModelList.tsx
@@ -365,7 +365,7 @@ export const ModelList = ({
 
     const modelsMapKeys = Object.keys(modelsMap);
 
-    onSelect(recentModelsIds[1] ?? modelsMap[modelsMapKeys[0]]);
+    onSelect(recentModelsIds[1] ?? modelsMap[modelsMapKeys[0]]?.reference);
     selectedConversations.forEach((conv) => {
       if (
         conv.model.id === currentEntity?.reference ||
@@ -375,7 +375,10 @@ export const ModelList = ({
           ConversationsActions.updateConversation({
             id: conv.id,
             values: {
-              model: { id: recentModelsIds[1] ?? modelsMap[modelsMapKeys[0]] },
+              model: {
+                id:
+                  recentModelsIds[1] ?? modelsMap[modelsMapKeys[0]]?.reference,
+              },
             },
           }),
         );

--- a/apps/chat/src/store/conversations/conversations.epics.ts
+++ b/apps/chat/src/store/conversations/conversations.epics.ts
@@ -409,7 +409,7 @@ const createNewConversationsEpic: AppEpic = (action$, state$) =>
                       ),
                 messages: [],
                 model: {
-                  id: model.id,
+                  id: model.reference,
                 },
                 prompt: DEFAULT_SYSTEM_PROMPT,
                 temperature:

--- a/apps/chat/src/store/overlay/overlay.epics.ts
+++ b/apps/chat/src/store/overlay/overlay.epics.ts
@@ -286,16 +286,19 @@ const setOverlayOptionsEpic: AppEpic = (action$, state$) =>
           if (currentConversation) {
             const models = ModelsSelectors.selectModels(state$.value);
 
-            const newAiEntity = models.find(({ id }) => id === finalModelId) as
-              | DialAIEntityModel
-              | undefined;
+            const newAiEntity = models.find(
+              ({ reference, id }) =>
+                id === finalModelId || reference === finalModelId,
+            ) as DialAIEntityModel | undefined;
 
             actions.push(
               of(
                 ConversationsActions.updateConversation({
                   id: currentConversation.id,
                   values: {
-                    model: { id: finalModelId },
+                    model: {
+                      id: newAiEntity?.reference ?? finalModelId,
+                    },
                   },
                 }),
               ),


### PR DESCRIPTION
**Description:**

use `model.reference` instead of `model.id` everywhere in `conversation.model.id` (Error 412)

Issues:

- Issue #2080

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
