### PR TITLE
fix(chat): hide chat settings in isolated view (Issue #2721)

### DIFF
--- a/apps/chat/src/components/Chat/EmptyChatDescription.tsx
+++ b/apps/chat/src/components/Chat/EmptyChatDescription.tsx
@@ -14,6 +14,7 @@ import { Translation } from '@/src/types/translation';
 import { ConversationsActions } from '@/src/store/conversations/conversations.reducers';
 import { useAppDispatch, useAppSelector } from '@/src/store/hooks';
 import { ModelsSelectors } from '@/src/store/models/models.reducers';
+import { SettingsSelectors } from '@/src/store/settings/settings.reducers';
 
 import { ModelIcon } from '../Chatbar/ModelIcon';
 import { EntityMarkdownDescription } from '../Common/MarkdownDescription';
@@ -43,6 +44,8 @@ export const EmptyChatDescription = ({
     ModelsSelectors.selectInstalledModelIds,
   );
   const models = useAppSelector(ModelsSelectors.selectModels);
+  const isIsolatedView = useAppSelector(SettingsSelectors.selectIsIsolatedView);
+
   const versions = useMemo(
     () =>
       models.filter(
@@ -148,8 +151,9 @@ export const EmptyChatDescription = ({
               </div>
               {/* )} */}
             </div>
-            <div className="flex gap-3 divide-x divide-primary leading-4">
-              {/* <button
+            {!isIsolatedView && (
+              <div className="flex gap-3 divide-x divide-primary leading-4">
+                {/* <button
                 className={classNames(
                   'text-left text-accent-primary disabled:cursor-not-allowed',
                 )}
@@ -158,16 +162,17 @@ export const EmptyChatDescription = ({
               >
                 {t('Change agent')}
               </button> */}
-              <button
-                className={classNames(
-                  'text-left text-accent-primary disabled:cursor-not-allowed', // TODO: add `pl-3`
-                )}
-                data-qa="configure-settings"
-                onClick={handleOpenSettings}
-              >
-                {t('Configure settings')}
-              </button>
-            </div>
+                <button
+                  className={classNames(
+                    'text-left text-accent-primary disabled:cursor-not-allowed', // TODO: add `pl-3`
+                  )}
+                  data-qa="configure-settings"
+                  onClick={handleOpenSettings}
+                >
+                  {t('Configure settings')}
+                </button>
+              </div>
+            )}
           </div>
         )}
       </div>


### PR DESCRIPTION
**Description:**

- hide empty chat settings button in isolated view

Issues:

- Issue #2721 

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
