### PR TITLE
fix(chat): fix displaying of completion url in review request (Issue #2510)

### DIFF
--- a/apps/chat/src/components/Chat/Publish/ReviewApplicationDialogView.tsx
+++ b/apps/chat/src/components/Chat/Publish/ReviewApplicationDialogView.tsx
@@ -11,6 +11,8 @@ import { Translation } from '@/src/types/translation';
 import { ApplicationSelectors } from '@/src/store/application/application.reducers';
 import { useAppSelector } from '@/src/store/hooks';
 
+import { FEATURES_ENDPOINTS } from '@/src/constants/applications';
+
 import { ModelIcon } from '../../Chatbar/ModelIcon';
 import { PublicationControls } from './PublicationChatControls';
 
@@ -121,7 +123,9 @@ export function ReviewApplicationDialogView() {
             {t('Completion URL:')}
           </span>
           <span className="max-w-[414px] break-all text-primary">
-            {application?.completionUrl}
+            {application?.function?.mapping?.[
+              FEATURES_ENDPOINTS.chat_completion
+            ] ?? application?.completionUrl}
           </span>
         </div>
       </div>


### PR DESCRIPTION
**Description:**

fix displaying of completion url in review request

Issues:

- Issue #2510

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
