### PR TITLE
fix(chat): add warning messages for published or shared application icon (Issue #3047)

### DIFF
--- a/apps/chat/src/components/Chat/Publish/PublicationItemsList.tsx
+++ b/apps/chat/src/components/Chat/Publish/PublicationItemsList.tsx
@@ -580,7 +580,7 @@ export const PublicationItemsList = memo(
                   <ErrorMessage
                     type="warning"
                     error={t(
-                      `The icon used for this app is in the ${isEntityIdPublic({ id: entity.iconUrl }) ? 'organization' : 'shared'} section and cannot be published. Please replace the icon, otherwise the app will be published with the default one.`,
+                      `The icon used for this application is in the "${isEntityIdPublic({ id: entity.iconUrl }) ? 'Organization' : 'Shared with me'}" section and cannot be published. Please replace the icon, otherwise the application will be published with the default one.`,
                     )}
                   />
                 </CollapsibleSection>


### PR DESCRIPTION
**Description:**

add warning messages for published or shared application icon

Issues:

- Issue #3047

**UI changes**

![image](https://github.com/user-attachments/assets/2eba7f64-aa41-4482-92b4-52faf36c6e31)
![image](https://github.com/user-attachments/assets/2d086812-d93a-4a43-8d4f-1ab457ea7199)
![image](https://github.com/user-attachments/assets/fd1478dc-e388-417a-af69-f36ccbe68df9)
![image](https://github.com/user-attachments/assets/460b96a7-a521-485f-ac92-cae65a931151)

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
