### PR TITLE
fix(chat): disable prompt use when chat input is hidden (Issue #3159)

### DIFF
--- a/apps/chat/src/components/Chat/Chat.tsx
+++ b/apps/chat/src/components/Chat/Chat.tsx
@@ -893,9 +893,12 @@ export function Chat() {
     ChatSelectors.selectIsConfigurationSchemaLoading,
   );
 
-  const configurationModelId = selectedConversations.find((conv) =>
+  const configurationAppReference = selectedConversations.find((conv) =>
     doesModelHaveConfiguration(modelsMap[conv.model.id]),
   )?.model?.id;
+  const configurationAppId = configurationAppReference
+    ? modelsMap[configurationAppReference]?.id
+    : undefined;
 
   useEffect(() => {
     dispatch(ChatActions.resetFormValue());
@@ -903,12 +906,12 @@ export function Chat() {
 
   useEffect(() => {
     dispatch(ChatActions.resetConfigurationSchema());
-    if (configurationModelId) {
+    if (configurationAppId) {
       dispatch(
-        ChatActions.getConfigurationSchema({ modelId: configurationModelId }),
+        ChatActions.getConfigurationSchema({ modelId: configurationAppId }),
       );
     }
-  }, [dispatch, configurationModelId, selectedConversationsIds]);
+  }, [dispatch, configurationAppId, selectedConversationsIds]);
 
   if (selectedPublication?.resources && !selectedConversationsIds.length) {
     return (

--- a/apps/chat/src/components/Chat/Chat.tsx
+++ b/apps/chat/src/components/Chat/Chat.tsx
@@ -126,6 +126,9 @@ export const ChatView = memo(() => {
   const selectedPublicationUrl = useAppSelector(
     PublicationSelectors.selectSelectedPublicationUrl,
   );
+  const notAvailableEntityType = useAppSelector(
+    ChatSelectors.selectNotAvailableEntityType,
+  );
 
   const [autoScrollEnabled, setAutoScrollEnabled] = useState<boolean>(true);
   const [showScrollDownButton, setShowScrollDownButton] =
@@ -135,7 +138,6 @@ export const ChatView = memo(() => {
   const [isLastMessageError, setIsLastMessageError] = useState(false);
   const [prevSelectedIds, setPrevSelectedIds] = useState<string[]>([]);
   const [inputHeight, setInputHeight] = useState<number>(142);
-  const [notAllowedType, setNotAllowedType] = useState<EntityType | null>(null);
 
   const handleTalkToConversationId = useCallback(
     (conversationId: string | null) => {
@@ -196,17 +198,24 @@ export const ChatView = memo(() => {
         }));
 
     if (isNotAllowedModel) {
-      setNotAllowedType(EntityType.Model);
+      dispatch(ChatActions.setNotAvailableEntityType(EntityType.Model));
     } else if (
       selectedConversations.some((conversation) =>
         conversation.selectedAddons.some((addonId) => !addonsMap[addonId]),
       )
     ) {
-      setNotAllowedType(EntityType.Addon);
+      dispatch(ChatActions.setNotAvailableEntityType(EntityType.Addon));
     } else {
-      setNotAllowedType(null);
+      dispatch(ChatActions.setNotAvailableEntityType(undefined));
     }
-  }, [selectedConversations, models, isModelsLoaded, addonsMap, modelsMap]);
+  }, [
+    selectedConversations,
+    models,
+    isModelsLoaded,
+    addonsMap,
+    modelsMap,
+    dispatch,
+  ]);
 
   const onLikeHandler = useCallback(
     (index: number, conversation: Conversation) => (rate: LikeState) => {
@@ -497,7 +506,7 @@ export const ChatView = memo(() => {
     !isExternal &&
     !messageIsStreaming &&
     !isLastMessageError &&
-    !notAllowedType;
+    !notAvailableEntityType;
   const showFloatingOverlay =
     isSmallScreen() && isAnyMenuOpen && !isIsolatedView;
   const isModelsInstalled = selectedConversations.every((conv) =>
@@ -715,7 +724,7 @@ export const ChatView = memo(() => {
                                             Feature.Likes,
                                           )}
                                           editDisabled={
-                                            !!notAllowedType ||
+                                            !!notAvailableEntityType ||
                                             isExternal ||
                                             isReplay ||
                                             isPlayback
@@ -745,11 +754,13 @@ export const ChatView = memo(() => {
                       )}
                     </div>
                   </div>
-                  {!isPlayback && notAllowedType && !selectedPublicationUrl ? (
+                  {!isPlayback &&
+                  notAvailableEntityType &&
+                  !selectedPublicationUrl ? (
                     <NotAllowedModel
                       showScrollDownButton={showScrollDownButton}
                       onScrollDownClick={handleScrollDown}
-                      type={notAllowedType}
+                      type={notAvailableEntityType}
                     />
                   ) : (
                     <>

--- a/apps/chat/src/components/Promptbar/components/Prompt.tsx
+++ b/apps/chat/src/components/Promptbar/components/Prompt.tsx
@@ -47,6 +47,7 @@ import { Translation } from '@/src/types/translation';
 import { ConversationsSelectors } from '@/src/store/conversations/conversations.reducers';
 import { useAppDispatch, useAppSelector } from '@/src/store/hooks';
 import { ImportExportActions } from '@/src/store/import-export/importExport.reducers';
+import { ModelsSelectors } from '@/src/store/models/models.reducers';
 import {
   PromptsActions,
   PromptsSelectors,
@@ -102,6 +103,12 @@ export const PromptComponent = ({
   const selectedPublicationUrl = useAppSelector(
     PublicationSelectors.selectSelectedPublicationUrl,
   );
+  const selectedConversations = useAppSelector(
+    ConversationsSelectors.selectSelectedConversations,
+  );
+  const installedModelIds = useAppSelector(
+    ModelsSelectors.selectInstalledModelIds,
+  );
   const allPrompts = useAppSelector(PromptsSelectors.selectPrompts);
   const { showModal, isModalPreviewMode } = useAppSelector(
     PromptsSelectors.selectIsEditModalOpen,
@@ -117,6 +124,9 @@ export const PromptComponent = ({
   const isSelectMode = useAppSelector(PromptsSelectors.selectIsSelectMode);
   const isPublishingEnabled = useAppSelector((state) =>
     SettingsSelectors.selectIsPublishingEnabled(state, FeatureType.Prompt),
+  );
+  const isConversationBlocksInput = useAppSelector(
+    ConversationsSelectors.selectIsSelectedConversationBlocksInput,
   );
 
   const collapsedSectionsSelector = useMemo(
@@ -153,6 +163,9 @@ export const PromptComponent = ({
   const isChosen = useMemo(
     () => chosenPromptIds.includes(prompt.id),
     [chosenPromptIds, prompt.id],
+  );
+  const isModelsInstalled = selectedConversations.every((conv) =>
+    installedModelIds.has(conv.model.id),
   );
 
   const { refs, context } = useFloating({
@@ -374,9 +387,7 @@ export const PromptComponent = ({
     [dispatch, prompt.id],
   );
 
-  const disableUsePrompt = useAppSelector(
-    ConversationsSelectors.selectIsSelectedConversationBlocksInput,
-  );
+  const disableUsePrompt = isConversationBlocksInput || !isModelsInstalled;
 
   const handleUse: MouseEventHandler<HTMLButtonElement> = useCallback(
     (e) => {

--- a/apps/chat/src/store/chat/chat.reducer.ts
+++ b/apps/chat/src/store/chat/chat.reducer.ts
@@ -1,5 +1,7 @@
 import { PayloadAction, createSlice } from '@reduxjs/toolkit';
 
+import { EntityType } from '@/src/types/common';
+
 import {
   MessageFormSchema,
   MessageFormValue,
@@ -12,6 +14,7 @@ export interface ChatState {
   configurationSchema?: MessageFormSchema;
   isConfigurationSchemaLoading: boolean;
   shouldFocusAndScroll?: boolean;
+  notAvailableEntityType?: EntityType;
 }
 
 const initialState: ChatState = {
@@ -72,6 +75,12 @@ export const chatSlice = createSlice({
     },
     setShouldFocusAndScroll: (state, { payload }: PayloadAction<boolean>) => {
       state.shouldFocusAndScroll = payload;
+    },
+    setNotAvailableEntityType: (
+      state,
+      { payload }: PayloadAction<EntityType | undefined>,
+    ) => {
+      state.notAvailableEntityType = payload;
     },
   },
 });

--- a/apps/chat/src/store/chat/chat.selectors.ts
+++ b/apps/chat/src/store/chat/chat.selectors.ts
@@ -29,6 +29,9 @@ const selectIsConfigurationBlocksInput = createSelector(
 const selectShouldFocusAndScroll = (state: RootState) =>
   rootSelector(state).shouldFocusAndScroll;
 
+const selectNotAvailableEntityType = (state: RootState) =>
+  rootSelector(state).notAvailableEntityType;
+
 export const ChatSelectors = {
   selectInputContent,
   selectChatFormValue,
@@ -36,4 +39,5 @@ export const ChatSelectors = {
   selectIsConfigurationSchemaLoading,
   selectIsConfigurationBlocksInput,
   selectShouldFocusAndScroll,
+  selectNotAvailableEntityType,
 };

--- a/apps/chat/src/store/conversations/conversations.selectors.ts
+++ b/apps/chat/src/store/conversations/conversations.selectors.ts
@@ -768,13 +768,18 @@ export const selectTalkToConversationId = (state: RootState) =>
   rootSelector(state).talkToConversationId;
 
 export const selectIsSelectedConversationBlocksInput = createSelector(
-  [selectSelectedConversations, ChatSelectors.selectIsConfigurationBlocksInput],
-  (conversations, isConfigurationBlocksInput) =>
+  [
+    selectSelectedConversations,
+    ChatSelectors.selectIsConfigurationBlocksInput,
+    ChatSelectors.selectNotAvailableEntityType,
+  ],
+  (conversations, isConfigurationBlocksInput, notAvailableEntityType) =>
     conversations.some(
       (conversation) =>
         conversation.sharedWithMe ||
         (!conversation.messages?.length &&
           (isConfigurationBlocksInput || isReplayConversation(conversation))) ||
+        notAvailableEntityType ||
         isPlaybackConversation(conversation) ||
         isEntityIdExternal(conversation) ||
         !conversation.messages ||


### PR DESCRIPTION
**Description:**

- move notAllowedType to global chat store, rename it to notAvailableEntityType
- add cases of disabled use prompt when input is hidden or not available
- fix passing application id to get configuration schema request

Issues:

- Issue #3159

**UI changes**

<Please, provide Screenshots or Figma links>

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
