### PR TITLE
fix(chat): change marketplace side panel home icon and color (Issue #2278)

### DIFF
--- a/apps/chat/src/components/Marketplace/MarketplaceFilterbar.tsx
+++ b/apps/chat/src/components/Marketplace/MarketplaceFilterbar.tsx
@@ -2,7 +2,7 @@ import {
   IconArrowLeft,
   IconCheck,
   IconChevronUp,
-  IconHome,
+  IconHome2,
   IconLayoutGrid,
   TablerIconsProps,
 } from '@tabler/icons-react';
@@ -161,12 +161,17 @@ const ActionButton = ({
         className={classNames(
           'flex min-h-9 shrink-0 grow cursor-pointer select-none items-center gap-3 rounded px-4 py-2 transition-colors duration-200 hover:bg-accent-primary-alpha hover:disabled:bg-transparent',
           {
-            'bg-accent-primary-alpha': selected,
+            'border-l-2 border-l-accent-primary bg-accent-primary-alpha':
+              selected,
           },
         )}
         data-qa={dataQa}
       >
-        <Icon className="text-secondary" width={18} height={18} />
+        <Icon
+          className={selected ? 'text-accent-primary' : 'text-secondary'}
+          width={18}
+          height={18}
+        />
         {isOpen ? caption : ''}
       </button>
     </div>
@@ -248,7 +253,7 @@ export const MarketplaceFilterbar = () => {
           isOpen={showFilterbar}
           onClick={handleHomeClick}
           caption={t('All applications')}
-          Icon={IconHome}
+          Icon={IconHome2}
           selected={selectedTab === MarketplaceTabs.HOME}
           dataQa="home-page"
         />


### PR DESCRIPTION
Description:

1. icons for selected item in side panel have incorrect color
2. no vertical blue line at the beginning of the string
3. incorrect 'home' icon

Issues:

- Issue #2278 

**UI changes**

Before: 
<img width="288" alt="Снимок экрана 2024-10-08 в 19 16 56" src="https://github.com/user-attachments/assets/d64e23c0-58cb-4187-b0e0-12f2e8d469e0">
<img width="66" alt="Снимок экрана 2024-10-08 в 19 17 01" src="https://github.com/user-attachments/assets/e1b18528-f041-4c87-b4c6-ddf650c1fdda">

After: 
<img width="282" alt="Снимок экрана 2024-10-08 в 19 16 19" src="https://github.com/user-attachments/assets/9663b17f-a468-465d-9dd7-a2d67a929d14">
<img width="66" alt="Снимок экрана 2024-10-08 в 19 16 30" src="https://github.com/user-attachments/assets/326fe2e1-c1cd-446c-ab9e-ae9c68901824">

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
