### PR TITLE
feat(chat): add tooltips to preview mode buttons in ApplicationSettings (Issue #3315)

### DIFF
--- a/apps/chat/src/components/AppsEditor/Settings/index.tsx
+++ b/apps/chat/src/components/AppsEditor/Settings/index.tsx
@@ -40,6 +40,7 @@ import { UISelectors } from '@/src/store/ui/ui.reducers';
 
 import { DEFAULT_QUICK_APPS_SCHEMA_ID } from '@/src/constants/quick-apps';
 
+import Tooltip from '../../Common/Tooltip';
 import { ApplicationView } from './ApplicationView';
 import { CodeAppView } from './CodeAppView';
 import { CustomApplicationEditorView } from './CustomApplicationEditorView';
@@ -54,7 +55,7 @@ import {
   getQuickAppDefaultValues,
 } from './form';
 
-import debounce from 'lodash-es/debounce';
+import { debounce } from 'lodash-es';
 
 interface Props {
   schema: ApiDetailedApplicationTypeSchema | null;
@@ -287,7 +288,9 @@ export const ApplicationSettings: React.FC<Props> = ({
                 className="text-secondary hover:text-accent-primary"
                 onClick={() => setPreviewMode('full')}
               >
-                <IconArrowsMaximize size={24} />
+                <Tooltip tooltip={t('Expand preview')}>
+                  <IconArrowsMaximize size={24} />
+                </Tooltip>
               </button>
             )}
             {previewMode === 'full' && (
@@ -295,14 +298,18 @@ export const ApplicationSettings: React.FC<Props> = ({
                 className="text-secondary hover:text-accent-primary"
                 onClick={() => setPreviewMode('half')}
               >
-                <IconLayoutSidebarRightCollapse size={24} />
+                <Tooltip tooltip={t('Split view')}>
+                  <IconLayoutSidebarRightCollapse size={24} />
+                </Tooltip>
               </button>
             )}
             <button
               className="text-secondary hover:text-accent-primary"
               onClick={() => setPreviewMode('closed')}
             >
-              <IconArrowsMinimize size={24} />
+              <Tooltip tooltip={t('Hide preview')}>
+                <IconArrowsMinimize size={24} />
+              </Tooltip>
             </button>
           </div>
         </div>
@@ -332,14 +339,20 @@ export const ApplicationSettings: React.FC<Props> = ({
               setPreviewMode('full');
             }}
           >
-            <IconArrowsMaximize size={24} />
+            <Tooltip tooltip={t('Expand preview')}>
+              <IconArrowsMaximize size={24} />
+            </Tooltip>
           </button>
+
           <button
             className="text-secondary hover:text-accent-primary"
             onClick={() => setPreviewMode('half')}
           >
-            <IconLayoutSidebarLeftCollapse size={24} />
+            <Tooltip tooltip={t('Split view')}>
+              <IconLayoutSidebarLeftCollapse size={24} />
+            </Tooltip>
           </button>
+
           <span
             className="select-none text-primary"
             style={{ writingMode: 'vertical-rl' }}

--- a/apps/chat/src/components/AppsEditor/Settings/index.tsx
+++ b/apps/chat/src/components/AppsEditor/Settings/index.tsx
@@ -55,7 +55,7 @@ import {
   getQuickAppDefaultValues,
 } from './form';
 
-import { debounce } from 'lodash-es';
+import debounce from 'lodash-es/debounce';
 
 interface Props {
   schema: ApiDetailedApplicationTypeSchema | null;


### PR DESCRIPTION
**Description:**
Added tooltips for the mode-switching buttons in the application conversation preview.

Issues:

- Issue #3315

**UI changes**

![image](https://github.com/user-attachments/assets/7c7792c9-3628-4c49-9b56-5994fbe16490)
![image](https://github.com/user-attachments/assets/aac3479a-1f17-4b6a-8ed2-2512b03986ec)
![image](https://github.com/user-attachments/assets/c7f25069-aee8-412c-8073-56facc121068)


**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
