### PR TITLE
fix(chat): fix code app file delete icon displaying (Issue #2574)

### DIFF
--- a/apps/chat/src/components/Common/ApplicationWizard/CodeAppView/SourceFilesEditor.tsx
+++ b/apps/chat/src/components/Common/ApplicationWizard/CodeAppView/SourceFilesEditor.tsx
@@ -83,17 +83,19 @@ const _SourceFilesEditor: FC<SourceFilesEditorProps> = ({
               data-qa="change-button"
               onClick={handleToggleFileManager}
             >
-              {t('Change')}
+              {value ? t('Change') : t('Add')}
             </span>
-            <button
-              onClick={() => {
-                onChange?.('');
-              }}
-              type="button"
-              className="text-secondary hover:text-accent-primary"
-            >
-              <IconTrashX size={18} />
-            </button>
+            {value && (
+              <button
+                onClick={() => {
+                  onChange?.('');
+                }}
+                type="button"
+                className="text-secondary hover:text-accent-primary"
+              >
+                <IconTrashX size={18} />
+              </button>
+            )}
           </div>
         </div>
       </div>


### PR DESCRIPTION
**Description:**

Delete icon displayed in "Select folder with source files" field when not folder selected

Issues:

- Issue #2574 

**UI changes**

<img width="1073" alt="Снимок экрана 2024-11-14 в 14 39 09" src="https://github.com/user-attachments/assets/d53ecc2e-2005-408c-9834-11a3c77c70d0">
<img width="1066" alt="Снимок экрана 2024-11-14 в 14 39 19" src="https://github.com/user-attachments/assets/994da350-7d49-479a-aecd-b29a89de045e">

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
