### PR TITLE
fix(chat): fix app log visibility for Admin, disable 'Use application' button (Issue #2526, #2531)

### DIFF
--- a/apps/chat/src/components/Marketplace/ApplicationDetails/ApplicationFooter.tsx
+++ b/apps/chat/src/components/Marketplace/ApplicationDetails/ApplicationFooter.tsx
@@ -249,7 +249,9 @@ export const ApplicationDetailsFooter = ({
             onClick={onUseEntity}
             className="button button-primary flex shrink-0 items-center gap-3"
             data-qa="use-button"
-            disabled={playerStatus !== SimpleApplicationStatus.UNDEPLOY}
+            disabled={
+              !isExecutable || playerStatus !== SimpleApplicationStatus.UNDEPLOY
+            }
           >
             <IconPlayerPlay size={18} />
             <span className="hidden md:block">

--- a/apps/chat/src/components/Marketplace/ApplicationDetails/ApplicationFooter.tsx
+++ b/apps/chat/src/components/Marketplace/ApplicationDetails/ApplicationFooter.tsx
@@ -144,25 +144,23 @@ export const ApplicationDetailsFooter = ({
     <section className="flex px-3 py-4 md:px-6">
       <div className="flex w-full items-center justify-between">
         <div className="flex items-center gap-2">
-          {((isPublicApp && isAdmin) || isMyApp) &&
-            isExecutable &&
-            isCodeAppsEnabled && (
-              <Tooltip tooltip={t(getFunctionTooltip(entity))}>
-                <button
-                  disabled={playerStatus === SimpleApplicationStatus.UPDATING}
-                  onClick={handleUpdateFunctionStatus}
-                  className={classNames('icon-button', {
-                    ['button-error']:
-                      playerStatus === SimpleApplicationStatus.UNDEPLOY,
-                    ['button-accent-secondary']:
-                      playerStatus === SimpleApplicationStatus.DEPLOY,
-                  })}
-                  data-qa="application-status-toggler"
-                >
-                  <PlayerIcon size={24} />
-                </button>
-              </Tooltip>
-            )}
+          {isExecutable && isCodeAppsEnabled && (
+            <Tooltip tooltip={t(getFunctionTooltip(entity))}>
+              <button
+                disabled={playerStatus === SimpleApplicationStatus.UPDATING}
+                onClick={handleUpdateFunctionStatus}
+                className={classNames('icon-button', {
+                  ['button-error']:
+                    playerStatus === SimpleApplicationStatus.UNDEPLOY,
+                  ['button-accent-secondary']:
+                    playerStatus === SimpleApplicationStatus.DEPLOY,
+                })}
+                data-qa="application-status-toggler"
+              >
+                <PlayerIcon size={24} />
+              </button>
+            </Tooltip>
+          )}
 
           {isMyApp ? (
             <Tooltip tooltip={t(getDisabledTooltip(entity, 'Delete'))}>
@@ -226,7 +224,7 @@ export const ApplicationDetailsFooter = ({
               </button>
             </Tooltip>
           )}
-          {((isPublicApp && isAdmin) || isMyApp) &&
+          {isExecutable &&
             playerStatus === SimpleApplicationStatus.UNDEPLOY && (
               <Tooltip tooltip={t('Application logs')}>
                 <button

--- a/apps/chat/src/components/Marketplace/ApplicationDetails/ApplicationFooter.tsx
+++ b/apps/chat/src/components/Marketplace/ApplicationDetails/ApplicationFooter.tsx
@@ -144,23 +144,25 @@ export const ApplicationDetailsFooter = ({
     <section className="flex px-3 py-4 md:px-6">
       <div className="flex w-full items-center justify-between">
         <div className="flex items-center gap-2">
-          {isExecutable && isCodeAppsEnabled && (
-            <Tooltip tooltip={t(getFunctionTooltip(entity))}>
-              <button
-                disabled={playerStatus === SimpleApplicationStatus.UPDATING}
-                onClick={handleUpdateFunctionStatus}
-                className={classNames('icon-button', {
-                  ['button-error']:
-                    playerStatus === SimpleApplicationStatus.UNDEPLOY,
-                  ['button-accent-secondary']:
-                    playerStatus === SimpleApplicationStatus.DEPLOY,
-                })}
-                data-qa="application-status-toggler"
-              >
-                <PlayerIcon size={24} />
-              </button>
-            </Tooltip>
-          )}
+          {((isPublicApp && isAdmin) || isMyApp) &&
+            isExecutable &&
+            isCodeAppsEnabled && (
+              <Tooltip tooltip={t(getFunctionTooltip(entity))}>
+                <button
+                  disabled={playerStatus === SimpleApplicationStatus.UPDATING}
+                  onClick={handleUpdateFunctionStatus}
+                  className={classNames('icon-button', {
+                    ['button-error']:
+                      playerStatus === SimpleApplicationStatus.UNDEPLOY,
+                    ['button-accent-secondary']:
+                      playerStatus === SimpleApplicationStatus.DEPLOY,
+                  })}
+                  data-qa="application-status-toggler"
+                >
+                  <PlayerIcon size={24} />
+                </button>
+              </Tooltip>
+            )}
 
           {isMyApp ? (
             <Tooltip tooltip={t(getDisabledTooltip(entity, 'Delete'))}>
@@ -224,17 +226,18 @@ export const ApplicationDetailsFooter = ({
               </button>
             </Tooltip>
           )}
-          {playerStatus === SimpleApplicationStatus.UNDEPLOY && (
-            <Tooltip tooltip={t('Application logs')}>
-              <button
-                onClick={() => onLogsClick(entity)}
-                className="icon-button"
-                data-qa="application-logs"
-              >
-                <IconFileDescription size={24} />
-              </button>
-            </Tooltip>
-          )}
+          {((isPublicApp && isAdmin) || isMyApp) &&
+            playerStatus === SimpleApplicationStatus.UNDEPLOY && (
+              <Tooltip tooltip={t('Application logs')}>
+                <button
+                  onClick={() => onLogsClick(entity)}
+                  className="icon-button"
+                  data-qa="application-logs"
+                >
+                  <IconFileDescription size={24} />
+                </button>
+              </Tooltip>
+            )}
         </div>
         <div className="flex w-full items-center justify-end gap-4">
           <ModelVersionSelect
@@ -248,6 +251,7 @@ export const ApplicationDetailsFooter = ({
             onClick={onUseEntity}
             className="button button-primary flex shrink-0 items-center gap-3"
             data-qa="use-button"
+            disabled={playerStatus !== SimpleApplicationStatus.UNDEPLOY}
           >
             <IconPlayerPlay size={18} />
             <span className="hidden md:block">

--- a/apps/chat/src/components/Marketplace/ApplicationDetails/ApplicationFooter.tsx
+++ b/apps/chat/src/components/Marketplace/ApplicationDetails/ApplicationFooter.tsx
@@ -250,7 +250,8 @@ export const ApplicationDetailsFooter = ({
             className="button button-primary flex shrink-0 items-center gap-3"
             data-qa="use-button"
             disabled={
-              !isExecutable || playerStatus !== SimpleApplicationStatus.UNDEPLOY
+              !isExecutableApp(entity) ||
+              playerStatus !== SimpleApplicationStatus.UNDEPLOY
             }
           >
             <IconPlayerPlay size={18} />

--- a/apps/chat/src/components/Marketplace/ApplicationDetails/ApplicationFooter.tsx
+++ b/apps/chat/src/components/Marketplace/ApplicationDetails/ApplicationFooter.tsx
@@ -250,7 +250,7 @@ export const ApplicationDetailsFooter = ({
             className="button button-primary flex shrink-0 items-center gap-3"
             data-qa="use-button"
             disabled={
-              !isExecutableApp(entity) ||
+              isExecutableApp(entity) &&
               playerStatus !== SimpleApplicationStatus.UNDEPLOY
             }
           >


### PR DESCRIPTION
**Description:**

Need to disable Use application button for Code apps in state Undeployed
Application log for published and deployed Code app should be available for Admin only

Issues:

- Issue #2526 
- Issue #2531 

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
