### PR TITLE
fix(chat): update icons and panel width (#2389)

### DIFF
--- a/apps/chat/src/components/Marketplace/MarketplaceFilterbar.tsx
+++ b/apps/chat/src/components/Marketplace/MarketplaceFilterbar.tsx
@@ -159,7 +159,7 @@ const ActionButton = ({
       <button
         onClick={onClick}
         className={classNames(
-          'flex min-h-9 shrink-0 grow cursor-pointer select-none items-center gap-3 rounded border-l-2 px-4 py-2 transition-colors duration-200 hover:bg-accent-primary-alpha hover:disabled:bg-transparent',
+          'flex shrink-0 grow cursor-pointer select-none items-center gap-3 rounded border-l-2 py-[5px] pl-3 transition-colors duration-200 hover:bg-accent-primary-alpha hover:disabled:bg-transparent',
           selected
             ? 'border-l-accent-primary bg-accent-primary-alpha'
             : 'border-l-transparent',
@@ -169,8 +169,8 @@ const ActionButton = ({
         <Tooltip tooltip={caption}>
           <Icon
             className={selected ? 'text-accent-primary' : 'text-secondary'}
-            width={18}
-            height={18}
+            width={24}
+            height={24}
           />
         </Tooltip>
         {isOpen ? caption : ''}
@@ -237,12 +237,14 @@ export const MarketplaceFilterbar = () => {
   return (
     <nav
       className={classNames(
-        showFilterbar ? 'w-[284px]' : 'invisible md:visible md:w-[64px]',
+        showFilterbar
+          ? 'w-[320px] md:w-[260px]'
+          : 'invisible md:visible md:w-[64px]',
         'group/sidebar absolute left-0 top-0 z-40 h-full shrink-0 flex-col gap-px divide-y divide-tertiary bg-layer-3 md:sticky md:z-0',
       )}
       data-qa="marketplace-sidebar"
     >
-      <div>
+      <div className="py-1">
         <ActionButton
           isOpen={showFilterbar}
           onClick={() => router.push('/')}
@@ -250,11 +252,13 @@ export const MarketplaceFilterbar = () => {
           Icon={IconArrowLeft}
           dataQa="back-to-chat"
         />
+      </div>
+      <div className="py-1">
         <ActionButton
           isOpen={showFilterbar}
           onClick={handleHomeClick}
           caption={t('DIAL Marketplace')}
-          Icon={IconHome2}
+          Icon={IconLayoutGrid}
           selected={selectedTab === MarketplaceTabs.HOME}
           dataQa="home-page"
         />
@@ -262,7 +266,7 @@ export const MarketplaceFilterbar = () => {
           isOpen={showFilterbar}
           onClick={handleMyAppsClick}
           caption={t('My workspace')}
-          Icon={IconLayoutGrid}
+          Icon={IconHome2}
           selected={selectedTab === MarketplaceTabs.MY_APPLICATIONS}
           dataQa="my-applications"
         />

--- a/apps/chat/src/components/Marketplace/MarketplaceHeader.tsx
+++ b/apps/chat/src/components/Marketplace/MarketplaceHeader.tsx
@@ -74,7 +74,7 @@ export const MarketplaceHeader = () => {
       )}
       data-qa="header"
     >
-      <Tooltip isTriggerClickable tooltip={t('DIAL Marketplace')}>
+      <Tooltip isTriggerClickable tooltip={t('Control panel')}>
         <div
           className="flex h-full cursor-pointer items-center justify-center border-r border-tertiary px-3 md:px-5"
           data-qa="left-panel-toggle"


### PR DESCRIPTION
**Description:**

1. Update icons. Expected
<img width="384" alt="Снимок экрана 2024-10-18 в 14 16 46" src="https://github.com/user-attachments/assets/eef5017f-018a-4a07-a390-3c8d2a9ef177">

2. On laptop and tablet: Conversation list panel default size is 260 px. Expected: The same size should be for DIAL marketplace panel.

3. Expected: On mobile: Conversation panel = Dial Marketplace panel = 320 px

Issues:

- Issue #2389 

**UI changes**

Before:
<img width="76" alt="Снимок экрана 2024-10-18 в 14 17 30" src="https://github.com/user-attachments/assets/f53abec3-2a4f-4ac8-9e44-eeb280eaac6b">
<img width="297" alt="Снимок экрана 2024-10-18 в 14 17 43" src="https://github.com/user-attachments/assets/31c66685-9c07-4fc3-8d50-044914f62e3d">

After:
<img width="75" alt="Снимок экрана 2024-10-18 в 14 17 51" src="https://github.com/user-attachments/assets/eec9093e-77a6-42ec-b198-2bad6dd57e85">
<img width="272" alt="Снимок экрана 2024-10-18 в 14 17 56" src="https://github.com/user-attachments/assets/176b9ac5-89cc-44be-9aa8-bb67bf01d6b0">

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
