### PR TITLE
fix(chat): fix chat history blinking on conversations change (Issue #2401)

### DIFF
--- a/apps/chat/src/components/Chat/Chat.tsx
+++ b/apps/chat/src/components/Chat/Chat.tsx
@@ -1,5 +1,13 @@
 import { FloatingOverlay } from '@floating-ui/react';
-import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  memo,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 
 import { useTranslation } from 'next-i18next';
 
@@ -293,7 +301,7 @@ export const ChatView = memo(() => {
     };
   }, [handleScroll, mergedMessages.length, messageIsStreaming]);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (selectedConversations.length > 0) {
       const mergedMessages: MergedMessages[] = [];
       const firstConversationMessages = excludeSystemMessages(


### PR DESCRIPTION
**Description:**

- wrap chat history change logic with useLayoutEffect

Issues:

- Issue #2401 

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
