### PR TITLE
fix(chat): disable autocomplete for folder rename input (Issue #2888)

### DIFF
--- a/apps/chat/src/components/Chat/RenameConversationModal.tsx
+++ b/apps/chat/src/components/Chat/RenameConversationModal.tsx
@@ -190,7 +190,7 @@ const RenameConversationView = () => {
         }
         onKeyDown={handleEnterDown}
         className="w-full rounded border border-primary bg-transparent px-3 py-2.5 leading-4 outline-none placeholder:text-secondary focus-visible:border-accent-primary"
-        autoComplete='off'
+        autoComplete="off"
       />
       <div className="relative flex justify-end gap-3">
         <button

--- a/apps/chat/src/components/Chat/RenameConversationModal.tsx
+++ b/apps/chat/src/components/Chat/RenameConversationModal.tsx
@@ -190,6 +190,7 @@ const RenameConversationView = () => {
         }
         onKeyDown={handleEnterDown}
         className="w-full rounded border border-primary bg-transparent px-3 py-2.5 leading-4 outline-none placeholder:text-secondary focus-visible:border-accent-primary"
+        autoComplete='off'
       />
       <div className="relative flex justify-end gap-3">
         <button

--- a/apps/chat/src/components/Folder/Folder.tsx
+++ b/apps/chat/src/components/Folder/Folder.tsx
@@ -966,6 +966,7 @@ const Folder = <T extends ConversationInfo | PromptInfo | DialFile>({
               onKeyDown={handleEnterDown}
               ref={renameInputRef}
               name="edit-input"
+              autoComplete="off"
             />
           </div>
         ) : (


### PR DESCRIPTION
**Description:**

disable autocomplete for folder rename input

Issues:

- Issue #2888

**UI changes**

![image](https://github.com/user-attachments/assets/0d1d4cbb-81a0-43d8-b550-c9ed692eef69)

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
