### PR TITLE
fix(chat): fix manage attachments icon color (Issue #2233)

### DIFF
--- a/apps/chat/src/components/Files/FileItem.tsx
+++ b/apps/chat/src/components/Files/FileItem.tsx
@@ -138,7 +138,7 @@ export const FileItem = ({
                 className={classNames(
                   item.status !== UploadStatus.LOADING &&
                     canAttachFiles &&
-                    'group-hover/file-item:hidden',
+                    'text-secondary group-hover/file-item:hidden',
                 )}
                 size={18}
               />


### PR DESCRIPTION
**Description:**

Icons of files has incorrect color on Manage Attachments

Issues:

- Issue #2233 

**UI changes**

<img width="525" alt="Снимок экрана 2024-10-13 в 00 28 21" src="https://github.com/user-attachments/assets/f57d1fea-853a-448a-b614-ec952b4f9c17">

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
