### PR TITLE
fix(chat): set defaultAuthProvider to null instead of undefined

### DIFF
--- a/apps/chat/src/pages/api/auth/[...nextauth].ts
+++ b/apps/chat/src/pages/api/auth/[...nextauth].ts
@@ -29,7 +29,7 @@ function defaultCookies(
       options: {
         httpOnly: true,
         sameSite,
-        path: '/',
+        path: '',
         secure: useSecureCookies,
       },
     },

--- a/apps/chat/src/pages/api/auth/[...nextauth].ts
+++ b/apps/chat/src/pages/api/auth/[...nextauth].ts
@@ -29,7 +29,7 @@ function defaultCookies(
       options: {
         httpOnly: true,
         sameSite,
-        path: '',
+        path: '/',
         secure: useSecureCookies,
       },
     },

--- a/apps/chat/src/utils/server/get-common-page-props.ts
+++ b/apps/chat/src/utils/server/get-common-page-props.ts
@@ -146,7 +146,7 @@ export const getCommonPageProps: GetServerSideProps = async ({
         locale ?? 'en',
         Object.values(Translation),
       )),
-      defaultAuthProvider: DEFAULT_PROVIDER ?? null,
+      defaultAuthProvider: DEFAULT_PROVIDER,
     },
   };
 };

--- a/apps/chat/src/utils/server/get-common-page-props.ts
+++ b/apps/chat/src/utils/server/get-common-page-props.ts
@@ -146,7 +146,7 @@ export const getCommonPageProps: GetServerSideProps = async ({
         locale ?? 'en',
         Object.values(Translation),
       )),
-      defaultAuthProvider: DEFAULT_PROVIDER ?? undefined,
+      defaultAuthProvider: DEFAULT_PROVIDER ?? null,
     },
   };
 };


### PR DESCRIPTION
**Description:**

This PR ensures that defaultAuthProvider is set to null instead of undefined, as undefined cannot be serialized in JSON.

Issues:

- Issue #<TICKET_ID>

**UI changes**

<Please, provide Screenshots or Figma links>

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
