### PR TITLE
fix(chat): fix downloading without extension and name of code block (Issue #2867, #2868)

### DIFF
--- a/apps/chat/src/components/Markdown/CodeBlock.tsx
+++ b/apps/chat/src/components/Markdown/CodeBlock.tsx
@@ -80,7 +80,7 @@ export const CodeBlock: FC<Props> = memo(
         return;
       }
 
-      const blob = new Blob([value], { type: 'text/plain' });
+      const blob = new Blob([value], { type: 'attachment/plain' });
       const url = URL.createObjectURL(blob);
       const link = document.createElement('a');
       link.download = fileName;
@@ -107,7 +107,7 @@ export const CodeBlock: FC<Props> = memo(
               : 'border-secondary bg-layer-1',
           )}
         >
-          <span className="lowercase">{displayLanguage}</span>
+          <span className="lowercase">{language}</span>
 
           {!isLastMessageStreaming && (
             <div

--- a/apps/chat/src/components/Markdown/CodeBlock.tsx
+++ b/apps/chat/src/components/Markdown/CodeBlock.tsx
@@ -60,8 +60,9 @@ export const CodeBlock: FC<Props> = memo(
         }, 2000);
       });
     }, [value]);
-
-    const displayLanguage = languageNameMapping[language] || language;
+    const lowercaseLanguage = language.toLocaleLowerCase();
+    const displayLanguage =
+      languageNameMapping[lowercaseLanguage] || lowercaseLanguage;
 
     const downloadAsFile = useCallback(() => {
       // languageExtensionMapping allows set empty extension
@@ -107,7 +108,7 @@ export const CodeBlock: FC<Props> = memo(
               : 'border-secondary bg-layer-1',
           )}
         >
-          <span className="lowercase">{language}</span>
+          <span>{lowercaseLanguage}</span>
 
           {!isLastMessageStreaming && (
             <div

--- a/apps/chat/src/components/Markdown/CodeBlock.tsx
+++ b/apps/chat/src/components/Markdown/CodeBlock.tsx
@@ -60,7 +60,7 @@ export const CodeBlock: FC<Props> = memo(
         }, 2000);
       });
     }, [value]);
-    const lowercaseLanguage = language.toLocaleLowerCase();
+    const lowercaseLanguage = language.toLowerCase();
     const displayLanguage =
       languageNameMapping[lowercaseLanguage] || lowercaseLanguage;
 

--- a/apps/chat/src/store/conversations/conversations.selectors.ts
+++ b/apps/chat/src/store/conversations/conversations.selectors.ts
@@ -65,7 +65,7 @@ const rootSelector = (state: RootState): ConversationsState =>
   state.conversations;
 
 export const selectConversations = (state: RootState): ConversationInfo[] =>
-  state.conversations.conversations;
+  rootSelector(state).conversations;
 
 export const selectNotExternalConversations = createSelector(
   [selectConversations],

--- a/apps/chat/src/utils/app/folders.ts
+++ b/apps/chat/src/utils/app/folders.ts
@@ -116,7 +116,7 @@ export const getNextDefaultName = (
   parentFolderId?: string,
 ): string => {
   const prefix = `${defaultName} `;
-  const regex = new RegExp(`^${escapeRegExp(prefix)}(\\d+)$`);
+  const regex = new RegExp(`^${escapeRegExp(prefix)}(\\d{1,7})$`);
 
   if (!entities.length && !index) {
     return !startWithEmptyPostfix ? `${prefix}${1 + index}` : defaultName;
@@ -165,7 +165,7 @@ export const generateNextName = (
   entities: ShareEntity[],
   index = 0,
 ) => {
-  const regex = new RegExp(`^${defaultName} (\\d+)$`);
+  const regex = new RegExp(`^${defaultName} (\\d{1,7})$`);
   return currentName.match(regex)
     ? getNextDefaultName(defaultName, entities, index)
     : getNextDefaultName(currentName, entities, index, true);


### PR DESCRIPTION
**Description:**

- fix downloading without extension 
- fix name of code block with sh-script
- fix Dockerfile and Makefile syntax highlighting

Issues:

- Issue #2867
- Issue #2868

**UI changes**
![image](https://github.com/user-attachments/assets/36d4503f-dbdf-40e5-bdb0-1f94c537d6e6)
![image](https://github.com/user-attachments/assets/a9356d0b-3938-4def-b748-97b40aedf794)
![image](https://github.com/user-attachments/assets/b87e68d0-d42b-4700-ae23-6ab000346dad)


**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
