### PR TITLE
fix(chat): fix clip icon appearance (Issue #2063)

### DIFF
--- a/apps/chat/src/components/Common/ApplicationDialog.tsx
+++ b/apps/chat/src/components/Common/ApplicationDialog.tsx
@@ -298,12 +298,9 @@ const ApplicationDialogView: React.FC<Props> = ({
   const onSubmit = (data: FormData) => {
     const preparedData = {
       ...data,
-<<<<<<< HEAD
       maxInputAttachments: maxInputAttachmentsValue,
-=======
       name: data.name.trim(),
       description: data.description.trim(),
->>>>>>> cee4429fa522ee800c39e4ed49f0dcb895fa757a
       features: featuresInput ? JSON.parse(featuresInput) : null,
       type: EntityType.Application,
       isDefault: false,

--- a/apps/chat/src/components/Common/ApplicationDialog.tsx
+++ b/apps/chat/src/components/Common/ApplicationDialog.tsx
@@ -118,7 +118,7 @@ const ApplicationDialogView: React.FC<Props> = ({
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const [isPublishing, setIsPublishing] = useState(false);
   const [maxInputAttachmentsValue, setMaxInputAttachmentsValue] = useState(
-    selectedApplication?.maxInputAttachments ?? undefined,
+    selectedApplication?.maxInputAttachments,
   );
 
   const inputClassName = classNames('input-form input-invalid peer mx-0');
@@ -572,9 +572,10 @@ const ApplicationDialogView: React.FC<Props> = ({
               className={inputClassName}
               placeholder={t('Enter the maximum number of attachments') || ''}
               onChange={(e) => {
+                const numericValue = e.target.value.replace(/[^0-9]/g, '');
                 const value =
-                  e.target.value !== '' ? Number(e.target.value) : undefined;
-                if (!e.target.value || Number.isSafeInteger(value)) {
+                  numericValue !== '' ? Number(numericValue) : undefined;
+                if (!value || Number.isSafeInteger(value)) {
                   setMaxInputAttachmentsValue(value);
                 }
                 handleChangeHandlerAttachments?.(e);

--- a/apps/chat/src/components/Common/ApplicationDialog.tsx
+++ b/apps/chat/src/components/Common/ApplicationDialog.tsx
@@ -113,7 +113,7 @@ const ApplicationDialogView: React.FC<Props> = ({
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const [isPublishing, setIsPublishing] = useState(false);
   const [maxInputAttachmentsValue, setMaxInputAttachmentsValue] = useState(
-    selectedApplication?.maxInputAttachments || undefined,
+    selectedApplication?.maxInputAttachments ?? undefined,
   );
 
   const inputClassName = classNames('input-form input-invalid peer mx-0');
@@ -136,18 +136,21 @@ const ApplicationDialogView: React.FC<Props> = ({
         setDeleteLogo(false);
         setLocalLogoFile(newIconUrl);
         setValue('iconUrl', newIconUrl);
+        trigger('iconUrl');
       } else {
         setLocalLogoFile(undefined);
         setValue('iconUrl', '');
+        trigger('iconUrl');
       }
     },
-    [files, setValue],
+    [files, setValue, trigger],
   );
 
   const onDeleteLocalLogoHandler = () => {
     setLocalLogoFile(undefined);
     setDeleteLogo(true);
     setValue('iconUrl', '');
+    trigger('iconUrl');
   };
 
   const handlePublish = (e: React.FormEvent) => {
@@ -290,6 +293,7 @@ const ApplicationDialogView: React.FC<Props> = ({
   const onSubmit = (data: FormData) => {
     const preparedData = {
       ...data,
+      maxInputAttachments: maxInputAttachmentsValue,
       features: featuresInput ? JSON.parse(featuresInput) : null,
       type: EntityType.Application,
       isDefault: false,
@@ -551,9 +555,8 @@ const ApplicationDialogView: React.FC<Props> = ({
               className={inputClassName}
               placeholder={t('Enter the maximum number of attachments') || ''}
               onChange={(e) => {
-                const value = e.target.value
-                  ? Number(e.target.value)
-                  : undefined;
+                const value =
+                  e.target.value !== '' ? Number(e.target.value) : undefined;
                 if (!e.target.value || Number.isSafeInteger(value)) {
                   setMaxInputAttachmentsValue(value);
                 }


### PR DESCRIPTION
**Description:**

If the user application has the "Max. attachments count" field equal to 0, then the clip icon in the chat should not be displayed, it is displayed if it is a number or empty (if empty it takes the maximum integer value)

Issues:

- Issue #2063 

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
