### PR TITLE
fix(chat): fix runtime selector displaying on full tab mode (Issue #2527)

### DIFF
--- a/apps/chat/src/components/Common/ApplicationWizard/CodeAppView/CodeEditor.tsx
+++ b/apps/chat/src/components/Common/ApplicationWizard/CodeAppView/CodeEditor.tsx
@@ -309,7 +309,7 @@ export const CodeEditor = ({ sourcesFolderId, setValue }: Props) => {
       <div
         className={classNames(
           'flex min-h-[400px] w-full max-w-full',
-          isFullScreen ? 'fixed inset-0' : 'h-[400px]',
+          isFullScreen ? 'fixed inset-0 z-50' : 'h-[400px]',
         )}
       >
         <div className="flex max-h-full min-w-0 shrink flex-col gap-0.5 divide-y divide-tertiary rounded border border-tertiary bg-layer-3">


### PR DESCRIPTION
…527)

**Description:**

fix runtime selector displaying on full tab mode

Issues:

- Issue #2527

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
