### PR TITLE
fix(chat): fix stroke appearance (Issue #2113)

### DIFF
--- a/apps/chat/src/components/Chat/MessageAttachments.tsx
+++ b/apps/chat/src/components/Chat/MessageAttachments.tsx
@@ -34,7 +34,7 @@ export const MessageAttachments = ({ attachments, isInner }: Props) => {
       className="rounded border border-secondary bg-layer-1"
     >
       <button
-        className="flex w-full items-center gap-2 p-2 text-sm"
+        className="flex w-full items-center justify-between gap-2 p-2 text-sm"
         onClick={() => setIsSectionOpened((val) => !val)}
         data-qa="grouped-attachments"
       >

--- a/apps/chat/src/components/Chat/MessageStage.tsx
+++ b/apps/chat/src/components/Chat/MessageStage.tsx
@@ -84,7 +84,7 @@ export const MessageStage = ({ stage }: Props) => {
     <div className="block min-w-0 shrink rounded border border-secondary bg-layer-1">
       {hasContent ? (
         <button
-          className="flex w-full min-w-0 shrink items-center gap-2 p-2"
+          className="flex w-full min-w-0 shrink items-center justify-between gap-2 p-2"
           onClick={() => {
             setIsOpened((opened) => !opened);
           }}


### PR DESCRIPTION
**Description:**

The strokes of the upper and lower blocks are different

Issues:

- Issue #2113 

**UI changes**

Before:
<img width="804" alt="Снимок экрана 2024-11-07 в 14 36 12" src="https://github.com/user-attachments/assets/d4d8d8ee-39f6-42fc-a441-2b63f5b78a68">

After:
<img width="692" alt="Снимок экрана 2024-11-07 в 14 36 00" src="https://github.com/user-attachments/assets/7837081b-aecd-4a74-87ac-1d3eb6eff52b">

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
