### PR TITLE
fix(chat): fix opening Select agent if HideEmptyChatChangeAgent feature is enabled (Issue #3307)

### DIFF
--- a/apps/chat/src/store/conversations/conversations.epics.ts
+++ b/apps/chat/src/store/conversations/conversations.epics.ts
@@ -132,6 +132,7 @@ import {
 import {
   ConversationInfo,
   CustomVisualizerData,
+  Feature,
   Message,
   MessageSettings,
   Role,
@@ -479,6 +480,12 @@ const createNewConversationsEpic: AppEpic = (action$, state$) =>
                 state$.value,
               );
 
+            const isEmptyChatChangeAgentHidden =
+              SettingsSelectors.isFeatureEnabled(
+                state$.value,
+                Feature.HideEmptyChatChangeAgent,
+              );
+
             return concat(
               of(
                 ConversationsActions.createNotLocalConversations({
@@ -496,6 +503,7 @@ const createNewConversationsEpic: AppEpic = (action$, state$) =>
                 }),
               ),
               headerCreateNew &&
+                !isEmptyChatChangeAgentHidden &&
                 selectedConversationsIds.length === 1 &&
                 isEntityIdLocal({ id: selectedConversationsIds[0] })
                 ? of(


### PR DESCRIPTION
**Description:**

fix opening Select agent if HideEmptyChatChangeAgent feature is enabled

Issues:

- Issue #3307

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
