### PR TITLE
fix(chat): remove discard requests for own files (Issue #2193)

### DIFF
--- a/apps/chat/src/components/Files/FileManagerModal.tsx
+++ b/apps/chat/src/components/Files/FileManagerModal.tsx
@@ -566,12 +566,14 @@ export const FileManagerModal = ({
         .filter(({ id }) => deletingFileIds.includes(id))
         .map(({ id }) => id);
 
-      dispatch(
-        ShareActions.discardSharedWithMe({
-          resourceIds: sharedWithMeFilesIds,
-          featureType: FeatureType.File,
-        }),
-      );
+      if (sharedWithMeFilesIds.length) {
+        dispatch(
+          ShareActions.discardSharedWithMe({
+            resourceIds: sharedWithMeFilesIds,
+            featureType: FeatureType.File,
+          }),
+        );
+      }
       dispatch(FilesActions.deleteFilesList({ fileIds: deletingFileIds }));
       if (selectedFilesIds === deletingFileIds) {
         setSelectedFilesIds([]);
@@ -583,12 +585,14 @@ export const FileManagerModal = ({
       const sharedWithMeFoldersIds = sharedWithMeRootFolders
         .filter(({ id }) => deletingFolderIds.includes(id))
         .map(({ id }) => id);
-      dispatch(
-        ShareActions.discardSharedWithMe({
-          resourceIds: sharedWithMeFoldersIds,
-          featureType: FeatureType.File,
-        }),
-      );
+      if (sharedWithMeFoldersIds.length) {
+        dispatch(
+          ShareActions.discardSharedWithMe({
+            resourceIds: sharedWithMeFoldersIds,
+            featureType: FeatureType.File,
+          }),
+        );
+      }
       if (selectedFolderIds === deletingFolderIds) {
         setSelectedFolderIds([]);
       }


### PR DESCRIPTION
**Description:**

- dicard share only for files that were shared with the user (on delete)

Issues:

- Issue #2193 

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
