### PR TITLE
fix(chat): change version dropdown maximum width (Issue #2428)

### DIFF
--- a/apps/chat/src/components/Chat/Publish/VersionSelector.tsx
+++ b/apps/chat/src/components/Chat/Publish/VersionSelector.tsx
@@ -100,6 +100,7 @@ export function VersionSelector({
     return (
       <Menu
         onOpenChange={setIsVersionSelectOpen}
+        dropdownWidth={82}
         className="flex shrink-0 items-center"
         disabled={allVersions.length <= 1}
         trigger={

--- a/apps/chat/src/components/Common/DropdownMenu.tsx
+++ b/apps/chat/src/components/Common/DropdownMenu.tsx
@@ -66,6 +66,7 @@ const MenuContext = createContext<{
 
 interface MenuProps {
   listClassName?: string;
+  dropdownWidth?: number;
   trigger?: ReactNode;
   nested?: boolean;
   children?: ReactNode;
@@ -89,6 +90,7 @@ export const MenuComponent = forwardRef<
     style,
     className,
     listClassName,
+    dropdownWidth,
     label,
     trigger,
     type = 'dropdown',
@@ -157,7 +159,7 @@ export const MenuComponent = forwardRef<
               apply({ rects, availableWidth, availableHeight, elements }) {
                 setFloatingWidth(rects.reference.width);
                 Object.assign(elements.floating.style, {
-                  maxWidth: `${availableWidth}px`,
+                  maxWidth: `${!dropdownWidth && availableWidth}px`,
                   maxHeight: `${availableHeight}px`,
                 });
               },
@@ -296,7 +298,8 @@ export const MenuComponent = forwardRef<
                     ...floatingStyles,
                     ...style,
                     ...(type === 'dropdown' && {
-                      width: `${isNested ? floatingWidth : 110}px`,
+                      [dropdownWidth ? 'maxWidth' : 'width']:
+                        `${dropdownWidth || floatingWidth}px`,
                     }),
                   }}
                   {...getFloatingProps()}


### PR DESCRIPTION
**Description:**

click on user name in the right top corner -> dropdown's length does not fit the user name's length
select sellting
click on Theme dropdown-> dropdown's length does not fit the control's length

Issues:

- Issue #2428 

**UI changes**

<img width="211" alt="Снимок экрана 2024-10-22 в 22 09 27" src="https://github.com/user-attachments/assets/779fd3fb-6651-4893-9a67-c26ff1c510e2">
<img width="504" alt="Снимок экрана 2024-10-22 в 22 09 33" src="https://github.com/user-attachments/assets/98469655-bb7b-4a3a-8800-66a1d1478458">
<img width="127" alt="Снимок экрана 2024-10-22 в 22 09 51" src="https://github.com/user-attachments/assets/8cacdd2e-e973-4b84-8547-f76fcfe5e00d">

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
