### PR TITLE
fix(chat): fix custom applications versions sorting (Issue #2670)

### DIFF
--- a/apps/chat/src/components/Chat/ModelVersionSelect.tsx
+++ b/apps/chat/src/components/Chat/ModelVersionSelect.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useState } from 'react';
 
 import { useTranslation } from 'next-i18next';
 
@@ -12,7 +12,6 @@ import { Menu, MenuItem } from '@/src/components/Common/DropdownMenu';
 import { ModelIcon } from '../Chatbar/ModelIcon';
 
 import ChevronDownIcon from '@/public/images/icons/chevron-down.svg';
-import orderBy from 'lodash-es/orderBy';
 
 const VersionPrefix = () => {
   const { t } = useTranslation(Translation.Chat);
@@ -46,11 +45,6 @@ export const ModelVersionSelect = ({
     onSelect(entity);
     setIsOpen(false);
   };
-
-  const sortedEntities = useMemo(
-    () => orderBy(entities, 'version', 'desc'),
-    [entities],
-  );
 
   if (entities.length < 2) {
     if (entities.length && entities[0].version) {
@@ -97,7 +91,7 @@ export const ModelVersionSelect = ({
         </div>
       }
     >
-      {sortedEntities.map((entity) => (
+      {entities.map((entity) => (
         <MenuItem
           key={entity.id}
           className={classNames(

--- a/apps/chat/src/store/models/models.reducers.ts
+++ b/apps/chat/src/store/models/models.reducers.ts
@@ -22,7 +22,9 @@ import { RootState } from '../index';
 import { UploadStatus } from '@epam/ai-dial-shared';
 import { sortBy } from 'lodash-es';
 import cloneDeep from 'lodash-es/cloneDeep';
+import groupBy from 'lodash-es/groupBy';
 import omit from 'lodash-es/omit';
+import orderBy from 'lodash-es/orderBy';
 import uniq from 'lodash-es/uniq';
 
 export interface ModelsState {
@@ -304,7 +306,17 @@ const selectIsRecentModelsLoaded = createSelector([rootSelector], (state) => {
 });
 
 const selectModels = createSelector([rootSelector], (state) => {
-  return sortBy(state.models, (model) => model.name.toLowerCase());
+  const groups = groupBy(state.models, (model) =>
+    model.reference === model.id ? 'rest' : 'custom',
+  );
+
+  return sortBy(
+    [
+      ...(groups.rest ?? []),
+      ...orderBy(groups.custom ?? [], 'version', 'desc'),
+    ],
+    (model) => model.name.toLowerCase(),
+  );
 });
 
 const selectModelTopics = createSelector([rootSelector], (state) => {


### PR DESCRIPTION
**Description:**

- separately sort custom applications by versions in descending order

Issues:

- Issue #2670 

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
