### PR TITLE
fix(overlay): trigger getting shared conversations if feature presented

### DIFF
--- a/apps/chat/src/store/overlay/overlay.epics.ts
+++ b/apps/chat/src/store/overlay/overlay.epics.ts
@@ -49,6 +49,7 @@ import {
   SettingsActions,
   SettingsSelectors,
 } from '../settings/settings.reducers';
+import { ShareActions } from '../share/share.reducers';
 import { UIActions, UISelectors } from '../ui/ui.reducers';
 import { OverlayActions, OverlaySelectors } from './overlay.reducers';
 
@@ -407,6 +408,11 @@ const setOverlayOptionsEpic: AppEpic = (action$, state$) =>
             actions.push(
               of(SettingsActions.setEnabledFeatures(features as Feature[])),
             );
+            if (features.includes(Feature.ConversationsSharing)) {
+              actions.push(
+                of(ShareActions.triggerGettingSharedConversationListings()),
+              );
+            }
           } else {
             const incorrectFeatures = features
               .filter((feature) => !validateFeature(feature))


### PR DESCRIPTION
**Description:**

When feature shared conversation is not presented by default we are not getting it in list of conversations even if we pass it through overlay options

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
