### PR TITLE
Autofix: Change the verb in Prompt limit exceeded message

### DIFF
--- a/apps/chat/src/components/Files/AttachButton.tsx
+++ b/apps/chat/src/components/Files/AttachButton.tsx
@@ -85,7 +85,7 @@ export const AttachButton = ({
       [
         {
           name: t(
-            `Attach ${canAttachFolders ? 'folders' : ''}${canAttachFiles && canAttachFolders ? ' and ' : ''}${canAttachFiles ? ' uploaded files' : ''}`,
+            `Insert ${canAttachFolders ? 'folders' : ''}${canAttachFiles && canAttachFolders ? ' and ' : ''}${canAttachFiles ? ' uploaded files' : ''}`,
           ),
           dataQa: 'attach_uploaded',
           display: canAttachFiles || canAttachFolders,


### PR DESCRIPTION
The solution involves updating the text in the AttachButton component from 'select' to 'insert' for better clarity. This change is made in the `apps/chat/src/components/Files/AttachButton.tsx` file.