### PR TITLE
fix(chat): wrap with layout per page (Issue #2666)

### DIFF
--- a/apps/chat/src/pages/_app.tsx
+++ b/apps/chat/src/pages/_app.tsx
@@ -1,9 +1,13 @@
 import { SessionProvider, SessionProviderProps } from 'next-auth/react';
+import { ReactElement, ReactNode } from 'react';
 import { Provider } from 'react-redux';
 
+import { NextPage } from 'next';
 import { appWithTranslation } from 'next-i18next';
 import type { AppProps } from 'next/app';
 import { Inconsolata, Inter } from 'next/font/google';
+
+import { SettingsState } from '@/src/store/settings/settings.reducers';
 
 import Layout from '../components/Layout';
 import { Toasts } from '../components/Toasts/Toasts';
@@ -12,6 +16,14 @@ import { HomeProps } from '.';
 
 import { createStore } from '@/src/store';
 import '@/src/styles/globals.css';
+
+export type NextPageWithLayout<P = object, IP = P> = NextPage<P, IP> & {
+  getLayout?: (page: ReactElement, settings: SettingsState) => ReactNode;
+};
+
+export function getLayout(page: ReactElement, settings: SettingsState) {
+  return <Layout settings={settings}>{page}</Layout>;
+}
 
 export const inter = Inter({
   subsets: ['latin'],
@@ -24,22 +36,26 @@ export const inconsolata = Inconsolata({
   variable: '--font-inconsolata',
 });
 
-function App({
-  Component,
-  ...rest
-}: AppProps<SessionProviderProps & HomeProps>) {
+type AppPropsWithLayout = AppProps<SessionProviderProps & HomeProps> & {
+  Component: NextPageWithLayout;
+};
+
+function App({ Component, ...rest }: AppPropsWithLayout) {
   const store = createStore({
     settings: rest.pageProps.initialState?.settings,
   });
+
+  const getPage = Component.getLayout ?? ((page) => page);
 
   return (
     <SessionProvider session={rest.pageProps.session} basePath={'api/auth'}>
       <Provider store={store}>
         <div className={`${inter.variable} font`}>
           <Toasts />
-          <Layout settings={rest.pageProps.initialState?.settings}>
-            <Component {...rest.pageProps} />
-          </Layout>
+          {getPage(
+            <Component {...rest.pageProps} />,
+            rest.pageProps.initialState?.settings,
+          )}
         </div>
       </Provider>
     </SessionProvider>

--- a/apps/chat/src/pages/index.tsx
+++ b/apps/chat/src/pages/index.tsx
@@ -13,6 +13,8 @@ import {
   selectShowSelectToMigrateWindow,
 } from '@/src/store/ui/ui.reducers';
 
+import { getLayout } from '@/src/pages/_app';
+
 import ShareModal from '../components/Chat/ShareModal';
 import { ImportExportLoader } from '../components/Chatbar/ImportExportLoader';
 import { AnnouncementsBanner } from '../components/Common/AnnouncementBanner';
@@ -34,7 +36,7 @@ export interface HomeProps {
   };
 }
 
-export default function Home() {
+function Home() {
   useCustomizations();
 
   const isProfileOpen = useAppSelector(UISelectors.selectIsProfileOpen);
@@ -119,5 +121,9 @@ export default function Home() {
     </>
   );
 }
+
+Home.getLayout = getLayout;
+
+export default Home;
 
 export const getServerSideProps = getCommonPageProps;

--- a/apps/chat/src/pages/marketplace/index.tsx
+++ b/apps/chat/src/pages/marketplace/index.tsx
@@ -9,6 +9,8 @@ import { MarketplaceActions } from '@/src/store/marketplace/marketplace.reducers
 import { SettingsSelectors } from '@/src/store/settings/settings.reducers';
 import { UISelectors } from '@/src/store/ui/ui.reducers';
 
+import { getLayout } from '@/src/pages/_app';
+
 import Loader from '@/src/components/Common/Loader';
 import { UserMobile } from '@/src/components/Header/User/UserMobile';
 import { Marketplace as MarketplaceView } from '@/src/components/Marketplace/Marketplace';
@@ -17,7 +19,7 @@ import { MarketplaceHeader } from '@/src/components/Marketplace/MarketplaceHeade
 
 import { Feature } from '@epam/ai-dial-shared';
 
-export default function Marketplace() {
+function Marketplace() {
   const dispatch = useAppDispatch();
 
   const isProfileOpen = useAppSelector(UISelectors.selectIsProfileOpen);
@@ -52,5 +54,9 @@ export default function Marketplace() {
     </div>
   );
 }
+
+Marketplace.getLayout = getLayout;
+
+export default Marketplace;
 
 export const getServerSideProps = getCommonPageProps;


### PR DESCRIPTION
**Description:**

- wrap with layout only home page and marketplace
- solution looked up in [next docs](https://nextjs.org/docs/pages/building-your-application/routing/pages-and-layouts#with-typescript)

Issues:

- Issue #2666 

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
