### PR TITLE
fix(chat): hide `clientdata` folder (Issue #2704)

### DIFF
--- a/apps/chat-e2e/src/core/dialFixtures.ts
+++ b/apps/chat-e2e/src/core/dialFixtures.ts
@@ -114,6 +114,7 @@ import { TemperatureSlider } from '@/src/ui/webElements/temperatureSlider';
 import { Tooltip } from '@/src/ui/webElements/tooltip';
 import { UploadFromDeviceModal } from '@/src/ui/webElements/uploadFromDeviceModal';
 import { VariableModalDialog } from '@/src/ui/webElements/variableModalDialog';
+import { BucketUtil } from '@/src/utils';
 import { allure } from 'allure-playwright';
 import path from 'path';
 import { APIRequestContext } from 'playwright-core';
@@ -564,6 +565,7 @@ const dialTest = test.extend<
   ) => {
     const additionalSecondShareUserFileApiHelper = new FileApiHelper(
       additionalSecondShareUserRequestContext,
+      BucketUtil.getAdditionalSecondShareUserBucket(),
     );
     await use(additionalSecondShareUserFileApiHelper);
   },

--- a/apps/chat-e2e/src/core/dialSharedWithMeFixtures.ts
+++ b/apps/chat-e2e/src/core/dialSharedWithMeFixtures.ts
@@ -198,6 +198,7 @@ const dialSharedWithMeTest = dialTest.extend<{
   ) => {
     const additionalShareUserFileApiHelper = new FileApiHelper(
       additionalShareUserRequestContext,
+      BucketUtil.getAdditionalShareUserBucket(),
     );
     await use(additionalShareUserFileApiHelper);
   },

--- a/apps/chat-e2e/src/testData/api/fileApiHelper.ts
+++ b/apps/chat-e2e/src/testData/api/fileApiHelper.ts
@@ -6,8 +6,16 @@ import { BucketUtil, ItemUtil } from '@/src/utils';
 import { expect } from '@playwright/test';
 import * as fs from 'fs';
 import path from 'path';
+import { APIRequestContext } from 'playwright-core';
 
 export class FileApiHelper extends BaseApiHelper {
+  private readonly userBucket?: string;
+
+  constructor(request: APIRequestContext, userBucket?: string) {
+    super(request);
+    this.userBucket = userBucket;
+  }
+
   public async putFile(filename: string, parentPath?: string) {
     const encodedFilename = encodeURIComponent(filename);
     const encodedParentPath = parentPath
@@ -15,7 +23,7 @@ export class FileApiHelper extends BaseApiHelper {
       : undefined;
     const filePath = path.join(Attachment.attachmentPath, filename);
     const bufferedFile = fs.readFileSync(filePath);
-    const baseUrl = `${API.fileHost}/${BucketUtil.getBucket()}`;
+    const baseUrl = `${API.fileHost}/${this.userBucket ?? BucketUtil.getBucket()}`;
     const url = parentPath
       ? `${baseUrl}/${encodedParentPath}/${encodedFilename}`
       : `${baseUrl}/${encodedFilename}`;
@@ -65,7 +73,7 @@ export class FileApiHelper extends BaseApiHelper {
   public async listEntities(nodeType: BackendDataNodeType, url?: string) {
     const host = url
       ? `${API.listingHost}/${url.substring(0, url.length - 1)}`
-      : `${API.filesListingHost()}/${BucketUtil.getBucket()}`;
+      : `${API.filesListingHost()}/${this.userBucket ?? BucketUtil.getBucket()}`;
     const response = await this.request.get(host, {
       params: {
         filter: nodeType,

--- a/apps/chat-e2e/src/testData/api/itemApiHelper.ts
+++ b/apps/chat-e2e/src/testData/api/itemApiHelper.ts
@@ -10,10 +10,12 @@ import { APIRequestContext } from 'playwright-core';
 
 export class ItemApiHelper extends BaseApiHelper {
   private readonly userBucket?: string;
+
   constructor(request: APIRequestContext, userBucket?: string) {
     super(request);
     this.userBucket = userBucket;
   }
+
   public async deleteAllData(bucket?: string, isOverlay = false) {
     const bucketToUse = this.userBucket ?? bucket;
     const conversations = await this.listItems(

--- a/apps/chat-e2e/src/tests/sharedFilesAttachments.test.ts
+++ b/apps/chat-e2e/src/tests/sharedFilesAttachments.test.ts
@@ -504,6 +504,7 @@ dialSharedWithMeTest(
     conversationData,
     dataInjector,
     fileApiHelper,
+    additionalShareUserFileApiHelper,
     mainUserShareApiHelper,
     additionalUserShareApiHelper,
     additionalShareUserSendMessage,
@@ -580,6 +581,11 @@ dialSharedWithMeTest(
           await fileApiHelper.putFile(
             user1ConversationInFolderImageInResponse1,
           );
+
+        //upload file into 'All files' section to have it visible
+        await additionalShareUserFileApiHelper.putFile(
+          Attachment.heartImageName,
+        );
       },
     );
 

--- a/apps/chat/src/utils/app/data/file-service.ts
+++ b/apps/chat/src/utils/app/data/file-service.ts
@@ -10,6 +10,8 @@ import {
 import { FolderType } from '@/src/types/folder';
 import { HTTPMethod } from '@/src/types/http';
 
+import { CLIENTDATA_PATH } from '@/src/constants/client-data';
+
 import { ApiUtils } from '../../server/api';
 import { constructPath } from '../file';
 import { getFileRootId } from '../id';
@@ -121,30 +123,37 @@ export class FileService {
       this.getListingUrl({ path: parentPath, resultQuery }),
     ).pipe(
       map((folders: BackendFileFolder[]) => {
-        return folders.map((folder): FileFolderInterface => {
-          const relativePath = folder.parentPath
-            ? ApiUtils.decodeApiUrl(folder.parentPath)
-            : undefined;
+        return folders
+          .filter(
+            (folder) => !!folder.parentPath || folder.name !== CLIENTDATA_PATH,
+          )
+          .map((folder): FileFolderInterface => {
+            const relativePath = folder.parentPath
+              ? ApiUtils.decodeApiUrl(folder.parentPath)
+              : undefined;
 
-          return {
-            id: constructPath(
-              ApiKeys.Files,
-              folder.bucket,
-              relativePath,
-              folder.name,
-            ),
-            name: folder.name,
-            type: FolderType.File,
-            absolutePath: constructPath(
-              ApiKeys.Files,
-              folder.bucket,
-              relativePath,
-            ),
-            relativePath: relativePath,
-            folderId: constructPath(getFileRootId(folder.bucket), relativePath),
-            serverSynced: true,
-          };
-        });
+            return {
+              id: constructPath(
+                ApiKeys.Files,
+                folder.bucket,
+                relativePath,
+                folder.name,
+              ),
+              name: folder.name,
+              type: FolderType.File,
+              absolutePath: constructPath(
+                ApiKeys.Files,
+                folder.bucket,
+                relativePath,
+              ),
+              relativePath: relativePath,
+              folderId: constructPath(
+                getFileRootId(folder.bucket),
+                relativePath,
+              ),
+              serverSynced: true,
+            };
+          });
       }),
     );
   }


### PR DESCRIPTION
**Description:**

hide `clientdata` folder

Issues:

- Issue #2704

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
