### PR TITLE
feat(chat): hide message templates for Isolated view and change order of header buttons (Issue #2814, #2815)

### DIFF
--- a/apps/chat/src/components/Chat/ChatHeader/Header.tsx
+++ b/apps/chat/src/components/Chat/ChatHeader/Header.tsx
@@ -186,28 +186,50 @@ export const ChatHeader = ({
         data-qa="chat-header"
       >
         {isShowChatInfo && (
-          <Tooltip
-            tooltip={conversation.name}
-            triggerClassName={classNames(
-              'truncate text-center',
-              isChatFullWidth &&
-                'flex h-full max-w-full items-center justify-center lg:max-w-[90%]',
-              conversation.publicationInfo?.action === PublishActions.DELETE &&
-                'text-error',
-            )}
-          >
-            <span
-              className={classNames(
-                'truncate whitespace-pre text-center',
-                !isChatFullWidth &&
-                  'block max-w-full md:max-w-[330px] lg:max-w-[425px]',
-                isConversationInvalid && 'text-secondary',
+          <>
+            <Tooltip
+              tooltip={conversation.name}
+              triggerClassName={classNames(
+                'truncate text-center',
+                isChatFullWidth &&
+                  'flex h-full max-w-full items-center justify-center lg:max-w-[90%]',
+                conversation.publicationInfo?.action ===
+                  PublishActions.DELETE && 'text-error',
               )}
-              data-qa="chat-title"
             >
-              {conversation.name}
-            </span>
-          </Tooltip>
+              <span
+                className={classNames(
+                  'truncate whitespace-pre text-center',
+                  !isChatFullWidth &&
+                    'block max-w-full md:max-w-[330px] lg:max-w-[425px]',
+                  isConversationInvalid && 'text-secondary',
+                )}
+                data-qa="chat-title"
+              >
+                {conversation.name}
+              </span>
+            </Tooltip>
+            {publicVersionGroupId && (
+              <span className="h-[18px] border-l border-l-primary pl-2">
+                {!isReviewEntity ? (
+                  <PublicVersionSelector
+                    publicVersionGroupId={publicVersionGroupId}
+                    onChangeSelectedVersion={handleChangeSelectedVersion}
+                  />
+                ) : (
+                  <p
+                    className={classNames(
+                      conversation.publicationInfo?.action ===
+                        PublishActions.DELETE && 'text-error',
+                    )}
+                    data-qa="version"
+                  >
+                    {t('v.')} {conversation.publicationInfo?.version}
+                  </p>
+                )}
+              </span>
+            )}
+          </>
         )}
         <div className="flex lg:[&>*:first-child]:border-l lg:[&>*:not(:first-child)]:pl-2 [&>*:not(:last-child)]:border-r [&>*:not(:last-child)]:pr-2 [&>*]:border-x-primary [&>*]:pl-2">
           {isShowChatInfo && (
@@ -365,34 +387,6 @@ export const ChatHeader = ({
                   </button>
                 </Tooltip>
               )}
-            {isPlayback && !isExternal && (
-              <button
-                className="cursor-pointer text-accent-primary"
-                onClick={onCancelPlaybackMode}
-                data-qa="cancel-playback-mode"
-              >
-                {screenState === ScreenState.MOBILE
-                  ? t('Stop')
-                  : t('Stop playback')}
-              </button>
-            )}
-            {publicVersionGroupId &&
-              (!isReviewEntity ? (
-                <PublicVersionSelector
-                  publicVersionGroupId={publicVersionGroupId}
-                  onChangeSelectedVersion={handleChangeSelectedVersion}
-                />
-              ) : (
-                <p
-                  className={classNames(
-                    conversation.publicationInfo?.action ===
-                      PublishActions.DELETE && 'text-error',
-                  )}
-                  data-qa="version"
-                >
-                  {t('v.')} {conversation.publicationInfo?.version}
-                </p>
-              ))}
 
             {isContextMenuVisible && (
               <ConversationContextMenu
@@ -404,6 +398,18 @@ export const ChatHeader = ({
                 isHeaderMenu
                 disabledState={isMessageStreaming}
               />
+            )}
+
+            {isPlayback && !isExternal && (
+              <button
+                className="cursor-pointer text-accent-primary"
+                onClick={onCancelPlaybackMode}
+                data-qa="cancel-playback-mode"
+              >
+                {screenState === ScreenState.MOBILE
+                  ? t('Stop')
+                  : t('Stop playback')}
+              </button>
             )}
 
             {isCompareMode && selectedConversationIds.length > 1 && (

--- a/apps/chat/src/utils/server/get-common-page-props.ts
+++ b/apps/chat/src/utils/server/get-common-page-props.ts
@@ -35,6 +35,7 @@ import { URL, URLSearchParams } from 'url';
 const disabledFeaturesForIsolatedView = new Set([
   Feature.ConversationsSection,
   Feature.PromptsSection,
+  Feature.MessageTemplates,
 ]);
 
 const hiddenFeaturesForIsolatedView = [


### PR DESCRIPTION
**Description:**

- hide message templates for Isolated view 
- change order of header buttons

Issues:

- Issue #2814
- Issue #2815

**UI changes**
1)
![image](https://github.com/user-attachments/assets/625b7ef9-0766-429b-9a0b-1b3b68797da9)
2)
![image](https://github.com/user-attachments/assets/34dd8e32-3c1a-4d7a-9c5b-2cedd9c156c2)

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
