### PR TITLE
fix(chat): fix logo click during response generation (Issue #2748)

### DIFF
--- a/apps/chat/src/components/Header/Logo.tsx
+++ b/apps/chat/src/components/Header/Logo.tsx
@@ -1,5 +1,7 @@
 import { useRouter } from 'next/router';
 
+import classNames from 'classnames';
+
 import { ApiUtils } from '@/src/utils/server/api';
 
 import {
@@ -30,6 +32,10 @@ export const Logo = () => {
     SettingsSelectors.isFeatureEnabled(state, Feature.CustomLogo),
   );
 
+  const messageIsStreaming = useAppSelector(
+    ConversationsSelectors.selectIsConversationsStreaming,
+  );
+
   const customLogoUrl =
     isCustomLogoFeatureEnabled &&
     customLogo &&
@@ -53,14 +59,18 @@ export const Logo = () => {
   };
 
   return (
-    <span
+    <button
       onClick={handleLogoClick}
-      className="mx-auto min-w-[110px] cursor-pointer bg-contain bg-center bg-no-repeat md:ml-5 lg:bg-left"
+      disabled={messageIsStreaming}
+      className={classNames(
+        'mx-auto min-w-[110px] bg-contain bg-center bg-no-repeat md:ml-5 lg:bg-left',
+        messageIsStreaming ? 'cursor-not-allowed' : 'cursor-pointer',
+      )}
       style={{
         backgroundImage: customLogoUrl
           ? `url(${cssEscape(customLogoUrl)})`
           : `var(--app-logo)`,
       }}
-    ></span>
+    ></button>
   );
 };

--- a/apps/chat/src/components/Header/Logo.tsx
+++ b/apps/chat/src/components/Header/Logo.tsx
@@ -1,7 +1,5 @@
 import { useRouter } from 'next/router';
 
-import classNames from 'classnames';
-
 import { ApiUtils } from '@/src/utils/server/api';
 
 import {
@@ -62,10 +60,7 @@ export const Logo = () => {
     <button
       onClick={handleLogoClick}
       disabled={messageIsStreaming}
-      className={classNames(
-        'mx-auto min-w-[110px] bg-contain bg-center bg-no-repeat md:ml-5 lg:bg-left',
-        messageIsStreaming ? 'cursor-not-allowed' : 'cursor-pointer',
-      )}
+      className="mx-auto min-w-[110px] bg-contain bg-center bg-no-repeat disabled:cursor-not-allowed md:ml-5 lg:bg-left"
       style={{
         backgroundImage: customLogoUrl
           ? `url(${cssEscape(customLogoUrl)})`


### PR DESCRIPTION
**Description:**

Logo should not be clickable while model response is being regenerated. Please implement the same behaviour as for the + button

Issues:

- Issue #2748 

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
