### PR TITLE
fix(chat): adds last conversation temperature setting retrieving from the local storage (Issue #3116)

### DIFF
--- a/apps/chat/src/store/conversations/conversations.epics.ts
+++ b/apps/chat/src/store/conversations/conversations.epics.ts
@@ -3095,7 +3095,7 @@ const updateLastConversationSettingsEpic: AppEpic = (action$, state$) =>
     })),
     switchMap(({ lastConversation }) =>
       forkJoin({
-        oldTemperature: of((lastConversation as Conversation)?.temperature),
+        oldLastConversationSettings: DataService.getLastConversationSettings(),
         wasAlreadyUploaded: of(
           lastConversation?.status === UploadStatus.LOADED,
         ),
@@ -3115,31 +3115,39 @@ const updateLastConversationSettingsEpic: AppEpic = (action$, state$) =>
             : of(lastConversation as Conversation),
       }),
     ),
-    switchMap(({ lastConversation, oldTemperature, wasAlreadyUploaded }) => {
-      if (
-        !lastConversation ||
-        // don't save for temp empty conversation to be able to reset settings by "New conversation"
-        isEntityIdLocal(lastConversation) ||
-        // don't save if already uploaded and nothing changed
-        (wasAlreadyUploaded && oldTemperature === lastConversation.temperature)
-      ) {
-        return EMPTY;
-      }
+    switchMap(
+      ({
+        lastConversation,
+        oldLastConversationSettings,
+        wasAlreadyUploaded,
+      }) => {
+        if (
+          !lastConversation ||
+          // don't save for temp empty conversation to be able to reset settings by "New conversation"
+          isEntityIdLocal(lastConversation) ||
+          // don't save if already uploaded and nothing changed
+          (wasAlreadyUploaded &&
+            oldLastConversationSettings?.temperature ===
+              lastConversation.temperature)
+        ) {
+          return EMPTY;
+        }
 
-      return concat(
-        of(
-          ConversationsActions.setLastConversationSettings({
-            temperature: lastConversation.temperature,
-          }),
-        ),
-        of(
-          ConversationsActions.uploadConversationsByIdsSuccess({
-            setIds: new Set(lastConversation.id),
-            conversations: [lastConversation],
-          }),
-        ),
-      );
-    }),
+        return concat(
+          of(
+            ConversationsActions.setLastConversationSettings({
+              temperature: lastConversation.temperature,
+            }),
+          ),
+          of(
+            ConversationsActions.uploadConversationsByIdsSuccess({
+              setIds: new Set(lastConversation.id),
+              conversations: [lastConversation],
+            }),
+          ),
+        );
+      },
+    ),
   );
 
 const setLastConversationSettingsEpic: AppEpic = (action$) =>


### PR DESCRIPTION
**Description:**

adds last conversation temperature setting retrieving from the local storage

Issues:

- Issue #3116

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
