### PR TITLE
fix(chat): add `invitationId` validation

### DIFF
--- a/apps/chat/src/pages/api/share/accept.ts
+++ b/apps/chat/src/pages/api/share/accept.ts
@@ -2,6 +2,7 @@ import { NextApiRequest, NextApiResponse } from 'next';
 import { getServerSession } from 'next-auth';
 import { getToken } from 'next-auth/jwt';
 
+import { validateInvitationId } from '@/src/utils/app/share';
 import { validateServerSession } from '@/src/utils/auth/session';
 import { getApiHeaders } from '@/src/utils/server/get-headers';
 import { logger } from '@/src/utils/server/logger';
@@ -27,6 +28,8 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
 
   try {
     const { invitationId } = req.body;
+
+    validateInvitationId(invitationId);
 
     const proxyRes = await fetch(
       `${process.env.DIAL_API_HOST}/v1/invitations/${invitationId}?accept=true`,

--- a/apps/chat/src/pages/api/share/details.ts
+++ b/apps/chat/src/pages/api/share/details.ts
@@ -2,6 +2,7 @@ import { NextApiRequest, NextApiResponse } from 'next';
 import { getServerSession } from 'next-auth';
 import { getToken } from 'next-auth/jwt';
 
+import { validateInvitationId } from '@/src/utils/app/share';
 import { validateServerSession } from '@/src/utils/auth/session';
 import { getApiHeaders } from '@/src/utils/server/get-headers';
 import { logger } from '@/src/utils/server/logger';
@@ -28,11 +29,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
   try {
     const { invitationId } = req.body;
 
-    // Validate invitationId to ensure it only contains alphanumeric characters and is of a reasonable length
-    const isValidInvitationId = /^[a-zA-Z0-9]{1,50}$/.test(invitationId);
-    if (!isValidInvitationId) {
-      throw new DialAIError('Invalid invitationId', '', '', '400');
-    }
+    validateInvitationId(invitationId);
 
     const proxyRes = await fetch(
       `${process.env.DIAL_API_HOST}/v1/invitations/${invitationId}`,

--- a/apps/chat/src/pages/api/share/details.ts
+++ b/apps/chat/src/pages/api/share/details.ts
@@ -28,6 +28,12 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
   try {
     const { invitationId } = req.body;
 
+    // Validate invitationId to ensure it only contains alphanumeric characters and is of a reasonable length
+    const isValidInvitationId = /^[a-zA-Z0-9]{1,50}$/.test(invitationId);
+    if (!isValidInvitationId) {
+      throw new DialAIError('Invalid invitationId', '', '', '400');
+    }
+
     const proxyRes = await fetch(
       `${process.env.DIAL_API_HOST}/v1/invitations/${invitationId}`,
       {

--- a/apps/chat/src/utils/app/share.ts
+++ b/apps/chat/src/utils/app/share.ts
@@ -33,7 +33,7 @@ export const getShareType = (
 
 export const validateInvitationId = (invitationId: string) => {
   // Validate invitationId to ensure it only contains alphanumeric characters and is of a reasonable length
-  const isValidInvitationId = /^[A-Za-z0-9-]{1,50}$/.test(invitationId);
+  const isValidInvitationId = /^[A-Za-z0-9-]+$/.test(invitationId);
   if (!isValidInvitationId) {
     throw new DialAIError('Invalid invitationId', '', '', '400');
   }

--- a/apps/chat/src/utils/app/share.ts
+++ b/apps/chat/src/utils/app/share.ts
@@ -1,4 +1,5 @@
 import { FeatureType } from '@/src/types/common';
+import { DialAIError } from '@/src/types/error';
 import { SharingType } from '@/src/types/share';
 
 export const getShareType = (
@@ -27,5 +28,13 @@ export const getShareType = (
       default:
         return undefined;
     }
+  }
+};
+
+export const validateInvitationId = (invitationId: string) => {
+  // Validate invitationId to ensure it only contains alphanumeric characters and is of a reasonable length
+  const isValidInvitationId = /^[A-Za-z0-9-]{1,50}$/.test(invitationId);
+  if (!isValidInvitationId) {
+    throw new DialAIError('Invalid invitationId', '', '', '400');
   }
 };


### PR DESCRIPTION
Fixes [https://github.com/epam/ai-dial-chat/security/code-scanning/22](https://github.com/epam/ai-dial-chat/security/code-scanning/22)

To fix the SSRF vulnerability, we need to validate and sanitize the `invitationId` before using it to construct the URL. One way to do this is to ensure that `invitationId` matches a specific pattern or set of allowed values. This can be done using a whitelist of valid `invitationId` values or by using a regular expression to validate the format of `invitationId`.

In this case, we will use a regular expression to ensure that `invitationId` only contains alphanumeric characters and is of a reasonable length. This will prevent malicious input from being used to manipulate the URL.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
