### PR TITLE
fix(chat): hide disabled edit button on mobile (Issue #2784)

### DIFF
--- a/apps/chat/src/components/Chat/ChatMessage/MessageButtons.tsx
+++ b/apps/chat/src/components/Chat/ChatMessage/MessageButtons.tsx
@@ -407,17 +407,18 @@ export const MessageMobileButtons = ({
             }
           />
         )}
-        <MenuItem
-          className="hover:bg-accent-primary-alpha focus:visible disabled:cursor-not-allowed group-hover:visible"
-          onClick={() => onToggleEditing(!isEditing)}
-          disabled={editDisabled}
-          item={
-            <div className="flex items-center gap-3">
-              <IconEdit className="text-secondary" size={18} />
-              <p>{t('Edit')}</p>
-            </div>
-          }
-        />
+        {!editDisabled && (
+          <MenuItem
+            className="hover:bg-accent-primary-alpha focus:visible disabled:cursor-not-allowed group-hover:visible"
+            onClick={() => onToggleEditing(!isEditing)}
+            item={
+              <div className="flex items-center gap-3">
+                <IconEdit className="text-secondary" size={18} />
+                <p>{t('Edit')}</p>
+              </div>
+            }
+          />
+        )}
         <MenuItem
           className="hover:bg-accent-primary-alpha focus:visible group-hover:visible"
           onClick={onDelete}

--- a/apps/chat/src/components/Chat/ChatMessage/MessageButtons.tsx
+++ b/apps/chat/src/components/Chat/ChatMessage/MessageButtons.tsx
@@ -92,12 +92,11 @@ export const MessageUserButtons = ({
               </button>
             </Tooltip>
           )}
-          {isEditAvailable && (
+          {isEditAvailable && !editDisabled && (
             <Tooltip placement="top" isTriggerClickable tooltip={t('Edit')}>
               <button
                 className="text-secondary hover:text-accent-primary disabled:cursor-not-allowed"
                 onClick={toggleEditing}
-                disabled={editDisabled}
               >
                 <IconEdit size={18} />
               </button>


### PR DESCRIPTION
**Description:**

- hide disabled edit button on mobile view

Issues:

- Issue #2784 

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
