### PR TITLE
feat(chat-e2e): trace capture behavior change

### DIFF
--- a/apps/chat-e2e/config/chat.playwright.config.ts
+++ b/apps/chat-e2e/config/chat.playwright.config.ts
@@ -33,9 +33,9 @@ export default defineConfig({
     actionTimeout: 20000,
     /* Base URL to use in actions like `await page.goto('/')`. */
     baseURL: process.env.E2E_HOST ?? 'http://localhost:3000',
-    video: 'retry-with-video',
+    video: 'retain-on-failure',
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
-    trace: 'retry-with-trace',
+    trace: 'retain-on-failure',
     screenshot: 'only-on-failure',
     permissions: ['clipboard-read', 'clipboard-write'],
   },

--- a/apps/chat-e2e/config/chat.playwright.config.ts
+++ b/apps/chat-e2e/config/chat.playwright.config.ts
@@ -33,7 +33,7 @@ export default defineConfig({
     actionTimeout: 20000,
     /* Base URL to use in actions like `await page.goto('/')`. */
     baseURL: process.env.E2E_HOST ?? 'http://localhost:3000',
-    video: 'retain-on-failure',
+    video: 'retry-with-video',
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'retain-on-failure',
     screenshot: 'only-on-failure',


### PR DESCRIPTION
**Description:**

trace capture behavior change
From now on, we can observe trace for all failed runs and retries, even for flaky tests.

![image](https://github.com/user-attachments/assets/df1bf58c-855c-4f82-9352-0097a6458fdb)
![image](https://github.com/user-attachments/assets/2a1523df-f0a7-44aa-a57a-5f4cc75142bb)

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
