### PR TITLE
fix(chat): fix filter text box hint (Issue #2371)

### DIFF
--- a/apps/chat/src/components/Chat/Publish/TargetAudienceFilterComponent.tsx
+++ b/apps/chat/src/components/Chat/Publish/TargetAudienceFilterComponent.tsx
@@ -246,7 +246,7 @@ export function TargetAudienceFilterComponent({
         id="targets"
       />
       <RulesSelect
-        menuClassName="max-w-full italic"
+        menuClassName="max-w-full italic md:max-w-[100px]"
         // TODO: uncomment when it will be supported on core
         // menuClassName={classNames(
         //   'max-w-full italic',
@@ -271,6 +271,7 @@ export function TargetAudienceFilterComponent({
           getItemLabel={getItemLabel}
           getItemValue={getItemLabel}
           onChangeSelectedItems={handleChangeFilterParams}
+          fontSize="text-xs"
           placeholder={t('Enter one or more options...') as string}
         />
       )}

--- a/apps/chat/src/components/Common/MultipleComboBox.tsx
+++ b/apps/chat/src/components/Common/MultipleComboBox.tsx
@@ -70,6 +70,7 @@ interface Props<T> {
   onChangeSelectedItems: (value: T[]) => void;
   hasDeleteAll?: boolean;
   itemHeightClassName?: string;
+  fontSize?: string;
   className?: string;
   validationRegExp?: RegExp;
   handleError?: () => void;
@@ -87,6 +88,7 @@ export function MultipleComboBox<T>({
   disabled,
   hasDeleteAll = false,
   itemHeightClassName,
+  fontSize = 'text-sm',
   getItemLabel,
   getItemValue,
   onChangeSelectedItems,
@@ -296,8 +298,9 @@ export function MultipleComboBox<T>({
             disabled={disabled}
             placeholder={selectedItems.length ? '' : placeholder || ''}
             className={classNames(
-              'w-full min-w-[10px] overflow-auto whitespace-break-spaces break-words bg-transparent text-sm outline-none placeholder:text-secondary',
+              'w-full min-w-[10px] overflow-auto whitespace-break-spaces break-words bg-transparent outline-none placeholder:text-secondary',
               selectedItems.length ? 'pl-1' : 'pl-2',
+              fontSize,
             )}
             {...getInputProps({
               ...getDropdownProps({


### PR DESCRIPTION
**Description:**

Hint text is not visible in filter's text box
Font size is 14px for hint for Contains and Equals -> bug (should be 12px)

Issues:

- Issue #2371 

**UI changes**

<img width="532" alt="Снимок экрана 2024-11-13 в 22 00 32" src="https://github.com/user-attachments/assets/3cb3f425-60f1-4f19-9adf-fef32cd82545">

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
