### PR TITLE
chore(chat): get rid of takeUntil and race conditions when accepting share invitation (Issue #2599)

### DIFF
--- a/apps/chat/src/pages/index.tsx
+++ b/apps/chat/src/pages/index.tsx
@@ -1,11 +1,9 @@
-import { useEffect } from 'react';
-
 import { getCommonPageProps } from '@/src/utils/server/get-common-page-props';
 
 import { ImportExportSelectors } from '../store/import-export/importExport.reducers';
 import { MigrationSelectors } from '../store/migration/migration.reducers';
-import { ShareActions, ShareSelectors } from '../store/share/share.reducers';
-import { useAppDispatch, useAppSelector } from '@/src/store/hooks';
+import { ShareSelectors } from '../store/share/share.reducers';
+import { useAppSelector } from '@/src/store/hooks';
 import {
   SettingsSelectors,
   SettingsState,
@@ -14,8 +12,6 @@ import {
   UISelectors,
   selectShowSelectToMigrateWindow,
 } from '@/src/store/ui/ui.reducers';
-
-import { SHARE_QUERY_PARAM } from '../constants/share';
 
 import ShareModal from '../components/Chat/ShareModal';
 import { ImportExportLoader } from '../components/Chatbar/ImportExportLoader';
@@ -40,8 +36,6 @@ export interface HomeProps {
 
 export default function Home() {
   useCustomizations();
-
-  const dispatch = useAppDispatch();
 
   const isProfileOpen = useAppSelector(UISelectors.selectIsProfileOpen);
   const isShareModalClosed = useAppSelector(
@@ -73,17 +67,6 @@ export default function Home() {
   const isReplaceModalOpened = useAppSelector(
     ImportExportSelectors.selectIsShowReplaceDialog,
   );
-
-  useEffect(() => {
-    const searchParams = new URLSearchParams(window.location.search);
-    if (searchParams.has(SHARE_QUERY_PARAM)) {
-      dispatch(
-        ShareActions.acceptShareInvitation({
-          invitationId: searchParams.get(SHARE_QUERY_PARAM)!,
-        }),
-      );
-    }
-  }, [dispatch]);
 
   if (conversationsToMigrateCount !== 0 || promptsToMigrateCount !== 0) {
     if (

--- a/apps/chat/src/store/conversations/conversations.epics.ts
+++ b/apps/chat/src/store/conversations/conversations.epics.ts
@@ -159,11 +159,6 @@ const initSelectedConversationsEpic: AppEpic = (action$, state$) =>
         return EMPTY;
       }
 
-      const previousRoute = UISelectors.selectPreviousRoute(state$.value);
-      const shouldCreateNewConv =
-        previousRoute &&
-        !previousRoute.includes(`?${MarketplaceQueryParams.fromConversation}=`);
-
       return ConversationService.getSelectedConversationsIds().pipe(
         switchMap((selectedConversationsIds) => {
           const overlayConversationId =
@@ -174,7 +169,7 @@ const initSelectedConversationsEpic: AppEpic = (action$, state$) =>
               ? [overlayConversationId]
               : selectedConversationsIds;
 
-          if (!selectedIds.length || shouldCreateNewConv) {
+          if (!selectedIds.length) {
             return forkJoin({
               selectedConversations: of([]),
               selectedIds: of([]),
@@ -201,10 +196,17 @@ const initSelectedConversationsEpic: AppEpic = (action$, state$) =>
                 const validConversations = conversations.filter(
                   Boolean,
                 ) as Conversation[];
+                const previousRoute = UISelectors.selectPreviousRoute(
+                  state$.value,
+                );
+                const shouldCreateNewConv = !previousRoute?.includes(
+                  `?${MarketplaceQueryParams.fromConversation}=`,
+                );
 
                 return validConversations
                   .filter(
                     ({ messages }) =>
+                      !shouldCreateNewConv ||
                       !messages.filter((m) => m.role !== Role.System).length,
                   )
                   .map(regenerateConversationId);

--- a/apps/chat/src/store/conversations/conversations.epics.ts
+++ b/apps/chat/src/store/conversations/conversations.epics.ts
@@ -277,6 +277,14 @@ const initSelectedConversationsEpic: AppEpic = (action$, state$) =>
                   }),
                 }),
               ),
+              of(
+                UIActions.setOpenedFoldersIds({
+                  openedFolderIds: selectedConversationsIds.flatMap(
+                    getParentFolderIdsFromEntityId,
+                  ),
+                  featureType: FeatureType.Chat,
+                }),
+              ),
               ...actions,
             );
           }

--- a/apps/chat/src/store/conversations/conversations.epics.ts
+++ b/apps/chat/src/store/conversations/conversations.epics.ts
@@ -21,7 +21,6 @@ import {
   startWith,
   switchMap,
   take,
-  takeUntil,
   takeWhile,
   tap,
   throwError,
@@ -102,6 +101,7 @@ import {
 import { errorsMessages } from '@/src/constants/errors';
 import { MarketplaceQueryParams } from '@/src/constants/marketplace';
 import { defaultReplay } from '@/src/constants/replay';
+import { SHARE_QUERY_PARAM } from '@/src/constants/share';
 
 import { AddonsActions, AddonsSelectors } from '../addons/addons.reducers';
 import { FilesActions } from '../files/files.reducers';
@@ -128,62 +128,59 @@ import uniq from 'lodash-es/uniq';
 const initEpic: AppEpic = (action$) =>
   action$.pipe(
     filter((action) => ConversationsActions.init.match(action)),
-    switchMap(() =>
-      concat(
-        of(ConversationsActions.initSelectedConversations()),
+    switchMap(() => {
+      const searchParams = new URLSearchParams(window.location.search);
+
+      return concat(
+        iif(
+          () => searchParams.has(SHARE_QUERY_PARAM),
+          of(
+            ShareActions.acceptShareInvitation({
+              invitationId: searchParams.get(SHARE_QUERY_PARAM)!,
+            }),
+          ),
+          of(ConversationsActions.initSelectedConversations()),
+        ),
         of(ConversationsActions.initFoldersAndConversations()),
-      ),
-    ),
+      );
+    }),
   );
 
 const initSelectedConversationsEpic: AppEpic = (action$, state$) =>
   action$.pipe(
     filter(ConversationsActions.initSelectedConversations.match),
-    takeUntil(action$.pipe(filter(ShareActions.acceptShareInvitation.match))),
-    // use getSelectedConversations to load selected conversations, we can unsubscribe from this action if we try to accept a share link
     switchMap(() => {
       const isOverlay = SettingsSelectors.selectIsOverlay(state$.value);
       const optionsReceived = OverlaySelectors.selectOptionsReceived(
         state$.value,
       );
+
+      if (isOverlay && !optionsReceived) {
+        return EMPTY;
+      }
+
       const previousRoute = UISelectors.selectPreviousRoute(state$.value);
-
-      return iif(
-        () => !isOverlay || !!optionsReceived,
-        of(
-          ConversationsActions.getSelectedConversations({
-            createNew: !previousRoute?.includes(
-              `?${MarketplaceQueryParams.fromConversation}=`,
-            ),
-          }),
-        ),
-        EMPTY,
+      const shouldCreateNewConv = !previousRoute?.includes(
+        `?${MarketplaceQueryParams.fromConversation}=`,
       );
-    }),
-  );
 
-const getSelectedConversationsEpic: AppEpic = (action$, state$) =>
-  action$.pipe(
-    filter(ConversationsActions.getSelectedConversations.match),
-    switchMap(({ payload }) =>
-      ConversationService.getSelectedConversationsIds().pipe(
+      return ConversationService.getSelectedConversationsIds().pipe(
         switchMap((selectedConversationsIds) => {
           const overlayConversationId =
             SettingsSelectors.selectOverlayConversationId(state$.value);
-
-          const isOverlay = SettingsSelectors.selectIsOverlay(state$.value);
 
           const selectedIds =
             isOverlay && overlayConversationId
               ? [overlayConversationId]
               : selectedConversationsIds;
 
-          if (!selectedIds.length) {
+          if (!selectedIds.length || shouldCreateNewConv) {
             return forkJoin({
               selectedConversations: of([]),
               selectedIds: of([]),
             });
           }
+
           return forkJoin({
             selectedConversations: zip(
               selectedIds.map((id) =>
@@ -199,37 +196,39 @@ const getSelectedConversationsEpic: AppEpic = (action$, state$) =>
                   }),
                 ),
               ),
+            ).pipe(
+              map((conversations) => {
+                const validConversations = conversations.filter(
+                  Boolean,
+                ) as Conversation[];
+
+                return validConversations
+                  .filter(
+                    ({ messages }) =>
+                      !messages.filter((m) => m.role !== Role.System).length,
+                  )
+                  .map(regenerateConversationId);
+              }),
             ),
             selectedIds: of(selectedIds),
           });
         }),
         map(({ selectedConversations, selectedIds }) => {
-          const conversations = selectedConversations
-            .filter(
-              (conv) =>
-                !!conv &&
-                (!payload?.createNew ||
-                  !conv.messages.filter((m) => m.role !== Role.System).length),
-            )
-            .map((conv) => regenerateConversationId(conv!));
-          if (!selectedIds.length || !conversations.length) {
+          if (!selectedIds.length || !selectedConversations.length) {
             return {
               conversations: [],
               selectedConversationsIds: [],
             };
           }
 
-          const existingSelectedConversationsIds = selectedIds.filter((id) =>
-            conversations.some((conv) => conv.id === id),
-          );
-
           return {
-            conversations,
-            selectedConversationsIds: existingSelectedConversationsIds,
+            conversations: selectedConversations,
+            selectedConversationsIds: selectedIds.filter((id) =>
+              selectedConversations.some((conv) => conv.id === id),
+            ),
           };
         }),
         switchMap(({ conversations, selectedConversationsIds }) => {
-          const actions: Observable<AnyAction>[] = [];
           const isIsolatedView = SettingsSelectors.selectIsIsolatedView(
             state$.value,
           );
@@ -240,25 +239,20 @@ const getSelectedConversationsEpic: AppEpic = (action$, state$) =>
               state$.value,
             );
 
-            actions.push(
-              of(
-                ConversationsActions.createNewConversations({
-                  names: [`isolated_${isolatedModelId}`],
-                  shouldUploadConversationsForCompare: true,
-                }),
-              ),
+            return of(
+              ConversationsActions.createNewConversations({
+                names: [`isolated_${isolatedModelId}`],
+                shouldUploadConversationsForCompare: true,
+              }),
             );
-            return concat(...actions);
           }
 
           if (conversations.length) {
-            actions.push(
+            return concat(
               of(
                 ConversationsActions.addConversations({
                   conversations: conversations.map((conv) => {
-                    const isPublicConv = isEntityIdPublic(conv);
-
-                    if (!isPublicConv) {
+                    if (!isEntityIdPublic(conv)) {
                       return conv;
                     }
 
@@ -275,41 +269,33 @@ const getSelectedConversationsEpic: AppEpic = (action$, state$) =>
                   }),
                 }),
               ),
-            );
-            const paths = selectedConversationsIds.flatMap((id) =>
-              getParentFolderIdsFromEntityId(id),
-            );
-            actions.push(
               of(
                 UIActions.setOpenedFoldersIds({
-                  openedFolderIds: paths,
+                  openedFolderIds: selectedConversationsIds.flatMap(
+                    getParentFolderIdsFromEntityId,
+                  ),
                   featureType: FeatureType.Chat,
                 }),
               ),
             );
           }
-          actions.push(
+
+          return concat(
             of(
               ConversationsActions.selectConversations({
                 conversationIds: selectedConversationsIds,
               }),
             ),
+            of(
+              ConversationsActions.createNewConversations({
+                names: [translate(DEFAULT_CONVERSATION_NAME)],
+                shouldUploadConversationsForCompare: true,
+              }),
+            ),
           );
-          if (!conversations.length) {
-            actions.push(
-              of(
-                ConversationsActions.createNewConversations({
-                  names: [translate(DEFAULT_CONVERSATION_NAME)],
-                  shouldUploadConversationsForCompare: true,
-                }),
-              ),
-            );
-          }
-
-          return concat(...actions);
         }),
-      ),
-    ),
+      );
+    }),
   );
 
 const initFoldersAndConversationsEpic: AppEpic = (action$) =>
@@ -3064,7 +3050,6 @@ export const ConversationsEpics = combineEpics(
   // select
   selectConversationsEpic,
   uploadSelectedConversationsEpic,
-  getSelectedConversationsEpic,
 
   saveNewConversationEpic,
   createNewConversationsSuccessEpic,

--- a/apps/chat/src/store/conversations/conversations.epics.ts
+++ b/apps/chat/src/store/conversations/conversations.epics.ts
@@ -160,9 +160,9 @@ const initSelectedConversationsEpic: AppEpic = (action$, state$) =>
       }
 
       const previousRoute = UISelectors.selectPreviousRoute(state$.value);
-      const shouldCreateNewConv = !previousRoute?.includes(
-        `?${MarketplaceQueryParams.fromConversation}=`,
-      );
+      const shouldCreateNewConv =
+        previousRoute &&
+        !previousRoute.includes(`?${MarketplaceQueryParams.fromConversation}=`);
 
       return ConversationService.getSelectedConversationsIds().pipe(
         switchMap((selectedConversationsIds) => {
@@ -247,6 +247,14 @@ const initSelectedConversationsEpic: AppEpic = (action$, state$) =>
             );
           }
 
+          const actions: Observable<AnyAction>[] = [
+            of(
+              ConversationsActions.selectConversations({
+                conversationIds: selectedConversationsIds,
+              }),
+            ),
+          ];
+
           if (conversations.length) {
             return concat(
               of(
@@ -269,23 +277,12 @@ const initSelectedConversationsEpic: AppEpic = (action$, state$) =>
                   }),
                 }),
               ),
-              of(
-                UIActions.setOpenedFoldersIds({
-                  openedFolderIds: selectedConversationsIds.flatMap(
-                    getParentFolderIdsFromEntityId,
-                  ),
-                  featureType: FeatureType.Chat,
-                }),
-              ),
+              ...actions,
             );
           }
 
           return concat(
-            of(
-              ConversationsActions.selectConversations({
-                conversationIds: selectedConversationsIds,
-              }),
-            ),
+            ...actions,
             of(
               ConversationsActions.createNewConversations({
                 names: [translate(DEFAULT_CONVERSATION_NAME)],

--- a/apps/chat/src/store/conversations/conversations.reducers.ts
+++ b/apps/chat/src/store/conversations/conversations.reducers.ts
@@ -71,10 +71,6 @@ export const conversationsSlice = createSlice({
     initFoldersAndConversationsSuccess: (state) => {
       state.conversationsLoaded = true;
     },
-    getSelectedConversations: (
-      state,
-      _action: PayloadAction<{ createNew: boolean } | undefined>,
-    ) => state,
     saveConversation: (state, _action: PayloadAction<Conversation>) => state,
     saveConversationSuccess: (state) => {
       if (state.isMessageSending) {

--- a/apps/chat/src/store/share/share.epics.ts
+++ b/apps/chat/src/store/share/share.epics.ts
@@ -343,7 +343,7 @@ const acceptInvitationFailEpic: AppEpic = (action$) =>
 
       return concat(
         of(ShareActions.resetAcceptedEntityInfo()),
-        of(ConversationsActions.getSelectedConversations()),
+        of(ConversationsActions.initSelectedConversations()),
         of(
           UIActions.showErrorToast(
             translate(payload.message || errorsMessages.acceptShareFailed),
@@ -670,7 +670,7 @@ const getSharedListingSuccessEpic: AppEpic = (action$, state$) =>
 
             if (!selectedConv) {
               // shared with me could be already selected, so we haven't to upload it twice
-              actions.push(ConversationsActions.getSelectedConversations());
+              actions.push(ConversationsActions.initSelectedConversations());
             }
 
             actions.push(ShareActions.resetAcceptedEntityInfo());


### PR DESCRIPTION
**Description:**

get rid of takeUntil and race conditions when accepting share invitation

Issues:

- Issue #2599

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
