### PR TITLE
fix(chat): update marketplace icons tooltips (#2377)

### DIFF
--- a/apps/chat/src/components/Chatbar/Chatbar.tsx
+++ b/apps/chat/src/components/Chatbar/Chatbar.tsx
@@ -25,6 +25,7 @@ import { DEFAULT_CONVERSATION_NAME } from '@/src/constants/default-ui-settings';
 import { Spinner } from '@/src/components/Common/Spinner';
 
 import PlusIcon from '../../../public/images/icons/plus-large.svg';
+import Tooltip from '../Common/Tooltip';
 import Sidebar from '../Sidebar';
 import { ChatFolders } from './ChatFolders';
 import { ChatbarSettings } from './ChatbarSettings';
@@ -63,7 +64,9 @@ const ChatActionsBlock = () => {
             onClick={() => router.push('/marketplace')}
             data-qa="link-to-marketplace"
           >
-            <IconApps className="text-secondary" width={24} height={24} />
+            <Tooltip tooltip={t('DIAL Marketplace')}>
+              <IconApps className="text-secondary" width={24} height={24} />
+            </Tooltip>
             {t('DIAL Marketplace')}
           </button>
         </div>
@@ -85,7 +88,9 @@ const ChatActionsBlock = () => {
           {isActiveNewConversationRequest ? (
             <Spinner size={24} className="text-secondary" />
           ) : (
-            <PlusIcon className="text-secondary" width={24} height={24} />
+            <Tooltip tooltip={t('New conversation')}>
+              <PlusIcon className="text-secondary" width={24} height={24} />
+            </Tooltip>
           )}
           {t('New conversation')}
         </button>

--- a/apps/chat/src/components/Marketplace/MarketplaceFilterbar.tsx
+++ b/apps/chat/src/components/Marketplace/MarketplaceFilterbar.tsx
@@ -26,6 +26,8 @@ import { UISelectors } from '@/src/store/ui/ui.reducers';
 
 import { FilterTypes, MarketplaceTabs } from '@/src/constants/marketplace';
 
+import Tooltip from '../Common/Tooltip';
+
 import { capitalize } from 'lodash';
 
 interface FilterItemProps {
@@ -164,11 +166,13 @@ const ActionButton = ({
         )}
         data-qa={dataQa}
       >
-        <Icon
-          className={selected ? 'text-accent-primary' : 'text-secondary'}
-          width={18}
-          height={18}
-        />
+        <Tooltip tooltip={caption}>
+          <Icon
+            className={selected ? 'text-accent-primary' : 'text-secondary'}
+            width={18}
+            height={18}
+          />
+        </Tooltip>
         {isOpen ? caption : ''}
       </button>
     </div>

--- a/apps/chat/src/components/Marketplace/MarketplaceHeader.tsx
+++ b/apps/chat/src/components/Marketplace/MarketplaceHeader.tsx
@@ -1,10 +1,14 @@
 import { IconX } from '@tabler/icons-react';
 import { useCallback } from 'react';
 
+import { useTranslation } from 'next-i18next';
+
 import classNames from 'classnames';
 
 import { isSmallScreen } from '@/src/utils/app/mobile';
 import { ApiUtils } from '@/src/utils/server/api';
+
+import { Translation } from '@/src/types/translation';
 
 import { useAppDispatch, useAppSelector } from '@/src/store/hooks';
 import { SettingsSelectors } from '@/src/store/settings/settings.reducers';
@@ -19,12 +23,14 @@ import { SettingDialog } from '@/src/components/Settings/SettingDialog';
 
 import MoveLeftIcon from '../../../public/images/icons/move-left.svg';
 import MoveRightIcon from '../../../public/images/icons/move-right.svg';
+import Tooltip from '../Common/Tooltip';
 import { User } from '../Header/User/User';
 
 import { Feature } from '@epam/ai-dial-shared';
 import cssEscape from 'css.escape';
 
 export const MarketplaceHeader = () => {
+  const { t } = useTranslation(Translation.Header);
   const showFilterbar = useAppSelector(
     UISelectors.selectShowMarketplaceFilterbar,
   );
@@ -68,33 +74,35 @@ export const MarketplaceHeader = () => {
       )}
       data-qa="header"
     >
-      <div
-        className="flex h-full cursor-pointer items-center justify-center border-r border-tertiary px-3 md:px-5"
-        data-qa="left-panel-toggle"
-        onClick={handleToggleFilterbar}
-      >
-        {showFilterbar ? (
-          <>
-            <IconX
-              className="text-secondary md:hidden"
-              width={headerIconSize}
-              height={headerIconSize}
-            />
+      <Tooltip isTriggerClickable tooltip={t('DIAL Marketplace')}>
+        <div
+          className="flex h-full cursor-pointer items-center justify-center border-r border-tertiary px-3 md:px-5"
+          data-qa="left-panel-toggle"
+          onClick={handleToggleFilterbar}
+        >
+          {showFilterbar ? (
+            <>
+              <IconX
+                className="text-secondary md:hidden"
+                width={headerIconSize}
+                height={headerIconSize}
+              />
 
-            <MoveLeftIcon
-              className="text-secondary hover:text-accent-secondary max-md:hidden"
+              <MoveLeftIcon
+                className="text-secondary hover:text-accent-secondary max-md:hidden"
+                width={headerIconSize}
+                height={headerIconSize}
+              />
+            </>
+          ) : (
+            <MoveRightIcon
+              className="text-secondary hover:text-accent-secondary"
               width={headerIconSize}
               height={headerIconSize}
             />
-          </>
-        ) : (
-          <MoveRightIcon
-            className="text-secondary hover:text-accent-secondary"
-            width={headerIconSize}
-            height={headerIconSize}
-          />
-        )}
-      </div>
+          )}
+        </div>
+      </Tooltip>
 
       <div className="flex grow justify-between">
         <span

--- a/apps/chat/src/components/Promptbar/Promptbar.tsx
+++ b/apps/chat/src/components/Promptbar/Promptbar.tsx
@@ -25,6 +25,7 @@ import { PromptbarSettings } from './components/PromptbarSettings';
 import { Prompts } from './components/Prompts';
 
 import PlusIcon from '../../../public/images/icons/plus-large.svg';
+import Tooltip from '../Common/Tooltip';
 import Sidebar from '../Sidebar';
 
 const PromptActionsBlock = () => {
@@ -77,7 +78,9 @@ const PromptActionsBlock = () => {
         disabled={isNewPromptCreating}
         data-qa="new-entity"
       >
-        <PlusIcon className="text-secondary" width={24} height={24} />
+        <Tooltip tooltip={t('New prompt')}>
+          <PlusIcon className="text-secondary" width={24} height={24} />
+        </Tooltip>
         {t('New prompt')}
       </button>
       {showModal && !isModalPreviewMode && (


### PR DESCRIPTION
**Description:**

There are no any tooltips for DIAL Marketplace icons. It's good to have them when the panel is collapsed

Issues:

- Issue #2377 

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
