### PR TITLE
fix(chat): change tree paddings in side panels (Issue #2213)

### DIFF
--- a/apps/chat-e2e/src/tests/chatBarFolderConversation.test.ts
+++ b/apps/chat-e2e/src/tests/chatBarFolderConversation.test.ts
@@ -739,9 +739,11 @@ dialTest(
             ExpectedConstants.newFolderWithIndexTitle(i - 1),
           ),
         );
-        await folderConversations.expandFolder(
-          ExpectedConstants.newFolderWithIndexTitle(i),
-        );
+        if (i !== 4) {
+          await folderConversations.expandFolder(
+            ExpectedConstants.newFolderWithIndexTitle(i),
+          );
+        }
       }
     });
 

--- a/apps/chat-e2e/src/tests/folderPrompts.test.ts
+++ b/apps/chat-e2e/src/tests/folderPrompts.test.ts
@@ -259,13 +259,13 @@ dialTest(
     await dialHomePage.openHomePage();
     await dialHomePage.waitForPageLoaded();
     await promptBar.createNewFolder();
-    await folderPrompts.expandFolder(
-      ExpectedConstants.newFolderWithIndexTitle(1),
-    );
 
     await prompts.openEntityDropdownMenu(prompt.name);
     await promptDropdownMenu.selectMenuOption(MenuOptions.moveTo);
     await prompts.selectMoveToMenuOption(
+      ExpectedConstants.newFolderWithIndexTitle(1),
+    );
+    await folderPrompts.expandFolder(
       ExpectedConstants.newFolderWithIndexTitle(1),
     );
     const isFolderPromptVisible = await folderPrompts.isFolderEntityVisible(

--- a/apps/chat-e2e/src/tests/promptFolderNumeration.test.ts
+++ b/apps/chat-e2e/src/tests/promptFolderNumeration.test.ts
@@ -268,11 +268,9 @@ dialTest(
           ),
         );
       }
-      for (let i = 2; i <= 3; i++) {
-        await folderPrompts.expandFolder(
-          ExpectedConstants.newPromptFolderWithIndexTitle(i),
-        );
-      }
+      await folderPrompts.expandFolder(
+        ExpectedConstants.newPromptFolderWithIndexTitle(2),
+      );
     });
 
     await dialTest.step('Rename all folders to the same name', async () => {

--- a/apps/chat-e2e/src/ui/webElements/entityTree/folders.ts
+++ b/apps/chat-e2e/src/ui/webElements/entityTree/folders.ts
@@ -263,14 +263,15 @@ export class Folders extends BaseElement {
     };
     const folder = this.getFolderByName(name, index);
     await folder.waitFor();
+    const expandIcon = this.getFolderExpandIcon(name, index);
     if (isApiStorageType && mergedOptions.isHttpMethodTriggered) {
       const respPromise = this.page.waitForResponse((resp) =>
         resp.url().includes(mergedOptions.httpHost!),
       );
-      await this.getFolderExpandIcon(name, index).click();
+      await expandIcon.click();
       return respPromise;
     }
-    await folder.click();
+    await expandIcon.click();
   }
 
   public async getFolderNameColor(name: string, index?: number) {

--- a/apps/chat/src/components/Chatbar/Conversation.tsx
+++ b/apps/chat/src/components/Chatbar/Conversation.tsx
@@ -678,7 +678,7 @@ export const ConversationComponent = ({
         additionalItemData?.isSidePanelItem ? 'h-[34px]' : 'h-[30px]',
       )}
       style={{
-        paddingLeft: (level && `${0.875 + level * 1.5}rem`) || '0.875rem',
+        paddingLeft: (level && `${level * 30 + 16}px`) || '0.875rem',
       }}
       onContextMenu={handleContextMenuOpen}
       data-qa="conversation"

--- a/apps/chat/src/components/Common/ReplaceConfirmationModal/Components.tsx
+++ b/apps/chat/src/components/Common/ReplaceConfirmationModal/Components.tsx
@@ -114,7 +114,7 @@ export const EntityRow = ({
         entityRowClassNames,
       )}
       style={{
-        paddingLeft: (level && `${0.875 + level * 1.5}rem`) || '0.875rem',
+        paddingLeft: (level && `${level * 30 + 16}px`) || '0.875rem',
       }}
       data-qa={dataQA}
     >

--- a/apps/chat/src/components/Common/ReplaceConfirmationModal/Components.tsx
+++ b/apps/chat/src/components/Common/ReplaceConfirmationModal/Components.tsx
@@ -114,7 +114,7 @@ export const EntityRow = ({
         entityRowClassNames,
       )}
       style={{
-        paddingLeft: (level && `${level * 30 + 16}px`) || '0.875rem',
+        paddingLeft: (level && `${level * 24 + 16}px`) || '0.875rem',
       }}
       data-qa={dataQA}
     >

--- a/apps/chat/src/components/Folder/Folder.tsx
+++ b/apps/chat/src/components/Folder/Folder.tsx
@@ -834,6 +834,7 @@ const Folder = <T extends ConversationInfo | PromptInfo | DialFile>({
 
   const iconSize = additionalItemData?.isSidePanelItem ? 24 : 18;
   const folderIconStrokeWidth = additionalItemData?.isSidePanelItem ? 1.5 : 2;
+  const isSidePanelItem = additionalItemData?.isSidePanelItem;
 
   return (
     <div
@@ -984,7 +985,7 @@ const Folder = <T extends ConversationInfo | PromptInfo | DialFile>({
           <div
             className="group/folder-item flex max-w-full items-center gap-1 py-2 pr-3"
             style={{
-              paddingLeft: `${level * 30}px`,
+              paddingLeft: `${level * (isSidePanelItem ? 30 : 24)}px`,
             }}
           >
             <CaretIconComponent

--- a/apps/chat/src/components/Folder/Folder.tsx
+++ b/apps/chat/src/components/Folder/Folder.tsx
@@ -983,7 +983,7 @@ const Folder = <T extends ConversationInfo | PromptInfo | DialFile>({
           <div
             className="group/folder-item flex max-w-full items-center gap-1 py-2 pr-3"
             style={{
-              paddingLeft: `${level * 24}px`,
+              paddingLeft: `${level * 30}px`,
             }}
           >
             <CaretIconComponent

--- a/apps/chat/src/components/Promptbar/components/Prompt.tsx
+++ b/apps/chat/src/components/Promptbar/components/Prompt.tsx
@@ -388,7 +388,7 @@ export const PromptComponent = ({
           }
         }}
         style={{
-          paddingLeft: (level && `${0.875 + level * 1.5}rem`) || '0.875rem',
+          paddingLeft: (level && `${level * 30 + 16}px`) || '0.875rem',
         }}
         onContextMenu={handleContextMenuOpen}
         data-qa="prompt"


### PR DESCRIPTION
**Description:**

Change tree paddings in side panels

Issues:

- Issue #2213 

**UI changes**

Before:
<img width="261" alt="Снимок экрана 2024-10-15 в 18 26 18" src="https://github.com/user-attachments/assets/3f274c18-b5b2-4bb8-8e62-b4264a6af19b">

After:
<img width="268" alt="Снимок экрана 2024-10-15 в 18 27 14" src="https://github.com/user-attachments/assets/074f73ae-3a8a-4d32-8f0a-406ca026ef9c">

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
