### PR TITLE
feat(chat): implement `hide-user-settings` flag (Issue #3223)

### DIFF
--- a/apps/chat/src/components/Header/User/UserDesktop.tsx
+++ b/apps/chat/src/components/Header/User/UserDesktop.tsx
@@ -7,7 +7,8 @@ import { useTranslation } from '@/src/hooks/useTranslation';
 
 import { Translation } from '@/src/types/translation';
 
-import { useAppDispatch } from '@/src/store/hooks';
+import { useAppDispatch, useAppSelector } from '@/src/store/hooks';
+import { SettingsSelectors } from '@/src/store/settings/settings.reducers';
 import { UIActions } from '@/src/store/ui/ui.reducers';
 
 import { ConfirmDialog } from '@/src/components/Common/ConfirmDialog';
@@ -17,6 +18,7 @@ import ChevronDownIcon from '@/public/images/icons/chevron-down.svg';
 import LogOutIcon from '@/public/images/icons/log-out.svg';
 import UserIcon from '@/public/images/icons/user.svg';
 import { Inversify } from '@epam/ai-dial-modulify-ui';
+import { Feature } from '@epam/ai-dial-shared';
 
 export const UserDesktop = Inversify.register('UserDesktop', () => {
   const { t } = useTranslation(Translation.Header);
@@ -25,6 +27,9 @@ export const UserDesktop = Inversify.register('UserDesktop', () => {
     useState(false);
   const { session, handleLogout } = useLogout();
   const dispatch = useAppDispatch();
+  const isHideUserSettingsEnabled = useAppSelector((state) =>
+    SettingsSelectors.isFeatureEnabled(state, Feature.HideUserSettings),
+  );
 
   return (
     <>
@@ -63,19 +68,21 @@ export const UserDesktop = Inversify.register('UserDesktop', () => {
           </div>
         }
       >
-        <MenuItem
-          id="user-settings-menu-item"
-          className="hover:bg-accent-primary-alpha"
-          item={
-            <div className="flex">
-              <IconSettings size={18} className="text-secondary" />
-              <span className="ml-3">{t('Settings')}</span>
-            </div>
-          }
-          onClick={() => {
-            dispatch(UIActions.setIsUserSettingsOpen(true));
-          }}
-        />
+        {!isHideUserSettingsEnabled && (
+          <MenuItem
+            id="user-settings-menu-item"
+            className="hover:bg-accent-primary-alpha"
+            item={
+              <div className="flex">
+                <IconSettings size={18} className="text-secondary" />
+                <span className="ml-3">{t('Settings')}</span>
+              </div>
+            }
+            onClick={() => {
+              dispatch(UIActions.setIsUserSettingsOpen(true));
+            }}
+          />
+        )}
         <MenuItem
           id="logout-menu-item"
           className="hover:bg-accent-primary-alpha"

--- a/apps/chat/src/components/Header/User/UserMobile.tsx
+++ b/apps/chat/src/components/Header/User/UserMobile.tsx
@@ -24,6 +24,7 @@ import { withRenderWhen } from '../../Common/RenderWhen';
 import { withRenderForScreen } from '../../Common/ScreenRender';
 
 import { Inversify } from '@epam/ai-dial-modulify-ui';
+import { Feature } from '@epam/ai-dial-shared';
 
 const UserInfo = () => {
   const { t } = useTranslation(Translation.Header);
@@ -112,9 +113,12 @@ const Logout = () => {
   );
 };
 const UserMenu = () => {
+  const isHideUserSettingsEnabled = useAppSelector((state) =>
+    SettingsSelectors.isFeatureEnabled(state, Feature.HideUserSettings),
+  );
   return (
     <div className="flex flex-col gap-1 p-2">
-      <UserSettings />
+      {!isHideUserSettingsEnabled && <UserSettings />}
       <Logout />
     </div>
   );

--- a/libs/shared/src/types/features.ts
+++ b/libs/shared/src/types/features.ts
@@ -30,6 +30,7 @@ export enum Feature {
   CodeApps = 'code-apps', // Enable Code apps
   DisallowChangeAgent = 'disallow-change-agent', //Disallow "Change agent" button
   MarketplaceTableView = 'marketplace-table-view', //Disallow "Change agent" button
+  HideUserSettings = 'hide-user-settings', // Hide user settings
 }
 
 export const availableFeatures: Record<Feature, boolean> = {
@@ -64,4 +65,5 @@ export const availableFeatures: Record<Feature, boolean> = {
   [Feature.CodeApps]: true,
   [Feature.DisallowChangeAgent]: true,
   [Feature.MarketplaceTableView]: true,
+  [Feature.HideUserSettings]: true,
 };


### PR DESCRIPTION
**Description:**

implement `hide-user-settings` flag

Issues:

- Issue #3223

**UI changes**

![image](https://github.com/user-attachments/assets/4b7b7dff-876e-4bc9-a242-2919d9f1b5f9)
![image](https://github.com/user-attachments/assets/f75e00c5-a6ea-4860-9bb5-bbcb76241600)


**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
