### PR TITLE
fix(chat): add default values in application dialog (Issue #2477)

### DIFF
--- a/apps/chat/src/components/Common/ApplicationWizard/CodeAppView/CodeAppView.tsx
+++ b/apps/chat/src/components/Common/ApplicationWizard/CodeAppView/CodeAppView.tsx
@@ -54,19 +54,19 @@ const features = [
   {
     label: FEATURES_ENDPOINTS_NAMES[FEATURES_ENDPOINTS.chat_completion],
     value: FEATURES_ENDPOINTS.chat_completion,
-    defaultEndpoint:
+    defaultValue:
       FEATURES_ENDPOINTS_DEFAULT_VALUES[FEATURES_ENDPOINTS.chat_completion],
   },
   {
     label: FEATURES_ENDPOINTS_NAMES[FEATURES_ENDPOINTS.rate_endpoint],
     value: FEATURES_ENDPOINTS.rate_endpoint,
-    defaultEndpoint:
+    defaultValue:
       FEATURES_ENDPOINTS_DEFAULT_VALUES[FEATURES_ENDPOINTS.rate_endpoint],
   },
   {
     label: FEATURES_ENDPOINTS_NAMES[FEATURES_ENDPOINTS.configuration_endpoint],
     value: FEATURES_ENDPOINTS.configuration_endpoint,
-    defaultEndpoint:
+    defaultValue:
       FEATURES_ENDPOINTS_DEFAULT_VALUES[
         FEATURES_ENDPOINTS.configuration_endpoint
       ],
@@ -96,13 +96,8 @@ export const CodeAppView: React.FC<ViewProps> = ({
   const files = useAppSelector(FilesSelectors.selectFiles);
   const topics = useAppSelector(SettingsSelectors.selectTopics);
   const models = useAppSelector(ModelsSelectors.selectModels);
-  const installedModelIds = useAppSelector(
-    ModelsSelectors.selectInstalledModelIds,
-  );
 
-  const filteredModels = models
-    .filter((model) => installedModelIds.has(model.reference))
-    .map((model) => ({ ...model, folderId: '' }));
+  const filteredModels = models.map((model) => ({ ...model, folderId: '' }));
 
   const topicOptions = useMemo(() => topics.map(topicToOption), [topics]);
 

--- a/apps/chat/src/components/Common/ApplicationWizard/CodeAppView/CodeAppView.tsx
+++ b/apps/chat/src/components/Common/ApplicationWizard/CodeAppView/CodeAppView.tsx
@@ -97,7 +97,10 @@ export const CodeAppView: React.FC<ViewProps> = ({
   const topics = useAppSelector(SettingsSelectors.selectTopics);
   const models = useAppSelector(ModelsSelectors.selectModels);
 
-  const filteredModels = models.map((model) => ({ ...model, folderId: '' }));
+  const modelsWithFolderId = models.map((model) => ({
+    ...model,
+    folderId: '',
+  }));
 
   const topicOptions = useMemo(() => topics.map(topicToOption), [topics]);
 
@@ -110,7 +113,7 @@ export const CodeAppView: React.FC<ViewProps> = ({
     handleSubmit: submitWrapper,
     setValue,
   } = useForm<FormData>({
-    defaultValues: getDefaultValues(selectedApplication, filteredModels),
+    defaultValues: getDefaultValues(selectedApplication, modelsWithFolderId),
     mode: 'onChange',
     reValidateMode: 'onChange',
   });

--- a/apps/chat/src/components/Common/ApplicationWizard/CodeAppView/CodeAppView.tsx
+++ b/apps/chat/src/components/Common/ApplicationWizard/CodeAppView/CodeAppView.tsx
@@ -14,10 +14,12 @@ import { Translation } from '@/src/types/translation';
 import { ApplicationActions } from '@/src/store/application/application.reducers';
 import { FilesSelectors } from '@/src/store/files/files.reducers';
 import { useAppDispatch, useAppSelector } from '@/src/store/hooks';
+import { ModelsSelectors } from '@/src/store/models/models.reducers';
 import { SettingsSelectors } from '@/src/store/settings/settings.reducers';
 
 import {
   FEATURES_ENDPOINTS,
+  FEATURES_ENDPOINTS_DEFAULT_VALUES,
   FEATURES_ENDPOINTS_NAMES,
 } from '@/src/constants/applications';
 import { IMAGE_TYPES } from '@/src/constants/chat';
@@ -52,14 +54,22 @@ const features = [
   {
     label: FEATURES_ENDPOINTS_NAMES[FEATURES_ENDPOINTS.completion],
     value: FEATURES_ENDPOINTS.completion,
+    defaultEndpoint:
+      FEATURES_ENDPOINTS_DEFAULT_VALUES[FEATURES_ENDPOINTS.completion],
   },
   {
     label: FEATURES_ENDPOINTS_NAMES[FEATURES_ENDPOINTS.rate_endpoint],
     value: FEATURES_ENDPOINTS.rate_endpoint,
+    defaultEndpoint:
+      FEATURES_ENDPOINTS_DEFAULT_VALUES[FEATURES_ENDPOINTS.rate_endpoint],
   },
   {
     label: FEATURES_ENDPOINTS_NAMES[FEATURES_ENDPOINTS.configuration_endpoint],
     value: FEATURES_ENDPOINTS.configuration_endpoint,
+    defaultEndpoint:
+      FEATURES_ENDPOINTS_DEFAULT_VALUES[
+        FEATURES_ENDPOINTS.configuration_endpoint
+      ],
   },
 ];
 
@@ -87,6 +97,14 @@ export const CodeAppView: React.FC<ViewProps> = ({
 
   const files = useAppSelector(FilesSelectors.selectFiles);
   const topics = useAppSelector(SettingsSelectors.selectTopics);
+  const models = useAppSelector(ModelsSelectors.selectModels);
+  const installedModelIds = useAppSelector(
+    ModelsSelectors.selectInstalledModelIds,
+  );
+
+  const filteredModels = models
+    .filter((model) => installedModelIds.has(model.reference))
+    .map((model) => ({ ...model, folderId: '' }));
 
   const topicOptions = useMemo(() => topics.map(topicToOption), [topics]);
 
@@ -98,7 +116,7 @@ export const CodeAppView: React.FC<ViewProps> = ({
     clearErrors,
     handleSubmit: submitWrapper,
   } = useForm<FormData>({
-    defaultValues: getDefaultValues(selectedApplication),
+    defaultValues: getDefaultValues(selectedApplication, filteredModels),
     mode: 'onChange',
     reValidateMode: 'onChange',
   });
@@ -169,11 +187,9 @@ export const CodeAppView: React.FC<ViewProps> = ({
         <Controller
           name="iconUrl"
           control={control}
-          rules={validators['iconUrl']}
           render={({ field }) => (
             <LogoSelector
               label={t('Icon')}
-              mandatory
               localLogo={field.value?.split('/')?.pop()}
               onLogoSelect={(v) => field.onChange(getLogoId(v))}
               onDeleteLocalLogoHandler={() => field.onChange('')}

--- a/apps/chat/src/components/Common/ApplicationWizard/CustomAppView.tsx
+++ b/apps/chat/src/components/Common/ApplicationWizard/CustomAppView.tsx
@@ -58,7 +58,10 @@ export const CustomAppView: React.FC<ViewProps> = ({
   const topics = useAppSelector(SettingsSelectors.selectTopics);
   const models = useAppSelector(ModelsSelectors.selectModels);
 
-  const filteredModels = models.map((model) => ({ ...model, folderId: '' }));
+  const modelsWithFolderId = models.map((model) => ({
+    ...model,
+    folderId: '',
+  }));
 
   const topicOptions = useMemo(() => topics.map(topicToOption), [topics]);
 
@@ -70,7 +73,7 @@ export const CustomAppView: React.FC<ViewProps> = ({
     clearErrors,
     handleSubmit: submitWrapper,
   } = useForm<FormData>({
-    defaultValues: getDefaultValues(selectedApplication, filteredModels),
+    defaultValues: getDefaultValues(selectedApplication, modelsWithFolderId),
     mode: 'onChange',
     reValidateMode: 'onChange',
   });

--- a/apps/chat/src/components/Common/ApplicationWizard/CustomAppView.tsx
+++ b/apps/chat/src/components/Common/ApplicationWizard/CustomAppView.tsx
@@ -11,6 +11,7 @@ import { Translation } from '@/src/types/translation';
 import { ApplicationActions } from '@/src/store/application/application.reducers';
 import { FilesSelectors } from '@/src/store/files/files.reducers';
 import { useAppDispatch, useAppSelector } from '@/src/store/hooks';
+import { ModelsSelectors } from '@/src/store/models/models.reducers';
 import { SettingsSelectors } from '@/src/store/settings/settings.reducers';
 
 import { IMAGE_TYPES } from '@/src/constants/chat';
@@ -55,6 +56,14 @@ export const CustomAppView: React.FC<ViewProps> = ({
 
   const files = useAppSelector(FilesSelectors.selectFiles);
   const topics = useAppSelector(SettingsSelectors.selectTopics);
+  const models = useAppSelector(ModelsSelectors.selectModels);
+  const installedModelIds = useAppSelector(
+    ModelsSelectors.selectInstalledModelIds,
+  );
+
+  const filteredModels = models
+    .filter((model) => installedModelIds.has(model.reference))
+    .map((model) => ({ ...model, folderId: '' }));
 
   const topicOptions = useMemo(() => topics.map(topicToOption), [topics]);
 
@@ -66,7 +75,7 @@ export const CustomAppView: React.FC<ViewProps> = ({
     clearErrors,
     handleSubmit: submitWrapper,
   } = useForm<FormData>({
-    defaultValues: getDefaultValues(selectedApplication),
+    defaultValues: getDefaultValues(selectedApplication, filteredModels),
     mode: 'onChange',
     reValidateMode: 'onChange',
   });
@@ -133,11 +142,9 @@ export const CustomAppView: React.FC<ViewProps> = ({
         <Controller
           name="iconUrl"
           control={control}
-          rules={validators['iconUrl']}
           render={({ field }) => (
             <LogoSelector
               label={t('Icon')}
-              mandatory
               localLogo={field.value?.split('/')?.pop()}
               onLogoSelect={(v) => field.onChange(getLogoId(v))}
               onDeleteLocalLogoHandler={() => field.onChange('')}

--- a/apps/chat/src/components/Common/ApplicationWizard/CustomAppView.tsx
+++ b/apps/chat/src/components/Common/ApplicationWizard/CustomAppView.tsx
@@ -57,13 +57,8 @@ export const CustomAppView: React.FC<ViewProps> = ({
   const files = useAppSelector(FilesSelectors.selectFiles);
   const topics = useAppSelector(SettingsSelectors.selectTopics);
   const models = useAppSelector(ModelsSelectors.selectModels);
-  const installedModelIds = useAppSelector(
-    ModelsSelectors.selectInstalledModelIds,
-  );
 
-  const filteredModels = models
-    .filter((model) => installedModelIds.has(model.reference))
-    .map((model) => ({ ...model, folderId: '' }));
+  const filteredModels = models.map((model) => ({ ...model, folderId: '' }));
 
   const topicOptions = useMemo(() => topics.map(topicToOption), [topics]);
 

--- a/apps/chat/src/components/Common/ApplicationWizard/QuickAppView.tsx
+++ b/apps/chat/src/components/Common/ApplicationWizard/QuickAppView.tsx
@@ -12,6 +12,7 @@ import { Translation } from '@/src/types/translation';
 import { ApplicationActions } from '@/src/store/application/application.reducers';
 import { FilesSelectors } from '@/src/store/files/files.reducers';
 import { useAppDispatch, useAppSelector } from '@/src/store/hooks';
+import { ModelsSelectors } from '@/src/store/models/models.reducers';
 import { SettingsSelectors } from '@/src/store/settings/settings.reducers';
 import { UISelectors } from '@/src/store/ui/ui.reducers';
 
@@ -56,6 +57,14 @@ export const QuickAppView: React.FC<ViewProps> = ({
   const files = useAppSelector(FilesSelectors.selectFiles);
   const theme = useAppSelector(UISelectors.selectThemeState);
   const topics = useAppSelector(SettingsSelectors.selectTopics);
+  const models = useAppSelector(ModelsSelectors.selectModels);
+  const installedModelIds = useAppSelector(
+    ModelsSelectors.selectInstalledModelIds,
+  );
+
+  const filteredModels = models
+    .filter((model) => installedModelIds.has(model.reference))
+    .map((model) => ({ ...model, folderId: '' }));
 
   const topicOptions = useMemo(() => topics.map(topicToOption), [topics]);
 
@@ -65,7 +74,7 @@ export const QuickAppView: React.FC<ViewProps> = ({
     control,
     formState: { errors, isValid },
   } = useForm<FormData>({
-    defaultValues: getDefaultValues(selectedApplication),
+    defaultValues: getDefaultValues(selectedApplication, filteredModels),
     mode: 'onChange',
     reValidateMode: 'onChange',
   });
@@ -132,11 +141,9 @@ export const QuickAppView: React.FC<ViewProps> = ({
         <Controller
           name="iconUrl"
           control={control}
-          rules={validators['iconUrl']}
           render={({ field }) => (
             <LogoSelector
               label={t('Icon')}
-              mandatory
               localLogo={field.value?.split('/')?.pop()}
               onLogoSelect={(v) => field.onChange(getLogoId(v))}
               onDeleteLocalLogoHandler={() => field.onChange('')}

--- a/apps/chat/src/components/Common/ApplicationWizard/QuickAppView.tsx
+++ b/apps/chat/src/components/Common/ApplicationWizard/QuickAppView.tsx
@@ -58,13 +58,8 @@ export const QuickAppView: React.FC<ViewProps> = ({
   const theme = useAppSelector(UISelectors.selectThemeState);
   const topics = useAppSelector(SettingsSelectors.selectTopics);
   const models = useAppSelector(ModelsSelectors.selectModels);
-  const installedModelIds = useAppSelector(
-    ModelsSelectors.selectInstalledModelIds,
-  );
 
-  const filteredModels = models
-    .filter((model) => installedModelIds.has(model.reference))
-    .map((model) => ({ ...model, folderId: '' }));
+  const filteredModels = models.map((model) => ({ ...model, folderId: '' }));
 
   const topicOptions = useMemo(() => topics.map(topicToOption), [topics]);
 

--- a/apps/chat/src/components/Common/ApplicationWizard/QuickAppView.tsx
+++ b/apps/chat/src/components/Common/ApplicationWizard/QuickAppView.tsx
@@ -59,7 +59,10 @@ export const QuickAppView: React.FC<ViewProps> = ({
   const topics = useAppSelector(SettingsSelectors.selectTopics);
   const models = useAppSelector(ModelsSelectors.selectModels);
 
-  const filteredModels = models.map((model) => ({ ...model, folderId: '' }));
+  const modelsWithFolderId = models.map((model) => ({
+    ...model,
+    folderId: '',
+  }));
 
   const topicOptions = useMemo(() => topics.map(topicToOption), [topics]);
 
@@ -69,7 +72,7 @@ export const QuickAppView: React.FC<ViewProps> = ({
     control,
     formState: { errors, isValid },
   } = useForm<FormData>({
-    defaultValues: getDefaultValues(selectedApplication, filteredModels),
+    defaultValues: getDefaultValues(selectedApplication, modelsWithFolderId),
     mode: 'onChange',
     reValidateMode: 'onChange',
   });

--- a/apps/chat/src/components/Common/ApplicationWizard/form.ts
+++ b/apps/chat/src/components/Common/ApplicationWizard/form.ts
@@ -33,6 +33,7 @@ import {
   DEFAULT_TEMPERATURE,
 } from '@/src/constants/default-ui-settings';
 import { MIME_FORMAT_REGEX } from '@/src/constants/file';
+import { DEFAULT_VERSION } from '@/src/constants/public';
 
 import { DynamicField } from '@/src/components/Common/Forms/DynamicFormFields';
 
@@ -291,11 +292,9 @@ export const getDefaultValues = (
 ): FormData => ({
   name:
     app?.name ??
-    (models
-      ? getNextDefaultName(DEFAULT_APPLICATION_NAME, models, 0, true)
-      : ''),
+    getNextDefaultName(DEFAULT_APPLICATION_NAME, models ?? [], 0, true),
   description: app ? getModelDescription(app) : '',
-  version: app?.version ?? '0.0.1',
+  version: app?.version ?? DEFAULT_VERSION,
   iconUrl: app?.iconUrl ?? '',
   topics: app?.topics ?? [],
   inputAttachmentTypes: app?.inputAttachmentTypes ?? [],

--- a/apps/chat/src/components/Common/ApplicationWizard/form.ts
+++ b/apps/chat/src/components/Common/ApplicationWizard/form.ts
@@ -11,6 +11,7 @@ import {
   getQuickAppConfig,
 } from '@/src/utils/app/application';
 import { notAllowedSymbols } from '@/src/utils/app/file';
+import { getNextDefaultName } from '@/src/utils/app/folders';
 import { ApiUtils } from '@/src/utils/server/api';
 
 import {
@@ -23,13 +24,18 @@ import { QuickAppConfig } from '@/src/types/quick-apps';
 
 import {
   FEATURES_ENDPOINTS,
+  FEATURES_ENDPOINTS_DEFAULT_VALUES,
   FEATURES_ENDPOINTS_NAMES,
 } from '@/src/constants/applications';
-import { DEFAULT_TEMPERATURE } from '@/src/constants/default-ui-settings';
+import {
+  DEFAULT_APPLICATION_NAME,
+  DEFAULT_TEMPERATURE,
+} from '@/src/constants/default-ui-settings';
 import { MIME_FORMAT_REGEX } from '@/src/constants/file';
 
 import { DynamicField } from '@/src/components/Common/Forms/DynamicFormFields';
 
+import { ShareEntity } from '@epam/ai-dial-shared';
 import isObject from 'lodash-es/isObject';
 
 export interface FormData {
@@ -88,9 +94,6 @@ export const validators: Validators = {
     setValueAs: (v) => {
       return (v as string).replace(/[^0-9.]/g, '');
     },
-  },
-  iconUrl: {
-    required: 'Icon is required',
   },
   features: {
     validate: (data) => {
@@ -268,10 +271,17 @@ const getToolsetStr = (config: QuickAppConfig) => {
   }
 };
 
-export const getDefaultValues = (app?: CustomApplicationModel): FormData => ({
-  name: app?.name ?? '',
+export const getDefaultValues = (
+  app?: CustomApplicationModel,
+  models?: ShareEntity[],
+): FormData => ({
+  name:
+    app?.name ??
+    (models
+      ? getNextDefaultName(DEFAULT_APPLICATION_NAME, models, 0, true)
+      : ''),
   description: app ? getModelDescription(app) : '',
-  version: app?.version ?? '',
+  version: app?.version ?? '0.0.1',
   iconUrl: app?.iconUrl ?? '',
   topics: app?.topics ?? [],
   inputAttachmentTypes: app?.inputAttachmentTypes ?? [],
@@ -297,7 +307,9 @@ export const getDefaultValues = (app?: CustomApplicationModel): FormData => ({
         {
           label: FEATURES_ENDPOINTS.completion,
           visibleName: FEATURES_ENDPOINTS_NAMES[FEATURES_ENDPOINTS.completion],
-          value: '',
+          value:
+            FEATURES_ENDPOINTS_DEFAULT_VALUES[FEATURES_ENDPOINTS.completion] ||
+            '',
           editableKey: false,
           static: true,
         },

--- a/apps/chat/src/components/Common/Forms/DynamicFormFields.tsx
+++ b/apps/chat/src/components/Common/Forms/DynamicFormFields.tsx
@@ -79,7 +79,7 @@ export const DynamicFormFields = <
   const handleAdd = (option?: SelectOption<string, string>) => {
     append({
       label: option?.value ?? '',
-      value: '',
+      value: option?.defaultEndpoint ?? '',
       editableKey: !option,
       visibleName: option?.label,
     } as FieldArray<T, K>);
@@ -101,11 +101,11 @@ export const DynamicFormFields = <
           className="flex gap-3 rounded border border-tertiary bg-layer-3 px-3 py-2"
         >
           {!mapField(field).editableKey ? (
-            <div className="w-[120px] px-2 py-1 text-sm text-primary">
+            <div className="w-[125px] px-2 py-1 text-sm text-primary">
               {mapField(field).visibleName ?? mapField(field).label}
             </div>
           ) : (
-            <div className="w-[120px]">
+            <div className="w-[125px]">
               <input
                 {...register(`${name}.${i}.label` as Path<T>, keyOptions)}
                 className={classNames(

--- a/apps/chat/src/components/Common/Forms/DynamicFormFields.tsx
+++ b/apps/chat/src/components/Common/Forms/DynamicFormFields.tsx
@@ -79,7 +79,7 @@ export const DynamicFormFields = <
   const handleAdd = (option?: SelectOption<string, string>) => {
     append({
       label: option?.value ?? '',
-      value: option?.defaultEndpoint ?? '',
+      value: option?.defaultValue ?? '',
       editableKey: !option,
       visibleName: option?.label,
     } as FieldArray<T, K>);

--- a/apps/chat/src/constants/applications.ts
+++ b/apps/chat/src/constants/applications.ts
@@ -5,7 +5,13 @@ export const FEATURES_ENDPOINTS = {
 };
 
 export const FEATURES_ENDPOINTS_NAMES = {
-  [FEATURES_ENDPOINTS.completion]: 'Completion',
+  [FEATURES_ENDPOINTS.completion]: 'Chat completion',
   [FEATURES_ENDPOINTS.rate_endpoint]: 'Rate',
   [FEATURES_ENDPOINTS.configuration_endpoint]: 'Configuration',
+};
+
+export const FEATURES_ENDPOINTS_DEFAULT_VALUES = {
+  [FEATURES_ENDPOINTS.completion]: '/openai/deployments/app/chat/completions',
+  [FEATURES_ENDPOINTS.rate_endpoint]: '/v1/app/rate',
+  [FEATURES_ENDPOINTS.configuration_endpoint]: '',
 };

--- a/apps/chat/src/constants/applications.ts
+++ b/apps/chat/src/constants/applications.ts
@@ -11,7 +11,8 @@ export const FEATURES_ENDPOINTS_NAMES = {
 };
 
 export const FEATURES_ENDPOINTS_DEFAULT_VALUES = {
-  [FEATURES_ENDPOINTS.chat_completion]: '/openai/deployments/app/chat/completions',
+  [FEATURES_ENDPOINTS.chat_completion]:
+    '/openai/deployments/app/chat/completions',
   [FEATURES_ENDPOINTS.rate_endpoint]: '/v1/app/rate',
   [FEATURES_ENDPOINTS.configuration_endpoint]: '',
 };

--- a/apps/chat/src/constants/default-ui-settings.ts
+++ b/apps/chat/src/constants/default-ui-settings.ts
@@ -6,6 +6,7 @@ export const OVERLAY_HEADER_ICON_SIZE = 18;
 export const DEFAULT_CONVERSATION_NAME = 'New conversation';
 export const DEFAULT_PROMPT_NAME = 'Prompt';
 export const DEFAULT_FOLDER_NAME = 'New folder';
+export const DEFAULT_APPLICATION_NAME = 'Untitled app';
 export const EMPTY_MODEL_ID = 'empty';
 
 export const FALLBACK_MODEL_ID = 'gpt-35-turbo';

--- a/apps/chat/src/store/application/application.epics.ts
+++ b/apps/chat/src/store/application/application.epics.ts
@@ -36,7 +36,7 @@ const createApplicationEpic: AppEpic = (action$) =>
   action$.pipe(
     filter(ApplicationActions.create.match),
     switchMap(({ payload }) => {
-      if (!payload.version || !payload.iconUrl) {
+      if (!payload.version) {
         return EMPTY;
       }
 

--- a/apps/chat/src/types/common.ts
+++ b/apps/chat/src/types/common.ts
@@ -115,6 +115,7 @@ export interface DropdownSelectorOption {
 export interface SelectOption<L, V> {
   label: L;
   value: V;
+  defaultEndpoint?: string;
 }
 
 export enum PageType {

--- a/apps/chat/src/types/common.ts
+++ b/apps/chat/src/types/common.ts
@@ -115,7 +115,7 @@ export interface DropdownSelectorOption {
 export interface SelectOption<L, V> {
   label: L;
   value: V;
-  defaultEndpoint?: string;
+  defaultValue?: string;
 }
 
 export enum PageType {


### PR DESCRIPTION
**Description:**

Need to add default value for entrypoint/name/version/icon fields

Issues:

- Issue #2477 

**UI changes**

<img width="710" alt="Снимок экрана 2024-10-31 в 12 06 14" src="https://github.com/user-attachments/assets/526c5789-9d0d-4d7e-b9d3-c6a287b4c834">
<img width="707" alt="Снимок экрана 2024-10-31 в 12 06 53" src="https://github.com/user-attachments/assets/a2d3f7a0-4fbc-4533-8ea6-69276837f8b2">
<img width="705" alt="Снимок экрана 2024-10-31 в 12 06 33" src="https://github.com/user-attachments/assets/aced5a07-7164-49ab-8f8f-d9a8e9863dd8">
<img width="686" alt="Снимок экрана 2024-10-31 в 12 06 44" src="https://github.com/user-attachments/assets/678386b7-b98a-4509-a846-27aee2823126">

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
