### PR TITLE
fix(chat): change code editor confirmation buttons order (Issue #2734)

### DIFF
--- a/apps/chat/src/components/Common/ApplicationWizard/CodeAppView/CodeAppView.tsx
+++ b/apps/chat/src/components/Common/ApplicationWizard/CodeAppView/CodeAppView.tsx
@@ -189,19 +189,19 @@ export const CodeAppView: FC<ViewProps> = ({
   const modalOptions = useMemo(
     () => [
       {
-        label: 'Save',
-        dataQa: 'save-option',
+        label: "Don't save",
+        dataQa: 'not-save-option',
+        className: 'button-secondary',
         onClick: () => {
-          dispatch(CodeEditorActions.saveAllModifiedFiles());
           editorConfirmation && handleSubmit(editorConfirmation);
           setEditorConfirmation(undefined);
         },
       },
       {
-        label: "Don't save",
-        dataQa: 'not-save-option',
-        className: 'button-secondary',
+        label: 'Save',
+        dataQa: 'save-option',
         onClick: () => {
+          dispatch(CodeEditorActions.saveAllModifiedFiles());
           editorConfirmation && handleSubmit(editorConfirmation);
           setEditorConfirmation(undefined);
         },


### PR DESCRIPTION
**Description:**

- move confirm button to the right side

Issues:

- Issue #2734 

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
