### PR TITLE
fix(chat): add back to chat button on marketplace mobile (Issue #2243)

### DIFF
--- a/apps/chat/src/components/Header/BackToChatMobile.tsx
+++ b/apps/chat/src/components/Header/BackToChatMobile.tsx
@@ -15,7 +15,7 @@ export const BackToChatMobile = () => {
   return (
     <Tooltip isTriggerClickable tooltip={t('Back to Chat')}>
       <button
-        className="flex h-full items-center justify-center border-r border-tertiary px-2 md:px-3 lg:hidden"
+        className="flex h-full items-center justify-center border-r border-tertiary px-2 md:hidden md:px-3"
         onClick={() => {
           router.push('/');
         }}

--- a/apps/chat/src/components/Header/BackToChatMobile.tsx
+++ b/apps/chat/src/components/Header/BackToChatMobile.tsx
@@ -1,0 +1,33 @@
+import { IconArrowLeft } from '@tabler/icons-react';
+
+import { useTranslation } from 'next-i18next';
+import { useRouter } from 'next/router';
+
+import { Translation } from '@/src/types/translation';
+
+import Tooltip from '../Common/Tooltip';
+
+export const BackToChatMobile = () => {
+  const { t } = useTranslation(Translation.Header);
+
+  const router = useRouter();
+
+  return (
+    <Tooltip isTriggerClickable tooltip={t('Back to Chat')}>
+      <button
+        className="flex h-full items-center justify-center border-r border-tertiary px-2 md:px-3 lg:hidden"
+        onClick={() => {
+          router.push('/');
+        }}
+      >
+        <div className="flex items-center justify-center rounded p-[3px]">
+          <IconArrowLeft
+            className="text-secondary hover:text-accent-secondary"
+            width={25}
+            height={25}
+          />
+        </div>
+      </button>
+    </Tooltip>
+  );
+};

--- a/apps/chat/src/components/Marketplace/MarketplaceHeader.tsx
+++ b/apps/chat/src/components/Marketplace/MarketplaceHeader.tsx
@@ -24,6 +24,7 @@ import { SettingDialog } from '@/src/components/Settings/SettingDialog';
 import MoveLeftIcon from '../../../public/images/icons/move-left.svg';
 import MoveRightIcon from '../../../public/images/icons/move-right.svg';
 import Tooltip from '../Common/Tooltip';
+import { BackToChatMobile } from '../Header/BackToChatMobile';
 import { User } from '../Header/User/User';
 
 import { Feature } from '@epam/ai-dial-shared';
@@ -103,7 +104,7 @@ export const MarketplaceHeader = () => {
           )}
         </div>
       </Tooltip>
-
+      <BackToChatMobile />
       <div className="flex grow justify-between">
         <span
           className={classNames(


### PR DESCRIPTION
**Description:**

Need to add arrow "Back to chat" to header for mobile view

Issues:

- Issue #2243 

**UI changes**

<img width="375" alt="Снимок экрана 2024-10-23 в 15 37 10" src="https://github.com/user-attachments/assets/ef9c1663-aa27-462f-9b7a-c63c5e8b9f68">
<img width="921" alt="Снимок экрана 2024-10-23 в 15 37 20" src="https://github.com/user-attachments/assets/e3993afd-ad89-4002-9f84-a63caaeece0b">

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
