### PR TITLE
fix(chat): fix colors (Issue #2113)

### DIFF
--- a/apps/chat/src/components/Chat/MessageAttachments.tsx
+++ b/apps/chat/src/components/Chat/MessageAttachments.tsx
@@ -31,7 +31,7 @@ export const MessageAttachments = ({ attachments, isInner }: Props) => {
   return isUnderSection && !isInner ? (
     <div
       data-no-context-menu
-      className="rounded border border-primary bg-layer-1"
+      className="rounded border border-secondary bg-layer-1"
     >
       <button
         className="flex w-full items-center gap-2 p-2 text-sm"


### PR DESCRIPTION
**Description:**

The strokes of the upper and lower blocks are different

Issues:

- Issue #2113 

**UI changes**

<img width="699" alt="Снимок экрана 2024-11-04 в 09 35 31" src="https://github.com/user-attachments/assets/dad1aa73-cb77-4106-92dc-9230e1a5ff65">

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
