### PR TITLE
fix(chat): removes technical text when renaming a [replay] conversation (Issue #2425)

### DIFF
--- a/apps/chat/src/components/Chatbar/Conversation.tsx
+++ b/apps/chat/src/components/Chatbar/Conversation.tsx
@@ -692,7 +692,6 @@ export const ConversationComponent = ({
             {conversation.isReplay && (
               <span className="flex shrink-0">
                 <ReplayAsIsIcon strokeWidth={strokeWidth} size={iconSize} />
-                strokeWidth={strokeWidth}
               </span>
             )}
 


### PR DESCRIPTION
**Description:**

removes technical text when renaming a conversation

Issues:

- Issue #2425

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
