### PR TITLE
feat(chat): implement new `advanced-view` flag (Issue #3333)

### DIFF
--- a/apps/chat-e2e/src/assertions/api/apiAssertion.ts
+++ b/apps/chat-e2e/src/assertions/api/apiAssertion.ts
@@ -2,12 +2,12 @@ import { ChatBody } from '@/chat/types/chat';
 import { MoveModel } from '@/chat/types/common';
 import { DialAIEntityModel } from '@/chat/types/models';
 import { ExpectedConstants, ExpectedMessages } from '@/src/testData';
-import { Message } from '@epam/ai-dial-shared';
+import { ConversationEntityModel, Message } from '@epam/ai-dial-shared';
 import { expect } from '@playwright/test';
 import { APIResponse } from 'playwright-core';
 
 export class ApiAssertion {
-  public async assertResponseCode(
+  public assertResponseCode(
     response: APIResponse,
     modelId: string,
     expectedStatus: number,
@@ -53,16 +53,16 @@ export class ApiAssertion {
       .toMatch(ExpectedConstants.responseFileUrlContentPattern(modelId));
   }
 
-  public async assertRequestModelId(
+  public assertRequestModelId(
     request: ChatBody,
-    expectedModel: DialAIEntityModel,
+    expectedModel: DialAIEntityModel | ConversationEntityModel,
   ) {
     expect
       .soft(request.model?.id, ExpectedMessages.chatRequestModelIsValid)
       .toBe(expectedModel.id);
   }
 
-  public async assertRequestTemperature(
+  public assertRequestTemperature(
     request: ChatBody,
     expectedTemperature: number,
   ) {
@@ -71,7 +71,7 @@ export class ApiAssertion {
       .toBe(expectedTemperature);
   }
 
-  public async assertRequestPrompt(
+  public assertRequestPrompt(
     request: ChatBody,
     expectedPrompt: string | undefined,
   ) {
@@ -86,16 +86,13 @@ export class ApiAssertion {
     }
   }
 
-  public async assertRequestAddons(
-    request: ChatBody,
-    expectedAddons: string[],
-  ) {
+  public assertRequestAddons(request: ChatBody, expectedAddons: string[]) {
     expect
       .soft(request.selectedAddons, ExpectedMessages.chatRequestAddonsAreValid)
       .toEqual(expectedAddons);
   }
 
-  public async verifyRequestAttachments(
+  public verifyRequestAttachments(
     request: ChatBody,
     ...expectedAttachmentUrls: string[]
   ) {
@@ -114,7 +111,7 @@ export class ApiAssertion {
     }
   }
 
-  public async assertRequestMessage(
+  public assertRequestMessage(
     requestMessage: Message,
     expectedMessage: string,
   ) {
@@ -123,7 +120,7 @@ export class ApiAssertion {
       .toBe(expectedMessage);
   }
 
-  public async assertMoveRequest(
+  public assertMoveRequest(
     request: MoveModel,
     expectedDestination: string,
     expectedSource: string,

--- a/apps/chat-e2e/src/assertions/chatHeaderAssertion.ts
+++ b/apps/chat-e2e/src/assertions/chatHeaderAssertion.ts
@@ -50,4 +50,14 @@ export class ChatHeaderAssertion<T extends ChatHeader> extends BaseAssertion {
       expectedIcon,
     );
   }
+
+  public async assertHeaderAddonIcon(expectedAddonIcons: string[]) {
+    const actualAddonIcons = await this.chatHeader.getHeaderAddonsIcons();
+    for (let i = 0; i < actualAddonIcons.length; i++) {
+      await super.assertEntityIcon(
+        actualAddonIcons[i].iconLocator,
+        expectedAddonIcons[i],
+      );
+    }
+  }
 }

--- a/apps/chat-e2e/src/core/localStorageManager.ts
+++ b/apps/chat-e2e/src/core/localStorageManager.ts
@@ -53,6 +53,14 @@ export class LocalStorageManager {
     window.localStorage.setItem('chatbarWidth', width);
   };
 
+  setShowChatBarKey = () => (isDisplayed: boolean) => {
+    window.localStorage.setItem('showChatbar', JSON.stringify(isDisplayed));
+  };
+
+  setShowPromptBarKey = () => (isDisplayed: boolean) => {
+    window.localStorage.setItem('showPromptbar', JSON.stringify(isDisplayed));
+  };
+
   async setConversationHistory(...conversation: Conversation[]) {
     await this.page.addInitScript(
       this.setConversationHistoryKey(),
@@ -204,6 +212,24 @@ export class LocalStorageManager {
 
   async setChatbarWidth(width: string) {
     await this.page.addInitScript(this.setChatbarWidthKey(), width);
+  }
+
+  async setShowChatBar(isDisplayed: boolean) {
+    await this.page.addInitScript(this.setShowChatBarKey(), isDisplayed);
+  }
+
+  async setShowPromptBar(isDisplayed: boolean) {
+    await this.page.addInitScript(this.setShowPromptBarKey(), isDisplayed);
+  }
+
+  async setShowSideBarPanels(
+    options: {
+      isChatBarDisplayed: boolean;
+      isPromptBarDisplayed: boolean;
+    } = { isChatBarDisplayed: true, isPromptBarDisplayed: true },
+  ) {
+    await this.setShowChatBar(options.isChatBarDisplayed);
+    await this.setShowPromptBar(options.isPromptBarDisplayed);
   }
 
   async getSelectedConversationIds(originHost?: string) {

--- a/apps/chat-e2e/src/tests/abortedReplay.test.ts
+++ b/apps/chat-e2e/src/tests/abortedReplay.test.ts
@@ -106,6 +106,7 @@ dialTest(
         await localStorageManager.setChatCollapsedSection(
           CollapsedSections.Organization,
         );
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -332,6 +333,7 @@ dialTest(
         await localStorageManager.setChatCollapsedSection(
           CollapsedSections.Organization,
         );
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -382,6 +384,7 @@ dialTest(
     chatMessages,
     conversations,
     baseAssertion,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-1535');
     const message = GeneratorUtil.randomString(10);
@@ -400,6 +403,7 @@ dialTest(
         conversation,
         replayConversation,
       ]);
+      await localStorageManager.setShowSideBarPanels();
     });
 
     await dialTest.step(
@@ -466,6 +470,7 @@ dialTest(
     context,
     sendMessage,
     conversations,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-514', 'EPMRTC-1165');
     let conversation: Conversation;
@@ -478,6 +483,7 @@ dialTest(
         conversation,
         replayConversation,
       ]);
+      await localStorageManager.setShowSideBarPanels();
     });
 
     await dialTest.step(
@@ -534,6 +540,7 @@ dialTest(
     dataInjector,
     setTestIds,
     conversations,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-1312');
     let errorConversation: Conversation;
@@ -550,6 +557,7 @@ dialTest(
           errorConversation,
           replayConversation,
         ]);
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 

--- a/apps/chat-e2e/src/tests/accountSettings.test.ts
+++ b/apps/chat-e2e/src/tests/accountSettings.test.ts
@@ -18,12 +18,14 @@ dialTest(
     setTestIds,
     chatBar,
     accountSettingsAssertion,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-812');
 
     await dialTest.step(
       'Open account menu and verify icon is changed to expanded',
       async () => {
+        await localStorageManager.setShowSideBarPanels();
         await dialHomePage.openHomePage();
         await dialHomePage.waitForPageLoaded();
         await accountSettings.openAccountDropdownMenu();
@@ -57,12 +59,14 @@ dialTest(
     settingsModalAssertion,
     setTestIds,
     settingsModal,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-360');
 
     await dialTest.step(
       'Open account settings and verify "Theme" field has "Dark" value, "Save" button is available',
       async () => {
+        await localStorageManager.setShowSideBarPanels();
         await dialHomePage.openHomePage();
         await dialHomePage.waitForPageLoaded();
         await accountSettings.openAccountDropdownMenu();
@@ -103,6 +107,7 @@ dialTest(
     conversationData,
     dataInjector,
     conversations,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-1704', 'EPMRTC-1705', 'EPMRTC-1708');
     let sendMessageInputInitWidth: number;
@@ -119,6 +124,7 @@ dialTest(
           name,
         );
         await dataInjector.createConversations([conversation]);
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 

--- a/apps/chat-e2e/src/tests/agentSelection.test.ts
+++ b/apps/chat-e2e/src/tests/agentSelection.test.ts
@@ -430,6 +430,7 @@ dialTest(
     );
     const addedModel = GeneratorUtil.randomArrayElement(availableModels);
     await localStorageManager.setRecentModelsIdsOnce(...models);
+    await localStorageManager.setShowSideBarPanels();
 
     // Create conversations
     const conversation2Name = GeneratorUtil.randomString(10);
@@ -456,7 +457,6 @@ dialTest(
       });
       await dialHomePage.waitForPageLoaded();
       await agentInfoAssertion.assertAgentName(initialModel1.name);
-      await localStorageManager.setShowSideBarPanels();
     });
 
     await dialTest.step(

--- a/apps/chat-e2e/src/tests/agentSelection.test.ts
+++ b/apps/chat-e2e/src/tests/agentSelection.test.ts
@@ -59,6 +59,7 @@ dialTest(
       'Prepare models and set recent models in local storage',
       async () => {
         await localStorageManager.setRecentModelsIdsOnce(...models);
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -284,6 +285,7 @@ dialAdminTest(
           await adminPublicationApiHelper.approveRequest(publication);
           // delete the original conversation to prevent name duplicates
           await itemApiHelper.deleteEntity(conversation);
+          await localStorageManager.setShowSideBarPanels();
         }
       },
     );
@@ -454,6 +456,7 @@ dialTest(
       });
       await dialHomePage.waitForPageLoaded();
       await agentInfoAssertion.assertAgentName(initialModel1.name);
+      await localStorageManager.setShowSideBarPanels();
     });
 
     await dialTest.step(
@@ -602,6 +605,7 @@ dialTest(
     );
     const [firstModel, secondModel] = models;
     await localStorageManager.setRecentModelsIdsOnce(...models);
+    await localStorageManager.setShowSideBarPanels();
 
     await dialTest.step('Open Dial', async () => {
       await dialHomePage.openHomePage({
@@ -684,6 +688,7 @@ dialSharedWithMeTest(
       ]);
     await mainUserShareApiHelper.acceptInvite(shareByLinkResponse);
     await localStorageManager.setRecentModelsIdsOnce(...models);
+    await localStorageManager.setShowSideBarPanels();
 
     await dialSharedWithMeTest.step('Open Dial by the main user', async () => {
       await dialHomePage.openHomePage({

--- a/apps/chat-e2e/src/tests/announcementBanner.test.ts
+++ b/apps/chat-e2e/src/tests/announcementBanner.test.ts
@@ -21,6 +21,7 @@ dialTest(
       context,
       providerLogin,
       setTestIds,
+      localStorageManager,
     },
     testInfo,
   ) => {
@@ -32,6 +33,7 @@ dialTest(
     await dialTest.step('Prepare any conversation', async () => {
       conversation = conversationData.prepareDefaultConversation();
       await dataInjector.createConversations([conversation]);
+      await localStorageManager.setShowSideBarPanels();
     });
 
     await dialTest.step(

--- a/apps/chat-e2e/src/tests/chatApi/assistantPlusAddons.test.ts
+++ b/apps/chat-e2e/src/tests/chatApi/assistantPlusAddons.test.ts
@@ -20,7 +20,7 @@ for (const entity of entityPlusAddonsRequests) {
         entity.request,
       );
       const response = await chatApiHelper.postRequest(conversation);
-      await apiAssertion.assertResponseCode(response, entity.assistantId, 200);
+      apiAssertion.assertResponseCode(response, entity.assistantId, 200);
       await apiAssertion.assertResponseTextContent(
         response,
         entity.assistantId,

--- a/apps/chat-e2e/src/tests/chatApi/entityArithmeticRequest.test.ts
+++ b/apps/chat-e2e/src/tests/chatApi/entityArithmeticRequest.test.ts
@@ -31,7 +31,7 @@ for (const entity of arithmeticRequestModels) {
       );
       conversation.messages[0].content = request;
       const response = await chatApiHelper.postRequest(conversation);
-      await apiAssertion.assertResponseCode(response, entity.entityId, 200);
+      apiAssertion.assertResponseCode(response, entity.entityId, 200);
       await apiAssertion.assertResponseTextContent(
         response,
         entity.entityId,

--- a/apps/chat-e2e/src/tests/chatApi/entityPlusAddons.test.ts
+++ b/apps/chat-e2e/src/tests/chatApi/entityPlusAddons.test.ts
@@ -22,7 +22,7 @@ for (const entity of entityPlusAddonsRequests) {
         conversation.prompt = entity.systemPrompt;
       }
       const response = await chatApiHelper.postRequest(conversation);
-      await apiAssertion.assertResponseCode(response, entity.entityId, 200);
+      apiAssertion.assertResponseCode(response, entity.entityId, 200);
       await apiAssertion.assertResponseTextContent(
         response,
         entity.entityId,

--- a/apps/chat-e2e/src/tests/chatApi/entityPlusAttachmentRequest.test.ts
+++ b/apps/chat-e2e/src/tests/chatApi/entityPlusAttachmentRequest.test.ts
@@ -31,7 +31,7 @@ for (const entity of entityPlusAttachmentRequests) {
         conversation.prompt = entity.systemPrompt;
       }
       const response = await chatApiHelper.postRequest(conversation);
-      await apiAssertion.assertResponseCode(response, entity.entityId, 200);
+      apiAssertion.assertResponseCode(response, entity.entityId, 200);
       await apiAssertion.assertResponseTextContent(
         response,
         entity.entityId,
@@ -70,11 +70,7 @@ dialTest(
     const replayConversation =
       conversationData.prepareDefaultReplayConversation(conversation);
     const modelResponse = await chatApiHelper.postRequest(replayConversation);
-    await apiAssertion.assertResponseCode(
-      modelResponse,
-      replayEntity.entityId,
-      200,
-    );
+    apiAssertion.assertResponseCode(modelResponse, replayEntity.entityId, 200);
     await apiAssertion.assertResponseTextContent(
       modelResponse,
       replayEntity.entityId,

--- a/apps/chat-e2e/src/tests/chatApi/entitySimpleRequest.test.ts
+++ b/apps/chat-e2e/src/tests/chatApi/entitySimpleRequest.test.ts
@@ -23,7 +23,7 @@ for (const entity of entitySimpleRequests) {
         conversation.prompt = entity.systemPrompt;
       }
       const response = await chatApiHelper.postRequest(conversation);
-      await apiAssertion.assertResponseCode(response, entity.entityId, 200);
+      apiAssertion.assertResponseCode(response, entity.entityId, 200);
       entity.isAttachmentResponse
         ? await apiAssertion.assertResponseAttachment(response, entity.entityId)
         : await apiAssertion.assertResponseTextContent(
@@ -55,7 +55,7 @@ dialTest(
     const replayConversation =
       conversationData.prepareDefaultReplayConversation(conversation);
     const response = await chatApiHelper.postRequest(replayConversation);
-    await apiAssertion.assertResponseCode(response, replayEntity.entityId, 200);
+    apiAssertion.assertResponseCode(response, replayEntity.entityId, 200);
     await apiAssertion.assertResponseAttachment(
       response,
       replayEntity.entityId,

--- a/apps/chat-e2e/src/tests/chatBarConversation.test.ts
+++ b/apps/chat-e2e/src/tests/chatBarConversation.test.ts
@@ -37,7 +37,16 @@ dialTest(
     'Chat sorting. Today for newly created chat.\n' +
     'A dot at the end is removed if chat was named automatically\n' +
     'Chat name: restricted special characters are removed from chat name if to name automatically',
-  async ({ dialHomePage, conversations, chat, chatMessages, setTestIds }) => {
+  async ({
+    dialHomePage,
+    conversations,
+    chat,
+    chatMessages,
+    setTestIds,
+    header,
+    baseAssertion,
+    chatBar,
+  }) => {
     setTestIds('EPMRTC-583', 'EPMRTC-776', 'EPMRTC-2894', 'EPMRTC-2957');
     const messageToSend = `.Hi${ExpectedConstants.restrictedNameChars}...`;
     const expectedConversationName = '.Hi';
@@ -48,7 +57,9 @@ dialTest(
         await dialHomePage.openHomePage({
           iconsToBeLoaded: [defaultModel.iconUrl],
         });
-        await dialHomePage.waitForPageLoaded();
+        await dialHomePage.waitForPageLoaded({ skipSidebars: true });
+        await header.leftPanelToggle.click();
+        await baseAssertion.assertElementState(chatBar, 'visible');
         await dialHomePage.mockChatTextResponse(
           MockedChatApiResponseBodies.simpleTextBody,
         );
@@ -103,6 +114,7 @@ dialTest(
     setTestIds,
     renameConversationModal,
     renameConversationModalAssertion,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-588', 'EPMRTC-816', 'EPMRTC-1494');
     const newName = 'new name to cancel';
@@ -115,6 +127,7 @@ dialTest(
         conversationName,
       );
       await dataInjector.createConversations([conversation]);
+      await localStorageManager.setShowSideBarPanels();
     });
 
     await dialTest.step(
@@ -206,10 +219,12 @@ dialTest(
     dataInjector,
     setTestIds,
     renameConversationModal,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-584', 'EPMRTC-819');
     const conversation = conversationData.prepareDefaultConversation();
     await dataInjector.createConversations([conversation]);
+    await localStorageManager.setShowSideBarPanels();
 
     const newName = GeneratorUtil.randomString(70);
     await dialHomePage.openHomePage();
@@ -266,6 +281,7 @@ dialTest(
     errorPopup,
     toast,
     renameConversationModal,
+    localStorageManager,
   }) => {
     setTestIds(
       'EPMRTC-585',
@@ -283,6 +299,7 @@ dialTest(
     );
     const conversation = conversationData.prepareDefaultConversation();
     await dataInjector.createConversations([conversation]);
+    await localStorageManager.setShowSideBarPanels();
 
     await dialHomePage.openHomePage();
     await dialHomePage.waitForPageLoaded();
@@ -342,10 +359,12 @@ dialTest.skip(
     conversationData,
     dataInjector,
     setTestIds,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-594', 'EPMRTC-3054');
     const conversation = conversationData.prepareDefaultConversation();
     await dataInjector.createConversations([conversation]);
+    await localStorageManager.setShowSideBarPanels();
 
     await dialHomePage.openHomePage();
     await dialHomePage.waitForPageLoaded();
@@ -381,6 +400,7 @@ dialTest(
     dataInjector,
     setTestIds,
     renameConversationModal,
+    localStorageManager,
   }) => {
     setTestIds(
       'EPMRTC-595',
@@ -396,6 +416,7 @@ dialTest(
     await dialTest.step('Prepare simple conversation', async () => {
       conversation = conversationData.prepareDefaultConversation();
       await dataInjector.createConversations([conversation]);
+      await localStorageManager.setShowSideBarPanels();
     });
 
     await dialTest.step(
@@ -509,6 +530,7 @@ dialTest(
     conversationDropdownMenu,
     setTestIds,
     confirmationDialog,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-607');
     const conversationInFolder =
@@ -517,6 +539,7 @@ dialTest(
       conversationInFolder.conversations,
       conversationInFolder.folders,
     );
+    await localStorageManager.setShowSideBarPanels();
 
     await dialHomePage.openHomePage();
     await dialHomePage.waitForPageLoaded();
@@ -549,10 +572,12 @@ dialTest(
     dataInjector,
     confirmationDialog,
     setTestIds,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-608');
     const conversation = conversationData.prepareDefaultConversation();
     await dataInjector.createConversations([conversation]);
+    await localStorageManager.setShowSideBarPanels();
 
     await dialHomePage.openHomePage({
       iconsToBeLoaded: [defaultModel.iconUrl],
@@ -586,6 +611,7 @@ dialTest.skip(
     conversationData,
     dataInjector,
     setTestIds,
+    localStorageManager,
   }) => {
     setTestIds(
       'EPMRTC-775',
@@ -613,6 +639,7 @@ dialTest.skip(
       lastWeekConversation,
       lastMonthConversation,
     ]);
+    await localStorageManager.setShowSideBarPanels();
 
     await dialHomePage.openHomePage();
     await dialHomePage.waitForPageLoaded();
@@ -684,10 +711,12 @@ dialTest(
     dataInjector,
     folderConversations,
     setTestIds,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-864');
     const conversation = conversationData.prepareDefaultConversation();
     await dataInjector.createConversations([conversation]);
+    await localStorageManager.setShowSideBarPanels();
 
     await dialHomePage.openHomePage();
     await dialHomePage.waitForPageLoaded();
@@ -735,6 +764,7 @@ dialTest(
     folderDropdownMenu,
     chatBar,
     setTestIds,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-863', 'EPMRTC-942');
     const folderName = GeneratorUtil.randomString(70);
@@ -745,6 +775,7 @@ dialTest(
       async () => {
         conversation = conversationData.prepareDefaultConversation();
         await dataInjector.createConversations([conversation]);
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -807,6 +838,7 @@ dialTest(
     confirmationDialog,
     dataInjector,
     setTestIds,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-610');
     conversationData.resetData();
@@ -818,6 +850,7 @@ dialTest(
       [singleConversation, ...conversationInFolder.conversations],
       conversationInFolder.folders,
     );
+    await localStorageManager.setShowSideBarPanels();
 
     await dialHomePage.openHomePage();
     await dialHomePage.waitForPageLoaded();
@@ -884,6 +917,7 @@ dialTest(
     const promptInFolder = promptData.prepareDefaultPromptInFolder();
     promptData.resetData();
     const singlePrompt = promptData.prepareDefaultPrompt();
+    await localStorageManager.setShowSideBarPanels();
 
     await dialHomePage.openHomePage();
     await dialHomePage.waitForPageLoaded();
@@ -1057,6 +1091,7 @@ dialTest.skip(
           lastMonthConversation,
           otherConversation,
         );
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -1108,6 +1143,7 @@ dialTest(
     chatBar,
     chatBarSearch,
     setTestIds,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-1188');
     const firstSearchTerm = 'EPAM';
@@ -1132,6 +1168,7 @@ dialTest(
           firstConversation,
           secondConversation,
         ]);
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -1196,6 +1233,7 @@ dialTest(
     folderConversations,
     chatBarSearch,
     setTestIds,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-1201');
 
@@ -1251,6 +1289,7 @@ dialTest(
           firstFolder,
           secondFolder,
         );
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -1317,6 +1356,7 @@ dialTest(
     chat,
     setTestIds,
     renameConversationModal,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-2849', 'EPMRTC-2959');
     const updatedConversationName = `😂👍🥳 😷 🤧 🤠 🥴😇 😈 ⭐あおㅁㄹñ¿äß`;
@@ -1325,6 +1365,7 @@ dialTest(
     await dialTest.step('Prepare new conversation', async () => {
       conversation = conversationData.prepareDefaultConversation();
       await dataInjector.createConversations([conversation]);
+      await localStorageManager.setShowSideBarPanels();
     });
 
     await dialTest.step(
@@ -1390,12 +1431,14 @@ for (const [request, expectedConversationName] of testRequestMap.entries()) {
       sendMessage,
       chatMessages,
       setTestIds,
+      localStorageManager,
     }) => {
       setTestIds('EPMRTC-3007', 'EPMRTC-3015', 'EPMRTC-2853', 'EPMRTC-2961');
 
       await dialTest.step(
         'Send request to chat and verify control chars are replaced with spaces',
         async () => {
+          await localStorageManager.setShowSideBarPanels();
           await dialHomePage.openHomePage();
           await dialHomePage.waitForPageLoaded();
           await sendMessage.send(request);
@@ -1431,6 +1474,7 @@ dialTest(
     dataInjector,
     chatMessages,
     setTestIds,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-2958');
     const updatedRequest = `Chat${ExpectedConstants.restrictedNameChars}name.....`;
@@ -1440,6 +1484,7 @@ dialTest(
     await dialTest.step('Prepare new conversation', async () => {
       conversation = conversationData.prepareDefaultConversation();
       await dataInjector.createConversations([conversation]);
+      await localStorageManager.setShowSideBarPanels();
     });
 
     await dialTest.step(

--- a/apps/chat-e2e/src/tests/chatBarFolderConversation.test.ts
+++ b/apps/chat-e2e/src/tests/chatBarFolderConversation.test.ts
@@ -31,6 +31,7 @@ dialTest(
     dataInjector,
     page,
     setTestIds,
+    localStorageManager,
   }) => {
     setTestIds(
       'EPMRTC-569',
@@ -70,6 +71,7 @@ dialTest(
           folderEmptyConversation.folders,
           folderReplayConversation.folders,
         );
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -157,6 +159,7 @@ dialTest(
       CollapsedSections.Organization,
       CollapsedSections.SharedWithMe,
     );
+    await localStorageManager.setShowSideBarPanels();
     await dialHomePage.openHomePage();
     await dialHomePage.waitForPageLoaded();
 
@@ -219,6 +222,7 @@ dialTest(
     sendMessage,
     page,
     setTestIds,
+    localStorageManager,
   }) => {
     setTestIds(
       'EPMRTC-572',
@@ -231,6 +235,7 @@ dialTest(
     let editFolderInput: EditInput;
 
     await dialTest.step('Start editing folder and cancel', async () => {
+      await localStorageManager.setShowSideBarPanels();
       await dialHomePage.openHomePage();
       await dialHomePage.waitForPageLoaded();
       await chatBar.createNewFolder();
@@ -328,6 +333,7 @@ dialTest(
     folderDropdownMenu,
     toast,
     setTestIds,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-573', 'EPMRTC-574', 'EPMRTC-3190');
     const folderName = GeneratorUtil.randomString(70);
@@ -346,6 +352,7 @@ dialTest(
           conversationInFolder.conversations,
           conversationInFolder.folders,
         );
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -420,6 +427,7 @@ dialTest(
     folderConversations,
     dataInjector,
     setTestIds,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-579');
     let conversationInFolder: FolderConversation;
@@ -430,7 +438,9 @@ dialTest(
         conversationInFolder.conversations,
         conversationInFolder.folders,
       );
+      await localStorageManager.setShowSideBarPanels();
     });
+
     await dialTest.step(
       'Verify folder arrow icon is changes on expand/collapse folder',
       async () => {
@@ -476,6 +486,7 @@ dialTest(
         CollapsedSections.Organization,
         CollapsedSections.SharedWithMe,
       );
+      await localStorageManager.setShowSideBarPanels();
       await dialHomePage.openHomePage();
       await dialHomePage.waitForPageLoaded();
 
@@ -559,6 +570,7 @@ dialTest(
     chatBarFolderAssertion,
     conversationAssertion,
     setTestIds,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-605');
     const conversationInFolder =
@@ -567,6 +579,7 @@ dialTest(
       conversationInFolder.conversations,
       conversationInFolder.folders,
     );
+    await localStorageManager.setShowSideBarPanels();
 
     await dialHomePage.openHomePage();
     await dialHomePage.waitForPageLoaded();
@@ -597,6 +610,7 @@ dialTest(
     conversations,
     confirmationDialog,
     setTestIds,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-1372');
     const levelsCount = 4;
@@ -614,6 +628,7 @@ dialTest(
           nestedConversations,
           ...nestedFolders,
         );
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -676,12 +691,14 @@ dialTest(
     conversationDropdownMenu,
     chatBar,
     setTestIds,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-1277');
 
     await dialTest.step(
       'Create a new folder and rename to name with special symbols',
       async () => {
+        await localStorageManager.setShowSideBarPanels();
         await dialHomePage.openHomePage();
         await dialHomePage.waitForPageLoaded();
         await chatBar.createNewFolder();
@@ -717,6 +734,7 @@ dialTest(
     chatMessages,
     chat,
     setTestIds,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-2954');
     const updatedFolderName = `😂👍🥳 😷 🤧 🤠 🥴😇 😈 ⭐あおㅁㄹñ¿äß`;
@@ -729,6 +747,7 @@ dialTest(
         folderConversation.conversations,
         folderConversation.folders,
       );
+      await localStorageManager.setShowSideBarPanels();
     });
 
     await dialTest.step(
@@ -802,6 +821,7 @@ dialTest(
         CollapsedSections.Organization,
         CollapsedSections.SharedWithMe,
       );
+      await localStorageManager.setShowSideBarPanels();
 
       await dialHomePage.openHomePage();
       await dialHomePage.waitForPageLoaded();
@@ -959,6 +979,7 @@ dialTest(
         await dialHomePage.openHomePage();
         await dialHomePage.waitForPageLoaded();
         await conversations.selectConversation(conversation.name);
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 

--- a/apps/chat-e2e/src/tests/chatBarFolderConversation.test.ts
+++ b/apps/chat-e2e/src/tests/chatBarFolderConversation.test.ts
@@ -972,6 +972,7 @@ dialTest(
       CollapsedSections.Organization,
       CollapsedSections.SharedWithMe,
     );
+    await localStorageManager.setShowSideBarPanels();
 
     await dialTest.step(
       'Create New conversation and send any message there',
@@ -979,7 +980,6 @@ dialTest(
         await dialHomePage.openHomePage();
         await dialHomePage.waitForPageLoaded();
         await conversations.selectConversation(conversation.name);
-        await localStorageManager.setShowSideBarPanels();
       },
     );
 

--- a/apps/chat-e2e/src/tests/chatExportImport.test.ts
+++ b/apps/chat-e2e/src/tests/chatExportImport.test.ts
@@ -48,6 +48,7 @@ dialTest(
     setTestIds,
     conversationData,
     dataInjector,
+    localStorageManager,
     chatBar,
     folderDropdownMenu,
     conversationDropdownMenu,
@@ -69,6 +70,7 @@ dialTest(
           [...conversationInFolder.conversations, conversationOutsideFolder],
           conversationInFolder.folders,
         );
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -164,6 +166,7 @@ dialTest(
     conversations,
     chatBar,
     confirmationDialog,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-907');
     let nestedFolders: FolderInterface[];
@@ -186,6 +189,7 @@ dialTest(
           [...nestedConversations, conversationOutsideFolder],
           ...nestedFolders,
         );
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -253,6 +257,7 @@ dialTest(
     conversations,
     chatBar,
     chatHeader,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-913');
     let conversationsInFolder: FolderConversation;
@@ -276,6 +281,7 @@ dialTest(
           [...conversationsInFolder.conversations, conversationOutsideFolder],
           conversationsInFolder.folders,
         );
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -396,6 +402,7 @@ dialTest(
     chatMessages,
     chat,
     chatBar,
+    localStorageManager,
   }) => {
     dialTest.skip(simpleRequestModel === undefined, noSimpleModelSkipReason);
     setTestIds('EPMRTC-923', 'EPMRTC-924', 'EPMRTC-925', 'EPMRTC-3075');
@@ -413,6 +420,7 @@ dialTest(
         threeConversationsData = ImportConversation.prepareConversationFile(
           importedRootConversation,
         );
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -504,6 +512,7 @@ dialTest(
     iconApiHelper,
     agentInfo,
     baseAssertion,
+    localStorageManager,
   }) => {
     dialTest.skip(
       [
@@ -523,6 +532,7 @@ dialTest(
     await dialTest.step(
       'Import conversation from 1.4 app version and verify folder with Gpt-3.5 chat and its history is visible',
       async () => {
+        await localStorageManager.setShowSideBarPanels();
         await dialHomePage.openHomePage();
         await dialHomePage.waitForPageLoaded();
         await dialHomePage.importFile(
@@ -633,6 +643,7 @@ dialTest(
     confirmationDialog,
     conversationDropdownMenu,
     folderDropdownMenu,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-1359', 'EPMRTC-1368', 'EPMRTC-1369');
     let nestedFolders: FolderInterface[];
@@ -649,6 +660,7 @@ dialTest(
           nestedConversations,
           ...nestedFolders,
         );
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -795,6 +807,7 @@ dialTest(
           nestedConversations,
           ...nestedFolders,
         );
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -932,6 +945,7 @@ dialTest(
           CollapsedSections.Organization,
           CollapsedSections.SharedWithMe,
         );
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 

--- a/apps/chat-e2e/src/tests/chatExportImportWithAttachment.test.ts
+++ b/apps/chat-e2e/src/tests/chatExportImportWithAttachment.test.ts
@@ -36,6 +36,7 @@ dialTest(
     conversationDropdownMenu,
     importExportLoader,
     setTestIds,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-1980');
     let cancelExportConversation: Conversation;
@@ -50,6 +51,7 @@ dialTest(
             defaultModel.id,
           );
         await dataInjector.createConversations([cancelExportConversation]);
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -93,12 +95,14 @@ dialTest(
     conversations,
     importExportLoader,
     setTestIds,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-1982');
 
     await dialTest.step(
       'Import file, stop import in the middle and verify chat is not imported',
       async () => {
+        await localStorageManager.setShowSideBarPanels();
         await dialHomePage.openHomePage();
         await dialHomePage.waitForPageLoaded();
         const beforeImportConversations =
@@ -142,6 +146,7 @@ dialTest(
     talkToAgentDialog,
     marketplacePage,
     setTestIds,
+    localStorageManager,
   }) => {
     setTestIds(
       'EPMRTC-1975',
@@ -185,6 +190,7 @@ dialTest(
           requestImageConversation,
         );
         await dataInjector.createConversations([historyConversation]);
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -377,6 +383,7 @@ dialTest(
     chatMessagesAssertion,
     conversationAssertion,
     setTestIds,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-3521');
     let responseImageConversation: Conversation;
@@ -421,6 +428,7 @@ dialTest(
           historyConversation,
           playbackConversation,
         ]);
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -535,6 +543,7 @@ dialTest(
     agentInfoAssertion,
     apiAssertion,
     setTestIds,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-914');
     let historyConversation: Conversation;
@@ -568,6 +577,7 @@ dialTest(
           historyConversation,
           replayConversation,
         ]);
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -617,14 +627,11 @@ dialTest(
           MockedChatApiResponseBodies.simpleTextBody,
         );
         const replayRequests = await chat.startReplayForDifferentModels();
-        await apiAssertion.verifyRequestAttachments(
+        apiAssertion.verifyRequestAttachments(
           replayRequests[0],
           requestImageUrl,
         );
-        await apiAssertion.verifyRequestAttachments(
-          replayRequests[1],
-          requestDocUrl,
-        );
+        apiAssertion.verifyRequestAttachments(replayRequests[1], requestDocUrl);
       },
     );
 
@@ -675,6 +682,7 @@ dialTest(
     conversationAssertion,
     sendMessageAssertion,
     setTestIds,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-3942');
     let historyConversation: Conversation;
@@ -709,6 +717,7 @@ dialTest(
           historyConversation,
           replayConversation,
         ]);
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 

--- a/apps/chat-e2e/src/tests/chatHeader.test.ts
+++ b/apps/chat-e2e/src/tests/chatHeader.test.ts
@@ -33,6 +33,7 @@ dialTest(
     chatHeaderAssertion,
     conversationInfoTooltipAssertion,
     conversations,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-1115', 'EPMRTC-473');
     let conversation: Conversation;
@@ -50,6 +51,7 @@ dialTest(
           defaultModel,
         );
         await dataInjector.createConversations([conversation]);
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -175,6 +177,7 @@ dialTest(
     agentInfoAssertion,
     agentInfo,
     conversations,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-490', 'EPMRTC-491');
     let conversation: Conversation;
@@ -185,6 +188,7 @@ dialTest(
         'third request',
       ]);
       await dataInjector.createConversations([conversation]);
+      await localStorageManager.setShowSideBarPanels();
     });
 
     await dialTest.step(

--- a/apps/chat-e2e/src/tests/chatHeaderSettings.test.ts
+++ b/apps/chat-e2e/src/tests/chatHeaderSettings.test.ts
@@ -40,6 +40,7 @@ dialTest(
         conversation = conversationData.prepareDefaultConversation();
         await dataInjector.createConversations([conversation]);
         await localStorageManager.setRecentModelsIds(randomModel);
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 

--- a/apps/chat-e2e/src/tests/chatSelectionFunctionality.test.ts
+++ b/apps/chat-e2e/src/tests/chatSelectionFunctionality.test.ts
@@ -34,6 +34,7 @@ dialTest(
     conversationDropdownMenu,
     downloadAssertion,
     renameConversationModal,
+    localStorageManager,
   }) => {
     setTestIds(
       'EPMRTC-934',
@@ -61,6 +62,7 @@ dialTest(
         firstConversation,
         secondConversation,
       ]);
+      await localStorageManager.setShowSideBarPanels();
     });
 
     await dialTest.step('Open start page', async () => {

--- a/apps/chat-e2e/src/tests/chatSwitch.test.ts
+++ b/apps/chat-e2e/src/tests/chatSwitch.test.ts
@@ -29,6 +29,7 @@ dialTest(
     conversationDropdownMenu,
     compareConversation,
     conversationToCompareAssertion,
+    localStorageManager,
   }) => {
     dialTest.skip(simpleRequestModel === undefined, noSimpleModelSkipReason);
     setTestIds(
@@ -71,6 +72,7 @@ dialTest(
           replayConversation,
           comparedConversation,
         ]);
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 

--- a/apps/chat-e2e/src/tests/compareMode.test.ts
+++ b/apps/chat-e2e/src/tests/compareMode.test.ts
@@ -46,12 +46,14 @@ dialTest(
     compare,
     chat,
     conversationAssertion,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-537');
     await dialTest.step(
       'Click on compare button on bottom of chat bar and verify compare mode is opened for new two chats',
       async () => {
         const request = 'test';
+        await localStorageManager.setShowSideBarPanels();
         await dialHomePage.openHomePage();
         await dialHomePage.waitForPageLoaded();
         await chatBar.openCompareMode();
@@ -91,6 +93,7 @@ dialTest(
     iconApiHelper,
     conversationToCompareAssertion,
     folderConversations,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-546', 'EPMRTC-383');
     let firstModelConversation: Conversation;
@@ -136,6 +139,7 @@ dialTest(
         ],
         modelConversationInFolder.folders,
       );
+      await localStorageManager.setShowSideBarPanels();
     });
 
     await dialTest.step(
@@ -227,6 +231,7 @@ dialTest(
     dataInjector,
     compare,
     baseAssertion,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-1133', 'EPMRTC-541');
     let modelConversation: Conversation;
@@ -254,6 +259,7 @@ dialTest(
           replayConversation,
           playbackConversation,
         ]);
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -316,6 +322,7 @@ dialTest(
     conversations,
     conversationDropdownMenu,
     compareConversation,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-544', 'EPMRTC-545');
     let firstConversation: Conversation;
@@ -331,6 +338,7 @@ dialTest(
           firstConversation,
           secondConversation,
         ]);
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -386,6 +394,7 @@ dialTest(
     conversations,
     conversationDropdownMenu,
     compareConversation,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-540');
     const firstRequest = 'What is EPAM official name?';
@@ -442,6 +451,7 @@ dialTest(
           forthConversation,
           fifthConversation,
         ]);
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -486,6 +496,7 @@ dialTest(
     conversationDropdownMenu,
     compareConversation,
     conversationAssertion,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-552', 'EPMRTC-558');
 
@@ -515,6 +526,7 @@ dialTest(
         firstConversation,
         secondConversation,
       ]);
+      await localStorageManager.setShowSideBarPanels();
     });
 
     await dialTest.step(
@@ -639,6 +651,7 @@ dialTest(
     conversationDropdownMenu,
     conversations,
     compareConversation,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-555');
     const request = ['beautiful', 'second message'];
@@ -665,6 +678,7 @@ dialTest(
         firstConversation,
         secondConversation,
       ]);
+      await localStorageManager.setShowSideBarPanels();
     });
 
     await dialTest.step(
@@ -785,6 +799,7 @@ dialTest(
           firstUpdatedRandomModel,
           secondUpdatedRandomModel,
         );
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -946,6 +961,7 @@ dialTest(
     conversations,
     conversationDropdownMenu,
     compareConversation,
+    localStorageManager,
   }) => {
     dialTest.slow();
     setTestIds('EPMRTC-556', 'EPMRTC-1134');
@@ -963,6 +979,7 @@ dialTest(
         firstConversation,
         secondConversation,
       ]);
+      await localStorageManager.setShowSideBarPanels();
     });
 
     await dialTest.step(
@@ -1039,6 +1056,7 @@ dialTest(
     rightChatHeader,
     compareConversation,
     baseAssertion,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-536', 'EPMRTC-1168');
     const request = 'What is epam official name';
@@ -1091,6 +1109,7 @@ dialTest(
           thirdConversation,
           fourthConversation,
         ]);
+        await localStorageManager.setShowSideBarPanels();
         matchedConversations.push(
           thirdConversation.name,
           secondConversation.name,
@@ -1289,6 +1308,7 @@ dialTest(
     compareConversation,
     conversationDropdownMenu,
     leftChatHeader,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-542', 'EPMRTC-543', 'EPMRTC-548', 'EPMRTC-828');
     let firstConversation: Conversation;
@@ -1316,6 +1336,7 @@ dialTest(
           firstConversation,
           secondConversation,
         ]);
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -1399,6 +1420,7 @@ dialTest(
     compare,
     compareConversation,
     chat,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-557');
     let firstFolderConversation: FolderConversation;
@@ -1428,6 +1450,7 @@ dialTest(
         firstFolderConversation.folders,
         secondFolderConversation.folders,
       );
+      await localStorageManager.setShowSideBarPanels();
     });
 
     await dialTest.step(
@@ -1505,6 +1528,7 @@ dialTest(
     compare,
     compareConversation,
     renameConversationModal,
+    localStorageManager,
   }) => {
     setTestIds(
       'EPMRTC-560',
@@ -1538,6 +1562,7 @@ dialTest(
           firstConversation,
           secondConversation,
         ]);
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 

--- a/apps/chat-e2e/src/tests/conversationNameNumeration.test.ts
+++ b/apps/chat-e2e/src/tests/conversationNameNumeration.test.ts
@@ -27,6 +27,7 @@ dialTest.skip(
     conversationData,
     dataInjector,
     setTestIds,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-1624', 'EPMRTC-2955');
     let conversation: Conversation;
@@ -42,6 +43,7 @@ dialTest.skip(
           initialConversationName,
         );
         await dataInjector.createConversations([conversation]);
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -80,6 +82,7 @@ dialTest.skip(
     conversationDropdownMenu,
     setTestIds,
     renameConversationModal,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-1625');
     let firstConversation: Conversation;
@@ -105,6 +108,7 @@ dialTest.skip(
           firstConversation,
           secondConversation,
         ]);
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -164,6 +168,7 @@ dialTest.skip(
     conversationDropdownMenu,
     confirmationDialog,
     setTestIds,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-1626');
     const latestIndex = 3;
@@ -181,6 +186,7 @@ dialTest.skip(
           conversationData.resetData();
         }
         await dataInjector.createConversations(conversationsArray);
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -248,6 +254,7 @@ dialTest(
           CollapsedSections.Organization,
           CollapsedSections.SharedWithMe,
         );
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -302,6 +309,7 @@ dialTest(
     chat,
     chatHeader,
     setTestIds,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-2798');
     const requestBasedConversationName = 'test';
@@ -315,6 +323,7 @@ dialTest(
           requestBasedConversationName,
         );
         await dataInjector.createConversations([conversation]);
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -409,6 +418,7 @@ dialTest(
           CollapsedSections.Organization,
           CollapsedSections.SharedWithMe,
         );
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -521,6 +531,7 @@ dialTest(
     conversationDropdownMenu,
     setTestIds,
     renameConversationModal,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-2933');
     let firstConversation: Conversation;
@@ -534,6 +545,7 @@ dialTest(
         firstConversation,
         secondConversation,
       ]);
+      await localStorageManager.setShowSideBarPanels();
     });
 
     await dialTest.step(
@@ -597,6 +609,7 @@ dialTest(
         await localStorageManager.setChatCollapsedSection(
           CollapsedSections.Organization,
         );
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 

--- a/apps/chat-e2e/src/tests/conversationWithAttachment.test.ts
+++ b/apps/chat-e2e/src/tests/conversationWithAttachment.test.ts
@@ -60,6 +60,7 @@ dialTest(
         await fileApiHelper.putFile(file);
       }
       await localStorageManager.setRecentModelsIds(randomModelWithAttachment);
+      await localStorageManager.setShowSideBarPanels();
     });
 
     await dialTest.step(
@@ -183,6 +184,7 @@ dialTest(
     await dialTest.step('Upload file to app', async () => {
       await fileApiHelper.putFile(Attachment.sunImageName);
       await localStorageManager.setRecentModelsIds(randomModelWithAttachment);
+      await localStorageManager.setShowSideBarPanels();
     });
 
     await dialTest.step(
@@ -245,6 +247,7 @@ dialTest(
       'Create new conversation based on model with input attachments and upload attachment from device',
       async () => {
         await localStorageManager.setRecentModelsIds(randomModelWithAttachment);
+        await localStorageManager.setShowSideBarPanels();
         await dialHomePage.openHomePage();
         await dialHomePage.waitForPageLoaded();
         await sendMessage.attachmentMenuTrigger.click();
@@ -325,6 +328,7 @@ dialTest(
     await dialTest.step('Upload file to app', async () => {
       await fileApiHelper.putFile(Attachment.longImageName);
       await localStorageManager.setRecentModelsIds(randomModelWithAttachment);
+      await localStorageManager.setShowSideBarPanels();
     });
 
     await dialTest.step(
@@ -484,6 +488,7 @@ dialTest(
       'Create new conversation based on model with input attachments and upload attachment from device in offline mode',
       async () => {
         await localStorageManager.setRecentModelsIds(randomModelWithAttachment);
+        await localStorageManager.setShowSideBarPanels();
         await dialHomePage.openHomePage();
         await dialHomePage.waitForPageLoaded();
         await sendMessage.attachmentMenuTrigger.click();
@@ -598,6 +603,7 @@ dialTest(
         await localStorageManager.setRecentModelsIds(
           randomModelWithImageAttachment,
         );
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -684,6 +690,7 @@ dialTest(
         await localStorageManager.setRecentModelsIds(
           randomModelWithoutFolderLinkAttachments,
         );
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 

--- a/apps/chat-e2e/src/tests/conversationWithAttachmentInResponse.test.ts
+++ b/apps/chat-e2e/src/tests/conversationWithAttachmentInResponse.test.ts
@@ -48,6 +48,7 @@ dialTest(
           );
         await dataInjector.createConversations([responseImageConversation]);
         await localStorageManager.setRecentModelsIds(updatedModel);
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 

--- a/apps/chat-e2e/src/tests/conversationWithStage.test.ts
+++ b/apps/chat-e2e/src/tests/conversationWithStage.test.ts
@@ -13,6 +13,7 @@ dialTest(
     chatMessages,
     chatMessagesAssertion,
     conversations,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-1757');
     let conversation: Conversation;
@@ -27,6 +28,7 @@ dialTest(
           stagesCount,
         );
         await dataInjector.createConversations([conversation]);
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 

--- a/apps/chat-e2e/src/tests/defaultModelSettings.test.ts
+++ b/apps/chat-e2e/src/tests/defaultModelSettings.test.ts
@@ -66,6 +66,7 @@ dialTest(
       'Verify default model is selected by default',
       async () => {
         await localStorageManager.seLastConversationSettingsOnce();
+        await localStorageManager.setShowSideBarPanels();
         await dialHomePage.openHomePage();
         await dialHomePage.waitForPageLoaded();
         await chat.changeAgentButton.click();
@@ -233,6 +234,7 @@ dialTest(
       'Verify Send button is disabled if no request message set and tooltip is shown on button hover',
       async () => {
         await localStorageManager.setRecentModelsIds(nonDefaultModel);
+        await localStorageManager.setShowSideBarPanels();
         await dialHomePage.openHomePage();
         await dialHomePage.waitForPageLoaded();
         const isSendMessageBtnEnabled =
@@ -354,6 +356,7 @@ dialTest(
     );
     await localStorageManager.setRecentModelsIds(randomModel);
     await localStorageManager.seLastConversationSettingsOnce();
+    await localStorageManager.setShowSideBarPanels();
     await dialHomePage.openHomePage();
     await dialHomePage.waitForPageLoaded();
     await chat.configureSettingsButton.click();
@@ -413,6 +416,7 @@ dialTest(
     talkToAgentDialogAssertion,
     baseAssertion,
     setTestIds,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-1044');
     const appName = GeneratorUtil.randomApplicationName();
@@ -425,6 +429,7 @@ dialTest(
       await applicationApiHelper.createApplication(customAppModel);
       const configModels = await modelApiHelper.getModels();
       configApp = configModels.find((m) => m.name === appName)!;
+      await localStorageManager.setShowSideBarPanels();
     });
 
     await dialTest.step(
@@ -479,6 +484,7 @@ dialTest.skip(
     chat,
     modelApiHelper,
     setTestIds,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-408');
     const randomEntity = GeneratorUtil.randomArrayElement(
@@ -492,6 +498,7 @@ dialTest.skip(
     await dialTest.step(
       'Create new conversation and click "Search on My workspace" link',
       async () => {
+        await localStorageManager.setShowSideBarPanels();
         await dialHomePage.openHomePage();
         await dialHomePage.waitForPageLoaded();
         await chat.changeAgentButton.click();

--- a/apps/chat-e2e/src/tests/duplicateConversation.test.ts
+++ b/apps/chat-e2e/src/tests/duplicateConversation.test.ts
@@ -20,6 +20,7 @@ dialTest(
     conversationData,
     dataInjector,
     chatMessages,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-3000', 'EPMRTC-3056');
     let conversation: Conversation;
@@ -32,6 +33,7 @@ dialTest(
         secondRequest,
       ]);
       await dataInjector.createConversations([conversation]);
+      await localStorageManager.setShowSideBarPanels();
     });
 
     await dialTest.step(
@@ -92,6 +94,7 @@ dialTest(
       await localStorageManager.setChatCollapsedSection(
         CollapsedSections.Organization,
       );
+      await localStorageManager.setShowSideBarPanels();
     });
 
     await dialTest.step(

--- a/apps/chat-e2e/src/tests/duplicatePrompt.test.ts
+++ b/apps/chat-e2e/src/tests/duplicatePrompt.test.ts
@@ -21,6 +21,7 @@ dialTest(
     promptDropdownMenu,
     dataInjector,
     setTestIds,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-2998', 'EPMRTC-3049');
     let prompt: Prompt;
@@ -28,6 +29,7 @@ dialTest(
     await dialTest.step('Prepare prompt', async () => {
       prompt = promptData.preparePrompt(promptContent, promptDescr);
       await dataInjector.createPrompts([prompt]);
+      await localStorageManager.setShowSideBarPanels();
     });
 
     await dialTest.step(
@@ -73,6 +75,7 @@ dialTest(
     promptData,
     promptDropdownMenu,
     dataInjector,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-2999');
     let folderPrompt: FolderPrompt;
@@ -86,6 +89,7 @@ dialTest(
         folderPrompt.prompts,
         folderPrompt.folders,
       );
+      await localStorageManager.setShowSideBarPanels();
     });
 
     await dialTest.step(

--- a/apps/chat-e2e/src/tests/duplicateSharedConversations.test.ts
+++ b/apps/chat-e2e/src/tests/duplicateSharedConversations.test.ts
@@ -34,6 +34,7 @@ dialSharedWithMeTest(
     additionalShareUserChat,
     baseAssertion,
     additionalShareUserConversationAssertion,
+    additionalShareUserLocalStorageManager,
     setTestIds,
   }) => {
     setTestIds('EPMRTC-1845', 'EPMRTC-2768');
@@ -47,6 +48,7 @@ dialSharedWithMeTest(
         conversation,
       ]);
       await additionalUserShareApiHelper.acceptInvite(shareByLinkResponse);
+      await additionalShareUserLocalStorageManager.setShowSideBarPanels();
     });
 
     await dialSharedWithMeTest.step(
@@ -107,6 +109,7 @@ dialSharedWithMeTest(
     additionalShareUserChat,
     additionalShareUserSharedFolderConversations,
     setTestIds,
+    additionalShareUserLocalStorageManager,
   }) => {
     setTestIds('EPMRTC-1844');
     let folderConversation: FolderConversation;
@@ -128,6 +131,7 @@ dialSharedWithMeTest(
         );
         await additionalUserShareApiHelper.acceptInvite(shareByLinkResponse);
         conversationName = folderConversation.conversations[0].name;
+        await additionalShareUserLocalStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -191,6 +195,7 @@ dialSharedWithMeTest(
     setTestIds,
     baseAssertion,
     additionalShareUserConversationAssertion,
+    additionalShareUserLocalStorageManager,
   }) => {
     setTestIds('EPMRTC-1835', 'EPMRTC-1843', 'EPMRTC-1838');
     let firstComparedConversation: Conversation;
@@ -230,6 +235,7 @@ dialSharedWithMeTest(
           [thirdComparedConversation],
           BucketUtil.getAdditionalShareUserBucket(),
         );
+        await additionalShareUserLocalStorageManager.setShowSideBarPanels();
       },
     );
 

--- a/apps/chat-e2e/src/tests/duplicateSharedPrompts.test.ts
+++ b/apps/chat-e2e/src/tests/duplicateSharedPrompts.test.ts
@@ -19,6 +19,7 @@ dialSharedWithMeTest(
     additionalShareUserFolderPrompts,
     additionalShareUserPromptAssertion,
     setTestIds,
+    additionalShareUserLocalStorageManager,
   }) => {
     setTestIds('EPMRTC-1872', 'EPMRTC-2037');
     let folderPrompt: FolderPrompt;
@@ -42,6 +43,7 @@ dialSharedWithMeTest(
         await additionalUserShareApiHelper.acceptInvite(
           shareFolderByLinkResponse,
         );
+        await additionalShareUserLocalStorageManager.setShowSideBarPanels();
       },
     );
 

--- a/apps/chat-e2e/src/tests/editConversationWithAttachment.test.ts
+++ b/apps/chat-e2e/src/tests/editConversationWithAttachment.test.ts
@@ -29,6 +29,7 @@ dialTest(
     dataInjector,
     conversations,
     chatMessages,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-1583');
     const randomModelWithAttachment = GeneratorUtil.randomArrayElement(
@@ -51,6 +52,7 @@ dialTest(
             imageUrl,
           );
         await dataInjector.createConversations([conversation]);
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -121,6 +123,7 @@ dialTest(
         await fileApiHelper.putFile(file);
       }
       await localStorageManager.setRecentModelsIds(randomModelWithAttachment);
+      await localStorageManager.setShowSideBarPanels();
     });
 
     await dialTest.step(

--- a/apps/chat-e2e/src/tests/editMessageWithAttachment.test.ts
+++ b/apps/chat-e2e/src/tests/editMessageWithAttachment.test.ts
@@ -32,6 +32,7 @@ dialTest(
     attachmentDropdownMenu,
     uploadFromDeviceModal,
     page,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-1613', 'EPMRTC-1776');
     const randomModelWithAttachment = GeneratorUtil.randomArrayElement(
@@ -46,6 +47,7 @@ dialTest(
           randomModelWithAttachment,
         );
         await dataInjector.createConversations([conversation]);
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -132,6 +134,7 @@ dialTest(
     conversations,
     chatMessages,
     editMessageInputAttachments,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-1762', 'EPMRTC-1902');
     const randomModelWithAttachment = GeneratorUtil.randomArrayElement(
@@ -157,6 +160,7 @@ dialTest(
             imageUrl,
           );
         await dataInjector.createConversations([conversation]);
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -238,6 +242,7 @@ dialTest(
     conversations,
     editMessageInputAttachments,
     chat,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-1903');
     const randomModelWithAttachment = GeneratorUtil.randomArrayElement(
@@ -275,6 +280,7 @@ dialTest(
             ...attachmentUrls.slice(0, 2),
           );
         await dataInjector.createConversations([conversation]);
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -351,6 +357,7 @@ dialTest(
     dataInjector,
     chatMessages,
     conversations,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-3331', 'EPMRTC-3332');
     const randomModelWithAttachment = GeneratorUtil.randomArrayElement(
@@ -381,6 +388,7 @@ dialTest(
             ...attachmentUrls.slice(0, 3),
           );
         await dataInjector.createConversations([conversation]);
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 

--- a/apps/chat-e2e/src/tests/entityIcon.test.ts
+++ b/apps/chat-e2e/src/tests/entityIcon.test.ts
@@ -24,6 +24,7 @@ dialTest(
     marketplaceAgentsAssertion,
     chat,
     setTestIds,
+    localStorageManager,
   }) => {
     dialTest.slow();
     setTestIds('EPMRTC-1036', 'EPMRTC-1038');
@@ -31,6 +32,7 @@ dialTest(
     await dialTest.step(
       'Open "Select an agent for conversation" modal for new conversation',
       async () => {
+        await localStorageManager.setShowSideBarPanels();
         await dialHomePage.openHomePage();
         await dialHomePage.waitForPageLoaded();
         await chat.changeAgentButton.click();
@@ -96,6 +98,7 @@ dialTest.skip(
           conversationData.prepareEmptyConversation(simpleRequestModel);
         await dataInjector.createConversations([conversation]);
         await localStorageManager.setRecentModelsIds(simpleRequestModel!);
+        await localStorageManager.setShowSideBarPanels();
 
         await dialHomePage.openHomePage();
         await dialHomePage.waitForPageLoaded();

--- a/apps/chat-e2e/src/tests/errorUploadFromDevice.test.ts
+++ b/apps/chat-e2e/src/tests/errorUploadFromDevice.test.ts
@@ -19,12 +19,14 @@ dialTest(
     chatBar,
     uploadFromDeviceModal,
     baseAssertion,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-1777', 'EPMRTC-1778');
     const expectedErrorTextClassAttribute = 'truncate whitespace-pre-wrap';
 
     await dialTest.step('Upload file with long name to app', async () => {
       await fileApiHelper.putFile(Attachment.longImageName);
+      await localStorageManager.setShowSideBarPanels();
     });
 
     await dialTest.step(
@@ -75,6 +77,7 @@ dialTest(
     chatBar,
     uploadFromDeviceModal,
     baseAssertion,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-1780', 'EPMRTC-1802');
     const restrictedChar = GeneratorUtil.randomArrayElement(
@@ -83,6 +86,7 @@ dialTest(
     const notAllowedFilename = `${restrictedChar}${Attachment.sunImageName}`;
 
     await dialTest.step('Upload file through chat bar dots menu', async () => {
+      await localStorageManager.setShowSideBarPanels();
       await dialHomePage.openHomePage();
       await dialHomePage.waitForPageLoaded();
       await chatBar.openManageAttachmentsModal();
@@ -153,11 +157,13 @@ dialTest(
     uploadFromDeviceModal,
     fileApiHelper,
     baseAssertion,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-3217', 'EPMRTC-3194', 'EPMRTC-1779');
 
     await dialTest.step('Upload file with valid name to app', async () => {
       await fileApiHelper.putFile(Attachment.sunImageName);
+      await localStorageManager.setShowSideBarPanels();
     });
 
     await dialTest.step(
@@ -211,6 +217,7 @@ dialTest(
     chatBar,
     uploadFromDeviceModal,
     baseAssertion,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-3216', 'EPMRTC-3113');
     const dot = '.';
@@ -218,6 +225,7 @@ dialTest(
     await dialTest.step(
       'Upload file without extension through chat bar dots menu',
       async () => {
+        await localStorageManager.setShowSideBarPanels();
         await dialHomePage.openHomePage();
         await dialHomePage.waitForPageLoaded();
         await chatBar.openManageAttachmentsModal();

--- a/apps/chat-e2e/src/tests/folderNameNumeration.test.ts
+++ b/apps/chat-e2e/src/tests/folderNameNumeration.test.ts
@@ -26,6 +26,7 @@ dialTest(
     chatBar,
     confirmationDialog,
     setTestIds,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-1628', 'EPMRTC-2948', 'EPMRTC-1629');
     let folderConversation: FolderConversation;
@@ -49,6 +50,7 @@ dialTest(
           folderConversation.folders,
         );
         conversation = folderConversation.conversations[0];
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -143,6 +145,7 @@ dialTest(
     chatBar,
     toast,
     setTestIds,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-2949', 'EPMRTC-2952');
     let nestedFolders: FolderInterface[];
@@ -159,6 +162,7 @@ dialTest(
         ...nestedFolders,
       );
       expectedDuplicatedFolderName = nestedFolders[nestedFolderLevel - 2].name;
+      await localStorageManager.setShowSideBarPanels();
     });
 
     await dialTest.step(
@@ -258,6 +262,7 @@ dialTest(
           CollapsedSections.Organization,
           CollapsedSections.SharedWithMe,
         );
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 

--- a/apps/chat-e2e/src/tests/folderPrompts.test.ts
+++ b/apps/chat-e2e/src/tests/folderPrompts.test.ts
@@ -13,8 +13,15 @@ import { expect } from '@playwright/test';
 
 dialTest(
   'Create new prompt folder',
-  async ({ dialHomePage, promptBar, folderPrompts, setTestIds }) => {
+  async ({
+    dialHomePage,
+    promptBar,
+    folderPrompts,
+    setTestIds,
+    localStorageManager,
+  }) => {
     setTestIds('EPMRTC-944');
+    await localStorageManager.setShowSideBarPanels();
     await dialHomePage.openHomePage();
     await dialHomePage.waitForPageLoaded();
     await promptBar.createNewFolder();
@@ -37,6 +44,7 @@ dialTest(
     folderPrompts,
     dataInjector,
     setTestIds,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-946');
     const promptInFolder = promptData.prepareDefaultPromptInFolder();
@@ -45,6 +53,7 @@ dialTest(
       promptInFolder.folders,
     );
     const folderName = promptInFolder.folders.name;
+    await localStorageManager.setShowSideBarPanels();
 
     await dialHomePage.openHomePage();
     await dialHomePage.waitForPageLoaded();
@@ -76,6 +85,7 @@ dialTest(
     folderDropdownMenuAssertion,
     promptBarFolderAssertion,
     setTestIds,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-2730', 'EPMRTC-948', 'EPMRTC-1382');
     const newName = 'updated folder name';
@@ -84,6 +94,7 @@ dialTest(
     await dialTest.step(
       'Prepare nested folders hierarchy and expand it',
       async () => {
+        await localStorageManager.setShowSideBarPanels();
         await dialHomePage.openHomePage();
         await dialHomePage.waitForPageLoaded();
 
@@ -151,9 +162,11 @@ dialTest(
     folderPrompts,
     folderDropdownMenu,
     setTestIds,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-949');
     const newName = 'updated folder name';
+    await localStorageManager.setShowSideBarPanels();
     await dialHomePage.openHomePage();
     await dialHomePage.waitForPageLoaded();
     await promptBar.createNewFolder();
@@ -183,6 +196,7 @@ dialTest(
     folderPrompts,
     folderDropdownMenu,
     setTestIds,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-950');
     const promptInFolder = promptData.prepareDefaultPromptInFolder();
@@ -190,6 +204,7 @@ dialTest(
       promptInFolder.prompts,
       promptInFolder.folders,
     );
+    await localStorageManager.setShowSideBarPanels();
 
     const newName = 'updated folder name';
     await dialHomePage.openHomePage();
@@ -216,10 +231,12 @@ dialTest(
     dataInjector,
     folderPrompts,
     setTestIds,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-962');
     const prompt = promptData.prepareDefaultPrompt();
     await dataInjector.createPrompts([prompt]);
+    await localStorageManager.setShowSideBarPanels();
 
     await dialHomePage.openHomePage();
     await dialHomePage.waitForPageLoaded();
@@ -251,10 +268,12 @@ dialTest(
     folderPrompts,
     promptBar,
     setTestIds,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-963');
     const prompt = promptData.prepareDefaultPrompt();
     await dataInjector.createPrompts([prompt]);
+    await localStorageManager.setShowSideBarPanels();
 
     await dialHomePage.openHomePage();
     await dialHomePage.waitForPageLoaded();
@@ -289,6 +308,7 @@ dialTest(
     prompts,
     confirmationDialog,
     setTestIds,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-966');
     const promptInFolder = promptData.prepareDefaultPromptInFolder();
@@ -296,6 +316,7 @@ dialTest(
       promptInFolder.prompts,
       promptInFolder.folders,
     );
+    await localStorageManager.setShowSideBarPanels();
 
     await dialHomePage.openHomePage();
     await dialHomePage.waitForPageLoaded();
@@ -327,8 +348,10 @@ dialTest(
     promptDropdownMenu,
     confirmationDialog,
     setTestIds,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-967', 'EPMRTC-1383');
+    await localStorageManager.setShowSideBarPanels();
     await dialHomePage.openHomePage();
     await dialHomePage.waitForPageLoaded();
     for (let i = 1; i <= 3; i++) {
@@ -396,6 +419,7 @@ dialTest(
     promptDropdownMenu,
     setTestIds,
     confirmationDialog,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-968');
     const promptInFolder = promptData.prepareDefaultPromptInFolder();
@@ -403,6 +427,7 @@ dialTest(
       promptInFolder.prompts,
       promptInFolder.folders,
     );
+    await localStorageManager.setShowSideBarPanels();
 
     await dialHomePage.openHomePage();
     await dialHomePage.waitForPageLoaded();
@@ -436,6 +461,7 @@ dialTest(
     confirmationDialog,
     promptData,
     setTestIds,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-1384');
     const levelsCount = 4;
@@ -455,6 +481,7 @@ dialTest(
           promptData.resetData();
         }
         await dataInjector.createPrompts(nestedPrompts, ...nestedFolders);
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -518,6 +545,7 @@ dialTest(
     folderPrompts,
     promptBarSearch,
     setTestIds,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-1174');
     let firstFolderPrompt: FolderPrompt;
@@ -542,6 +570,7 @@ dialTest(
           firstFolderPrompt.folders,
           secondFolderPrompts.folders,
         );
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 

--- a/apps/chat-e2e/src/tests/footer.test.ts
+++ b/apps/chat-e2e/src/tests/footer.test.ts
@@ -4,12 +4,19 @@ import { expect } from '@playwright/test';
 
 dialTest(
   'EPAM AI Dial leads to kb',
-  async ({ dialHomePage, chat, footerAssertion, setTestIds }) => {
+  async ({
+    dialHomePage,
+    chat,
+    footerAssertion,
+    setTestIds,
+    localStorageManager,
+  }) => {
     setTestIds('EPMRTC-361');
 
     await dialTest.step(
       'Open app and verify footer with configured content is displayed',
       async () => {
+        await localStorageManager.setShowSideBarPanels();
         await dialHomePage.openHomePage();
         await dialHomePage.waitForPageLoaded();
         await footerAssertion.assertFooterState('visible');

--- a/apps/chat-e2e/src/tests/importSpecific.test.ts
+++ b/apps/chat-e2e/src/tests/importSpecific.test.ts
@@ -56,6 +56,7 @@ dialTest(
       await localStorageManager.setChatCollapsedSection(
         CollapsedSections.Organization,
       );
+      await localStorageManager.setShowSideBarPanels();
     });
 
     await dialTest.step('Export conversation', async () => {
@@ -171,6 +172,7 @@ dialTest(
       await localStorageManager.setPromptCollapsedSection(
         CollapsedSections.Organization,
       );
+      await localStorageManager.setShowSideBarPanels();
     });
 
     await dialTest.step('Export prompt', async () => {

--- a/apps/chat-e2e/src/tests/isolatedView.test.ts
+++ b/apps/chat-e2e/src/tests/isolatedView.test.ts
@@ -492,6 +492,7 @@ dialTest(
     await dialTest.step(
       'Reload into regular Dial and verify conversation exists',
       async () => {
+        await localStorageManager.setShowSideBarPanels();
         await dialHomePage.openHomePage();
         await dialHomePage.waitForPageLoaded();
         await conversationAssertion.assertEntityState(

--- a/apps/chat-e2e/src/tests/manageAttachment.test.ts
+++ b/apps/chat-e2e/src/tests/manageAttachment.test.ts
@@ -30,11 +30,13 @@ dialTest(
     confirmationDialog,
     chatBar,
     manageAttachmentsAssertion,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-1884', 'EPMRTC-3296');
 
     await dialTest.step('Upload file to app', async () => {
       await fileApiHelper.putFile(Attachment.sunImageName);
+      await localStorageManager.setShowSideBarPanels();
     });
 
     await dialTest.step(
@@ -144,6 +146,7 @@ dialTest(
         );
         await dataInjector.createConversations([conversation]);
         await localStorageManager.setRecentModelsIds(randomModelWithAttachment);
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -219,12 +222,14 @@ dialTest(
     attachFilesModal,
     uploadFromDeviceModal,
     chatBar,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-3302');
 
     await dialTest.step(
       'Open "Manage attachments" modal through chat side bar menu icon',
       async () => {
+        await localStorageManager.setShowSideBarPanels();
         await dialHomePage.openHomePage();
         await dialHomePage.waitForPageLoaded();
         await chatBar.openManageAttachmentsModal();
@@ -306,12 +311,14 @@ dialTest(
     uploadFromDeviceModal,
     chatBar,
     context,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-3304');
 
     await dialTest.step(
       'Open "Manage attachments" modal through chat side bar menu icon',
       async () => {
+        await localStorageManager.setShowSideBarPanels();
         await dialHomePage.openHomePage();
         await dialHomePage.waitForPageLoaded();
         await chatBar.openManageAttachmentsModal();
@@ -376,12 +383,14 @@ dialTest(
     uploadFromDeviceModal,
     chatBar,
     context,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-3303');
 
     await dialTest.step(
       'Open "Manage attachments" modal through chat side bar menu icon',
       async () => {
+        await localStorageManager.setShowSideBarPanels();
         await dialHomePage.openHomePage();
         await dialHomePage.waitForPageLoaded();
         await chatBar.openManageAttachmentsModal();
@@ -437,12 +446,14 @@ dialTest(
     attachFilesModal,
     uploadFromDeviceModal,
     chatBar,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-2015', 'EPMRTC-3187');
 
     await dialTest.step(
       'Upload file and set his name to contain special symbols',
       async () => {
+        await localStorageManager.setShowSideBarPanels();
         await dialHomePage.openHomePage();
         await dialHomePage.waitForPageLoaded();
         await chatBar.openManageAttachmentsModal();
@@ -523,6 +534,7 @@ dialTest(
         );
         await dataInjector.createConversations([conversation]);
         await localStorageManager.setRecentModelsIds(randomModelWithAttachment);
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -583,6 +595,7 @@ dialTest(
     chatBar,
     manageAttachmentsAssertion,
     attachedAllFiles,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-5396', 'EPMRTC-5526');
     const filesToTest = [
@@ -607,6 +620,7 @@ dialTest(
     ];
 
     await dialTest.step('Open Dial', async () => {
+      await localStorageManager.setShowSideBarPanels();
       await dialHomePage.openHomePage();
       await dialHomePage.waitForPageLoaded();
     });

--- a/apps/chat-e2e/src/tests/marketplaceFilters.test.ts
+++ b/apps/chat-e2e/src/tests/marketplaceFilters.test.ts
@@ -27,6 +27,7 @@ dialTest(
       marketplaceSidebar,
       dialHomePage,
       chatBar,
+      header,
       marketplaceUrlBuilder,
       context,
     },
@@ -96,7 +97,8 @@ dialTest(
           process.env.E2E_PASSWORD!,
           false,
         );
-        await dialHomePage.waitForPageLoaded();
+        await dialHomePage.waitForPageLoaded({ skipSidebars: true });
+        await header.leftPanelToggle.click();
         await chatBar.dialMarketplaceLink.click();
         await marketplacePage.waitForPageLoaded();
         await marketplaceSidebar.myWorkspaceButton.click();
@@ -192,7 +194,10 @@ dialTest(
                 GeneratorUtil.randomString(5),
               );
               await incognitoAppContainer.getHeader().backToChatButton.click();
-              await incognitoDialHomePage.waitForPageLoaded();
+              await incognitoDialHomePage.waitForPageLoaded({
+                skipSidebars: true,
+              });
+              await incognitoAppContainer.getHeader().leftPanelToggle.click();
               await incognitoAppContainer
                 .getChatBar()
                 .dialMarketplaceLink.click();

--- a/apps/chat-e2e/src/tests/marketplaceSearch.test.ts
+++ b/apps/chat-e2e/src/tests/marketplaceSearch.test.ts
@@ -52,6 +52,7 @@ dialTest(
       'Prepare one application visible in "My Workspace" and one available in the "Marketplace", both have common part in the name',
       async () => {
         const recentModelIds = await localStorageManager.getRecentModelsIds();
+        await localStorageManager.setShowSideBarPanels();
         const recentNames = ModelsUtil.getRecentAgentsNames(recentModelIds);
         const recentVersions =
           ModelsUtil.getRecentAgentsVersions(recentModelIds);

--- a/apps/chat-e2e/src/tests/mdTableModelResponse.test.ts
+++ b/apps/chat-e2e/src/tests/mdTableModelResponse.test.ts
@@ -60,6 +60,7 @@ dialTest(
     await dialTest.step('Set random application theme', async () => {
       theme = GeneratorUtil.randomArrayElement(Object.keys(ThemeId));
       await localStorageManager.setSettings(theme);
+      await localStorageManager.setShowSideBarPanels();
     });
 
     await dialTest.step(
@@ -203,6 +204,7 @@ dialTest.fixme(
     conversations,
     conversationData,
     dataInjector,
+    localStorageManager,
   }) => {
     dialTest.skip(simpleRequestModel === undefined, noSimpleModelSkipReason);
     setTestIds('EPMRTC-3123');
@@ -213,6 +215,7 @@ dialTest.fixme(
         simpleRequestModel!,
       );
       await dataInjector.createConversations([tableConversation]);
+      await localStorageManager.setShowSideBarPanels();
     });
 
     await dialTest.step(

--- a/apps/chat-e2e/src/tests/messageTemplate.test.ts
+++ b/apps/chat-e2e/src/tests/messageTemplate.test.ts
@@ -59,6 +59,7 @@ dialTest(
     conversationData,
     dataInjector,
     setTestIds,
+    localStorageManager,
   }) => {
     setTestIds(
       'EPMRTC-4251',
@@ -81,6 +82,7 @@ dialTest(
         requestContent,
       ]);
       await dataInjector.createConversations([conversation]);
+      await localStorageManager.setShowSideBarPanels();
     });
 
     await dialTest.step(
@@ -227,6 +229,7 @@ dialTest(
     conversationData,
     dataInjector,
     setTestIds,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-4270', 'EPMRTC-4276');
     const updatedSecondRowContent = secondRowContent.substring(0, 3);
@@ -240,6 +243,7 @@ dialTest(
           [requestContent],
         );
         await dataInjector.createConversations([conversation]);
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -355,6 +359,7 @@ dialTest(
     conversationData,
     dataInjector,
     setTestIds,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-4273');
     const request = requestContent.split('\n').slice(0, 2).join('\n');
@@ -376,6 +381,7 @@ dialTest(
             rowsMap,
           );
         await dataInjector.createConversations([conversation]);
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -448,6 +454,7 @@ dialTest(
     conversationData,
     dataInjector,
     setTestIds,
+    localStorageManager,
   }) => {
     setTestIds(
       'EPMRTC-4297',
@@ -471,6 +478,7 @@ dialTest(
           [request],
         );
         await dataInjector.createConversations([conversation]);
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -774,6 +782,7 @@ dialTest(
     variableModalDialog,
     variableModalAssertion,
     setTestIds,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-4298', 'EPMRTC-4372');
     const aVar = 'A';
@@ -811,6 +820,7 @@ dialTest(
           secondPromptContent(cVarPlaceholder, dVarPlaceholder),
         );
         await dataInjector.createPrompts([firstPrompt, secondPrompt]);
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -922,6 +932,7 @@ dialTest(
     apiAssertion,
     toast,
     setTestIds,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-4277', 'EPMRTC-4283', 'EPMRTC-4287');
     let simpleConversationMessage: Conversation;
@@ -948,6 +959,7 @@ dialTest(
         );
         await dataInjector.createConversations([conversation]);
         replayName = `${ExpectedConstants.replayConversation}${conversation.name}`;
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -1078,7 +1090,7 @@ dialTest(
           secondUpdatedValue,
         );
         const request = await variableModalDialog.submitReplayVariables();
-        await apiAssertion.assertRequestMessage(
+        apiAssertion.assertRequestMessage(
           request.messages[2],
           requestContent
             .replaceAll(thirdVarValue, firstUpdatedValue)
@@ -1102,6 +1114,7 @@ dialSharedWithMeTest(
     additionalShareUserChat,
     additionalShareUserVariableModalDialog,
     additionalShareUserVariableModalAssertion,
+    additionalShareUserLocalStorageManager,
     setTestIds,
   }) => {
     setTestIds('EPMRTC-4280');
@@ -1132,6 +1145,7 @@ dialSharedWithMeTest(
       const shareByLinkResponse =
         await mainUserShareApiHelper.shareEntityByLink([conversation]);
       await additionalUserShareApiHelper.acceptInvite(shareByLinkResponse);
+      await additionalShareUserLocalStorageManager.setShowSideBarPanels();
     });
 
     await dialTest.step(
@@ -1189,6 +1203,8 @@ dialAdminTest(
     adminVariableModal,
     adminVariableModalAssertion,
     setTestIds,
+    adminLocalStorageManager,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-4281', 'EPMRTC-4282');
     let simpleConversationMessage: Conversation;
@@ -1213,6 +1229,7 @@ dialAdminTest(
           templateConversationMessage,
         );
         await dataInjector.createConversations([conversation]);
+        await adminLocalStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -1274,6 +1291,7 @@ dialAdminTest(
     await dialTest.step(
       'Create a replay conversation from "Organization" section for published conversation and verify modal variable is displayed for the second conversation request on replaying',
       async () => {
+        await localStorageManager.setShowSideBarPanels();
         await dialHomePage.openHomePage();
         await dialHomePage.waitForPageLoaded();
         await organizationConversations.openEntityDropdownMenu(

--- a/apps/chat-e2e/src/tests/modelSettings.test.ts
+++ b/apps/chat-e2e/src/tests/modelSettings.test.ts
@@ -39,6 +39,7 @@ dialTest(
       ),
     );
     await localStorageManager.setRecentModelsIds(defaultModel, randomModel);
+    await localStorageManager.setShowSideBarPanels();
     await dialHomePage.openHomePage();
     await dialHomePage.waitForPageLoaded();
 
@@ -76,7 +77,13 @@ dialTest(
 
 dialTest(
   'System prompt contains combinations with :',
-  async ({ dialHomePage, agentSettings, chat, setTestIds }) => {
+  async ({
+    dialHomePage,
+    agentSettings,
+    chat,
+    setTestIds,
+    localStorageManager,
+  }) => {
     setTestIds('EPMRTC-1084');
     const prompts = [
       'test:',
@@ -85,6 +92,7 @@ dialTest(
       ' test:',
       'test test. test:',
     ];
+    await localStorageManager.setShowSideBarPanels();
     await dialHomePage.openHomePage();
     await dialHomePage.waitForPageLoaded();
     await chat.configureSettingsButton.click();

--- a/apps/chat-e2e/src/tests/monitoring/conversationExportImport.test.ts
+++ b/apps/chat-e2e/src/tests/monitoring/conversationExportImport.test.ts
@@ -14,6 +14,7 @@ dialTest(
     conversationDropdownMenu,
     confirmationDialog,
     conversationAssertion,
+    localStorageManager,
   }) => {
     let exportedData: UploadDownloadData;
     let conversationOutsideFolder: Conversation;
@@ -21,6 +22,7 @@ dialTest(
     await dialTest.step('Prepare conversation', async () => {
       conversationOutsideFolder = conversationData.prepareDefaultConversation();
       await dataInjector.createConversations([conversationOutsideFolder]);
+      await localStorageManager.setShowSideBarPanels();
     });
 
     await dialTest.step(

--- a/apps/chat-e2e/src/tests/monitoring/createNewConversation.test.ts
+++ b/apps/chat-e2e/src/tests/monitoring/createNewConversation.test.ts
@@ -33,6 +33,7 @@ dialTest(
     talkToAgentDialog,
     conversationSettingsModal,
     addons,
+    localStorageManager,
   }) => {
     const expectedAddons = ModelsUtil.getAddons();
     const request = 'test request';
@@ -40,6 +41,7 @@ dialTest(
     await dialTest.step(
       'Verify the list of recent entities and default settings for default model',
       async () => {
+        await localStorageManager.setShowSideBarPanels();
         await dialHomePage.openHomePage();
         await dialHomePage.waitForPageLoaded();
         await chat.changeAgentButton.click();

--- a/apps/chat-e2e/src/tests/monitoring/createNewPrompt.test.ts
+++ b/apps/chat-e2e/src/tests/monitoring/createNewPrompt.test.ts
@@ -2,12 +2,19 @@ import dialTest from '@/src/core/dialFixtures';
 
 dialTest(
   'Create new prompt',
-  async ({ dialHomePage, promptBar, promptModalDialog, promptAssertion }) => {
+  async ({
+    dialHomePage,
+    promptBar,
+    promptModalDialog,
+    promptAssertion,
+    localStorageManager,
+  }) => {
     const newName = 'test prompt';
     const newDescr = 'test description';
     const newValue = 'what is {{}}';
 
     await dialTest.step('Click "New prompt" button', async () => {
+      await localStorageManager.setShowSideBarPanels();
       await dialHomePage.openHomePage();
       await dialHomePage.waitForPageLoaded();
       await promptBar.createNewPrompt();

--- a/apps/chat-e2e/src/tests/monitoring/deleteFolderWithConversations.test.ts
+++ b/apps/chat-e2e/src/tests/monitoring/deleteFolderWithConversations.test.ts
@@ -13,6 +13,7 @@ dialTest(
     conversations,
     confirmationDialog,
     chatBarFolderAssertion,
+    localStorageManager,
   }) => {
     const conversationInFolder =
       conversationData.prepareDefaultConversationInFolder();
@@ -20,6 +21,7 @@ dialTest(
       conversationInFolder.conversations,
       conversationInFolder.folders,
     );
+    await localStorageManager.setShowSideBarPanels();
 
     await dialHomePage.openHomePage();
     await dialHomePage.waitForPageLoaded();

--- a/apps/chat-e2e/src/tests/monitoring/deleteFolderWithPrompts.test.ts
+++ b/apps/chat-e2e/src/tests/monitoring/deleteFolderWithPrompts.test.ts
@@ -12,6 +12,7 @@ dialTest(
     confirmationDialog,
     promptBarFolderAssertion,
     promptAssertion,
+    localStorageManager,
   }) => {
     let promptInFolder: FolderPrompt;
 
@@ -21,6 +22,7 @@ dialTest(
         promptInFolder.prompts,
         promptInFolder.folders,
       );
+      await localStorageManager.setShowSideBarPanels();
     });
 
     await dialTest.step(

--- a/apps/chat-e2e/src/tests/monitoring/editPrompt.test.ts
+++ b/apps/chat-e2e/src/tests/monitoring/editPrompt.test.ts
@@ -17,12 +17,14 @@ dialTest(
     promptDropdownMenu,
     promptModalDialog,
     promptAssertion,
+    localStorageManager,
   }) => {
     let prompt: Prompt;
 
     await dialTest.step('Prepare a prompt with all fields', async () => {
       prompt = promptData.prepareDefaultPrompt();
       await dataInjector.createPrompts([prompt]);
+      await localStorageManager.setShowSideBarPanels();
     });
 
     await dialTest.step(

--- a/apps/chat-e2e/src/tests/monitoring/promptExportImport.test.ts
+++ b/apps/chat-e2e/src/tests/monitoring/promptExportImport.test.ts
@@ -13,6 +13,7 @@ dialTest(
     promptBar,
     confirmationDialog,
     promptData,
+    localStorageManager,
   }) => {
     const levelsCount = 4;
     let nestedFolders: FolderInterface[];
@@ -26,6 +27,7 @@ dialTest(
         nestedPrompts =
           promptData.preparePromptsForNestedFolders(nestedFolders);
         await dataInjector.createPrompts(nestedPrompts, ...nestedFolders);
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 

--- a/apps/chat-e2e/src/tests/monitoring/renameConversation.test.ts
+++ b/apps/chat-e2e/src/tests/monitoring/renameConversation.test.ts
@@ -13,6 +13,7 @@ dialTest(
     dataInjector,
     conversationAssertion,
     renameConversationModal,
+    localStorageManager,
   }) => {
     const updatedConversationName = GeneratorUtil.randomString(5);
     let conversation: Conversation;
@@ -20,6 +21,7 @@ dialTest(
     await dialTest.step('Prepare new conversation', async () => {
       conversation = conversationData.prepareDefaultConversation();
       await dataInjector.createConversations([conversation]);
+      await localStorageManager.setShowSideBarPanels();
     });
 
     await dialTest.step('Rename conversation', async () => {

--- a/apps/chat-e2e/src/tests/monitoring/shareConversation.test.ts
+++ b/apps/chat-e2e/src/tests/monitoring/shareConversation.test.ts
@@ -18,7 +18,6 @@ dialSharedWithMeTest(
     shareModal,
     shareModalAssertion,
     localStorageManager,
-    additionalShareUserLocalStorageManager,
   }) => {
     let conversation: Conversation;
     let shareByLinkResponse: ShareByLinkResponseModel;
@@ -49,7 +48,6 @@ dialSharedWithMeTest(
     await dialSharedWithMeTest.step(
       'Open share link by another user and verify chat stays under Shared with me and is selected automatically',
       async () => {
-        await additionalShareUserLocalStorageManager.setShowSideBarPanels();
         await additionalShareUserDialHomePage.navigateToUrl(
           ExpectedConstants.sharedConversationUrl(
             shareByLinkResponse.invitationLink,
@@ -57,6 +55,7 @@ dialSharedWithMeTest(
         );
         await additionalShareUserDialHomePage.waitForPageLoaded({
           selectedSharedConversationName: conversation.name,
+          skipSidebars: true,
         });
         await expect
           .soft(

--- a/apps/chat-e2e/src/tests/monitoring/shareConversation.test.ts
+++ b/apps/chat-e2e/src/tests/monitoring/shareConversation.test.ts
@@ -17,6 +17,8 @@ dialSharedWithMeTest(
     conversationDropdownMenu,
     shareModal,
     shareModalAssertion,
+    localStorageManager,
+    additionalShareUserLocalStorageManager,
   }) => {
     let conversation: Conversation;
     let shareByLinkResponse: ShareByLinkResponseModel;
@@ -24,6 +26,7 @@ dialSharedWithMeTest(
     await dialTest.step('Prepare default conversation', async () => {
       conversation = conversationData.prepareDefaultConversation();
       await dataInjector.createConversations([conversation]);
+      await localStorageManager.setShowSideBarPanels();
     });
 
     await dialTest.step(
@@ -46,6 +49,7 @@ dialSharedWithMeTest(
     await dialSharedWithMeTest.step(
       'Open share link by another user and verify chat stays under Shared with me and is selected automatically',
       async () => {
+        await additionalShareUserLocalStorageManager.setShowSideBarPanels();
         await additionalShareUserDialHomePage.navigateToUrl(
           ExpectedConstants.sharedConversationUrl(
             shareByLinkResponse.invitationLink,

--- a/apps/chat-e2e/src/tests/monitoring/sharePrompt.test.ts
+++ b/apps/chat-e2e/src/tests/monitoring/sharePrompt.test.ts
@@ -16,6 +16,8 @@ dialSharedWithMeTest(
     prompts,
     promptDropdownMenu,
     shareModalAssertion,
+    localStorageManager,
+    additionalShareUserLocalStorageManager,
   }) => {
     let prompt: Prompt;
     let shareLinkResponse: ShareByLinkResponseModel;
@@ -23,6 +25,7 @@ dialSharedWithMeTest(
     await dialTest.step('Prepare a new prompt', async () => {
       prompt = promptData.prepareDefaultPrompt();
       await dataInjector.createPrompts([prompt]);
+      await localStorageManager.setShowSideBarPanels();
     });
 
     await dialTest.step(
@@ -41,6 +44,7 @@ dialSharedWithMeTest(
     await dialSharedWithMeTest.step(
       'Open share link by another user and verify prompt stays under expanded "Shared with me" section and prompt details popup is opened',
       async () => {
+        await additionalShareUserLocalStorageManager.setShowSideBarPanels();
         await additionalShareUserDialHomePage.navigateToUrl(
           ExpectedConstants.sharedConversationUrl(
             shareLinkResponse.invitationLink,

--- a/apps/chat-e2e/src/tests/monitoring/sharePrompt.test.ts
+++ b/apps/chat-e2e/src/tests/monitoring/sharePrompt.test.ts
@@ -17,7 +17,6 @@ dialSharedWithMeTest(
     promptDropdownMenu,
     shareModalAssertion,
     localStorageManager,
-    additionalShareUserLocalStorageManager,
   }) => {
     let prompt: Prompt;
     let shareLinkResponse: ShareByLinkResponseModel;
@@ -44,7 +43,6 @@ dialSharedWithMeTest(
     await dialSharedWithMeTest.step(
       'Open share link by another user and verify prompt stays under expanded "Shared with me" section and prompt details popup is opened',
       async () => {
-        await additionalShareUserLocalStorageManager.setShowSideBarPanels();
         await additionalShareUserDialHomePage.navigateToUrl(
           ExpectedConstants.sharedConversationUrl(
             shareLinkResponse.invitationLink,
@@ -52,6 +50,7 @@ dialSharedWithMeTest(
         );
         await additionalShareUserDialHomePage.waitForPageLoaded({
           isPromptShared: true,
+          skipSidebars: true,
         });
         await additionalShareUserSharedWithMePromptAssertion.assertEntityState(
           { name: prompt.name },

--- a/apps/chat-e2e/src/tests/newConversation.test.ts
+++ b/apps/chat-e2e/src/tests/newConversation.test.ts
@@ -44,6 +44,7 @@ dialTest(
     await localStorageManager.setRecentModelsIdsOnce(...models);
     await localStorageManager.setRecentAddonsIds(addon);
     await localStorageManager.setLastConversationSettings('');
+    await localStorageManager.setShowSideBarPanels();
 
     await dialTest.step('Open Dial', async () => {
       await dialHomePage.openHomePage({
@@ -175,6 +176,7 @@ dialSharedWithMeTest(
     sharedWithMeFolderDropdownMenu,
     sharedFolderConversations,
     sharedWithMeConversationAssertion,
+    localStorageManager,
   }) => {
     setTestIds(
       'EPMRTC-4791',
@@ -224,6 +226,7 @@ dialSharedWithMeTest(
           true,
         );
       await mainUserShareApiHelper.acceptInvite(shareFolderByLinkResponse);
+      await localStorageManager.setShowSideBarPanels();
     });
 
     await dialTest.step('Open app and create new conversation', async () => {
@@ -395,6 +398,7 @@ dialTest(
     const conversation = conversationData.prepareDefaultConversation(models[0]);
     await dataInjector.createConversations([conversation]);
     await localStorageManager.setRecentModelsIdsOnce(...models);
+    await localStorageManager.setShowSideBarPanels();
 
     await dialTest.step('Open Dial, navigate to Marketplace', async () => {
       await dialHomePage.openHomePage();
@@ -466,6 +470,7 @@ dialTest(
     await localStorageManager.setRecentModelsIdsOnce(model);
     await localStorageManager.setRecentAddonsIds(addon);
     await localStorageManager.setLastConversationSettings('');
+    await localStorageManager.setShowSideBarPanels();
     let initialConversationIds: string | undefined;
 
     await dialTest.step(

--- a/apps/chat-e2e/src/tests/newConversationOnRefresh.test.ts
+++ b/apps/chat-e2e/src/tests/newConversationOnRefresh.test.ts
@@ -51,6 +51,7 @@ dialTest(
           2,
         );
         await localStorageManager.setRecentModelsIdsOnce(...models);
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -248,6 +249,7 @@ dialTest(
         await localStorageManager.setChatCollapsedSection(
           CollapsedSections.Organization,
         );
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 

--- a/apps/chat-e2e/src/tests/overlay/headerFeature.test.ts
+++ b/apps/chat-e2e/src/tests/overlay/headerFeature.test.ts
@@ -269,8 +269,8 @@ dialOverlayTest(
       async () => {
         await overlayConversations.selectConversation(
           conversation.name,
-          { exactMatch: true },
           { isHttpMethodTriggered: false },
+          { exactMatch: true },
         );
         await overlayHeader.logo.click();
         await overlayBaseAssertion.assertElementState(

--- a/apps/chat-e2e/src/tests/overlay/modelIdFeature.test.ts
+++ b/apps/chat-e2e/src/tests/overlay/modelIdFeature.test.ts
@@ -95,7 +95,7 @@ dialOverlayTest(
         );
         const request =
           await overlayChat.sendRequestWithButton(randomAgentRequest);
-        await overlayApiAssertion.assertRequestModelId(request, randomModel);
+        overlayApiAssertion.assertRequestModelId(request, randomModel);
       },
     );
 
@@ -169,7 +169,7 @@ dialOverlayTest(
       async () => {
         const request =
           await overlayChat.sendRequestWithButton('second request');
-        await overlayApiAssertion.assertRequestModelId(request, expectedModel);
+        overlayApiAssertion.assertRequestModelId(request, expectedModel);
       },
     );
 

--- a/apps/chat-e2e/src/tests/parametrizedReplay.test.ts
+++ b/apps/chat-e2e/src/tests/parametrizedReplay.test.ts
@@ -61,6 +61,7 @@ dialTest(
     chatAssertion,
     page,
     chatMessagesAssertion,
+    localStorageManager,
   }) => {
     setTestIds(
       'EPMRTC-3886',
@@ -91,6 +92,7 @@ dialTest(
           conversation,
           replayConversation,
         ]);
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -246,6 +248,7 @@ dialTest(
           replayConversation,
         ]);
         await localStorageManager.setRecentModelsIds(randomModel);
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -332,6 +335,8 @@ dialSharedWithMeTest(
     additionalShareUserChat,
     additionalShareUserVariableModalAssertion,
     conversations,
+    localStorageManager,
+    additionalShareUserLocalStorageManager,
   }) => {
     setTestIds('EPMRTC-3895', 'EPMRTC-3893');
     let prompt: Prompt;
@@ -357,6 +362,8 @@ dialSharedWithMeTest(
         const shareByLinkResponse =
           await mainUserShareApiHelper.shareEntityByLink([conversation]);
         await additionalUserShareApiHelper.acceptInvite(shareByLinkResponse);
+        await localStorageManager.setShowSideBarPanels();
+        await additionalShareUserLocalStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -422,6 +429,7 @@ dialTest(
     variableModalAssertion,
     variableModalDialog,
     apiAssertion,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-3884');
     let firstPrompt: Prompt;
@@ -494,6 +502,7 @@ dialTest(
           historyConversation,
           replayConversation,
         ]);
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -527,7 +536,7 @@ dialTest(
       'Press Submit and verify modal with second prompt parameters is shown',
       async () => {
         const firstRequest = await variableModalDialog.submitReplayVariables();
-        await apiAssertion.assertRequestModelId(firstRequest, defaultModel);
+        apiAssertion.assertRequestModelId(firstRequest, defaultModel);
         await variableModalAssertion.assertVariableModalState('visible');
         await variableModalAssertion.assertPromptVariableValue(
           secondPromptCountryVar,
@@ -540,7 +549,7 @@ dialTest(
       'Press Submit and verify modal with third prompt parameters is shown',
       async () => {
         const secondRequest = await variableModalDialog.submitReplayVariables();
-        await apiAssertion.assertRequestModelId(secondRequest, defaultModel);
+        apiAssertion.assertRequestModelId(secondRequest, defaultModel);
         await variableModalAssertion.assertVariableModalState('visible');
         await variableModalAssertion.assertPromptVariableValue(
           thirdPromptPersonVar,
@@ -557,7 +566,7 @@ dialTest(
       'Press Submit and verify request with valid model is sent',
       async () => {
         const thirdRequest = await variableModalDialog.submitReplayVariables();
-        await apiAssertion.assertRequestModelId(thirdRequest, randomModel);
+        apiAssertion.assertRequestModelId(thirdRequest, randomModel);
       },
     );
   },

--- a/apps/chat-e2e/src/tests/playBack.test.ts
+++ b/apps/chat-e2e/src/tests/playBack.test.ts
@@ -68,6 +68,7 @@ dialTest(
 
         theme = GeneratorUtil.randomArrayElement(Object.keys(ThemeId));
         await localStorageManager.setSettings(theme);
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -399,6 +400,7 @@ dialTest(
     chatHeader,
     agentInfo,
     setTestIds,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-1420', 'EPMRTC-1421');
     let conversation: Conversation;
@@ -430,6 +432,7 @@ dialTest(
           conversation,
           playbackConversation,
         ]);
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -662,6 +665,7 @@ dialTest(
     playbackControl,
     setTestIds,
     conversations,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-1425');
     let conversation: Conversation;
@@ -684,6 +688,7 @@ dialTest(
           conversation,
           playbackConversation,
         ]);
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -741,6 +746,7 @@ dialTest(
     playbackControl,
     baseAssertion,
     setTestIds,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-1427', 'EPMRTC-1470', 'EPMRTC-1473', 'EPMRTC-1428');
     let conversation: Conversation;
@@ -760,6 +766,7 @@ dialTest(
           conversation,
           playbackConversation,
         ]);
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 

--- a/apps/chat-e2e/src/tests/promptExportImport.test.ts
+++ b/apps/chat-e2e/src/tests/promptExportImport.test.ts
@@ -44,6 +44,7 @@ dialTest(
     apiAssertion,
     sendMessageAssertion,
     chat,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-883', 'EPMRTC-895', 'EPMRTC-3835', 'EPMRTC-3822');
     let promptsInsideFolder: FolderPrompt;
@@ -75,6 +76,7 @@ dialTest(
           promptsInsideFolder.folders,
           ...nestedFolders,
         );
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -163,10 +165,7 @@ dialTest(
             promptContent,
             false,
           );
-          await apiAssertion.assertRequestMessage(
-            request.messages[0],
-            promptContent,
-          );
+          apiAssertion.assertRequestMessage(request.messages[0], promptContent);
         }
       },
     );
@@ -188,6 +187,7 @@ dialTest(
     promptDropdownMenu,
     promptModalDialog,
     confirmationDialog,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-884', 'EPMRTC-885', 'EPMRTC-896');
     let promptInsideFolder: FolderPrompt;
@@ -205,6 +205,7 @@ dialTest(
           promptOutsideFolder,
           ...promptInsideFolder.prompts,
         ]);
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -312,6 +313,7 @@ dialTest(
     promptData,
     promptDropdownMenu,
     confirmationDialog,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-886');
     let promptInsideFolder: FolderPrompt;
@@ -331,6 +333,7 @@ dialTest(
           [...promptInsideFolder.prompts, promptOutsideFolder],
           promptInsideFolder.folders,
         );
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -384,6 +387,7 @@ dialTest(
     folderPrompts,
     promptBar,
     promptData,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-889');
     let promptsInsideFolder: FolderPrompt;
@@ -405,6 +409,7 @@ dialTest(
           [...promptsInsideFolder.prompts, promptOutsideFolder],
           promptsInsideFolder.folders,
         );
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -508,12 +513,14 @@ dialTest(
     promptModalDialog,
     variableModalAssertion,
     sendMessageAssertion,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-1135');
     const aVariable = 'A';
     await dialTest.step(
       'Import prompt from 1.4 app version and verify folder with prompt is visible',
       async () => {
+        await localStorageManager.setShowSideBarPanels();
         await dialHomePage.openHomePage();
         await dialHomePage.waitForPageLoaded();
         await dialHomePage.importFile(
@@ -583,6 +590,7 @@ dialTest(
     promptData,
     promptDropdownMenu,
     folderDropdownMenu,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-1375', 'EPMRTC-1376', 'EPMRTC-1377');
     let nestedFolders: FolderInterface[];
@@ -597,6 +605,7 @@ dialTest(
           promptData.preparePromptsForNestedFolders(nestedFolders);
 
         await dataInjector.createPrompts([...nestedPrompts], ...nestedFolders);
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -716,6 +725,7 @@ dialTest(
     promptBar,
     promptData,
     promptDropdownMenu,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-1378');
     let nestedFolders: FolderInterface[];
@@ -730,6 +740,7 @@ dialTest(
           promptData.preparePromptsForNestedFolders(nestedFolders);
 
         await dataInjector.createPrompts(nestedPrompts, ...nestedFolders);
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -853,6 +864,7 @@ dialTest(
           CollapsedSections.Organization,
           CollapsedSections.SharedWithMe,
         );
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 

--- a/apps/chat-e2e/src/tests/promptFolderNamesakes.test.ts
+++ b/apps/chat-e2e/src/tests/promptFolderNamesakes.test.ts
@@ -16,11 +16,13 @@ dialTest(
     promptDropdownMenu,
     toast,
     setTestIds,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-2969');
     const duplicatedFolderName = 'Folder prompt';
 
     await dialTest.step('Create 2 new prompt folders', async () => {
+      await localStorageManager.setShowSideBarPanels();
       await dialHomePage.openHomePage();
       await dialHomePage.waitForPageLoaded();
       for (let i = 1; i <= 2; i++) {
@@ -87,6 +89,7 @@ dialTest(
           CollapsedSections.Organization,
           CollapsedSections.SharedWithMe,
         );
+        await localStorageManager.setShowSideBarPanels();
         await dialHomePage.openHomePage();
         await dialHomePage.waitForPageLoaded();
         for (let i = 1; i <= 2; i++) {
@@ -166,6 +169,7 @@ dialTest(
         CollapsedSections.Organization,
         CollapsedSections.SharedWithMe,
       );
+      await localStorageManager.setShowSideBarPanels();
       await dialHomePage.openHomePage();
       await dialHomePage.waitForPageLoaded();
       for (let i = 1; i <= 3; i++) {
@@ -256,6 +260,7 @@ dialTest(
         CollapsedSections.Organization,
         CollapsedSections.SharedWithMe,
       );
+      await localStorageManager.setShowSideBarPanels();
       await dialHomePage.openHomePage();
       await dialHomePage.waitForPageLoaded();
       for (let i = 1; i <= 2; i++) {

--- a/apps/chat-e2e/src/tests/promptFolderNumeration.test.ts
+++ b/apps/chat-e2e/src/tests/promptFolderNumeration.test.ts
@@ -10,12 +10,19 @@ import { expect } from '@playwright/test';
 
 dialTest(
   'Prompt folder: default numeration',
-  async ({ dialHomePage, promptBar, folderPrompts, setTestIds }) => {
+  async ({
+    dialHomePage,
+    promptBar,
+    folderPrompts,
+    setTestIds,
+    localStorageManager,
+  }) => {
     setTestIds('EPMRTC-1621');
 
     await dialTest.step(
       'Create several new prompt folders and verify their names are incremented',
       async () => {
+        await localStorageManager.setShowSideBarPanels();
         await dialHomePage.openHomePage();
         await dialHomePage.waitForPageLoaded();
         for (let i = 1; i <= 3; i++) {

--- a/apps/chat-e2e/src/tests/promptFolderNumeration.test.ts
+++ b/apps/chat-e2e/src/tests/promptFolderNumeration.test.ts
@@ -52,6 +52,7 @@ dialTest(
     folderPrompts,
     promptDropdownMenu,
     setTestIds,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-1623');
     let prompt: Prompt;
@@ -60,6 +61,7 @@ dialTest(
     await dialTest.step('Preparation', async () => {
       prompt = promptData.prepareDefaultPrompt();
       await dataInjector.createPrompts([prompt]);
+      await localStorageManager.setShowSideBarPanels();
     });
 
     await dialTest.step('Create a new folder', async () => {
@@ -113,6 +115,7 @@ dialTest(
     promptDropdownMenu,
     confirmationDialog,
     setTestIds,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-1622');
     let folderNumber = 1;
@@ -120,6 +123,7 @@ dialTest(
     await dialTest.step(
       'Create several new prompt folders and verify their names are incremented',
       async () => {
+        await localStorageManager.setShowSideBarPanels();
         await dialHomePage.openHomePage();
         await dialHomePage.waitForPageLoaded();
         for (folderNumber = 1; folderNumber < 3; folderNumber++) {
@@ -194,10 +198,12 @@ dialTest(
     folderPrompts,
     promptDropdownMenu,
     setTestIds,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-2967');
 
     await dialTest.step('Create a new folder', async () => {
+      await localStorageManager.setShowSideBarPanels();
       await dialHomePage.openHomePage();
       await dialHomePage.waitForPageLoaded();
       await promptBar.createNewFolder();
@@ -255,6 +261,7 @@ dialTest(
         CollapsedSections.Organization,
         CollapsedSections.SharedWithMe,
       );
+      await localStorageManager.setShowSideBarPanels();
       await dialHomePage.openHomePage();
       await dialHomePage.waitForPageLoaded();
       for (let i = 1; i <= 3; i++) {

--- a/apps/chat-e2e/src/tests/promptFoldersSpecialChars.test.ts
+++ b/apps/chat-e2e/src/tests/promptFoldersSpecialChars.test.ts
@@ -23,6 +23,7 @@ dialTest(
     setTestIds,
     promptBarFolderAssertion,
     toastAssertion,
+    localStorageManager,
   }) => {
     setTestIds(
       'EPMRTC-2975',
@@ -45,6 +46,7 @@ dialTest(
     const newNameWithEmojis = '😂👍🥳 😷 🤧 🤠 🥴😇 😈 ⭐あおㅁㄹñ¿äß';
 
     await dialTest.step('Create prompt folder', async () => {
+      await localStorageManager.setShowSideBarPanels();
       await dialHomePage.openHomePage();
       await dialHomePage.waitForPageLoaded();
 

--- a/apps/chat-e2e/src/tests/promptMaximumNameLength.test.ts
+++ b/apps/chat-e2e/src/tests/promptMaximumNameLength.test.ts
@@ -46,6 +46,7 @@ dialTest(
           CollapsedSections.Organization,
           CollapsedSections.SharedWithMe,
         );
+        await localStorageManager.setShowSideBarPanels();
         await dialHomePage.openHomePage();
         await dialHomePage.waitForPageLoaded();
         await promptBar.createNewPrompt();

--- a/apps/chat-e2e/src/tests/promptNumeration.test.ts
+++ b/apps/chat-e2e/src/tests/promptNumeration.test.ts
@@ -22,6 +22,7 @@ dialTest(
     confirmationDialog,
     toast,
     setTestIds,
+    localStorageManager,
   }) => {
     setTestIds(
       'EPMRTC-1619',
@@ -37,6 +38,7 @@ dialTest(
     await dialTest.step(
       'Create several new prompts and verify their names are incremented',
       async () => {
+        await localStorageManager.setShowSideBarPanels();
         await dialHomePage.openHomePage();
         await dialHomePage.waitForPageLoaded();
         for (let i = 1; i <= 3; i++) {
@@ -243,6 +245,7 @@ dialTest(
           CollapsedSections.Organization,
           CollapsedSections.SharedWithMe,
         );
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 

--- a/apps/chat-e2e/src/tests/promptUsage.test.ts
+++ b/apps/chat-e2e/src/tests/promptUsage.test.ts
@@ -27,6 +27,7 @@ dialTest(
     sendMessagePromptListAssertion,
     page,
     setTestIds,
+    localStorageManager,
   }) => {
     setTestIds(
       'EPMRTC-3843',
@@ -56,6 +57,7 @@ dialTest(
         promptData.resetData();
       }
       await dataInjector.createPrompts(prompts);
+      await localStorageManager.setShowSideBarPanels();
     });
 
     await dialTest.step(
@@ -133,6 +135,7 @@ dialTest(
     sendMessageAssertion,
     variableModalDialog,
     setTestIds,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-3823', 'EPMRTC-3803', 'EPMRTC-4371');
     let simplePrompt: Prompt;
@@ -155,6 +158,7 @@ dialTest(
         ExpectedConstants.newPromptTitle(2),
       );
       await dataInjector.createPrompts([simplePrompt, promptWithVariable]);
+      await localStorageManager.setShowSideBarPanels();
     });
 
     await dialTest.step(
@@ -218,6 +222,7 @@ dialTest(
     sendMessageAssertion,
     page,
     setTestIds,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-3844', 'EPMRTC-3838');
     let prompt: Prompt;
@@ -233,6 +238,7 @@ dialTest(
       async () => {
         prompt = promptData.preparePrompt(content);
         await dataInjector.createPrompts([prompt]);
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -271,6 +277,7 @@ dialTest(
     variableModalDialog,
     sendMessageAssertion,
     setTestIds,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-3829', 'EPMRTC-3830', 'EPMRTC-3842', 'EPMRTC-3832');
     let prompt: Prompt;
@@ -295,6 +302,7 @@ dialTest(
       async () => {
         prompt = promptData.preparePrompt(content);
         await dataInjector.createPrompts([prompt]);
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -435,6 +443,7 @@ dialTest(
     variableModalDialog,
     sendMessageAssertion,
     setTestIds,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-3833', 'EPMRTC-1015', 'EPMRTC-3865');
     let prompt: Prompt;
@@ -453,6 +462,7 @@ dialTest(
           promptName,
         );
         await dataInjector.createPrompts([prompt]);
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -519,6 +529,7 @@ dialTest(
     conversationDropdownMenu,
     chat,
     setTestIds,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-3821', 'EPMRTC-3883');
     let prompt: Prompt;
@@ -535,6 +546,7 @@ dialTest(
     await dialTest.step('Prepare prompt with vars', async () => {
       prompt = promptData.preparePrompt(promptContent);
       await dataInjector.createPrompts([prompt]);
+      await localStorageManager.setShowSideBarPanels();
     });
 
     await dialTest.step(
@@ -611,6 +623,7 @@ dialSharedWithMeTest(
     additionalShareUserAgentSettingAssertion,
     apiAssertion,
     setTestIds,
+    additionalShareUserLocalStorageManager,
   }) => {
     setTestIds('EPMRTC-3502');
     let folderPrompt: FolderPrompt;
@@ -647,6 +660,7 @@ dialSharedWithMeTest(
         await additionalUserShareApiHelper.acceptInvite(
           shareFolderByLinkResponse,
         );
+        await additionalShareUserLocalStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -706,7 +720,7 @@ dialSharedWithMeTest(
           'test',
           false,
         );
-        await apiAssertion.assertRequestPrompt(
+        apiAssertion.assertRequestPrompt(
           request,
           promptTemplate(promptParamValue) + promptInFolder.content,
         );

--- a/apps/chat-e2e/src/tests/prompts.test.ts
+++ b/apps/chat-e2e/src/tests/prompts.test.ts
@@ -22,6 +22,8 @@ dialTest(
     prompts,
     promptModalDialog,
     setTestIds,
+    header,
+    baseAssertion,
   }) => {
     setTestIds('EPMRTC-945', 'EPMRTC-956', 'EPMRTC-1452');
     await dialTest.step(
@@ -30,7 +32,9 @@ dialTest(
         'Prompt body can not be empty',
       async () => {
         await dialHomePage.openHomePage();
-        await dialHomePage.waitForPageLoaded();
+        await dialHomePage.waitForPageLoaded({ skipSidebars: true });
+        await header.rightPanelToggle.click();
+        await baseAssertion.assertElementState(promptBar, 'visible');
         await promptBar.hoverOverNewEntity();
         const newPromptCursor = await promptBar.getNewEntityCursor();
         expect
@@ -288,10 +292,12 @@ dialTest(
     dataInjector,
     promptDropdownMenu,
     setTestIds,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-952');
     const prompt = promptData.prepareDefaultPrompt();
     await dataInjector.createPrompts([prompt]);
+    await localStorageManager.setShowSideBarPanels();
 
     await dialHomePage.openHomePage();
     await dialHomePage.waitForPageLoaded();
@@ -325,10 +331,12 @@ dialTest(
     promptDropdownMenu,
     promptModalDialog,
     setTestIds,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-953');
     const prompt = promptData.prepareDefaultPrompt();
     await dataInjector.createPrompts([prompt]);
+    await localStorageManager.setShowSideBarPanels();
 
     await dialHomePage.openHomePage();
     await dialHomePage.waitForPageLoaded();
@@ -364,10 +372,12 @@ dialTest(
     promptDropdownMenu,
     promptModalDialog,
     setTestIds,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-954');
     const prompt = promptData.prepareDefaultPrompt();
     await dataInjector.createPrompts([prompt]);
+    await localStorageManager.setShowSideBarPanels();
 
     await dialHomePage.openHomePage();
     await dialHomePage.waitForPageLoaded();
@@ -423,10 +433,12 @@ dialTest(
     promptDropdownMenu,
     promptModalDialog,
     setTestIds,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-955', 'EPMRTC-1278');
     const prompt = promptData.prepareDefaultPrompt();
     await dataInjector.createPrompts([prompt]);
+    await localStorageManager.setShowSideBarPanels();
 
     await dialHomePage.openHomePage();
     await dialHomePage.waitForPageLoaded();
@@ -485,10 +497,12 @@ dialTest(
     promptDropdownMenu,
     setTestIds,
     confirmationDialog,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-969');
     const prompt = promptData.prepareDefaultPrompt();
     await dataInjector.createPrompts([prompt]);
+    await localStorageManager.setShowSideBarPanels();
 
     await dialHomePage.openHomePage();
     await dialHomePage.waitForPageLoaded();
@@ -514,10 +528,12 @@ dialTest(
     promptDropdownMenu,
     setTestIds,
     confirmationDialog,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-970');
     const prompt = promptData.prepareDefaultPrompt();
     await dataInjector.createPrompts([prompt]);
+    await localStorageManager.setShowSideBarPanels();
 
     await dialHomePage.openHomePage();
     await dialHomePage.waitForPageLoaded();
@@ -547,6 +563,7 @@ dialTest(
     confirmationDialog,
     prompts,
     setTestIds,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-971');
     const singlePrompt = promptData.prepareDefaultPrompt();
@@ -566,6 +583,7 @@ dialTest(
       [singleConversation, ...conversationInFolder.conversations],
       conversationInFolder.folders,
     );
+    await localStorageManager.setShowSideBarPanels();
 
     await dialHomePage.openHomePage();
     await dialHomePage.waitForPageLoaded();
@@ -647,6 +665,7 @@ dialTest(
     conversationData.resetData();
     const conversationInFolder =
       conversationData.prepareDefaultConversationInFolder();
+    await localStorageManager.setShowSideBarPanels();
 
     await dialHomePage.openHomePage();
     await dialHomePage.waitForPageLoaded();
@@ -770,8 +789,9 @@ dialTest(
 
 dialTest(
   `[UI] Delete all prompts button doesn't exist if not prompts are created`,
-  async ({ dialHomePage, promptBar, setTestIds }) => {
+  async ({ dialHomePage, promptBar, setTestIds, localStorageManager }) => {
     setTestIds('EPMRTC-973');
+    await localStorageManager.setShowSideBarPanels();
     await dialHomePage.openHomePage();
     await dialHomePage.waitForPageLoaded();
 
@@ -797,6 +817,7 @@ dialTest(
     variableModalAssertion,
     sendMessageAssertion,
     setTestIds,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-1012', 'EPMRTC-2007', 'EPMRTC-2911');
     const promptDescription = 'Prompt description';
@@ -810,6 +831,7 @@ dialTest(
       promptDescription,
     );
     await dataInjector.createPrompts([prompt]);
+    await localStorageManager.setShowSideBarPanels();
 
     await dialHomePage.openHomePage();
     await dialHomePage.waitForPageLoaded();
@@ -847,6 +869,7 @@ dialTest(
     variableModalDialog,
     sendMessageAssertion,
     setTestIds,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-1013');
     const promptContent = (first: string, second: string) =>
@@ -857,6 +880,7 @@ dialTest(
       promptContent(`{{${aVariable}}}`, `{{${bVariable}}}`),
     );
     await dataInjector.createPrompts([prompt]);
+    await localStorageManager.setShowSideBarPanels();
 
     await dialHomePage.openHomePage();
     await dialHomePage.waitForPageLoaded();
@@ -890,6 +914,7 @@ dialTest(
     promptBar,
     promptBarSearch,
     setTestIds,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-1173');
     let firstPrompt: Prompt;
@@ -922,6 +947,7 @@ dialTest(
         fourthPrompt,
         fifthPrompt,
       ]);
+      await localStorageManager.setShowSideBarPanels();
     });
 
     await dialTest.step(

--- a/apps/chat-e2e/src/tests/promptsNames.test.ts
+++ b/apps/chat-e2e/src/tests/promptsNames.test.ts
@@ -24,6 +24,7 @@ dialTest(
     promptAssertion,
     setTestIds,
     promptModalAssertion,
+    localStorageManager,
   }) => {
     setTestIds(
       'EPMRTC-2991',
@@ -42,6 +43,7 @@ dialTest(
       '😂👍🥳 😷 🤧 🤠 🥴😇 😈 ⭐あおㅁㄹñ¿äß😂👍🥳 😷 🤧 🤠 🥴😇 😈 ⭐あおㅁㄹñ¿äß😂👍🥳 😷 🤧 🤠 🥴😇 😈 ⭐あおㅁㄹñ¿äß';
     const nameWithSpaces = ' Prompt 1 ';
     const expectedNameWithSpaces = nameWithSpaces.trim();
+    await localStorageManager.setShowSideBarPanels();
 
     await dialTest.step('Add a dot at the end of a prompt name', async () => {
       await dialHomePage.openHomePage();

--- a/apps/chat-e2e/src/tests/publishConversation.test.ts
+++ b/apps/chat-e2e/src/tests/publishConversation.test.ts
@@ -63,6 +63,8 @@ dialAdminTest(
     adminTooltipAssertion,
     baseAssertion,
     setTestIds,
+    localStorageManager,
+    adminLocalStorageManager,
   }) => {
     dialAdminTest.slow();
     setTestIds(
@@ -93,6 +95,7 @@ dialAdminTest(
     await dialTest.step('Prepare a new conversation', async () => {
       conversation = conversationData.prepareDefaultConversation();
       await dataInjector.createConversations([conversation]);
+      await localStorageManager.setShowSideBarPanels();
     });
 
     await dialTest.step(
@@ -159,6 +162,7 @@ dialAdminTest(
     await dialAdminTest.step(
       'Login as admin and verify conversation publishing request is displayed under "Approve required" section',
       async () => {
+        await adminLocalStorageManager.setShowSideBarPanels();
         await adminDialHomePage.openHomePage();
         await adminDialHomePage.waitForPageLoaded();
         await adminApproveRequiredConversationsAssertion.assertFolderState(
@@ -423,6 +427,7 @@ dialAdminTest(
     adminChat,
     baseAssertion,
     setTestIds,
+    adminLocalStorageManager,
   }) => {
     setTestIds('EPMRTC-3575', 'EPMRTC-3584', 'EPMRTC-3589', 'EPMRTC-4057');
     const publicationNames = [
@@ -459,6 +464,7 @@ dialAdminTest(
             .build();
           await publicationApiHelper.createPublishRequest(publishRequest);
         }
+        await adminLocalStorageManager.setShowSideBarPanels();
 
         await adminDialHomePage.openHomePage();
         await adminDialHomePage.waitForPageLoaded();

--- a/apps/chat-e2e/src/tests/publishConversationToOrganisation.test.ts
+++ b/apps/chat-e2e/src/tests/publishConversationToOrganisation.test.ts
@@ -40,6 +40,8 @@ dialAdminTest(
     adminApproveRequiredConversationsAssertion,
     adminPublishingApprovalModalAssertion,
     setTestIds,
+    localStorageManager,
+    adminLocalStorageManager,
   }) => {
     dialAdminTest.slow();
     setTestIds('EPMRTC-3198', 'EPMRTC-3515', 'EPMRTC-4061');
@@ -92,6 +94,7 @@ dialAdminTest(
     await dialTest.step('Prepare a new conversation to publish', async () => {
       conversationToPublish = conversationData.prepareDefaultConversation();
       await dataInjector.createConversations([conversationToPublish]);
+      await localStorageManager.setShowSideBarPanels();
     });
 
     await dialTest.step(
@@ -145,6 +148,7 @@ dialAdminTest(
     await dialAdminTest.step(
       'Login as admin and verify conversation publishing request is displayed under "Approve required" section',
       async () => {
+        await adminLocalStorageManager.setShowSideBarPanels();
         await adminDialHomePage.openHomePage();
         await adminDialHomePage.waitForPageLoaded();
         await adminApproveRequiredConversationsAssertion.assertFolderState(
@@ -243,6 +247,8 @@ dialAdminTest(
     adminApproveRequiredConversationsAssertion,
     adminPublishingApprovalModalAssertion,
     setTestIds,
+    localStorageManager,
+    adminLocalStorageManager,
   }) => {
     dialAdminTest.slow();
     setTestIds(
@@ -270,6 +276,7 @@ dialAdminTest(
     await dialTest.step('Prepare a new conversation to publish', async () => {
       conversationToPublish = conversationData.prepareDefaultConversation();
       await dataInjector.createConversations([conversationToPublish]);
+      await localStorageManager.setShowSideBarPanels();
     });
 
     await dialTest.step(
@@ -444,6 +451,7 @@ dialAdminTest(
     await dialAdminTest.step(
       'Login as admin and verify conversation publishing request is displayed under "Approve required" section',
       async () => {
+        await adminLocalStorageManager.setShowSideBarPanels();
         await adminDialHomePage.openHomePage();
         await adminDialHomePage.waitForPageLoaded();
         await adminApproveRequiredConversationsAssertion.assertFolderState(

--- a/apps/chat-e2e/src/tests/publishConversationWithAttachment.test.ts
+++ b/apps/chat-e2e/src/tests/publishConversationWithAttachment.test.ts
@@ -68,6 +68,8 @@ dialAdminTest(
     baseAssertion,
     fileApiHelper,
     setTestIds,
+    localStorageManager,
+    adminLocalStorageManager,
   }) => {
     dialAdminTest.slow();
     setTestIds(
@@ -106,6 +108,7 @@ dialAdminTest(
           );
         conversationData.resetData();
         await dataInjector.createConversations([conversation]);
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -189,6 +192,7 @@ dialAdminTest(
     await dialAdminTest.step(
       'Login as admin and verify publishing request is displayed under "Approve required" section',
       async () => {
+        await adminLocalStorageManager.setShowSideBarPanels();
         await adminDialHomePage.openHomePage();
         await adminDialHomePage.waitForPageLoaded();
         await adminApproveRequiredConversationsAssertion.assertFolderState(
@@ -420,6 +424,8 @@ dialAdminTest(
     adminApproveRequiredConversations,
     adminFilesToApproveAssertion,
     setTestIds,
+    localStorageManager,
+    adminLocalStorageManager,
   }) => {
     dialAdminTest.slow();
     setTestIds('EPMRTC-3625');
@@ -445,6 +451,7 @@ dialAdminTest(
             modelWithInputAttachments,
           );
         await dataInjector.createConversations([plotlyConversation]);
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -484,6 +491,7 @@ dialAdminTest(
     await dialAdminTest.step(
       'Login as admin and verify publishing request is displayed under "Approve required" section',
       async () => {
+        await adminLocalStorageManager.setShowSideBarPanels();
         await adminDialHomePage.openHomePage();
         await adminDialHomePage.waitForPageLoaded();
         await adminApproveRequiredConversationsAssertion.assertFolderState(
@@ -649,7 +657,7 @@ dialAdminTest(
         );
         await adminConversationAssertion.assertSelectedConversation(replayName);
         const replayRequest = await adminChat.startReplay();
-        await apiAssertion.assertRequestMessage(
+        apiAssertion.assertRequestMessage(
           replayRequest.messages[0],
           plotlyConversation.messages[0].content,
         );

--- a/apps/chat-e2e/src/tests/publishFolderWithConversation.test.ts
+++ b/apps/chat-e2e/src/tests/publishFolderWithConversation.test.ts
@@ -52,6 +52,8 @@ dialAdminTest(
     baseAssertion,
     setTestIds,
     setIssueIds,
+    localStorageManager,
+    adminLocalStorageManager,
   }) => {
     setIssueIds('3350');
     setTestIds(
@@ -113,6 +115,7 @@ dialAdminTest(
           [...allConversations, conversationToReplay],
           ...nestedFolders,
         );
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -153,6 +156,7 @@ dialAdminTest(
     await dialAdminTest.step(
       'Login as admin and verify publishing request is displayed under "Approve required" section',
       async () => {
+        await adminLocalStorageManager.setShowSideBarPanels();
         await adminDialHomePage.openHomePage();
         await adminDialHomePage.waitForPageLoaded();
         await adminApproveRequiredConversationsAssertion.assertFolderState(
@@ -420,6 +424,8 @@ dialAdminTest(
     adminOrganizationFolderConversations,
     adminOrganizationFolderConversationAssertions,
     setTestIds,
+    localStorageManager,
+    adminLocalStorageManager,
   }) => {
     setTestIds(
       'EPMRTC-3613',
@@ -465,6 +471,7 @@ dialAdminTest(
           await publicationApiHelper.createPublishRequest(publishRequest);
         publicationsToUnpublish.push(publication);
         await adminPublicationApiHelper.approveRequest(publication);
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -619,6 +626,7 @@ dialAdminTest(
     await dialAdminTest.step(
       'Login as admin and verify publishing request is displayed under "Approve required" section',
       async () => {
+        await adminLocalStorageManager.setShowSideBarPanels();
         await adminDialHomePage.openHomePage();
         await adminDialHomePage.waitForPageLoaded();
         await adminApproveRequiredConversationsAssertion.assertFolderState(

--- a/apps/chat-e2e/src/tests/publishPrompt.test.ts
+++ b/apps/chat-e2e/src/tests/publishPrompt.test.ts
@@ -44,6 +44,8 @@ dialAdminTest(
     organizationFolderPrompts,
     confirmationDialog,
     folderDropdownMenu,
+    localStorageManager,
+    adminLocalStorageManager,
   }) => {
     dialAdminTest.slow();
     setTestIds(
@@ -70,6 +72,7 @@ dialAdminTest(
       promptData.resetData();
       prompt2 = promptData.prepareDefaultPrompt();
       await dataInjector.createPrompts([prompt1, prompt2]);
+      await localStorageManager.setShowSideBarPanels();
     });
 
     await dialTest.step('Publish a single prompt', async () => {
@@ -183,6 +186,7 @@ dialAdminTest(
     await dialAdminTest.step(
       'Login as admin and verify conversation publishing request is displayed under "Approve required" section',
       async () => {
+        await adminLocalStorageManager.setShowSideBarPanels();
         await adminDialHomePage.openHomePage();
         await adminDialHomePage.waitForPageLoaded();
         await adminApproveRequiredPromptsAssertion.assertFolderState(
@@ -482,6 +486,8 @@ dialAdminTest(
     folderDropdownMenu,
     publishingRequestModalAssertion,
     tooltipAssertion,
+    localStorageManager,
+    adminLocalStorageManager,
   }) => {
     dialAdminTest.slow();
     setTestIds(
@@ -507,6 +513,7 @@ dialAdminTest(
     await dialTest.step('Prepare a new prompt', async () => {
       prompt1 = promptData.prepareDefaultPrompt();
       await dataInjector.createPrompts([prompt1]);
+      await localStorageManager.setShowSideBarPanels();
     });
 
     await dialTest.step('Publish a single prompt', async () => {
@@ -611,6 +618,7 @@ dialAdminTest(
     await dialAdminTest.step(
       'Login as admin and verify conversation publishing request is displayed under "Approve required" section',
       async () => {
+        await adminLocalStorageManager.setShowSideBarPanels();
         await adminDialHomePage.openHomePage();
         await adminDialHomePage.waitForPageLoaded();
         await adminApproveRequiredPromptsAssertion.assertFolderState(

--- a/apps/chat-e2e/src/tests/replay.test.ts
+++ b/apps/chat-e2e/src/tests/replay.test.ts
@@ -58,6 +58,7 @@ dialTest(
     addons,
     conversationDropdownMenu,
     conversationDropdownMenuAssertion,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-501', 'EPMRTC-1264', 'EPMRTC-3452');
     let replayConversation: Conversation;
@@ -87,6 +88,7 @@ dialTest(
           firstConversation,
           replayConversation,
         ]);
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -186,6 +188,7 @@ dialTest(
     dataInjector,
     setTestIds,
     conversationDropdownMenu,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-503');
     let nestedFolders: FolderInterface[];
@@ -202,6 +205,7 @@ dialTest(
           nestedConversations,
           ...nestedFolders,
         );
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -287,6 +291,7 @@ dialTest(
         replayConversation,
       ]);
       await localStorageManager.setRecentModelsIds(replayModel);
+      await localStorageManager.setShowSideBarPanels();
     });
 
     let replayRequest: ChatBody;
@@ -380,10 +385,13 @@ dialTest(
     dataInjector,
     setTestIds,
     chatHeader,
+    iconApiHelper,
     chatHeaderAssertion,
     modelInfoTooltip,
     errorPopup,
-    iconApiHelper,
+    apiAssertion,
+    baseAssertion,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-1323', 'EPMRTC-1324');
     const replayTemp = 0.8;
@@ -391,12 +399,16 @@ dialTest(
     let conversation: Conversation;
     let replayConversation: Conversation;
     const expectedModelIcon = iconApiHelper.getEntityIcon(defaultModel);
+    const randomAddon = GeneratorUtil.randomArrayElement(
+      ModelsUtil.getAddons(),
+    )!;
+    const expectedAddonIcon = iconApiHelper.getEntityIcon(randomAddon);
 
     await dialTest.step('Prepare conversation to replay', async () => {
       conversation = conversationData.prepareModelConversation(
         replayTemp,
         replayPrompt,
-        [],
+        [randomAddon.id],
         defaultModel,
       );
       replayConversation =
@@ -405,6 +417,7 @@ dialTest(
         conversation,
         replayConversation,
       ]);
+      await localStorageManager.setShowSideBarPanels();
     });
 
     let replayRequest: ChatBody;
@@ -416,25 +429,18 @@ dialTest(
         });
         await dialHomePage.waitForPageLoaded();
         await conversations.selectConversation(replayConversation.name);
-        await dialHomePage.throttleAPIResponse(API.chatHost);
+        await dialHomePage.mockChatTextResponse(
+          MockedChatApiResponseBodies.simpleTextBody,
+        );
         replayRequest = await chat.startReplay(
           conversation.messages[0].content,
         );
-        expect
-          .soft(
-            replayRequest.model?.id,
-            ExpectedMessages.chatRequestModelIsValid,
-          )
-          .toBe(conversation.model.id);
-        expect
-          .soft(replayRequest.prompt, ExpectedMessages.chatRequestPromptIsValid)
-          .toBe(conversation.prompt);
-        expect
-          .soft(
-            replayRequest.temperature,
-            ExpectedMessages.chatRequestTemperatureIsValid,
-          )
-          .toBe(conversation.temperature);
+        apiAssertion.assertRequestModelId(replayRequest, conversation.model);
+        apiAssertion.assertRequestPrompt(replayRequest, conversation.prompt);
+        apiAssertion.assertRequestTemperature(
+          replayRequest,
+          conversation.temperature,
+        );
       },
     );
 
@@ -442,6 +448,7 @@ dialTest(
       'Verify chat header icons are the same as initial model',
       async () => {
         await chatHeaderAssertion.assertHeaderIcon(expectedModelIcon);
+        await chatHeaderAssertion.assertHeaderAddonIcon([expectedAddonIcon]);
       },
     );
 
@@ -451,25 +458,17 @@ dialTest(
         await errorPopup.cancelPopup();
         await chatHeader.hoverOverChatModel();
         const modelInfo = await modelInfoTooltip.getModelInfo();
-        expect
-          .soft(modelInfo, ExpectedMessages.chatInfoModelIsValid)
-          .toBe(defaultModel.name);
-
+        baseAssertion.assertValue(
+          modelInfo,
+          defaultModel.name,
+          ExpectedMessages.chatInfoModelIsValid,
+        );
         const modelVersionInfo = await modelInfoTooltip.getVersionInfo();
-        expect
-          .soft(modelVersionInfo, ExpectedMessages.chatInfoVersionIsValid)
-          .toBe(defaultModel.version);
-
-        //TODO: add setting verification when clarified where to display (TBD: Do we need to show settings icon for replay as is?)
-        // const promptInfo = await chatInfoTooltip.getPromptInfo();
-        // expect
-        //   .soft(promptInfo, ExpectedMessages.chatInfoPromptIsValid)
-        //   .toBe(conversation.prompt);
-        //
-        // const tempInfo = await chatInfoTooltip.getTemperatureInfo();
-        // expect
-        //   .soft(tempInfo, ExpectedMessages.chatInfoTemperatureIsValid)
-        //   .toBe(conversation.temperature.toString());
+        baseAssertion.assertValue(
+          modelVersionInfo,
+          defaultModel.version!,
+          ExpectedMessages.chatInfoVersionIsValid,
+        );
       },
     );
   },
@@ -490,6 +489,7 @@ dialTest(
     iconApiHelper,
     chatMessagesAssertion,
     setTestIds,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-1322', 'EPMRTC-388', 'EPMRTC-1466');
     let replayConversation: Conversation;
@@ -532,6 +532,7 @@ dialTest(
           historyConversation,
           replayConversation,
         ]);
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -546,27 +547,24 @@ dialTest(
         );
         const replayRequests = await chat.startReplayForDifferentModels();
 
-        await apiAssertion.assertRequestModelId(replayRequests[0], simpleModel);
-        await apiAssertion.assertRequestTemperature(
-          replayRequests[0],
-          simpleTemp,
-        );
-        await apiAssertion.assertRequestPrompt(replayRequests[0], simplePrompt);
-        await apiAssertion.assertRequestAddons(
+        apiAssertion.assertRequestModelId(replayRequests[0], simpleModel);
+        apiAssertion.assertRequestTemperature(replayRequests[0], simpleTemp);
+        apiAssertion.assertRequestPrompt(replayRequests[0], simplePrompt);
+        apiAssertion.assertRequestAddons(
           replayRequests[0],
           simpleConversation.selectedAddons,
         );
 
-        await apiAssertion.assertRequestModelId(replayRequests[1], addonModel);
-        await apiAssertion.assertRequestTemperature(
+        apiAssertion.assertRequestModelId(replayRequests[1], addonModel);
+        apiAssertion.assertRequestTemperature(
           replayRequests[1],
           addonConversation.temperature,
         );
-        await apiAssertion.assertRequestPrompt(
+        apiAssertion.assertRequestPrompt(
           replayRequests[1],
           addonConversation.prompt,
         );
-        await apiAssertion.assertRequestAddons(
+        apiAssertion.assertRequestAddons(
           replayRequests[1],
           addonConversation.selectedAddons,
         );
@@ -609,6 +607,7 @@ dialTest(
     setTestIds,
     conversationDropdownMenu,
     renameConversationModal,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-505', 'EPMRTC-506', 'EPMRTC-515', 'EPMRTC-516');
     let conversation: Conversation;
@@ -626,6 +625,7 @@ dialTest(
           conversation,
           replayConversation,
         ]);
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -718,6 +718,7 @@ dialTest(
     talkToAgentDialog,
     talkToAgentDialogAssertion,
     setTestIds,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-1328', 'EPMRTC-2839');
     let notAllowedModelConversation: Conversation;
@@ -736,6 +737,7 @@ dialTest(
           notAllowedModelConversation,
           replayConversation,
         ]);
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -767,7 +769,7 @@ dialTest(
       async () => {
         await talkToAgentDialog.selectAgent(defaultModel, marketplacePage);
         const replayRequest = await chat.startReplay();
-        await apiAssertion.assertRequestModelId(replayRequest, defaultModel);
+        apiAssertion.assertRequestModelId(replayRequest, defaultModel);
       },
     );
   },
@@ -816,6 +818,7 @@ dialTest(
         await localStorageManager.setRecentModelsIds(
           ...newModels.map((m) => ModelsUtil.getModel(m)!),
         );
+        await localStorageManager.setShowSideBarPanels();
         await dialHomePage.openHomePage();
         await dialHomePage.waitForPageLoaded();
         await dialHomePage.importFile({ path: filename }, () =>
@@ -884,6 +887,7 @@ dialTest(
     conversations,
     conversationDropdownMenu,
     setTestIds,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-500');
     let conversation: Conversation;
@@ -891,6 +895,7 @@ dialTest(
     await dialTest.step('Prepare empty conversation', async () => {
       conversation = conversationData.prepareEmptyConversation();
       await dataInjector.createConversations([conversation]);
+      await localStorageManager.setShowSideBarPanels();
     });
 
     await dialTest.step(

--- a/apps/chat-e2e/src/tests/scrolling.test.ts
+++ b/apps/chat-e2e/src/tests/scrolling.test.ts
@@ -31,6 +31,7 @@ dialTest(
     conversations,
     dataInjector,
     sendMessage,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-494', 'EPMRTC-492', 'EPMRTC-496');
     const deltaY = 50;
@@ -41,6 +42,7 @@ dialTest(
         GeneratorUtil.randomString(3000),
       ]);
       await dataInjector.createConversations([conversation]);
+      await localStorageManager.setShowSideBarPanels();
     });
 
     await dialTest.step(
@@ -140,6 +142,7 @@ dialTest(
     conversations,
     dataInjector,
     sendMessage,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-3071');
     let conversation: Conversation;
@@ -149,6 +152,7 @@ dialTest(
         GeneratorUtil.randomString(3000),
       ]);
       await dataInjector.createConversations([conversation]);
+      await localStorageManager.setShowSideBarPanels();
     });
 
     await dialTest.step(
@@ -192,6 +196,7 @@ dialTest(
     conversationDropdownMenu,
     conversationAssertion,
     header,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-493', 'EPMRTC-3072', 'EPMRTC-1783', 'EPMRTC-1754');
     let firstConversation: Conversation;
@@ -213,6 +218,7 @@ dialTest(
           firstConversation,
           secondConversation,
         ]);
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -311,6 +317,7 @@ dialTest(
     conversations,
     conversationDropdownMenu,
     compareConversation,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-3079');
     let firstConversation: Conversation;
@@ -344,6 +351,7 @@ dialTest(
           firstConversation,
           secondConversation,
         ]);
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -387,6 +395,7 @@ dialTest(
     conversations,
     dataInjector,
     chatMessages,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-3074');
     let stageConversation: Conversation;
@@ -398,6 +407,7 @@ dialTest(
           1,
         );
       await dataInjector.createConversations([stageConversation]);
+      await localStorageManager.setShowSideBarPanels();
     });
 
     await dialTest.step(
@@ -443,6 +453,7 @@ dialTest(
     fileApiHelper,
     chatMessagesAssertion,
     sendMessageAssertion,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-3073');
     let imageConversation: Conversation;
@@ -457,6 +468,7 @@ dialTest(
             defaultModel,
           );
         await dataInjector.createConversations([imageConversation]);
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -500,6 +512,7 @@ dialTest(
     dataInjector,
     setTestIds,
     chatMessages,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-3076');
     let conversation: Conversation;
@@ -516,6 +529,7 @@ dialTest(
             userRequests,
           );
         await dataInjector.createConversations([conversation]);
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 

--- a/apps/chat-e2e/src/tests/selectChatPanelEntity.test.ts
+++ b/apps/chat-e2e/src/tests/selectChatPanelEntity.test.ts
@@ -89,6 +89,7 @@ dialTest(
         await localStorageManager.setChatCollapsedSection(
           CollapsedSections.Organization,
         );
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -391,6 +392,7 @@ dialTest(
     chatBarFolderAssertion,
     conversationAssertion,
     setTestIds,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-3641', 'EPMRTC-3643');
     let nestedFolders: FolderInterface[];
@@ -425,6 +427,7 @@ dialTest(
           ...nestedFolders,
           rootFolder.folders,
         );
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -560,6 +563,7 @@ dialTest(
     chatBarFolderAssertion,
     conversationAssertion,
     setTestIds,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-3645', 'EPMRTC-3647', 'EPMRTC-3646');
     let nestedFolders: FolderInterface[];
@@ -594,6 +598,7 @@ dialTest(
           ...nestedFolders,
           rootFolder.folders,
         );
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -752,6 +757,7 @@ dialTest(
     dataInjector,
     chatBarFolderAssertion,
     setTestIds,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-3654');
     let nestedFolders: FolderInterface[];
@@ -790,6 +796,7 @@ dialTest(
           ...nestedFolders,
           secondLevelFolder.folders,
         );
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -972,6 +979,7 @@ dialTest(
     dataInjector,
     chatBarFolderAssertion,
     setTestIds,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-3663', 'EPMRTC-3649');
     let nestedFolders: FolderInterface[];
@@ -1010,6 +1018,7 @@ dialTest(
           ...nestedFolders,
           secondLevelFolder.folders,
         );
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -1268,6 +1277,7 @@ dialTest(
         await localStorageManager.setChatCollapsedSection(
           CollapsedSections.Organization,
         );
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -1448,6 +1458,7 @@ dialTest(
     dataInjector,
     chatBarAssertion,
     setTestIds,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-3650');
     let nestedFolders: FolderInterface[];
@@ -1468,6 +1479,7 @@ dialTest(
           [...nestedConversations, singleConversation],
           ...nestedFolders,
         );
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -1572,6 +1584,7 @@ dialTest(
     chatBar,
     confirmationDialog,
     setTestIds,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-3911');
     let nestedFolders: FolderInterface[];
@@ -1604,6 +1617,7 @@ dialTest(
           [...nestedConversations, lowLevelFolderConversation],
           ...nestedFolders,
         );
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 

--- a/apps/chat-e2e/src/tests/selectPromptPanelEntity.test.ts
+++ b/apps/chat-e2e/src/tests/selectPromptPanelEntity.test.ts
@@ -44,6 +44,7 @@ dialTest(
     await localStorageManager.setPromptCollapsedSection(
       CollapsedSections.Organization,
     );
+    await localStorageManager.setShowSideBarPanels();
 
     await dialTest.step(
       'Prepare nested folders with prompts inside each one, one more root folder with 2 prompts inside and one single prompt',
@@ -376,6 +377,7 @@ dialTest(
     promptBarFolderAssertion,
     promptAssertion,
     setTestIds,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-3670', 'EPMRTC-3671');
     let nestedFolders: FolderInterface[];
@@ -401,6 +403,7 @@ dialTest(
           ...nestedFolders,
           rootFolder.folders,
         );
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -522,6 +525,7 @@ dialTest(
     promptBarFolderAssertion,
     promptAssertion,
     setTestIds,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-3675', 'EPMRTC-3676', 'EPMRTC-3672');
     let nestedFolders: FolderInterface[];
@@ -549,6 +553,7 @@ dialTest(
           ...nestedFolders,
           rootFolder.folders,
         );
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -687,6 +692,7 @@ dialTest(
     promptBarFolderAssertion,
     page,
     setTestIds,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-3677');
     let nestedFolders: FolderInterface[];
@@ -714,6 +720,7 @@ dialTest(
           ...nestedFolders,
           secondLevelFolder.folders,
         );
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -885,6 +892,7 @@ dialTest(
     dataInjector,
     promptBarFolderAssertion,
     setTestIds,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-3678', 'EPMRTC-3681');
     let nestedFolders: FolderInterface[];
@@ -920,6 +928,7 @@ dialTest(
           ...nestedFolders,
           secondLevelFolder.folders,
         );
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -1143,6 +1152,7 @@ dialTest(
     promptBarFolderAssertion,
     page,
     setTestIds,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-3679', 'EPMRTC-3680', 'EPMRTC-3682');
     let nestedFolders: FolderInterface[];
@@ -1165,6 +1175,7 @@ dialTest(
           [...nestedPrompts, lowLevelFolderPrompt],
           ...nestedFolders,
         );
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -1344,6 +1355,7 @@ dialTest(
     dataInjector,
     promptModalDialog,
     setTestIds,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-3684');
     let nestedFolders: FolderInterface[];
@@ -1364,6 +1376,7 @@ dialTest(
           [...nestedPrompts, singlePrompt],
           ...nestedFolders,
         );
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -1462,6 +1475,7 @@ dialTest(
     promptBar,
     confirmationDialog,
     setTestIds,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-3912');
     let nestedFolders: FolderInterface[];
@@ -1490,6 +1504,7 @@ dialTest(
           [...nestedPrompts, lowLevelFolderPrompt],
           ...nestedFolders,
         );
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 

--- a/apps/chat-e2e/src/tests/selectUploadFolder.test.ts
+++ b/apps/chat-e2e/src/tests/selectUploadFolder.test.ts
@@ -25,6 +25,7 @@ dialTest(
     attachFilesModal,
     selectFolderModal,
     selectFolders,
+    localStorageManager,
   }) => {
     setTestIds(
       'EPMRTC-3253',
@@ -39,6 +40,7 @@ dialTest(
     await dialTest.step(
       'Open "Upload from device" modal through chat side bar clip icon and click on "Change" link',
       async () => {
+        await localStorageManager.setShowSideBarPanels();
         await dialHomePage.openHomePage();
         await dialHomePage.waitForPageLoaded();
         await chatBar.openManageAttachmentsModal();
@@ -160,6 +162,7 @@ dialTest(
     selectFolders,
     sendMessage,
     page,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-3248', 'EPMRTC-3249');
     const nameWithRestrictedChars = `Folder${ExpectedConstants.restrictedNameChars}name`;
@@ -167,6 +170,7 @@ dialTest(
     await dialTest.step(
       'Copy restricted symbols into buffer, open "Upload from device" modal through chat side bar clip icon and click on "Change" link',
       async () => {
+        await localStorageManager.setShowSideBarPanels();
         await dialHomePage.openHomePage();
         await dialHomePage.waitForPageLoaded();
         await sendMessage.fillRequestData(nameWithRestrictedChars);
@@ -232,6 +236,7 @@ dialTest(
     selectFolderModal,
     selectFolders,
     folderDropdownMenu,
+    localStorageManager,
   }) => {
     setTestIds(
       'EPMRTC-3271',
@@ -245,6 +250,7 @@ dialTest(
     await dialTest.step(
       'Open "Upload from device" modal through chat side bar clip icon and click on "Change" link',
       async () => {
+        await localStorageManager.setShowSideBarPanels();
         await dialHomePage.openHomePage();
         await dialHomePage.waitForPageLoaded();
         await chatBar.openManageAttachmentsModal();
@@ -345,6 +351,7 @@ dialTest(
     attachFilesModal,
     selectFolderModal,
     selectFolders,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-3244');
     const updateFoldeNameIndex = 999;
@@ -352,6 +359,7 @@ dialTest(
     await dialTest.step(
       'Open "Upload from device" modal through chat side bar clip icon and click on "Change" link',
       async () => {
+        await localStorageManager.setShowSideBarPanels();
         await dialHomePage.openHomePage();
         await dialHomePage.waitForPageLoaded();
         await chatBar.openManageAttachmentsModal();
@@ -415,12 +423,14 @@ dialTest(
     attachFilesModal,
     selectFolderModal,
     page,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-3269');
 
     await dialTest.step(
       'Open "Upload from device" modal through chat side bar clip icon and click on "Change" link',
       async () => {
+        await localStorageManager.setShowSideBarPanels();
         await dialHomePage.openHomePage();
         await dialHomePage.waitForPageLoaded();
         await chatBar.openManageAttachmentsModal();
@@ -469,6 +479,7 @@ dialTest(
     selectFolderModal,
     selectFolders,
     folderDropdownMenu,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-3256', 'EPMRTC-3258', 'EPMRTC-3257');
     const newChildFolderName = GeneratorUtil.randomString(10);
@@ -477,6 +488,7 @@ dialTest(
     await dialTest.step(
       'Open "Upload from device" modal through chat side bar clip icon and click on "Change" link',
       async () => {
+        await localStorageManager.setShowSideBarPanels();
         await dialHomePage.openHomePage();
         await dialHomePage.waitForPageLoaded();
         await chatBar.openManageAttachmentsModal();
@@ -578,12 +590,14 @@ dialTest(
     selectFolderModal,
     baseAssertion,
     selectFolders,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-3017', 'EPMRTC-3246');
 
     await dialTest.step(
       'Open "Upload from device" modal through chat side bar clip icon and click on "Change" link',
       async () => {
+        await localStorageManager.setShowSideBarPanels();
         await dialHomePage.openHomePage();
         await dialHomePage.waitForPageLoaded();
         await chatBar.openManageAttachmentsModal();
@@ -656,12 +670,14 @@ dialTest(
     attachFilesModal,
     selectFolderModal,
     selectFolders,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-3251');
 
     await dialTest.step(
       'Open "Upload from device" modal through chat side bar clip icon and click on "Change" link',
       async () => {
+        await localStorageManager.setShowSideBarPanels();
         await dialHomePage.openHomePage();
         await dialHomePage.waitForPageLoaded();
         await chatBar.openManageAttachmentsModal();

--- a/apps/chat-e2e/src/tests/shareConversationWithContent.test.ts
+++ b/apps/chat-e2e/src/tests/shareConversationWithContent.test.ts
@@ -49,6 +49,7 @@ dialSharedWithMeTest(
     additionalShareUserDataInjector,
     baseAssertion,
     setTestIds,
+    additionalShareUserLocalStorageManager,
   }) => {
     setTestIds('EPMRTC-1933', 'EPMRTC-2896', 'EPMRTC-4705');
     let responseImageConversation: Conversation;
@@ -139,6 +140,7 @@ dialSharedWithMeTest(
         await additionalShareUserDataInjector.createConversations([
           conversationWithSharedFile,
         ]);
+        await additionalShareUserLocalStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -339,6 +341,8 @@ dialSharedWithMeTest(
     additionalShareUserChatMessages,
     additionalShareUserSharedFolderConversations,
     setTestIds,
+    localStorageManager,
+    additionalShareUserLocalStorageManager,
   }) => {
     setTestIds('EPMRTC-2860');
     let responseImageConversation: Conversation;
@@ -399,6 +403,7 @@ dialSharedWithMeTest(
         conversationsInFolder =
           conversationData.prepareConversationsInFolder(sharedConversations);
         await dataInjector.createConversations(sharedConversations);
+        await localStorageManager.setShowSideBarPanels();
 
         responseImageAttachmentPath =
           responseImageConversation.messages[1]!.custom_content!.attachments![0]
@@ -459,6 +464,7 @@ dialSharedWithMeTest(
     await dialSharedWithMeTest.step(
       'Open shared conversations one by one and verify attachments, stages and code style are displayed correctly',
       async () => {
+        await additionalShareUserLocalStorageManager.setShowSideBarPanels();
         await additionalShareUserDialHomePage.openHomePage();
         await additionalShareUserDialHomePage.waitForPageLoaded();
         await additionalShareUserSharedFolderConversations.expandCollapseFolder(
@@ -575,6 +581,7 @@ dialSharedWithMeTest(
     additionalShareUserManageAttachmentsAssertion,
     additionalShareUserSharedWithMeConversations,
     additionalShareUserChatMessages,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-3518', 'EPMRTC-3102', 'EPMRTC-3101');
     let imageConversation: Conversation;
@@ -639,6 +646,7 @@ dialSharedWithMeTest(
     await dialSharedWithMeTest.step(
       'Open "Manage attachments" modal and verify shared files have arrow icons',
       async () => {
+        await localStorageManager.setShowSideBarPanels();
         await dialHomePage.openHomePage();
         await dialHomePage.waitForPageLoaded();
         await chatBar.openManageAttachmentsModal();
@@ -673,6 +681,7 @@ dialSharedWithMeTest(
     await dialSharedWithMeTest.step(
       'User2 opens the file in the shared chat and verifies pictures are shown in requests',
       async () => {
+        await additionalShareUserLocalStorageManager.setShowSideBarPanels();
         await additionalShareUserDialHomePage.openHomePage();
         await additionalShareUserDialHomePage.waitForPageLoaded();
         await additionalShareUserSharedWithMeConversations.selectConversation(
@@ -812,6 +821,7 @@ dialSharedWithMeTest(
     additionalShareUserSharedWithMeConversations,
     additionalShareUserSharedWithMeConversationDropdownMenu,
     setTestIds,
+    additionalShareUserLocalStorageManager,
   }) => {
     setTestIds('EPMRTC-3517');
     let responseImageConversation: Conversation;
@@ -871,6 +881,7 @@ dialSharedWithMeTest(
             playbackConversation,
           ]);
         await additionalUserShareApiHelper.acceptInvite(shareByLinkResponse);
+        await additionalShareUserLocalStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -1002,6 +1013,7 @@ dialSharedWithMeTest(
     additionalShareUserChatMessages,
     setTestIds,
     additionalShareUserSharedWithMeConversations,
+    additionalShareUserLocalStorageManager,
   }) => {
     setTestIds('EPMRTC-3112');
     let plotlyConversation: Conversation;
@@ -1029,6 +1041,7 @@ dialSharedWithMeTest(
         const shareByLinkResponse =
           await mainUserShareApiHelper.shareEntityByLink([plotlyConversation]);
         await additionalUserShareApiHelper.acceptInvite(shareByLinkResponse);
+        await additionalShareUserLocalStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -1078,6 +1091,7 @@ dialSharedWithMeTest(
     additionalShareUserChatMessages,
     additionalShareUserSharedWithMeConversations,
     setTestIds,
+    additionalShareUserLocalStorageManager,
   }) => {
     setTestIds('EPMRTC-3353');
     let attachmentLinkConversation: Conversation;
@@ -1103,6 +1117,7 @@ dialSharedWithMeTest(
             attachmentLinkConversation,
           ]);
         await additionalUserShareApiHelper.acceptInvite(shareByLinkResponse);
+        await additionalShareUserLocalStorageManager.setShowSideBarPanels();
       },
     );
 

--- a/apps/chat-e2e/src/tests/sharedChatIcons.test.ts
+++ b/apps/chat-e2e/src/tests/sharedChatIcons.test.ts
@@ -45,6 +45,7 @@ dialTest(
     confirmationDialog,
     conversationAssertion,
     setTestIds,
+    localStorageManager,
   }) => {
     setTestIds(
       'EPMRTC-1502',
@@ -67,6 +68,7 @@ dialTest(
     await dialTest.step('Prepare default conversation', async () => {
       conversation = conversationData.prepareDefaultConversation();
       await dataInjector.createConversations([conversation]);
+      await localStorageManager.setShowSideBarPanels();
     });
 
     await dialTest.step(
@@ -320,6 +322,7 @@ dialTest(
     chat,
     setTestIds,
     renameConversationModal,
+    iconApiHelper,
   }) => {
     setTestIds(
       'EPMRTC-1514',
@@ -369,6 +372,7 @@ dialTest(
         );
         await localStorageManager.setRecentAddonsIds(randomAddon);
         await localStorageManager.setRecentModelsIds(randomModel);
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -419,9 +423,11 @@ dialTest(
         await conversations.selectConversation(thirdConversationToShare.name);
         await chatHeader.chatAgent.click();
         await talkToAgentDialog.selectAgent(randomModel, marketplacePage);
-        await conversationAssertion.assertEntityArrowIconState(
-          { name: newName },
-          'visible',
+        const expectedRandomModelIcon =
+          iconApiHelper.getEntityIcon(randomModel);
+        await conversationAssertion.assertTreeEntityIcon(
+          { name: thirdConversationToShare.name },
+          expectedRandomModelIcon,
         );
       },
     );
@@ -468,6 +474,7 @@ dialTest(
     itemApiHelper,
     conversationAssertion,
     setTestIds,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-1510', 'EPMRTC-2002');
     const defaultModel = ModelsUtil.getDefaultModel()!;
@@ -526,6 +533,7 @@ dialTest(
           conversationToDeleteName,
         );
         await dataInjector.createConversations([conversationToDelete]);
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -564,6 +572,7 @@ dialTest(
     mainUserShareApiHelper,
     additionalUserShareApiHelper,
     setTestIds,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-1600', 'EPMRTC-1511');
     let firstSharedConversation: Conversation;
@@ -585,6 +594,7 @@ dialTest(
         const shareByLinkResponse =
           await mainUserShareApiHelper.shareEntityByLink([conversation]);
         await additionalUserShareApiHelper.acceptInvite(shareByLinkResponse);
+        await localStorageManager.setShowSideBarPanels();
       }
     });
 
@@ -662,6 +672,7 @@ dialTest(
     folderDropdownMenu,
     confirmationDialog,
     setTestIds,
+    localStorageManager,
   }) => {
     setTestIds(
       'EPMRTC-1810',
@@ -697,6 +708,7 @@ dialTest(
         await additionalUserShareApiHelper.acceptInvite(
           shareConversationByLinkResponse,
         );
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -807,6 +819,7 @@ dialTest(
     tooltip,
     setTestIds,
     page,
+    localStorageManager,
   }) => {
     setTestIds(
       'EPMRTC-2729',
@@ -825,6 +838,7 @@ dialTest(
       folderConversation =
         conversationData.prepareDefaultConversationInFolder(folderName);
       await dataInjector.createConversations(folderConversation.conversations);
+      await localStorageManager.setShowSideBarPanels();
     });
 
     await dialTest.step(
@@ -984,6 +998,7 @@ dialTest(
     chat,
     conversationAssertion,
     setTestIds,
+    localStorageManager,
   }) => {
     setTestIds(
       'EPMRTC-2748',
@@ -1003,6 +1018,7 @@ dialTest(
         conversation,
       ]);
       await additionalUserShareApiHelper.acceptInvite(shareByLinkResponse);
+      await localStorageManager.setShowSideBarPanels();
     });
 
     await dialTest.step(
@@ -1118,6 +1134,7 @@ dialTest(
     additionalSecondUserShareApiHelper,
     conversationAssertion,
     setTestIds,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-1507');
     let conversation: Conversation;
@@ -1146,6 +1163,7 @@ dialTest(
         await additionalSecondUserShareApiHelper.deleteSharedWithMeEntities(
           sharedEntities.resources.filter((e) => e.url === conversation.id),
         );
+        await localStorageManager.setShowSideBarPanels();
 
         await dialHomePage.openHomePage();
         await dialHomePage.waitForPageLoaded();
@@ -1187,6 +1205,7 @@ dialTest(
     additionalUserShareApiHelper,
     additionalSecondUserShareApiHelper,
     setTestIds,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-2755');
     let folderConversation: FolderConversation;
@@ -1222,6 +1241,7 @@ dialTest(
             (e) => e.name === folderConversation.folders.name,
           ),
         );
+        await localStorageManager.setShowSideBarPanels();
 
         await dialHomePage.openHomePage();
         await dialHomePage.waitForPageLoaded();

--- a/apps/chat-e2e/src/tests/sharedFilesAttachments.test.ts
+++ b/apps/chat-e2e/src/tests/sharedFilesAttachments.test.ts
@@ -194,6 +194,7 @@ dialSharedWithMeTest(
       await additionalUserShareApiHelper.acceptInvite(
         shareFolderByLinkResponse,
       );
+      await localStorageManager.setShowSideBarPanels();
     });
 
     await dialTest.step('Open start page', async () => {
@@ -296,6 +297,7 @@ dialSharedWithMeTest(
         await additionalShareUserLocalStorageManager.setRecentModelsIds(
           defaultModel,
         );
+        await additionalShareUserLocalStorageManager.setShowSideBarPanels();
         const newRequest = GeneratorUtil.randomString(10);
         await additionalShareUserDialHomePage.openHomePage();
         await additionalShareUserDialHomePage.waitForPageLoaded();
@@ -625,6 +627,7 @@ dialSharedWithMeTest(
         await additionalShareUserLocalStorageManager.setRecentModelsIds(
           attachmentModel,
         );
+        await additionalShareUserLocalStorageManager.setShowSideBarPanels();
         await localStorageManager.setRecentModelsIds(attachmentModel);
       },
     );

--- a/apps/chat-e2e/src/tests/sharedPromptFolderIcons.test.ts
+++ b/apps/chat-e2e/src/tests/sharedPromptFolderIcons.test.ts
@@ -58,6 +58,7 @@ dialTest(
           CollapsedSections.Organization,
           CollapsedSections.SharedWithMe,
         );
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -191,6 +192,7 @@ dialTest(
     additionalUserShareApiHelper,
     additionalSecondUserShareApiHelper,
     setTestIds,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-3166', 'EPMRTC-3161');
     let nestedFolders: FolderInterface[];
@@ -224,6 +226,7 @@ dialTest(
         await additionalUserShareApiHelper.acceptInvite(
           sharePromptByLinkResponse,
         );
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -317,6 +320,7 @@ dialTest(
     mainUserShareApiHelper,
     additionalUserShareApiHelper,
     setTestIds,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-3167');
     let nestedFolders: FolderInterface[];
@@ -338,6 +342,7 @@ dialTest(
         await additionalUserShareApiHelper.acceptInvite(
           sharePromptByLinkResponse,
         );
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -388,6 +393,7 @@ dialTest(
     additionalUserShareApiHelper,
     shareApiAssertion,
     setTestIds,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-3169', 'EPMRTC-2806');
     let folderPrompt: FolderPrompt;
@@ -410,6 +416,7 @@ dialTest(
         await additionalUserShareApiHelper.acceptInvite(
           sharePromptByLinkResponse,
         );
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 

--- a/apps/chat-e2e/src/tests/sharedPromptIcons.test.ts
+++ b/apps/chat-e2e/src/tests/sharedPromptIcons.test.ts
@@ -27,6 +27,7 @@ dialTest(
     shareModalAssertion,
     promptAssertion,
     setTestIds,
+    localStorageManager,
   }) => {
     setTestIds(
       'EPMRTC-1517',
@@ -44,6 +45,7 @@ dialTest(
     await dialTest.step('Prepare a new prompt', async () => {
       prompt = promptData.prepareDefaultPrompt();
       await dataInjector.createPrompts([prompt]);
+      await localStorageManager.setShowSideBarPanels();
     });
 
     await dialTest.step(
@@ -172,6 +174,7 @@ dialTest(
     additionalUserShareApiHelper,
     shareApiAssertion,
     setTestIds,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-1524', 'EPMRTC-3157', 'EPMRTC-3180');
     let prompt: Prompt;
@@ -185,6 +188,7 @@ dialTest(
         prompt,
       ]);
       await additionalUserShareApiHelper.acceptInvite(shareByLinkResponse);
+      await localStorageManager.setShowSideBarPanels();
     });
 
     await dialTest.step(
@@ -250,6 +254,7 @@ dialTest(
     additionalSecondUserShareApiHelper,
     promptAssertion,
     setTestIds,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-3158');
     let prompt: Prompt;
@@ -267,6 +272,7 @@ dialTest(
         await additionalSecondUserShareApiHelper.acceptInvite(
           shareByLinkResponse,
         );
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -321,6 +327,7 @@ dialTest(
     promptAssertion,
     shareApiAssertion,
     setTestIds,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-3159', 'EPMRTC-3181');
     let prompt: Prompt;
@@ -330,6 +337,7 @@ dialTest(
       prompt = promptData.prepareDefaultPrompt();
       recreatedPrompt = JSON.parse(JSON.stringify(prompt));
       await dataInjector.createPrompts([prompt]);
+      await localStorageManager.setShowSideBarPanels();
 
       const shareByLinkResponse =
         await mainUserShareApiHelper.shareEntityByLink([prompt]);

--- a/apps/chat-e2e/src/tests/sharedPromptView.test.ts
+++ b/apps/chat-e2e/src/tests/sharedPromptView.test.ts
@@ -155,7 +155,6 @@ dialSharedWithMeTest(
     additionalShareUserPromptModalDialog,
     apiAssertion,
     setTestIds,
-    additionalShareUserLocalStorageManager,
   }) => {
     setTestIds('EPMRTC-3185', 'EPMRTC-2032');
     let prompt: Prompt;
@@ -178,7 +177,6 @@ dialSharedWithMeTest(
     await dialSharedWithMeTest.step(
       'Click on "Duplicate" button on prompt preview modal and verify prompt is duplicated in Recent section',
       async () => {
-        await additionalShareUserLocalStorageManager.setShowSideBarPanels();
         await additionalShareUserDialHomePage.navigateToUrl(
           ExpectedConstants.sharedConversationUrl(
             shareByLinkResponse.invitationLink,
@@ -186,6 +184,7 @@ dialSharedWithMeTest(
         );
         await additionalShareUserDialHomePage.waitForPageLoaded({
           isPromptShared: true,
+          skipSidebars: true,
         });
         await additionalShareUserPromptPreviewModal.duplicatePrompt();
         await additionalShareUserPromptAssertion.assertEntityState(

--- a/apps/chat-e2e/src/tests/sharedPromptView.test.ts
+++ b/apps/chat-e2e/src/tests/sharedPromptView.test.ts
@@ -24,6 +24,7 @@ dialSharedWithMeTest(
     downloadAssertion,
     additionalShareUserConfirmationDialogAssertion,
     setTestIds,
+    additionalShareUserLocalStorageManager,
   }) => {
     setTestIds('EPMRTC-2035', 'EPMRTC-3183', 'EPMRTC-3184');
     let prompt: Prompt;
@@ -36,6 +37,7 @@ dialSharedWithMeTest(
         prompt,
       ]);
       await additionalUserShareApiHelper.acceptInvite(shareByLinkResponse);
+      await additionalShareUserLocalStorageManager.setShowSideBarPanels();
     });
 
     await dialSharedWithMeTest.step(
@@ -153,6 +155,7 @@ dialSharedWithMeTest(
     additionalShareUserPromptModalDialog,
     apiAssertion,
     setTestIds,
+    additionalShareUserLocalStorageManager,
   }) => {
     setTestIds('EPMRTC-3185', 'EPMRTC-2032');
     let prompt: Prompt;
@@ -175,6 +178,7 @@ dialSharedWithMeTest(
     await dialSharedWithMeTest.step(
       'Click on "Duplicate" button on prompt preview modal and verify prompt is duplicated in Recent section',
       async () => {
+        await additionalShareUserLocalStorageManager.setShowSideBarPanels();
         await additionalShareUserDialHomePage.navigateToUrl(
           ExpectedConstants.sharedConversationUrl(
             shareByLinkResponse.invitationLink,
@@ -224,7 +228,7 @@ dialSharedWithMeTest(
           { name: updatedName },
           'visible',
         );
-        await apiAssertion.assertMoveRequest(request, updatedName, prompt.name);
+        apiAssertion.assertMoveRequest(request, updatedName, prompt.name);
       },
     );
 

--- a/apps/chat-e2e/src/tests/sharedWithMeConversations.test.ts
+++ b/apps/chat-e2e/src/tests/sharedWithMeConversations.test.ts
@@ -45,6 +45,7 @@ dialSharedWithMeTest(
     additionalShareUserConfirmationDialog,
     additionalShareUserToast,
     setTestIds,
+    additionalShareUserLocalStorageManager,
   }) => {
     dialSharedWithMeTest.slow();
     setTestIds(
@@ -65,6 +66,7 @@ dialSharedWithMeTest(
       shareByLinkResponse = await mainUserShareApiHelper.shareEntityByLink([
         conversation,
       ]);
+      await additionalShareUserLocalStorageManager.setShowSideBarPanels();
     });
 
     await dialSharedWithMeTest.step(
@@ -188,6 +190,7 @@ dialSharedWithMeTest(
     dataInjector,
     mainUserShareApiHelper,
     setTestIds,
+    additionalShareUserLocalStorageManager,
   }) => {
     setTestIds('EPMRTC-1827', 'EPMRTC-1854');
     let conversationInFolder: FolderConversation;
@@ -207,6 +210,7 @@ dialSharedWithMeTest(
         shareByLinkResponse = await mainUserShareApiHelper.shareEntityByLink([
           conversation,
         ]);
+        await additionalShareUserLocalStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -263,6 +267,7 @@ dialSharedWithMeTest(
     mainUserShareApiHelper,
     additionalShareUserPage,
     setTestIds,
+    additionalShareUserLocalStorageManager,
   }) => {
     setTestIds('EPMRTC-1828', 'EPMRTC-2767', 'EPMRTC-1833', 'EPMRTC-2869');
     let nestedFolders: FolderInterface[];
@@ -285,6 +290,7 @@ dialSharedWithMeTest(
           [nestedConversations[0]],
           true,
         );
+        await additionalShareUserLocalStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -418,6 +424,7 @@ dialSharedWithMeTest(
     additionalUserShareApiHelper,
     setTestIds,
     localStorageManager,
+    additionalShareUserLocalStorageManager,
   }) => {
     setTestIds('EPMRTC-1829', 'EPMRTC-2771');
     let nestedFolders: FolderInterface[];
@@ -442,6 +449,8 @@ dialSharedWithMeTest(
         await localStorageManager.setChatCollapsedSection(
           CollapsedSections.Organization,
         );
+        await additionalShareUserLocalStorageManager.setShowSideBarPanels();
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -543,6 +552,7 @@ dialSharedWithMeTest(
     additionalUserShareApiHelper,
     additionalUserItemApiHelper,
     setTestIds,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-2758');
     let sharedConversationInFolder: FolderConversation;
@@ -582,6 +592,7 @@ dialSharedWithMeTest(
           true,
         );
         await additionalUserShareApiHelper.acceptInvite(shareByLinkResponse);
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -756,6 +767,7 @@ dialSharedWithMeTest(
     additionalShareUserSharedWithMeConversationDropdownMenu,
     additionalShareUserConfirmationDialog,
     setTestIds,
+    additionalShareUserLocalStorageManager,
   }) => {
     setTestIds('EPMRTC-1834');
     let conversationInFolder: FolderConversation;
@@ -776,6 +788,7 @@ dialSharedWithMeTest(
           conversation,
         ]);
         await additionalUserShareApiHelper.acceptInvite(shareByLinkResponse);
+        await additionalShareUserLocalStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -902,6 +915,8 @@ dialSharedWithMeTest(
     additionalShareUserToast,
     shareApiAssertion,
     setTestIds,
+    localStorageManager,
+    additionalShareUserLocalStorageManager,
   }) => {
     setTestIds('EPMRTC-2770', 'EPMRTC-2772', 'EPMRTC-2726');
     let conversationInFolder: FolderConversation;
@@ -935,6 +950,7 @@ dialSharedWithMeTest(
         await additionalUserShareApiHelper.acceptInvite(
           shareByLinkConversationResponse,
         );
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -981,6 +997,7 @@ dialSharedWithMeTest(
     await dialSharedWithMeTest.step(
       'Open again share conversation link by another user and verify error message is shown',
       async () => {
+        await additionalShareUserLocalStorageManager.setShowSideBarPanels();
         await additionalShareUserDialHomePage.navigateToUrl(
           ExpectedConstants.sharedConversationUrl(
             shareByLinkConversationResponse.invitationLink,
@@ -1009,6 +1026,7 @@ dialSharedWithMeTest(
     additionalShareUserChat,
     setTestIds,
     additionalShareUserSharedFolderConversations,
+    additionalShareUserLocalStorageManager,
   }) => {
     setTestIds('EPMRTC-1846');
     let conversationInFolder: FolderConversation;
@@ -1030,6 +1048,7 @@ dialSharedWithMeTest(
           true,
         );
         await additionalUserShareApiHelper.acceptInvite(shareByLinkResponse);
+        await additionalShareUserLocalStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -1096,6 +1115,7 @@ dialSharedWithMeTest(
     additionalShareUserConversations,
     additionalShareUserPlaybackControl,
     setTestIds,
+    additionalShareUserLocalStorageManager,
   }) => {
     setTestIds('EPMRTC-1847');
     let conversation: Conversation;
@@ -1108,6 +1128,7 @@ dialSharedWithMeTest(
         conversation,
       ]);
       await additionalUserShareApiHelper.acceptInvite(shareByLinkResponse);
+      await additionalShareUserLocalStorageManager.setShowSideBarPanels();
     });
 
     await dialSharedWithMeTest.step(
@@ -1155,6 +1176,7 @@ dialSharedWithMeTest(
     dataInjector,
     mainUserShareApiHelper,
     setTestIds,
+    additionalShareUserLocalStorageManager,
   }) => {
     setTestIds('EPMRTC-2807');
     let nestedFolders: FolderInterface[];
@@ -1180,6 +1202,7 @@ dialSharedWithMeTest(
           true,
           nestedFolders[nestedFolder - 2].name,
         );
+        await additionalShareUserLocalStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -1258,6 +1281,10 @@ dialTest(
         await dialHomePage.waitForPageLoaded({
           selectedSharedConversationName: conversation.name,
         });
+        await dialHomePage
+          .getAppContainer()
+          .getHeader()
+          .leftPanelToggle.click();
         const conversationBackgroundColor = await dialHomePage
           .getAppContainer()
           .getChatBar()

--- a/apps/chat-e2e/src/tests/sharedWithMeConversations.test.ts
+++ b/apps/chat-e2e/src/tests/sharedWithMeConversations.test.ts
@@ -45,7 +45,6 @@ dialSharedWithMeTest(
     additionalShareUserConfirmationDialog,
     additionalShareUserToast,
     setTestIds,
-    additionalShareUserLocalStorageManager,
   }) => {
     dialSharedWithMeTest.slow();
     setTestIds(
@@ -66,7 +65,6 @@ dialSharedWithMeTest(
       shareByLinkResponse = await mainUserShareApiHelper.shareEntityByLink([
         conversation,
       ]);
-      await additionalShareUserLocalStorageManager.setShowSideBarPanels();
     });
 
     await dialSharedWithMeTest.step(
@@ -94,6 +92,7 @@ dialSharedWithMeTest(
         );
         await additionalShareUserDialHomePage.waitForPageLoaded({
           selectedSharedConversationName: conversation.name,
+          skipSidebars: true,
         });
         await expect
           .soft(
@@ -1245,6 +1244,7 @@ dialTest(
       incognitoPage,
       incognitoProviderLogin,
       setTestIds,
+      baseAssertion,
     },
     testInfo,
   ) => {
@@ -1280,16 +1280,22 @@ dialTest(
         const dialHomePage = new DialHomePage(incognitoPage);
         await dialHomePage.waitForPageLoaded({
           selectedSharedConversationName: conversation.name,
+          skipSidebars: true,
         });
-        await dialHomePage
-          .getAppContainer()
-          .getHeader()
-          .leftPanelToggle.click();
-        const conversationBackgroundColor = await dialHomePage
-          .getAppContainer()
-          .getChatBar()
-          .getSharedWithMeConversationsTree()
-          .getEntityBackgroundColor(conversation.name);
+        const appContainer = dialHomePage.getAppContainer();
+        // await appContainer.getHeader().leftPanelToggle.click();
+        const chatBar = appContainer.getChatBar();
+        await baseAssertion.assertElementState(chatBar, 'visible');
+        const sharedWithMeConversationsTree =
+          chatBar.getSharedWithMeConversationsTree();
+        await baseAssertion.assertElementState(
+          sharedWithMeConversationsTree.getEntityByName(conversation.name),
+          'visible',
+        );
+        const conversationBackgroundColor =
+          await sharedWithMeConversationsTree.getEntityBackgroundColor(
+            conversation.name,
+          );
         expect
           .soft(
             conversationBackgroundColor,

--- a/apps/chat-e2e/src/tests/sharedWithMePromptFolders.test.ts
+++ b/apps/chat-e2e/src/tests/sharedWithMePromptFolders.test.ts
@@ -22,6 +22,7 @@ dialSharedWithMeTest(
     additionalShareUserSharedWithMePromptAssertion,
     additionalShareUserSharedPromptPreviewModalAssertion,
     setTestIds,
+    additionalShareUserLocalStorageManager,
   }) => {
     setTestIds('EPMRTC-1858', 'EPMRTC-1861', 'EPMRTC-3182');
     let folderPrompt: FolderPrompt;
@@ -54,6 +55,7 @@ dialSharedWithMeTest(
             folderPrompt.prompts,
             true,
           );
+        await additionalShareUserLocalStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -120,6 +122,7 @@ dialSharedWithMeTest(
     additionalShareUserSharedWithMeFolderDropdownMenu,
     additionalShareUserConfirmationDialog,
     setTestIds,
+    additionalShareUserLocalStorageManager,
   }) => {
     dialSharedWithMeTest.slow();
     setTestIds('EPMRTC-1860', 'EPMRTC-1866', 'EPMRTC-1863');
@@ -146,6 +149,7 @@ dialSharedWithMeTest(
             [nestedPrompts[sharedFolderIndex]],
             true,
           );
+        await additionalShareUserLocalStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -265,6 +269,7 @@ dialSharedWithMeTest(
     additionalShareUserPromptsDropdownMenuAssertion,
     additionalShareUserFolderDropdownMenuAssertion,
     setTestIds,
+    additionalShareUserLocalStorageManager,
   }) => {
     setTestIds('EPMRTC-1859', 'EPMRTC-3110', 'EPMRTC-1865');
     let nestedFolders: FolderInterface[];
@@ -290,6 +295,7 @@ dialSharedWithMeTest(
             [nestedPrompts[sharedFolderIndex]],
             true,
           );
+        await additionalShareUserLocalStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -392,6 +398,7 @@ dialSharedWithMeTest(
     additionalShareUserSendMessageAssertion,
     shareApiAssertion,
     setTestIds,
+    additionalShareUserLocalStorageManager,
   }) => {
     setTestIds('EPMRTC-2033', 'EPMRTC-1862', 'EPMRTC-3500', 'EPMRTC-1864');
     let folderPrompt: FolderPrompt;
@@ -433,6 +440,7 @@ dialSharedWithMeTest(
           sharedEntities,
           folder,
         );
+        await additionalShareUserLocalStorageManager.setShowSideBarPanels();
       },
     );
 

--- a/apps/chat-e2e/src/tests/sharedWithMePromptFolders.test.ts
+++ b/apps/chat-e2e/src/tests/sharedWithMePromptFolders.test.ts
@@ -2,7 +2,12 @@ import { FolderInterface } from '@/chat/types/folder';
 import { Prompt } from '@/chat/types/prompt';
 import { ShareByLinkResponseModel } from '@/chat/types/share';
 import dialSharedWithMeTest from '@/src/core/dialSharedWithMeFixtures';
-import { ExpectedConstants, FolderPrompt, MenuOptions } from '@/src/testData';
+import {
+  CollapsedSections,
+  ExpectedConstants,
+  FolderPrompt,
+  MenuOptions,
+} from '@/src/testData';
 import { GeneratorUtil, ItemUtil } from '@/src/utils';
 import { Entity } from '@epam/ai-dial-shared';
 
@@ -22,7 +27,6 @@ dialSharedWithMeTest(
     additionalShareUserSharedWithMePromptAssertion,
     additionalShareUserSharedPromptPreviewModalAssertion,
     setTestIds,
-    additionalShareUserLocalStorageManager,
   }) => {
     setTestIds('EPMRTC-1858', 'EPMRTC-1861', 'EPMRTC-3182');
     let folderPrompt: FolderPrompt;
@@ -55,7 +59,6 @@ dialSharedWithMeTest(
             folderPrompt.prompts,
             true,
           );
-        await additionalShareUserLocalStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -69,6 +72,7 @@ dialSharedWithMeTest(
         );
         await additionalShareUserDialHomePage.waitForPageLoaded({
           isPromptShared: true,
+          skipSidebars: true,
         });
         await additionalShareUserSharedPromptPreviewModalAssertion.assertPromptPreviewModalState(
           'visible',
@@ -92,6 +96,7 @@ dialSharedWithMeTest(
         );
         await additionalShareUserDialHomePage.waitForPageLoaded({
           isPromptShared: true,
+          skipSidebars: true,
         });
         await additionalShareUserSharedPromptPreviewModalAssertion.assertPromptPreviewModalState(
           'visible',
@@ -122,7 +127,6 @@ dialSharedWithMeTest(
     additionalShareUserSharedWithMeFolderDropdownMenu,
     additionalShareUserConfirmationDialog,
     setTestIds,
-    additionalShareUserLocalStorageManager,
   }) => {
     dialSharedWithMeTest.slow();
     setTestIds('EPMRTC-1860', 'EPMRTC-1866', 'EPMRTC-1863');
@@ -149,7 +153,6 @@ dialSharedWithMeTest(
             [nestedPrompts[sharedFolderIndex]],
             true,
           );
-        await additionalShareUserLocalStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -163,6 +166,7 @@ dialSharedWithMeTest(
         );
         await additionalShareUserDialHomePage.waitForPageLoaded({
           isPromptShared: true,
+          skipSidebars: true,
         });
         await additionalShareUserSharedPromptPreviewModalAssertion.assertPromptPreviewModalState(
           'visible',
@@ -233,6 +237,7 @@ dialSharedWithMeTest(
         );
         await additionalShareUserDialHomePage.waitForPageLoaded({
           isPromptShared: true,
+          skipSidebars: true,
         });
         await additionalShareUserSharedPromptPreviewModalAssertion.assertPromptPreviewModalState(
           'visible',
@@ -268,8 +273,8 @@ dialSharedWithMeTest(
     additionalShareUserSharedFolderPrompts,
     additionalShareUserPromptsDropdownMenuAssertion,
     additionalShareUserFolderDropdownMenuAssertion,
-    setTestIds,
     additionalShareUserLocalStorageManager,
+    setTestIds,
   }) => {
     setTestIds('EPMRTC-1859', 'EPMRTC-3110', 'EPMRTC-1865');
     let nestedFolders: FolderInterface[];
@@ -295,13 +300,15 @@ dialSharedWithMeTest(
             [nestedPrompts[sharedFolderIndex]],
             true,
           );
-        await additionalShareUserLocalStorageManager.setShowSideBarPanels();
       },
     );
 
     await dialSharedWithMeTest.step(
       'Accept share folder link and verify shared folder prompt preview modal is opened',
       async () => {
+        await additionalShareUserLocalStorageManager.setPromptCollapsedSection(
+          CollapsedSections.Organization,
+        );
         await additionalShareUserDialHomePage.navigateToUrl(
           ExpectedConstants.sharedConversationUrl(
             shareFolderByLinkResponse.invitationLink,
@@ -309,6 +316,7 @@ dialSharedWithMeTest(
         );
         await additionalShareUserDialHomePage.waitForPageLoaded({
           isPromptShared: true,
+          skipSidebars: true,
         });
         await additionalShareUserSharedPromptPreviewModalAssertion.assertPromptPreviewModalState(
           'visible',

--- a/apps/chat-e2e/src/tests/sharedWithMePrompts.test.ts
+++ b/apps/chat-e2e/src/tests/sharedWithMePrompts.test.ts
@@ -25,6 +25,7 @@ dialSharedWithMeTest(
     additionalShareUserVariableModalAssertion,
     additionalShareUserSendMessageAssertion,
     setTestIds,
+    additionalShareUserLocalStorageManager,
   }) => {
     setTestIds('EPMRTC-1857', 'EPMRTC-2036', 'EPMRTC-1935', 'EPMRTC-3173');
     let prompt: Prompt;
@@ -43,6 +44,7 @@ dialSharedWithMeTest(
       shareByLinkResponse = await mainUserShareApiHelper.shareEntityByLink([
         prompt,
       ]);
+      await additionalShareUserLocalStorageManager.setShowSideBarPanels();
     });
 
     await dialSharedWithMeTest.step(
@@ -146,6 +148,7 @@ dialTest(
     shareApiAssertion,
     promptAssertion,
     setTestIds,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-3179');
     let prompt: Prompt;
@@ -158,6 +161,7 @@ dialTest(
         prompt,
       ]);
       await additionalUserShareApiHelper.acceptInvite(shareByLinkResponse);
+      await localStorageManager.setShowSideBarPanels();
     });
 
     await dialTest.step(

--- a/apps/chat-e2e/src/tests/sharedWithMePrompts.test.ts
+++ b/apps/chat-e2e/src/tests/sharedWithMePrompts.test.ts
@@ -25,7 +25,6 @@ dialSharedWithMeTest(
     additionalShareUserVariableModalAssertion,
     additionalShareUserSendMessageAssertion,
     setTestIds,
-    additionalShareUserLocalStorageManager,
   }) => {
     setTestIds('EPMRTC-1857', 'EPMRTC-2036', 'EPMRTC-1935', 'EPMRTC-3173');
     let prompt: Prompt;
@@ -44,7 +43,6 @@ dialSharedWithMeTest(
       shareByLinkResponse = await mainUserShareApiHelper.shareEntityByLink([
         prompt,
       ]);
-      await additionalShareUserLocalStorageManager.setShowSideBarPanels();
     });
 
     await dialSharedWithMeTest.step(
@@ -57,6 +55,7 @@ dialSharedWithMeTest(
         );
         await additionalShareUserDialHomePage.waitForPageLoaded({
           isPromptShared: true,
+          skipSidebars: true,
         });
         await additionalShareUserSharedWithMePromptAssertion.assertEntityState(
           { name: prompt.name },

--- a/apps/chat-e2e/src/tests/sideBarFilters.test.ts
+++ b/apps/chat-e2e/src/tests/sideBarFilters.test.ts
@@ -30,6 +30,7 @@ dialTest(
     conversationAssertion,
     chatBarFolderAssertion,
     setTestIds,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-1597', 'EPMRTC-1631');
     let nestedFolders: FolderInterface[];
@@ -90,6 +91,7 @@ dialTest(
             ...nestedSharedConversations,
           ]);
         await additionalUserShareApiHelper.acceptInvite(shareConversationsLink);
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -208,6 +210,7 @@ dialTest(
     promptAssertion,
     promptBarFolderAssertion,
     setTestIds,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-1635', 'EPMRTC-1636');
     let nestedFolders: FolderInterface[];
@@ -262,6 +265,7 @@ dialTest(
             ...nestedSharedPrompts,
           ]);
         await additionalUserShareApiHelper.acceptInvite(shareNestedPromptsLink);
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 

--- a/apps/chat-e2e/src/tests/sidePanelEntityDragAndDrop.test.ts
+++ b/apps/chat-e2e/src/tests/sidePanelEntityDragAndDrop.test.ts
@@ -43,6 +43,7 @@ dialTest(
       CollapsedSections.Organization,
       CollapsedSections.SharedWithMe,
     );
+    await localStorageManager.setShowSideBarPanels();
     await dialHomePage.openHomePage({
       iconsToBeLoaded: [gpt35Model.iconUrl],
     });
@@ -122,6 +123,7 @@ dialTest(
           CollapsedSections.Organization,
           CollapsedSections.SharedWithMe,
         );
+        await localStorageManager.setShowSideBarPanels();
 
         await dataInjector.createConversations([
           conversationToDrop,
@@ -222,6 +224,7 @@ dialTest(
           CollapsedSections.Organization,
           CollapsedSections.SharedWithMe,
         );
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -279,6 +282,7 @@ dialTest(
       CollapsedSections.Organization,
       CollapsedSections.SharedWithMe,
     );
+    await localStorageManager.setShowSideBarPanels();
 
     await dialHomePage.openHomePage();
     await dialHomePage.waitForPageLoaded();
@@ -331,6 +335,7 @@ dialTest(
           CollapsedSections.Organization,
           CollapsedSections.SharedWithMe,
         );
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -413,6 +418,7 @@ dialTest(
           CollapsedSections.Organization,
           CollapsedSections.SharedWithMe,
         );
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 

--- a/apps/chat-e2e/src/tests/sidePanels.test.ts
+++ b/apps/chat-e2e/src/tests/sidePanels.test.ts
@@ -21,7 +21,7 @@ dialTest(
 
     await dialTest.step('Open chat panel', async () => {
       await dialHomePage.openHomePage();
-      await dialHomePage.waitForPageLoaded();
+      await dialHomePage.waitForPageLoaded({ skipSidebars: true });
       await header.leftPanelToggle.click();
       await baseAssertion.assertElementState(chatBar, 'visible');
     });

--- a/apps/chat-e2e/src/tests/sidePanels.test.ts
+++ b/apps/chat-e2e/src/tests/sidePanels.test.ts
@@ -9,47 +9,34 @@ dialTest(
   'Hide panel with chats.\n' +
     'Hide panel with prompts.\n' +
     "Browser refresh doesn't open hidden panels",
-  async ({ dialHomePage, setTestIds, chatBar, header, promptBar }) => {
+  async ({
+    dialHomePage,
+    setTestIds,
+    chatBar,
+    header,
+    promptBar,
+    baseAssertion,
+  }) => {
     setTestIds('EPMRTC-352', 'EPMRTC-353', 'EPMRTC-354');
-    let isChatPanelVisible;
-    let isPromptsPanelVisible;
 
-    await dialTest.step('Hide chat panel', async () => {
+    await dialTest.step('Open chat panel', async () => {
       await dialHomePage.openHomePage();
       await dialHomePage.waitForPageLoaded();
       await header.leftPanelToggle.click();
-      await expect
-        .soft(
-          chatBar.getElementLocator(),
-          ExpectedMessages.sideBarPanelIsHidden,
-        )
-        .toBeHidden();
+      await baseAssertion.assertElementState(chatBar, 'visible');
     });
 
-    await dialTest.step('Hide prompts panel', async () => {
+    await dialTest.step('Open prompts panel', async () => {
       await header.rightPanelToggle.click();
-      await expect
-        .soft(
-          promptBar.getElementLocator(),
-          ExpectedMessages.sideBarPanelIsHidden,
-        )
-        .toBeHidden();
+      await baseAssertion.assertElementState(promptBar, 'visible');
     });
 
     await dialTest.step(
       'Refresh page and verify both panels are hidden',
       async () => {
         await dialHomePage.reloadPage();
-        isChatPanelVisible = await chatBar.isVisible();
-        isPromptsPanelVisible = await promptBar.isVisible();
-        for (const isPanelVisible of [
-          isChatPanelVisible,
-          isPromptsPanelVisible,
-        ]) {
-          expect
-            .soft(isPanelVisible, ExpectedMessages.sideBarPanelIsHidden)
-            .toBeFalsy();
-        }
+        await baseAssertion.assertElementState(chatBar, 'visible');
+        await baseAssertion.assertElementState(promptBar, 'visible');
       },
     );
   },
@@ -70,6 +57,7 @@ dialTest(
     tooltip,
     conversationData,
     dataInjector,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-1642', 'EPMRTC-1650', 'EPMRTC-1641', 'EPMRTC-1647');
     let appBounding;
@@ -79,6 +67,7 @@ dialTest(
     await dialTest.step('Prepare conversation with the history', async () => {
       const conversation = conversationData.prepareDefaultConversation();
       await dataInjector.createConversations([conversation]);
+      await localStorageManager.setShowSideBarPanels();
     });
 
     await dialTest.step(

--- a/apps/chat-e2e/src/tests/tokenLimits.test.ts
+++ b/apps/chat-e2e/src/tests/tokenLimits.test.ts
@@ -48,6 +48,7 @@ dialTest(
         conversation = conversationData.prepareEmptyConversation(randomModel);
         await dataInjector.createConversations([conversation]);
         await localStorageManager.setRecentModelsIds(randomModel);
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 

--- a/apps/chat-e2e/src/tests/unpublishConversation.test.ts
+++ b/apps/chat-e2e/src/tests/unpublishConversation.test.ts
@@ -45,6 +45,8 @@ dialAdminTest(
     adminConversationToApproveAssertion,
     adminChatHeaderAssertion,
     setTestIds,
+    adminLocalStorageManager,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-3383', 'EPMRTC-3579', 'EPMRTC-3433');
     let publishedConversation: Conversation;
@@ -71,6 +73,7 @@ dialAdminTest(
         const publication =
           await publicationApiHelper.createPublishRequest(publishRequest);
         await adminPublicationApiHelper.approveRequest(publication);
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -167,6 +170,7 @@ dialAdminTest(
     await dialAdminTest.step(
       'Login as admin and verify conversation unpublishing request is displayed under "Approve required" section',
       async () => {
+        await adminLocalStorageManager.setShowSideBarPanels();
         await adminDialHomePage.openHomePage();
         await adminDialHomePage.waitForPageLoaded();
         await adminApproveRequiredConversationsAssertion.assertFolderState(

--- a/apps/chat-e2e/src/tests/unpublishFolderWithConversations.test.ts
+++ b/apps/chat-e2e/src/tests/unpublishFolderWithConversations.test.ts
@@ -53,6 +53,8 @@ dialAdminTest(
     adminFolderToApproveAssertion,
     organizationFolderConversationAssertions,
     setTestIds,
+    localStorageManager,
+    adminLocalStorageManager,
   }) => {
     dialAdminTest.slow();
     setTestIds('EPMRTC-3386', 'EPMRTC-3802', 'EPMRTC-3389');
@@ -100,6 +102,7 @@ dialAdminTest(
         await adminPublicationApiHelper.approveRequest(
           folderPublicationRequest,
         );
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -214,6 +217,7 @@ dialAdminTest(
     await dialAdminTest.step(
       'Login as admin and verify conversation unpublishing request is displayed under "Approve required" section',
       async () => {
+        await adminLocalStorageManager.setShowSideBarPanels();
         await adminDialHomePage.openHomePage();
         await adminDialHomePage.waitForPageLoaded();
         await adminApproveRequiredConversationsAssertion.assertFolderState(
@@ -445,6 +449,8 @@ dialAdminTest(
     adminFolderToApproveAssertion,
     organizationFolderConversationAssertions,
     setTestIds,
+    localStorageManager,
+    adminLocalStorageManager,
   }) => {
     setTestIds('EPMRTC-3429', 'EPMRTC-3800', 'EPMRTC-3801');
     let firstConversation: Conversation;
@@ -490,6 +496,7 @@ dialAdminTest(
           folderPublicationRequest,
         );
         folderConversations = [firstConversation.name, secondConversation.name];
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -568,6 +575,7 @@ dialAdminTest(
     await dialAdminTest.step(
       'Login as admin and verify both folder unpublishing requests are displayed under "Approve required" section',
       async () => {
+        await adminLocalStorageManager.setShowSideBarPanels();
         await adminDialHomePage.openHomePage();
         await adminDialHomePage.waitForPageLoaded();
         await adminApproveRequiredConversationsAssertion.assertFolderState(
@@ -773,6 +781,8 @@ dialAdminTest(
     adminFolderToApproveAssertion,
     organizationFolderConversationAssertions,
     setTestIds,
+    localStorageManager,
+    adminLocalStorageManager,
   }) => {
     setTestIds('EPMRTC-3808');
     let nestedFolders: FolderInterface[];
@@ -811,6 +821,7 @@ dialAdminTest(
         await adminPublicationApiHelper.approveRequest(
           folderPublicationRequest,
         );
+        await localStorageManager.setShowSideBarPanels();
 
         rootFolderName = nestedFolders[0].name;
         rootFolderConversationName = nestedConversations[0].name;
@@ -911,6 +922,7 @@ dialAdminTest(
     await dialAdminTest.step(
       'Login as admin and verify inner folder unpublishing request is displayed under "Approve required" section',
       async () => {
+        await adminLocalStorageManager.setShowSideBarPanels();
         await adminDialHomePage.openHomePage();
         await adminDialHomePage.waitForPageLoaded();
         await adminApproveRequiredConversationsAssertion.assertFolderState(

--- a/apps/chat-e2e/src/tests/uploadFileToFolder.test.ts
+++ b/apps/chat-e2e/src/tests/uploadFileToFolder.test.ts
@@ -19,12 +19,14 @@ dialTest(
     attachFilesModal,
     attachedAllFiles,
     uploadFromDeviceModal,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-3295', 'EPMRTC-3048');
 
     await dialTest.step(
       'Open "Manage attachments" modal, click on "New folder" icon and verify new folder with default name is created in edit mode',
       async () => {
+        await localStorageManager.setShowSideBarPanels();
         await dialHomePage.openHomePage();
         await dialHomePage.waitForPageLoaded();
         await chatBar.openManageAttachmentsModal();
@@ -118,12 +120,14 @@ dialTest(
     dialHomePage,
     tooltip,
     setTestIds,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-3022', 'EPMRTC-1615');
     const folderName = GeneratorUtil.randomString(7);
 
     await dialTest.step('Upload file to some folder', async () => {
       await fileApiHelper.putFile(Attachment.longImageName, folderName);
+      await localStorageManager.setShowSideBarPanels();
     });
 
     await dialTest.step(

--- a/apps/chat-e2e/src/tests/uploadFromDevice.test.ts
+++ b/apps/chat-e2e/src/tests/uploadFromDevice.test.ts
@@ -39,6 +39,7 @@ dialTest(
     await dialTest.step('Set random app theme', async () => {
       theme = GeneratorUtil.randomArrayElement(Object.keys(ThemeId));
       await localStorageManager.setSettings(theme);
+      await localStorageManager.setShowSideBarPanels();
     });
 
     await dialTest.step(
@@ -139,6 +140,7 @@ dialTest(
     attachFilesModal,
     uploadFromDeviceModal,
     page,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-3203', 'EPMRTC-3195', 'EPMRTC-3236');
     let deleteUploadedFileIcon: BaseElement;
@@ -150,6 +152,7 @@ dialTest(
     await dialTest.step(
       'Upload from device 2 files and verify file with long name is cut with dots, file extension is separated from file name',
       async () => {
+        await localStorageManager.setShowSideBarPanels();
         await dialHomePage.openHomePage();
         await dialHomePage.waitForPageLoaded();
         await chatBar.openManageAttachmentsModal();
@@ -314,6 +317,7 @@ dialTest(
         await localStorageManager.setRecentModelsIds(
           randomModelWithImageAttachment,
         );
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 
@@ -387,6 +391,7 @@ dialTest(
     setTestIds,
     attachFilesModal,
     uploadFromDeviceModal,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-3196', 'EPMRTC-3235');
     const attachments = [
@@ -397,6 +402,7 @@ dialTest(
     await dialTest.step(
       'Verify files with same names, zero size but different extensions can be uploaded',
       async () => {
+        await localStorageManager.setShowSideBarPanels();
         await dialHomePage.openHomePage();
         await dialHomePage.waitForPageLoaded();
         await chatBar.openManageAttachmentsModal();
@@ -428,6 +434,7 @@ dialTest(
     attachFilesModal,
     uploadFromDeviceModal,
     page,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-1674', 'EPMRTC-3023', 'EPMRTC-3215', 'EPMRTC-2922');
     const fileNameExtension = Attachment.sunImageName.split('.');
@@ -436,6 +443,7 @@ dialTest(
     await dialTest.step(
       'Upload files through "Upload from device" modal',
       async () => {
+        await localStorageManager.setShowSideBarPanels();
         await dialHomePage.openHomePage();
         await dialHomePage.waitForPageLoaded();
         await chatBar.openManageAttachmentsModal();
@@ -515,6 +523,7 @@ dialTest(
     conversationData,
     conversations,
     dataInjector,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-1614');
     const modelWithAttachmentExtensions = modelsWithAttachments.find(
@@ -532,6 +541,7 @@ dialTest(
         conversation =
           conversationData.prepareDefaultConversation(conversationModel);
         await dataInjector.createConversations([conversation]);
+        await localStorageManager.setShowSideBarPanels();
       },
     );
 

--- a/apps/chat-e2e/src/tests/workWithModels.test.ts
+++ b/apps/chat-e2e/src/tests/workWithModels.test.ts
@@ -36,6 +36,7 @@ dialTest(
     dataInjector,
     setTestIds,
     chatMessages,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-476');
     let conversation: Conversation;
@@ -48,6 +49,7 @@ dialTest(
       conversation =
         conversationData.prepareModelConversationBasedOnRequests(userRequests);
       await dataInjector.createConversations([conversation]);
+      await localStorageManager.setShowSideBarPanels();
     });
 
     await dialTest.step(
@@ -97,6 +99,7 @@ dialTest(
     await dialTest.step('Set random application theme', async () => {
       const theme = GeneratorUtil.randomArrayElement(Object.keys(ThemeId));
       await localStorageManager.setSettings(theme);
+      await localStorageManager.setShowSideBarPanels();
     });
 
     await dialTest.step(
@@ -181,6 +184,7 @@ dialTest(
     dataInjector,
     setTestIds,
     chatMessages,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-485', 'EPMRTC-486', 'EPMRTC-487');
     const editData = 'updated message';
@@ -190,6 +194,7 @@ dialTest(
       conversation =
         conversationData.prepareModelConversationBasedOnRequests(userRequests);
       await dataInjector.createConversations([conversation]);
+      await localStorageManager.setShowSideBarPanels();
     });
 
     await dialTest.step(
@@ -273,12 +278,14 @@ dialTest(
     setTestIds,
     chatMessages,
     confirmationDialog,
+    localStorageManager,
   }) => {
     setTestIds('EPMRTC-488', 'EPMRTC-489');
     const conversation =
       conversationData.prepareModelConversationBasedOnRequests(userRequests);
     await dialTest.step('Prepare conversation with 3 requests', async () => {
       await dataInjector.createConversations([conversation]);
+      await localStorageManager.setShowSideBarPanels();
     });
 
     await dialTest.step(
@@ -340,6 +347,7 @@ dialTest.skip(
       'Set system prompt for model and send request',
       async () => {
         await localStorageManager.setRecentModelsIds(simpleRequestModel!);
+        await localStorageManager.setShowSideBarPanels();
         await dialHomePage.openHomePage();
         await dialHomePage.waitForPageLoaded();
         await chat.changeAgentButton.click();
@@ -392,6 +400,7 @@ dialTest(
       const theme = GeneratorUtil.randomArrayElement(Object.keys(ThemeId));
       await localStorageManager.setSettings(theme);
       await localStorageManager.setRecentModelsIds(simpleRequestModel!);
+      await localStorageManager.setShowSideBarPanels();
     });
 
     await dialTest.step(
@@ -514,6 +523,7 @@ dialTest(
         const width = SIDEBAR_MIN_WIDTH + SIDEBAR_MIN_WIDTH / 3;
         await localStorageManager.setChatbarWidth(width.toFixed());
         await localStorageManager.setRecentModelsIds(simpleRequestModel!);
+        await localStorageManager.setShowSideBarPanels();
         await dialHomePage.openHomePage();
         await dialHomePage.waitForPageLoaded();
         await dialHomePage.throttleAPIResponse(API.chatHost);
@@ -553,6 +563,7 @@ dialTest(
       prompt = promptData.preparePrompt(promptContent);
       await dataInjector.createPrompts([prompt]);
       await localStorageManager.setRecentModelsIds(simpleRequestModel!);
+      await localStorageManager.setShowSideBarPanels();
     });
 
     await dialTest.step(

--- a/apps/chat/src/store/ui/ui.epics.ts
+++ b/apps/chat/src/store/ui/ui.epics.ts
@@ -16,7 +16,11 @@ import { AnyAction } from '@reduxjs/toolkit';
 import { combineEpics } from 'redux-observable';
 
 import { DataService } from '@/src/utils/app/data/data-service';
-import { isSmallScreen, isTabletScreen } from '@/src/utils/app/mobile';
+import {
+  isSmallScreen,
+  isTabletScreen,
+  isTabletScreenOrMobile,
+} from '@/src/utils/app/mobile';
 
 import { FeatureType } from '@/src/types/common';
 import { AppEpic } from '@/src/types/store';
@@ -29,6 +33,8 @@ import { Spinner } from '@/src/components/Common/Spinner';
 import { SettingsSelectors } from '../settings/settings.reducers';
 import { UIActions, UISelectors } from './ui.reducers';
 
+import { Feature } from '@epam/ai-dial-shared';
+
 const initEpic: AppEpic = (action$, state$) =>
   action$.pipe(
     filter(
@@ -40,14 +46,19 @@ const initEpic: AppEpic = (action$, state$) =>
       const isThemesDefined = SettingsSelectors.selectThemeHostDefined(
         state$.value,
       );
+      const isAdvancedView = SettingsSelectors.isFeatureEnabled(
+        state$.value,
+        Feature.AdvancedView,
+      );
+      const showPanelsByDefault = isAdvancedView && !isTabletScreenOrMobile();
 
       return forkJoin({
         theme: DataService.getTheme(),
         availableThemes: isThemesDefined
           ? DataService.getAvailableThemes()
           : of([]),
-        showChatbar: DataService.getShowChatbar(),
-        showPromptbar: DataService.getShowPromptbar(),
+        showChatbar: DataService.getShowChatbar(showPanelsByDefault),
+        showPromptbar: DataService.getShowPromptbar(showPanelsByDefault),
         showMarketplaceFilterbar: DataService.getShowMarketplaceFilterbar(),
         textOfClosedAnnouncement: DataService.getClosedAnnouncement(),
         chatbarWidth: DataService.getChatbarWidth(),

--- a/apps/chat/src/utils/app/data/data-service.ts
+++ b/apps/chat/src/utils/app/data/data-service.ts
@@ -113,22 +113,16 @@ export class DataService {
     );
   }
 
-  public static getShowChatbar(): Observable<boolean> {
-    return BrowserStorage.getData(
-      UIStorageKeys.ShowChatbar,
-      !isTabletScreenOrMobile(),
-    );
+  public static getShowChatbar(defaultValue: boolean): Observable<boolean> {
+    return BrowserStorage.getData(UIStorageKeys.ShowChatbar, defaultValue);
   }
 
   public static setShowChatbar(showChatbar: boolean): Observable<void> {
     return BrowserStorage.setData(UIStorageKeys.ShowChatbar, showChatbar);
   }
 
-  public static getShowPromptbar(): Observable<boolean> {
-    return BrowserStorage.getData(
-      UIStorageKeys.ShowPromptbar,
-      !isTabletScreenOrMobile(),
-    );
+  public static getShowPromptbar(defaultValue: boolean): Observable<boolean> {
+    return BrowserStorage.getData(UIStorageKeys.ShowPromptbar, defaultValue);
   }
 
   public static setShowPromptbar(showPromptbar: boolean): Observable<void> {

--- a/libs/shared/src/types/features.ts
+++ b/libs/shared/src/types/features.ts
@@ -31,6 +31,7 @@ export enum Feature {
   DisallowChangeAgent = 'disallow-change-agent', // Disallow "Change agent" button
   MarketplaceTableView = 'marketplace-table-view', // Enable table view in Marketplace
   HideUserSettings = 'hide-user-settings', // Hide user settings
+  AdvancedView = 'advanced-view', // Enable advanced view
 }
 
 export const availableFeatures: Record<Feature, boolean> = {
@@ -66,4 +67,5 @@ export const availableFeatures: Record<Feature, boolean> = {
   [Feature.DisallowChangeAgent]: true,
   [Feature.MarketplaceTableView]: true,
   [Feature.HideUserSettings]: true,
+  [Feature.AdvancedView]: true,
 };

--- a/libs/shared/src/types/features.ts
+++ b/libs/shared/src/types/features.ts
@@ -31,7 +31,7 @@ export enum Feature {
   DisallowChangeAgent = 'disallow-change-agent', // Disallow "Change agent" button
   MarketplaceTableView = 'marketplace-table-view', // Enable table view in Marketplace
   HideUserSettings = 'hide-user-settings', // Hide user settings
-  AdvancedView = 'advanced-view', // Enable advanced view
+  AdvancedView = 'advanced-view', // Enable advanced view: show chat and prompt sidebars by default on descktop
 }
 
 export const availableFeatures: Record<Feature, boolean> = {


### PR DESCRIPTION
**Description:**

implement new `advanced-view` flag to show chat and prompt sidebars by default

Issues:

- Issue #3333

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
