### PR TITLE
fix(chat): fix version groups cleanup after approving unpublish request (Issue #2727)

### DIFF
--- a/apps/chat/src/components/Chat/Publish/PublicVersionSelector.tsx
+++ b/apps/chat/src/components/Chat/Publish/PublicVersionSelector.tsx
@@ -23,13 +23,13 @@ interface Props {
   readonly?: boolean;
   groupVersions?: boolean;
   textBeforeSelector?: string | null;
+  selectedEntityId?: string;
+  excludeEntityId?: string;
   onChangeSelectedVersion?: (
     versionGroupId: string,
     newVersion: NonNullable<PublicVersionGroups[string]>['selectedVersion'],
     oldVersion: NonNullable<PublicVersionGroups[string]>['selectedVersion'],
   ) => void;
-  selectedEntityId?: string;
-  excludeEntityId?: string;
 }
 
 export function PublicVersionSelector({
@@ -38,9 +38,9 @@ export function PublicVersionSelector({
   readonly,
   groupVersions,
   textBeforeSelector,
-  onChangeSelectedVersion,
   selectedEntityId,
   excludeEntityId,
+  onChangeSelectedVersion,
 }: Props) {
   const { t } = useTranslation(Translation.Chat);
 

--- a/apps/chat/src/store/publication/publication.epics.ts
+++ b/apps/chat/src/store/publication/publication.epics.ts
@@ -838,7 +838,7 @@ const approvePublicationEpic: AppEpic = (action$, state$) =>
             });
 
             const versionGroups = uniq(
-              itemsToRemoveIds.map((id) =>
+              idsToExclude.map((id) =>
                 getIdWithoutVersionFromApiKey(id, parseConversationApiKey),
               ),
             );
@@ -860,6 +860,7 @@ const approvePublicationEpic: AppEpic = (action$, state$) =>
                       name: conv.name,
                       folderId: conv.folderId,
                       publicationInfo: {
+                        ...conv.publicationInfo,
                         isNotExist: true,
                       },
                       publishedWithMe: false,
@@ -990,7 +991,7 @@ const approvePublicationEpic: AppEpic = (action$, state$) =>
               return !hasPrompts && hasHiddenPrompts;
             });
             const versionGroups = uniq(
-              itemsToRemoveIds.map((id) => {
+              idsToExclude.map((id) => {
                 return getIdWithoutVersionFromApiKey(id, parsePromptApiKey);
               }),
             );
@@ -1011,6 +1012,7 @@ const approvePublicationEpic: AppEpic = (action$, state$) =>
                       name: prompt.name,
                       folderId: prompt.folderId,
                       publicationInfo: {
+                        ...prompt.publicationInfo,
                         isNotExist: true,
                       },
                       publishedWithMe: false,


### PR DESCRIPTION
**Description:**

fix version groups cleanup after approving unpublish request

Issues:

- Issue #2727

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
