### PR TITLE
fix(chat): fix new conversation loading spinner size for mobile (Issue #2701)

### DIFF
--- a/apps/chat/src/components/Header/CreateNewConversation.tsx
+++ b/apps/chat/src/components/Header/CreateNewConversation.tsx
@@ -54,8 +54,8 @@ export const CreateNewConversation = ({ iconSize }: Props) => {
       >
         {!areConversationsLoaded || isActiveNewConversationRequest ? (
           <Spinner
-            size={iconSize + 22}
-            className="cursor-pointer text-secondary md:px-2"
+            size={iconSize + 6}
+            className="cursor-pointer text-secondary md:mx-2"
           />
         ) : (
           <div


### PR DESCRIPTION
**Description:**

"New conversation" (Chat) loading spinner have incorrect size for mobile

Issues:

- Issue #2701 

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
