### PR TITLE
fix(chat): apply default name if click 'x' when creating a new file inside code editor (Issue #2553)

### DIFF
--- a/apps/chat/src/components/Common/ApplicationWizard/CodeAppView/CodeEditor.tsx
+++ b/apps/chat/src/components/Common/ApplicationWizard/CodeAppView/CodeEditor.tsx
@@ -452,6 +452,7 @@ export const CodeEditor = ({ sourcesFolderId, setValue }: Props) => {
                   setNewFileFolder(sourcesFolderId);
                   setNewFileName(getNextDefaultName('New file', rootFiles));
                 }}
+                disabled={!!newFileName}
                 className="text-secondary hover:text-accent-primary"
               >
                 <IconFilePlus size={18} />

--- a/apps/chat/src/components/Common/ApplicationWizard/CodeAppView/CodeEditor.tsx
+++ b/apps/chat/src/components/Common/ApplicationWizard/CodeAppView/CodeEditor.tsx
@@ -297,22 +297,25 @@ export const CodeEditor = ({ sourcesFolderId, setValue }: Props) => {
     [deletingFileId, dispatch],
   );
 
-  const handleUploadEmptyFile = useCallback(() => {
-    if (newFileName && sourcesFolderId) {
-      dispatch(
-        FilesActions.uploadFile({
-          fileContent: new File([''], newFileName, {
-            type: 'text/plain',
+  const handleUploadEmptyFile = useCallback(
+    (fileName: string) => {
+      if (fileName && sourcesFolderId) {
+        dispatch(
+          FilesActions.uploadFile({
+            fileContent: new File([''], fileName, {
+              type: 'text/plain',
+            }),
+            relativePath: getIdWithoutRootPathSegments(sourcesFolderId),
+            id: constructPath(sourcesFolderId, fileName),
+            name: fileName,
           }),
-          relativePath: getIdWithoutRootPathSegments(sourcesFolderId),
-          id: constructPath(sourcesFolderId, newFileName),
-          name: newFileName,
-        }),
-      );
-      setNewFileFolder(undefined);
-      setNewFileName('');
-    }
-  }, [dispatch, newFileName, sourcesFolderId]);
+        );
+        setNewFileFolder(undefined);
+        setNewFileName('');
+      }
+    },
+    [dispatch, sourcesFolderId],
+  );
 
   const FullScreenIcon = useMemo(
     () => (isFullScreen ? IconArrowsMinimize : IconArrowsMaximize),
@@ -408,14 +411,14 @@ export const CodeEditor = ({ sourcesFolderId, setValue }: Props) => {
                   onChange={(e) => setNewFileName(e.target.value)}
                   onKeyDown={(e) => {
                     if (e.key === 'Enter') {
-                      handleUploadEmptyFile();
+                      handleUploadEmptyFile(newFileName);
                     }
                   }}
                   autoFocus
                 />
                 <div className="absolute right-1 z-10 flex" data-qa="actions">
                   <SidebarActionButton
-                    handleClick={handleUploadEmptyFile}
+                    handleClick={() => handleUploadEmptyFile(newFileName)}
                     dataQA="confirm-edit"
                   >
                     <IconCheck
@@ -425,8 +428,9 @@ export const CodeEditor = ({ sourcesFolderId, setValue }: Props) => {
                   </SidebarActionButton>
                   <SidebarActionButton
                     handleClick={() => {
-                      setNewFileFolder(undefined);
-                      setNewFileName('');
+                      handleUploadEmptyFile(
+                        getNextDefaultName('New file', rootFiles),
+                      );
                     }}
                     dataQA="cancel-edit"
                   >


### PR DESCRIPTION
**Description:**

apply default name if click 'x' when creating a new file inside code editor

Issues:

- Issue #2553 

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
