### PR TITLE
fix(overlay-sandbox): fix `removeOverlay` conditions (Issue #3072)

### DIFF
--- a/apps/overlay-sandbox/app/cases/components/chatOverlayManagerWrapper.tsx
+++ b/apps/overlay-sandbox/app/cases/components/chatOverlayManagerWrapper.tsx
@@ -44,7 +44,7 @@ export const ChatOverlayManagerWrapper: React.FC<
         overlayManager.current?.removeOverlay(overlayManagerOptions.id);
       }
     };
-  });
+  }, [overlayManager.current, created]);
 
   useEffect(() => {
     overlayManager.current?.subscribe(

--- a/apps/overlay-sandbox/app/cases/components/chatOverlayManagerWrapper.tsx
+++ b/apps/overlay-sandbox/app/cases/components/chatOverlayManagerWrapper.tsx
@@ -44,7 +44,7 @@ export const ChatOverlayManagerWrapper: React.FC<
         overlayManager.current?.removeOverlay(overlayManagerOptions.id);
       }
     };
-  }, [overlayManager.current, created]);
+  }, [overlayManager.current, created, overlayManagerOptions.id]);
 
   useEffect(() => {
     overlayManager.current?.subscribe(

--- a/apps/overlay-sandbox/app/cases/components/chatOverlayManagerWrapper.tsx
+++ b/apps/overlay-sandbox/app/cases/components/chatOverlayManagerWrapper.tsx
@@ -44,7 +44,7 @@ export const ChatOverlayManagerWrapper: React.FC<
         overlayManager.current?.removeOverlay(overlayManagerOptions.id);
       }
     };
-  }, [overlayManager.current, created, overlayManagerOptions.id]);
+  }, [created, overlayManagerOptions.id]);
 
   useEffect(() => {
     overlayManager.current?.subscribe(


### PR DESCRIPTION
**Description:**

 fix `removeOverlay` conditions:
- don't remove Overlay manager on `Get messages`, `Get conversations` and etc

Issues:

- Issue #3072

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
