### PR TITLE
fix(chat): fix warning about old replay (Issue #2900)

### DIFF
--- a/apps/chat/src/components/Chat/TalkTo/TalkToCard.tsx
+++ b/apps/chat/src/components/Chat/TalkTo/TalkToCard.tsx
@@ -367,7 +367,7 @@ export const TalkToCard = ({
             isOldReplay ? 'mt-1.5 md:mt-1 xl:mt-2' : 'xl:mt-4',
           )}
         >
-          {isOldReplay && (
+          {entity.id === REPLAY_AS_IS_MODEL && isOldReplay && (
             <span className="text-xs leading-[15px] text-error">
               {t(
                 'Some messages were created in an older DIAL version and may not replay as expected.',

--- a/apps/chat/src/components/Chat/TalkTo/TalkToCard.tsx
+++ b/apps/chat/src/components/Chat/TalkTo/TalkToCard.tsx
@@ -164,6 +164,7 @@ export const TalkToCard = ({
 
   const isOldReplay = useMemo(() => {
     return (
+      entity.id === REPLAY_AS_IS_MODEL &&
       conversation.replay &&
       conversation.replay.isReplay &&
       conversation.replay.replayUserMessagesStack &&
@@ -171,7 +172,7 @@ export const TalkToCard = ({
         (message) => !message.model,
       )
     );
-  }, [conversation.replay]);
+  }, [conversation.replay, entity.id]);
 
   const menuItems: DisplayMenuItemProps[] = useMemo(
     () => [
@@ -367,7 +368,7 @@ export const TalkToCard = ({
             isOldReplay ? 'mt-1.5 md:mt-1 xl:mt-2' : 'xl:mt-4',
           )}
         >
-          {entity.id === REPLAY_AS_IS_MODEL && isOldReplay && (
+          {isOldReplay && (
             <span className="text-xs leading-[15px] text-error">
               {t(
                 'Some messages were created in an older DIAL version and may not replay as expected.',


### PR DESCRIPTION
**Description:**

fix warning about old replay

Issues:

- Issue #2900

**UI changes**
![image](https://github.com/user-attachments/assets/9f093e77-a12e-4752-9c0a-36582ae201cb)
->
![image](https://github.com/user-attachments/assets/a9c9c3ce-41b4-4b65-aa5b-aa3b9ab9acf4)


**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
