### PR TITLE
fix(chat): show like/dislike/copy buttons only if content message hasn't error message or content isn't empty (Issue #125)

### DIFF
--- a/apps/chat/src/components/Chat/ChatMessage/MessageButtons.tsx
+++ b/apps/chat/src/components/Chat/ChatMessage/MessageButtons.tsx
@@ -154,7 +154,7 @@ export const MessageAssistantButtons = ({
           </Button>
         </Tooltip>
       )}
-      {message.content.trim() &&
+      {(message.content.trim() || !message.errorMessage) &&
         (messageCopied ? (
           <Tooltip key="copied" placement="top" tooltip={t('Text copied')}>
             <IconCheck size={18} className="text-secondary" />

--- a/apps/chat/src/components/Chat/ChatMessage/MessageButtons.tsx
+++ b/apps/chat/src/components/Chat/ChatMessage/MessageButtons.tsx
@@ -154,81 +154,84 @@ export const MessageAssistantButtons = ({
           </Button>
         </Tooltip>
       )}
-      {messageCopied ? (
-        <Tooltip key="copied" placement="top" tooltip={t('Text copied')}>
-          <IconCheck size={18} className="text-secondary" />
-        </Tooltip>
-      ) : (
-        <Tooltip
-          key="copy"
-          placement="top"
-          isTriggerClickable
-          tooltip={t('Copy text')}
-        >
-          <Button className="text-secondary" onClick={copyOnClick}>
-            <IconCopy size={18} />
-          </Button>
-        </Tooltip>
-      )}
+      {message.content.trim() &&
+        (messageCopied ? (
+          <Tooltip key="copied" placement="top" tooltip={t('Text copied')}>
+            <IconCheck size={18} className="text-secondary" />
+          </Tooltip>
+        ) : (
+          <Tooltip
+            key="copy"
+            placement="top"
+            isTriggerClickable
+            tooltip={t('Copy text')}
+          >
+            <Button className="text-secondary" onClick={copyOnClick}>
+              <IconCopy size={18} />
+            </Button>
+          </Tooltip>
+        ))}
       <div className="flex flex-row gap-2">
-        {isLikesEnabled && !!message.responseId && (
-          <>
-            {message.like !== LikeState.Disliked && (
-              <Tooltip
-                placement="top"
-                isTriggerClickable={message.like !== LikeState.Liked}
-                tooltip={
-                  message.like !== LikeState.Liked ? t('Like') : t('Liked')
-                }
-              >
-                <Button
-                  onClick={() => {
-                    if (message.like !== LikeState.NoState) {
-                      onLike(LikeState.Liked);
-                    }
-                  }}
-                  className={
-                    message.like !== LikeState.Liked
-                      ? 'text-secondary'
-                      : 'text-accent-primary'
+        {isLikesEnabled &&
+          (!message.errorMessage ||
+            (message.content.trim() && message.errorMessage)) && (
+            <>
+              {message.like !== LikeState.Disliked && (
+                <Tooltip
+                  placement="top"
+                  isTriggerClickable={message.like !== LikeState.Liked}
+                  tooltip={
+                    message.like !== LikeState.Liked ? t('Like') : t('Liked')
                   }
-                  disabled={message.like === LikeState.Liked}
-                  data-qa="like"
                 >
-                  <IconThumbUp size={18} />
-                </Button>
-              </Tooltip>
-            )}
-            {message.like !== LikeState.Liked && (
-              <Tooltip
-                placement="top"
-                isTriggerClickable={message.like !== LikeState.Disliked}
-                tooltip={
-                  message.like !== LikeState.Disliked
-                    ? t('Dislike')
-                    : t('Disliked')
-                }
-              >
-                <Button
-                  onClick={() => {
-                    if (message.like !== LikeState.NoState) {
-                      onLike(LikeState.Disliked);
+                  <Button
+                    onClick={() => {
+                      if (message.like !== LikeState.NoState) {
+                        onLike(LikeState.Liked);
+                      }
+                    }}
+                    className={
+                      message.like !== LikeState.Liked
+                        ? 'text-secondary'
+                        : 'text-accent-primary'
                     }
-                  }}
-                  className={
+                    disabled={message.like === LikeState.Liked}
+                    data-qa="like"
+                  >
+                    <IconThumbUp size={18} />
+                  </Button>
+                </Tooltip>
+              )}
+              {message.like !== LikeState.Liked && (
+                <Tooltip
+                  placement="top"
+                  isTriggerClickable={message.like !== LikeState.Disliked}
+                  tooltip={
                     message.like !== LikeState.Disliked
-                      ? 'text-secondary'
-                      : 'text-accent-primary'
+                      ? t('Dislike')
+                      : t('Disliked')
                   }
-                  disabled={message.like === LikeState.Disliked}
-                  data-qa="dislike"
                 >
-                  <IconThumbDown size={18} />
-                </Button>
-              </Tooltip>
-            )}
-          </>
-        )}
+                  <Button
+                    onClick={() => {
+                      if (message.like !== LikeState.NoState) {
+                        onLike(LikeState.Disliked);
+                      }
+                    }}
+                    className={
+                      message.like !== LikeState.Disliked
+                        ? 'text-secondary'
+                        : 'text-accent-primary'
+                    }
+                    disabled={message.like === LikeState.Disliked}
+                    data-qa="dislike"
+                  >
+                    <IconThumbDown size={18} />
+                  </Button>
+                </Tooltip>
+              )}
+            </>
+          )}
       </div>
     </div>
   );


### PR DESCRIPTION
**Description:**

show like/dislike/copy buttons only if content message hasn't error message or content isn't empty

Issues:

- Issue #125

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
