### PR TITLE
fix(chat): fix displaying endpoints and environmental variable in review request (Issue #2521)

### DIFF
--- a/apps/chat/src/components/Chat/Publish/ReviewApplicationDialogView.tsx
+++ b/apps/chat/src/components/Chat/Publish/ReviewApplicationDialogView.tsx
@@ -132,15 +132,14 @@ export function ReviewApplicationDialogView() {
               </span>
             </div>
           )}
-        {application?.function?.mapping &&
-          !isEmpty(application?.function?.mapping) && (
-            <ReviewApplicationPropsSection
-              label="Endpoints"
-              appProps={application.function.mapping}
-              propsNames={FEATURES_ENDPOINTS_NAMES}
-            />
-          )}
-        {application?.function?.env && !isEmpty(application?.function?.env) && (
+        {!isEmpty(application?.function?.mapping) && (
+          <ReviewApplicationPropsSection
+            label="Endpoints"
+            appProps={application.function.mapping}
+            propsNames={FEATURES_ENDPOINTS_NAMES}
+          />
+        )}
+        {!isEmpty(application?.function?.env) && (
           <ReviewApplicationPropsSection
             label="Environment variables"
             appProps={application.function.env}

--- a/apps/chat/src/components/Chat/Publish/ReviewApplicationDialogView.tsx
+++ b/apps/chat/src/components/Chat/Publish/ReviewApplicationDialogView.tsx
@@ -17,7 +17,7 @@ import { ModelIcon } from '../../Chatbar/ModelIcon';
 import { PublicationControls } from './PublicationChatControls';
 import { ReviewApplicationPropsSection } from './ReviewApplicationPropsSection';
 
-import { isEmpty } from 'lodash-es';
+import isEmpty from 'lodash-es/isEmpty';
 
 export function ReviewApplicationDialogView() {
   const { t } = useTranslation(Translation.Chat);
@@ -132,15 +132,14 @@ export function ReviewApplicationDialogView() {
               </span>
             </div>
           )}
-        {application?.function?.mapping &&
-          !isEmpty(application.function.mapping) && (
-            <ReviewApplicationPropsSection
-              label="Endpoints"
-              appProps={application.function.mapping}
-              propsNames={FEATURES_ENDPOINTS_NAMES}
-            />
-          )}
-        {application?.function?.env && !isEmpty(application.function.env) && (
+        {!isEmpty(application?.function?.mapping)! && (
+          <ReviewApplicationPropsSection
+            label="Endpoints"
+            appProps={application.function.mapping}
+            propsNames={FEATURES_ENDPOINTS_NAMES}
+          />
+        )}
+        {!isEmpty(application?.function?.env)! && (
           <ReviewApplicationPropsSection
             label="Environment variables"
             appProps={application.function.env}

--- a/apps/chat/src/components/Chat/Publish/ReviewApplicationDialogView.tsx
+++ b/apps/chat/src/components/Chat/Publish/ReviewApplicationDialogView.tsx
@@ -11,8 +11,11 @@ import { Translation } from '@/src/types/translation';
 import { ApplicationSelectors } from '@/src/store/application/application.reducers';
 import { useAppSelector } from '@/src/store/hooks';
 
+import { FEATURES_ENDPOINTS_NAMES } from '@/src/constants/applications';
+
 import { ModelIcon } from '../../Chatbar/ModelIcon';
 import { PublicationControls } from './PublicationChatControls';
+import { ReviewApplicationPropsSection } from './ReviewApplicationPropsSection';
 
 export function ReviewApplicationDialogView() {
   const { t } = useTranslation(Translation.Chat);
@@ -116,14 +119,29 @@ export function ReviewApplicationDialogView() {
             </span>
           </div>
         )}
-        <div className="flex gap-4">
-          <span className="w-[122px] text-secondary">
-            {t('Completion URL:')}
-          </span>
-          <span className="max-w-[414px] break-all text-primary">
-            {application?.completionUrl}
-          </span>
-        </div>
+        {application?.completionUrl && (
+          <div className="flex gap-4">
+            <span className="w-[122px] text-secondary">
+              {t('Completion URL:')}
+            </span>
+            <span className="max-w-[414px] break-all text-primary">
+              {application.completionUrl}
+            </span>
+          </div>
+        )}
+        {application?.function?.mapping && (
+          <ReviewApplicationPropsSection
+            label="Endpoints"
+            appProps={application.function.mapping}
+            propsNames={FEATURES_ENDPOINTS_NAMES}
+          />
+        )}
+        {application?.function?.env && (
+          <ReviewApplicationPropsSection
+            label="Environment variables"
+            appProps={application.function.env}
+          />
+        )}
       </div>
       <div className="flex w-full items-center justify-end border-t-[1px] border-tertiary px-3 py-4 md:px-5">
         {controlsEntity && (

--- a/apps/chat/src/components/Chat/Publish/ReviewApplicationDialogView.tsx
+++ b/apps/chat/src/components/Chat/Publish/ReviewApplicationDialogView.tsx
@@ -135,14 +135,14 @@ export function ReviewApplicationDialogView() {
         {!isEmpty(application?.function?.mapping)! && (
           <ReviewApplicationPropsSection
             label="Endpoints"
-            appProps={application.function.mapping}
+            appProps={application?.function?.mapping ?? {}}
             propsNames={FEATURES_ENDPOINTS_NAMES}
           />
         )}
         {!isEmpty(application?.function?.env)! && (
           <ReviewApplicationPropsSection
             label="Environment variables"
-            appProps={application.function.env}
+            appProps={application?.function?.env ?? {}}
           />
         )}
       </div>

--- a/apps/chat/src/components/Chat/Publish/ReviewApplicationDialogView.tsx
+++ b/apps/chat/src/components/Chat/Publish/ReviewApplicationDialogView.tsx
@@ -132,17 +132,18 @@ export function ReviewApplicationDialogView() {
               </span>
             </div>
           )}
-        {!isEmpty(application?.function?.mapping) && (
-          <ReviewApplicationPropsSection
-            label="Endpoints"
-            appProps={application?.function?.mapping}
-            propsNames={FEATURES_ENDPOINTS_NAMES}
-          />
-        )}
-        {!isEmpty(application?.function?.env) && (
+        {application?.function?.mapping &&
+          !isEmpty(application?.function?.mapping) && (
+            <ReviewApplicationPropsSection
+              label="Endpoints"
+              appProps={application.function.mapping}
+              propsNames={FEATURES_ENDPOINTS_NAMES}
+            />
+          )}
+        {application?.function?.env && !isEmpty(application?.function?.env) && (
           <ReviewApplicationPropsSection
             label="Environment variables"
-            appProps={application?.function?.env}
+            appProps={application.function.env}
           />
         )}
       </div>

--- a/apps/chat/src/components/Chat/Publish/ReviewApplicationDialogView.tsx
+++ b/apps/chat/src/components/Chat/Publish/ReviewApplicationDialogView.tsx
@@ -133,14 +133,14 @@ export function ReviewApplicationDialogView() {
             </div>
           )}
         {application?.function?.mapping &&
-          !isEmpty(application?.function?.mapping) && (
+          !isEmpty(application.function.mapping) && (
             <ReviewApplicationPropsSection
               label="Endpoints"
               appProps={application.function.mapping}
               propsNames={FEATURES_ENDPOINTS_NAMES}
             />
           )}
-        {application?.function?.env && !isEmpty(application?.function?.env) && (
+        {application?.function?.env && !isEmpty(application.function.env) && (
           <ReviewApplicationPropsSection
             label="Environment variables"
             appProps={application.function.env}

--- a/apps/chat/src/components/Chat/Publish/ReviewApplicationDialogView.tsx
+++ b/apps/chat/src/components/Chat/Publish/ReviewApplicationDialogView.tsx
@@ -135,14 +135,14 @@ export function ReviewApplicationDialogView() {
         {!isEmpty(application?.function?.mapping) && (
           <ReviewApplicationPropsSection
             label="Endpoints"
-            appProps={application.function.mapping}
+            appProps={application?.function?.mapping}
             propsNames={FEATURES_ENDPOINTS_NAMES}
           />
         )}
         {!isEmpty(application?.function?.env) && (
           <ReviewApplicationPropsSection
             label="Environment variables"
-            appProps={application.function.env}
+            appProps={application?.function?.env}
           />
         )}
       </div>

--- a/apps/chat/src/components/Chat/Publish/ReviewApplicationPropsSection.tsx
+++ b/apps/chat/src/components/Chat/Publish/ReviewApplicationPropsSection.tsx
@@ -32,13 +32,13 @@ export const ReviewApplicationPropsSection = ({
   const { t } = useTranslation(Translation.Chat);
   return (
     <div className="flex gap-4">
-      <span className="w-[122px] text-secondary">{t(`${label}`)}:</span>
+      <span className="w-[122px] text-secondary">{t(label)}:</span>
       <div className="max-w-[414px]">
         {Object.entries(appProps).map(([key, value]) => {
           return (
             <ReviewApplicationPropsItem
               key={key}
-              itemLabel={propsNames ? t(`${propsNames[key]}`) : key}
+              itemLabel={propsNames ? t(propsNames[key]) : key}
               itemValue={value}
             />
           );

--- a/apps/chat/src/components/Chat/Publish/ReviewApplicationPropsSection.tsx
+++ b/apps/chat/src/components/Chat/Publish/ReviewApplicationPropsSection.tsx
@@ -1,0 +1,49 @@
+import { useTranslation } from 'next-i18next';
+
+import { Translation } from '@/src/types/translation';
+
+interface ItemProps {
+  itemLabel: string;
+  itemValue: string;
+}
+export const ReviewApplicationPropsItem = ({
+  itemLabel,
+  itemValue,
+}: ItemProps) => {
+  return (
+    <div className="flex gap-4 text-primary">
+      <span className="w-[122px] shrink-0">{itemLabel}:</span>
+      <span>{itemValue}</span>
+    </div>
+  );
+};
+
+interface SectionProps {
+  label: string;
+  appProps: Record<string, string>;
+  propsNames?: Record<string, string>;
+}
+
+export const ReviewApplicationPropsSection = ({
+  label,
+  appProps,
+  propsNames,
+}: SectionProps) => {
+  const { t } = useTranslation(Translation.Chat);
+  return (
+    <div className="flex gap-4">
+      <span className="w-[122px] text-secondary">{t(`${label}`)}:</span>
+      <div className="max-w-[414px]">
+        {Object.entries(appProps).map(([key, value]) => {
+          return (
+            <ReviewApplicationPropsItem
+              key={key}
+              itemLabel={propsNames ? t(`${propsNames[key]}`) : key}
+              itemValue={value}
+            />
+          );
+        })}
+      </div>
+    </div>
+  );
+};


### PR DESCRIPTION
**Description:**

Fix displaying fields "Endpoints" and "Environmental variable" in review form when admin review publication request

Issues:

- Issue #2521 

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
