### PR TITLE
fix: Hide 'Logs' button for the shared code application (Issue #3086)

### DIFF
--- a/apps/chat/src/components/Chat/TalkTo/TalkToCard.tsx
+++ b/apps/chat/src/components/Chat/TalkTo/TalkToCard.tsx
@@ -104,8 +104,7 @@ export const TalkToCard = ({
 
   const canWrite = canWriteSharedWithMe(entity);
 
-  const isExecutable =
-    isExecutableApp(entity) && (isMyEntity || isAdmin || canWrite);
+  const isExecutable = isExecutableApp(entity) && (isMyEntity || isAdmin); //TODO add  ```|| canWrite``` when core issues #655 and #672 will be ready
   const screenState = useScreenState();
 
   const isApplicationsSharingEnabled = useAppSelector((state) =>
@@ -173,7 +172,7 @@ export const TalkToCard = ({
         dataQa: 'status-change',
         disabled: playerStatus === SimpleApplicationStatus.UPDATING,
         display:
-          (isAdmin || isMyEntity) &&
+          (isAdmin || isMyEntity) && //TODO add  ```|| canWrite``` when core issues #655 will be ready
           !!entity.functionStatus &&
           isCodeAppsEnabled,
         Icon: PlayerContextIcon,

--- a/apps/chat/src/components/Marketplace/ApplicationCard.tsx
+++ b/apps/chat/src/components/Marketplace/ApplicationCard.tsx
@@ -122,8 +122,7 @@ export const ApplicationCard = ({
 
   const isModifyDisabled = isApplicationStatusUpdating(entity);
   const playerStatus = getApplicationSimpleStatus(entity);
-  const isExecutable =
-    isExecutableApp(entity) && (isMyApp || isAdmin || canWrite);
+  const isExecutable = isExecutableApp(entity) && (isMyApp || isAdmin); //TODO add  ```|| canWrite``` when core issues #655 and #672 will be ready
 
   const { iconSize, shareIconSize } = CardIconSizes[screenState];
 
@@ -168,7 +167,7 @@ export const ApplicationCard = ({
         dataQa: 'status-change',
         disabled: playerStatus === SimpleApplicationStatus.UPDATING,
         display:
-          (isAdmin || isMyApp) && !!entity.functionStatus && isCodeAppsEnabled,
+          (isAdmin || isMyApp) && !!entity.functionStatus && isCodeAppsEnabled, //TODO add  canWrite when core issues #655 will be ready
         Icon: PlayerContextIcon,
         iconClassName: PlayerContextIconClasses[playerStatus],
         onClick: (e: React.MouseEvent) => {

--- a/apps/chat/src/components/Marketplace/ApplicationDetails/ApplicationFooter.tsx
+++ b/apps/chat/src/components/Marketplace/ApplicationDetails/ApplicationFooter.tsx
@@ -125,8 +125,7 @@ export const ApplicationDetailsFooter = ({
 
   const canWrite = canWriteSharedWithMe(entity);
 
-  const isExecutable =
-    isExecutableApp(entity) && (isMyApp || isAdmin || canWrite);
+  const isExecutable = isExecutableApp(entity) && (isMyApp || isAdmin); //TODO add  ```|| canWrite``` when core issues #655 and #672 will be ready
 
   const isModifyDisabled = isApplicationStatusUpdating(entity);
   const playerStatus = getApplicationSimpleStatus(entity);


### PR DESCRIPTION
**Description:**

Since it is not possible to fetch logs for the shared code application, the 'Logs' button has been hidden.

Issues:

- Issue #3086 

**UI changes**

**Before:**
![image](https://github.com/user-attachments/assets/f09ad3ab-c038-43f2-8cb5-ef9aa93b2a8a)

**After:**
![image](https://github.com/user-attachments/assets/0f9fbef5-a9ce-4739-bc1d-ac45e2aee86b)


**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
