### PR TITLE
fix(chat): revert addon icon rendering (Issue #2144)

### DIFF
--- a/apps/chat/src/components/Chatbar/ModelIcon.tsx
+++ b/apps/chat/src/components/Chatbar/ModelIcon.tsx
@@ -49,7 +49,8 @@ const ModelIconTemplate = memo(
     return (
       <span
         className={classNames(
-          'relative inline-block shrink-0 overflow-hidden rounded-full bg-model-icon leading-none',
+          'relative inline-block shrink-0 bg-model-icon leading-none',
+          entity?.type !== EntityType.Addon && 'overflow-hidden rounded-full',
           isInvalid ? 'text-secondary' : 'text-primary',
           animate && 'animate-bounce',
         )}


### PR DESCRIPTION
**Description:**

revert addon icon rendering

Issues:

- Issue #2144

**UI changes**

![image](https://github.com/user-attachments/assets/918d2b5b-716b-41a1-8e8a-6bf29fe30779)
->
![image](https://github.com/user-attachments/assets/567a5eba-beb9-4a79-a167-fd22b1c37e45)


**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
