### PR TITLE
fix(chat): add attachment validation on blur event (Issue #2227)

### DIFF
--- a/apps/chat/src/components/Common/MultipleComboBox.tsx
+++ b/apps/chat/src/components/Common/MultipleComboBox.tsx
@@ -182,7 +182,7 @@ export function MultipleComboBox<T>({
     onStateChange({
       inputValue: newInputValue,
       type,
-      selectedItem: newSelectedItem,
+      selectedItem: newSelectedItem = inputValue as T,
     }) {
       switch (type) {
         case useCombobox.stateChangeTypes.InputKeyDownEnter:


### PR DESCRIPTION
**Description:**

Now validation appears only on Enter. but also should be if to move cursor out of the field (onblur event)

Issues:

- Issue #2227 

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
