### PR TITLE
feat(chat): regenerate on empty assistant message

### DIFF
--- a/apps/chat/src/components/Chat/ChatInput/ChatInputMessage.tsx
+++ b/apps/chat/src/components/Chat/ChatInput/ChatInputMessage.tsx
@@ -116,7 +116,8 @@ export const ChatInputMessage = ({
   const isModelsLoaded = useAppSelector(ModelsSelectors.selectIsModelsLoaded);
   const isChatFullWidth = useAppSelector(UISelectors.selectIsChatFullWidth);
 
-  const isError = isLastAssistantMessageEmpty || isMessageError;
+  const shouldRegenerate =
+    isLastMessageError || (isLastAssistantMessageEmpty && !messageIsStreaming);
 
   const selectedModels = useAppSelector(
     ConversationsSelectors.selectSelectedConversationsModels,
@@ -166,7 +167,7 @@ export const ChatInputMessage = ({
   ]);
   const isSendDisabled =
     isReplay ||
-    isError ||
+    isMessageError ||
     isInputEmpty ||
     !isModelsLoaded ||
     isUploadingFilePresent ||
@@ -205,6 +206,11 @@ export const ChatInputMessage = ({
       return;
     }
 
+    if (shouldRegenerate) {
+      onRegenerate();
+      return;
+    }
+
     if (isSendDisabled) {
       return;
     }
@@ -234,6 +240,7 @@ export const ChatInputMessage = ({
     }
   }, [
     messageIsStreaming,
+    shouldRegenerate,
     isSendDisabled,
     dispatch,
     onSend,
@@ -244,6 +251,7 @@ export const ChatInputMessage = ({
     setContent,
     textareaRef,
     onStopConversation,
+    onRegenerate,
   ]);
 
   const handleKeyDown = useCallback(
@@ -380,7 +388,7 @@ export const ChatInputMessage = ({
     if (isReplay) {
       return t('Please continue replay to continue working with conversation');
     }
-    if (isError) {
+    if (shouldRegenerate) {
       return t('Regenerate response');
     }
     if (isUploadingFilePresent) {
@@ -437,7 +445,7 @@ export const ChatInputMessage = ({
         />
         <ChatControls
           showReplayControls={showReplayControls}
-          onSend={isLastMessageError ? onRegenerate : handleSend}
+          onSend={shouldRegenerate ? onRegenerate : handleSend}
           tooltip={tooltipContent()}
           isLastMessageError={isLastMessageError}
           isLoading={isLoading}

--- a/apps/chat/src/components/Chat/ChatInput/SendMessageButton.tsx
+++ b/apps/chat/src/components/Chat/ChatInput/SendMessageButton.tsx
@@ -37,11 +37,19 @@ export const SendMessageButton = ({
     ConversationsSelectors.selectIsConversationsStreaming,
   );
 
-  if (isLastMessageError) {
+  const isLastAssistantMessageEmpty = useAppSelector(
+    ConversationsSelectors.selectIsLastAssistantMessageEmpty,
+  );
+
+  if (
+    isLastMessageError ||
+    (isLastAssistantMessageEmpty && !messageIsStreaming)
+  ) {
     return (
       <button
         className={classNames(
-          'absolute top-[calc(50%_-_12px)] rounded text-error hover:text-accent-primary',
+          'absolute top-[calc(50%_-_12px)] rounded hover:text-accent-primary',
+          isLastMessageError && 'text-error',
           isOverlay ? 'right-3' : 'right-4',
         )}
         onClick={onSend}


### PR DESCRIPTION
**Description:**
This fixes a small UX issue when user clicks "Stop" or presses "Enter" while assistant is still streaming and assistant message is empty so far.
Chat gets stopped, last message should be regenerated or deleted to unblock the chat.

This changes the flow:
- Chat is not blocked
- Send button changed to Regenerate button
- Press 'Enter' calls 'regenerate'

**UI changes**

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
