### PR TITLE
chore(chat): Remove useless createSelector from selectors (Issue #3360)

### DIFF
--- a/apps/chat/src/store/application/application.selectors.ts
+++ b/apps/chat/src/store/application/application.selectors.ts
@@ -8,25 +8,16 @@ import { UploadStatus } from '@epam/ai-dial-shared';
 
 const rootSelector = (state: RootState): ApplicationState => state.application;
 
-const selectAppLoading = createSelector(
-  [rootSelector],
-  (state) => state.appLoading,
-);
+const selectAppLoading = (state: RootState) => rootSelector(state).appLoading;
 
-const selectIsApplicationLoading = createSelector(
-  [selectAppLoading],
-  (status) => {
-    return status === UploadStatus.LOADING;
-  },
-);
+const selectIsApplicationLoading = (state: RootState) =>
+  selectAppLoading(state) === UploadStatus.LOADING;
 
-const selectIsLogsLoading = createSelector([rootSelector], (state) => {
-  return state.logsLoadingStatus === UploadStatus.LOADING;
-});
+const selectIsLogsLoading = (state: RootState) =>
+  rootSelector(state).logsLoadingStatus === UploadStatus.LOADING;
 
-const selectApplicationDetail = createSelector([rootSelector], (state) => {
-  return state.appDetails;
-});
+const selectApplicationDetail = (state: RootState) =>
+  rootSelector(state).appDetails;
 
 const selectApplicationLogs = createSelector([rootSelector], (state) => {
   const ansiRegex = new RegExp(String.fromCharCode(27) + '\\[[0-9;]*[mK]', 'g');
@@ -47,15 +38,11 @@ const selectApplicationLogs = createSelector([rootSelector], (state) => {
     .join('');
 });
 
-const selectShouldSaveApplication = createSelector(
-  [rootSelector],
-  (state) => state.shouldSaveApplication,
-);
+const selectShouldSaveApplication = (state: RootState) =>
+  rootSelector(state).shouldSaveApplication;
 
-const selectExitAfterSave = createSelector(
-  [rootSelector],
-  (state) => state.exitAfterSave,
-);
+const selectExitAfterSave = (state: RootState) =>
+  rootSelector(state).exitAfterSave;
 
 const selectPublicFolders = (state: RootState) =>
   rootSelector(state).publicFolders;

--- a/apps/chat/src/store/auth/auth.selectors.ts
+++ b/apps/chat/src/store/auth/auth.selectors.ts
@@ -35,9 +35,8 @@ const selectIsShouldLogin = createSelector(
     );
   },
 );
-const selectIsAdmin = createSelector([selectSessionData], (sessionData) => {
-  return isUserAdmin(sessionData);
-});
+const selectIsAdmin = (state: RootState) =>
+  isUserAdmin(selectSessionData(state));
 
 const selectUserName = (state: RootState) =>
   selectSessionData(state)?.user?.name ?? '';

--- a/apps/chat/src/store/chat/chat.selectors.ts
+++ b/apps/chat/src/store/chat/chat.selectors.ts
@@ -37,9 +37,8 @@ const selectNotAvailableEntityType = (state: RootState) =>
 const selectInfoModalState = (state: RootState) =>
   rootSelector(state).infoModalState;
 
-const selectInfoModalOpened = createSelector([rootSelector], (state) => {
-  return state.infoModalState !== ModalState.CLOSED;
-});
+const selectInfoModalOpened = (state: RootState) =>
+  selectInfoModalState(state) !== ModalState.CLOSED;
 
 const selectSelectedEntityInfo = (state: RootState) =>
   rootSelector(state).selectedEntityInfo;

--- a/apps/chat/src/store/codeEditor/codeEditor.selectors.ts
+++ b/apps/chat/src/store/codeEditor/codeEditor.selectors.ts
@@ -8,9 +8,8 @@ import { UploadStatus } from '@epam/ai-dial-shared';
 
 const rootSelector = (state: RootState): CodeEditorState => state.codeEditor;
 
-const selectFilesContent = createSelector([rootSelector], (state) => {
-  return state.filesContent;
-});
+const selectFilesContent = (state: RootState) =>
+  rootSelector(state).filesContent;
 
 const selectModifiedFileIds = createSelector(
   [selectFilesContent],
@@ -29,13 +28,11 @@ const selectFileContent = (fileId: string) =>
     return filesContents.find((file) => file.id === fileId);
   });
 
-const selectIsFileContentLoading = createSelector([rootSelector], (state) => {
-  return state.fileContentLoadingStatus === UploadStatus.LOADING;
-});
+const selectIsFileContentLoading = (state: RootState) =>
+  rootSelector(state).fileContentLoadingStatus === UploadStatus.LOADING;
 
-const selectSelectedFile = createSelector([rootSelector], (state) => {
-  return state.selectedFileId;
-});
+const selectSelectedFile = (state: RootState) =>
+  rootSelector(state).selectedFileId;
 
 export const CodeEditorSelectors = {
   selectFilesContent,

--- a/apps/chat/src/store/conversations/conversations.selectors.ts
+++ b/apps/chat/src/store/conversations/conversations.selectors.ts
@@ -239,12 +239,10 @@ export const selectSelectedConversationsFoldersIds = createSelector(
   },
 );
 
-export const selectFirstSelectedConversation = createSelector(
-  [selectSelectedConversations],
-  (conversations): Conversation | undefined => {
-    return conversations[0];
-  },
-);
+export const selectFirstSelectedConversation = (
+  state: RootState,
+): Conversation | undefined => selectSelectedConversations(state)[0];
+
 export const selectIsConversationsStreaming = createSelector(
   [selectSelectedConversations],
   (conversations) => {
@@ -314,12 +312,8 @@ export const selectWillReplayRequireVariables = createSelector(
     );
   },
 );
-export const selectIsSendMessageAborted = createSelector(
-  [selectConversationSignal],
-  (abortController) => {
-    return abortController.signal.aborted;
-  },
-);
+export const selectIsSendMessageAborted = (state: RootState) =>
+  selectConversationSignal(state).signal.aborted;
 
 export const selectIsReplaySelectedConversations = createSelector(
   [selectSelectedConversations],
@@ -481,12 +475,8 @@ export const selectCanAttachLink = createSelector(
   },
 );
 
-export const selectIsStartedCustomViewerConversation = createSelector(
-  [rootSelector],
-  (state) => {
-    return state.isStartedCustomViewerConversation;
-  },
-);
+export const selectIsStartedCustomViewerConversation = (state: RootState) =>
+  rootSelector(state).isStartedCustomViewerConversation;
 
 export const selectCanAttachFolders = createSelector(
   [selectSelectedConversationsModels],
@@ -797,10 +787,8 @@ export const selectIsSelectedConversationBlocksInput = createSelector(
     ),
 );
 
-export const selectPreviewConversationId = createSelector(
-  [rootSelector],
-  (state) => state.previewConversationId,
-);
+export const selectPreviewConversationId = (state: RootState) =>
+  rootSelector(state).previewConversationId;
 
 export const selectIsSelectedConversationsWithSchema = createSelector(
   [selectSelectedConversations],

--- a/apps/chat/src/store/files/files.selectors.ts
+++ b/apps/chat/src/store/files/files.selectors.ts
@@ -47,9 +47,9 @@ const selectFileById = createSelector(
     return files.find((file) => fileId === file.id);
   },
 );
-const selectSelectedFilesIds = createSelector([rootSelector], (state) => {
-  return state.selectedFilesIds;
-});
+const selectSelectedFilesIds = (state: RootState) =>
+  rootSelector(state).selectedFilesIds;
+
 const selectFolders = createSelector([rootSelector], (state) => {
   return [...state.folders].sort((a, b) =>
     a.name.toLowerCase() < b.name.toLowerCase() ? -1 : 1,
@@ -99,18 +99,18 @@ const selectIsUploadingFilePresent = createSelector(
     selectedFiles.some((file) => file.status === UploadStatus.LOADING),
 );
 
-const selectAreFoldersLoading = createSelector([rootSelector], (state) => {
-  return state.foldersStatus === UploadStatus.LOADING;
-});
-const selectAreFilesLoading = createSelector([rootSelector], (state) => {
-  return state.filesStatus === UploadStatus.LOADING;
-});
+const selectAreFoldersLoading = (state: RootState) =>
+  rootSelector(state).foldersStatus === UploadStatus.LOADING;
+
+const selectAreFilesLoading = (state: RootState) =>
+  rootSelector(state).filesStatus === UploadStatus.LOADING;
+
 const selectLoadingFolderIds = createSelector([rootSelector], (state) => {
   return state.loadingFolderId ? [state.loadingFolderId] : [];
 });
-const selectNewAddedFolderId = createSelector([rootSelector], (state) => {
-  return state.newAddedFolderId;
-});
+const selectNewAddedFolderId = (state: RootState) =>
+  rootSelector(state).newAddedFolderId;
+
 const selectFoldersWithSearchTerm = createSelector(
   [selectFolders, (_state, searchTerm: string) => searchTerm],
   (folders, searchTerm) => {
@@ -135,10 +135,7 @@ const selectPublicFolders = createSelector(
   },
 );
 
-const selectInitialized = createSelector(
-  [rootSelector],
-  (state) => state.initialized,
-);
+const selectInitialized = (state: RootState) => rootSelector(state).initialized;
 
 const selectFolderById = createSelector(
   [selectFolders, (_state, folderId: string) => folderId],

--- a/apps/chat/src/store/import-export/importExport.selectors.ts
+++ b/apps/chat/src/store/import-export/importExport.selectors.ts
@@ -9,67 +9,47 @@ import { UploadStatus } from '@epam/ai-dial-shared';
 const rootSelector = (state: RootState): ImportExportState =>
   state.importExport;
 
-const selectAttachmentsIdsToUpload = createSelector([rootSelector], (state) => {
-  return state.attachmentsIdsToUpload;
-});
-const selectUploadedAttachments = createSelector([rootSelector], (state) => {
-  return state.uploadedAttachments;
-});
+const selectAttachmentsIdsToUpload = (state: RootState) =>
+  rootSelector(state).attachmentsIdsToUpload;
 
-const selectAttachmentsErrors = createSelector([rootSelector], (state) => {
-  return state.attachmentsErrors;
-});
+const selectUploadedAttachments = (state: RootState) =>
+  rootSelector(state).uploadedAttachments;
 
-const selectImportedConversations = createSelector([rootSelector], (state) => {
-  return state.importedConversations;
-});
+const selectAttachmentsErrors = (state: RootState) =>
+  rootSelector(state).attachmentsErrors;
 
-const selectImportStatus = createSelector([rootSelector], (state) => {
-  return state.status;
-});
+const selectImportedConversations = (state: RootState) =>
+  rootSelector(state).importedConversations;
 
-const selectOperationName = createSelector([rootSelector], (state) => {
-  return state.operation;
-});
+const selectImportStatus = (state: RootState) => rootSelector(state).status;
 
-const selectIsLoadingImportExport = createSelector([rootSelector], (state) => {
-  return state.status === UploadStatus.LOADING;
-});
+const selectOperationName = (state: RootState) => rootSelector(state).operation;
 
-const selectIsShowReplaceDialog = createSelector([rootSelector], (state) => {
-  return state.isShowReplaceDialog;
-});
+const selectIsLoadingImportExport = (state: RootState) =>
+  selectImportStatus(state) === UploadStatus.LOADING;
 
-const selectFeatureType = createSelector([rootSelector], (state) => {
-  return state.featureType;
-});
+const selectIsShowReplaceDialog = (state: RootState) =>
+  rootSelector(state).isShowReplaceDialog;
 
-const selectDuplicatedConversations = createSelector(
-  [rootSelector],
-  (state) => {
-    return state.duplicatedConversations;
-  },
-);
+const selectFeatureType = (state: RootState) => rootSelector(state).featureType;
 
-const selectDuplicatedPrompts = createSelector([rootSelector], (state) => {
-  return state.duplicatedPrompts;
-});
+const selectDuplicatedConversations = (state: RootState) =>
+  rootSelector(state).duplicatedConversations;
 
-const selectDuplicatedFiles = createSelector([rootSelector], (state) => {
-  return state.duplicatedFiles;
-});
+const selectDuplicatedPrompts = (state: RootState) =>
+  rootSelector(state).duplicatedPrompts;
 
-const selectNonDuplicatedFiles = createSelector([rootSelector], (state) => {
-  return state.nonDuplicatedFiles;
-});
+const selectDuplicatedFiles = (state: RootState) =>
+  rootSelector(state).duplicatedFiles;
 
-const selectIgnoredAttachmentsIds = createSelector([rootSelector], (state) => {
-  return state.ignoredAttachmentsIds;
-});
+const selectNonDuplicatedFiles = (state: RootState) =>
+  rootSelector(state).nonDuplicatedFiles;
 
-const selectMappedActions = createSelector([rootSelector], (state) => {
-  return state.mappedActions;
-});
+const selectIgnoredAttachmentsIds = (state: RootState) =>
+  rootSelector(state).ignoredAttachmentsIds;
+
+const selectMappedActions = (state: RootState) =>
+  rootSelector(state).mappedActions;
 
 export const ImportExportSelectors = {
   selectAttachmentsIdsToUpload,

--- a/apps/chat/src/store/import-export/importExport.selectors.ts
+++ b/apps/chat/src/store/import-export/importExport.selectors.ts
@@ -1,5 +1,3 @@
-import { createSelector } from '@reduxjs/toolkit';
-
 import { RootState } from '@/src/types/store';
 
 import { ImportExportState } from './importExport.types';

--- a/apps/chat/src/store/marketplace/marketplace.selectors.ts
+++ b/apps/chat/src/store/marketplace/marketplace.selectors.ts
@@ -35,42 +35,29 @@ export const selectTableSort = (state: RootState) =>
 export const selectIsBannerVisible = (state: RootState) =>
   rootSelector(state).isBannerVisible;
 
-export const selectSelectedFilters = createSelector(
-  [rootSelector],
-  (state) => state.selectedFilters,
-);
+export const selectSelectedFilters = (state: RootState) =>
+  rootSelector(state).selectedFilters;
 
-export const selectSearchTerm = createSelector(
-  [rootSelector],
-  (state) => state.searchTerm,
-);
+export const selectSearchTerm = (state: RootState) =>
+  rootSelector(state).searchTerm;
 
 export const selectTrimmedSearchTerm = createSelector(
   [selectSearchTerm],
   (searchTerm) => searchTerm.trim(),
 );
 
-export const selectSelectedTab = createSelector(
-  [rootSelector],
-  (state) => state.selectedTab,
-);
+export const selectSelectedTab = (state: RootState) =>
+  rootSelector(state).selectedTab;
 
-export const selectApplyModelStatus = createSelector(
-  [rootSelector],
-  (state) => state.applyModelStatus,
-);
+export const selectApplyModelStatus = (state: RootState) =>
+  rootSelector(state).applyModelStatus;
 
-export const selectIsApplyingModel = createSelector(
-  [selectApplyModelStatus],
-  (applyModelStatus) =>
-    applyModelStatus !== UploadStatus.UNINITIALIZED &&
-    applyModelStatus !== UploadStatus.FAILED,
-);
+export const selectIsApplyingModel = (state: RootState) =>
+  selectApplyModelStatus(state) !== UploadStatus.UNINITIALIZED &&
+  selectApplyModelStatus(state) !== UploadStatus.FAILED;
 
-export const selectDetailsModel = createSelector(
-  [rootSelector],
-  (state) => state.detailsModel,
-);
+export const selectDetailsModel = (state: RootState) =>
+  rootSelector(state).detailsModel;
 
 export const selectSourceTypes = createSelector(
   [

--- a/apps/chat/src/store/migration/migration.selectors.ts
+++ b/apps/chat/src/store/migration/migration.selectors.ts
@@ -14,15 +14,11 @@ export const selectConversationsToMigrateAndMigratedCount = createSelector(
   }),
 );
 
-export const selectFailedMigratedConversations = createSelector(
-  [rootSelector],
-  (state) => state.failedMigratedConversations,
-);
+export const selectFailedMigratedConversations = (state: RootState) =>
+  rootSelector(state).failedMigratedConversations;
 
-export const selectIsChatsBackedUp = createSelector(
-  [rootSelector],
-  (state) => state.isChatsBackedUp,
-);
+export const selectIsChatsBackedUp = (state: RootState) =>
+  rootSelector(state).isChatsBackedUp;
 
 export const selectPromptsToMigrateAndMigratedCount = createSelector(
   [rootSelector],
@@ -32,17 +28,11 @@ export const selectPromptsToMigrateAndMigratedCount = createSelector(
   }),
 );
 
-export const selectFailedMigratedPrompts = createSelector(
-  [rootSelector],
-  (state) => state.failedMigratedPrompts,
-);
+export const selectFailedMigratedPrompts = (state: RootState) =>
+  rootSelector(state).failedMigratedPrompts;
 
-export const selectIsPromptsBackedUp = createSelector(
-  [rootSelector],
-  (state) => state.isPromptsBackedUp,
-);
+export const selectIsPromptsBackedUp = (state: RootState) =>
+  rootSelector(state).isPromptsBackedUp;
 
-export const selectInitialized = createSelector(
-  [rootSelector],
-  (state) => state.initialized,
-);
+export const selectInitialized = (state: RootState) =>
+  rootSelector(state).initialized;

--- a/apps/chat/src/store/models/models.selectors.ts
+++ b/apps/chat/src/store/models/models.selectors.ts
@@ -16,34 +16,23 @@ import uniq from 'lodash-es/uniq';
 
 const rootSelector = (state: RootState): ModelsState => state.models;
 
-export const selectModelsIsLoading = createSelector([rootSelector], (state) => {
-  return (
-    state.status === UploadStatus.LOADING ||
-    state.status === UploadStatus.UNINITIALIZED
-  );
-});
+const selectModelStatus = (state: RootState) => rootSelector(state).status;
 
-export const selectIsModelsLoaded = createSelector([rootSelector], (state) => {
-  return state.status === UploadStatus.LOADED;
-});
+export const selectModelsIsLoading = (state: RootState) =>
+  selectModelStatus(state) === UploadStatus.LOADING ||
+  selectModelStatus(state) === UploadStatus.UNINITIALIZED;
 
-export const selectIsInstalledModelsInitialized = createSelector(
-  [rootSelector],
-  (state) => {
-    return state.isInstalledModelsInitialized;
-  },
-);
+export const selectIsModelsLoaded = (state: RootState) =>
+  rootSelector(state).status === UploadStatus.LOADED;
 
-export const selectModelsError = createSelector([rootSelector], (state) => {
-  return state.error;
-});
+export const selectIsInstalledModelsInitialized = (state: RootState) =>
+  rootSelector(state).isInstalledModelsInitialized;
 
-export const selectIsRecentModelsLoaded = createSelector(
-  [rootSelector],
-  (state) => {
-    return state.recentModelsStatus === UploadStatus.LOADED;
-  },
-);
+export const selectModelsError = (state: RootState) =>
+  rootSelector(state).error;
+
+export const selectIsRecentModelsLoaded = (state: RootState) =>
+  rootSelector(state).recentModelsStatus === UploadStatus.LOADED;
 
 export const selectModels = createSelector([rootSelector], (state) => {
   const groups = groupBy(state.models, (model) =>
@@ -53,7 +42,7 @@ export const selectModels = createSelector([rootSelector], (state) => {
   return sortBy(
     [
       ...(groups.rest ?? []),
-      ...orderBy(groups.custom ?? [], 'version', 'desc'),
+      ...orderBy(groups.custom ?? [], 'version', 'desc'), //TODO: fix semVer sorting
     ],
     (model) => model.name.toLowerCase(),
   );
@@ -66,13 +55,11 @@ export const selectModelTopics = createSelector([rootSelector], (state) => {
   );
 });
 
-export const selectModelsMap = createSelector([rootSelector], (state) => {
-  return state.modelsMap;
-});
+export const selectModelsMap = (state: RootState) =>
+  rootSelector(state).modelsMap;
 
-export const selectRecentModelsIds = createSelector([rootSelector], (state) => {
-  return state.recentModelsIds;
-});
+export const selectRecentModelsIds = (state: RootState) =>
+  rootSelector(state).recentModelsIds;
 
 export const selectRecentModels = createSelector(
   [selectRecentModelsIds, selectModelsMap],
@@ -85,28 +72,19 @@ export const selectModelsOnly = createSelector([selectModels], (models) => {
   return models.filter((model) => model.type === EntityType.Model);
 });
 
-export const selectPublishRequestModels = createSelector(
-  [rootSelector],
-  (state) => {
-    return state.publishRequestModels;
-  },
-);
+export const selectPublishRequestModels = (state: RootState) =>
+  rootSelector(state).publishRequestModels;
 
-export const selectPublishedApplicationIds = createSelector(
-  [rootSelector],
-  (state) => {
-    return state.publishedApplicationIds;
-  },
-);
+export const selectPublishedApplicationIds = (state: RootState) =>
+  rootSelector(state).publishedApplicationIds;
 
-export const selectInstalledModels = createSelector([rootSelector], (state) => {
-  return state.installedModels;
-});
+export const selectInstalledModels = (state: RootState) =>
+  rootSelector(state).installedModels;
 
 export const selectInstalledModelIds = createSelector(
-  [rootSelector],
-  (state) => {
-    return new Set(state.installedModels.map(({ id }) => id));
+  [selectInstalledModels],
+  (installedModels) => {
+    return new Set(installedModels.map(({ id }) => id));
   },
 );
 
@@ -121,10 +99,8 @@ export const selectRecentWithInstalledModelsIds = createSelector(
   },
 );
 
-export const selectInitialized = createSelector(
-  [rootSelector],
-  (state) => state.initialized,
-);
+export const selectInitialized = (state: RootState) =>
+  rootSelector(state).initialized;
 
 export const selectCustomModels = createSelector([rootSelector], (state) => {
   return state.models.filter((model) => model.reference !== model.id);
@@ -144,12 +120,10 @@ export const selectSharedWriteModels = createSelector(
   },
 );
 
-export const selectModelById = createSelector(
-  [selectModelsMap, (_state, modelId) => modelId],
-  (modelsMap, modelId) => {
-    return modelsMap[modelId];
-  },
-);
+export const selectModelById = (
+  state: RootState,
+  modelId: string | undefined,
+) => (modelId ? selectModelsMap(state)[modelId] : undefined);
 
 export const selectAllGroupModelKeySet = (
   state: RootState,

--- a/apps/chat/src/store/overlay/overlay.selectors.ts
+++ b/apps/chat/src/store/overlay/overlay.selectors.ts
@@ -1,5 +1,3 @@
-import { createSelector } from '@reduxjs/toolkit';
-
 import { RootState } from '@/src/types/store';
 
 import { OverlayState } from './overlay.types';

--- a/apps/chat/src/store/overlay/overlay.selectors.ts
+++ b/apps/chat/src/store/overlay/overlay.selectors.ts
@@ -6,21 +6,16 @@ import { OverlayState } from './overlay.types';
 
 const rootSelector = (state: RootState): OverlayState => state.overlay;
 
-const selectHostDomain = createSelector([rootSelector], (state) => {
-  return state.hostDomain;
-});
+const selectHostDomain = (state: RootState) => rootSelector(state).hostDomain;
 
-const selectOverlaySystemPrompt = createSelector([rootSelector], (state) => {
-  return state.systemPrompt;
-});
+const selectOverlaySystemPrompt = (state: RootState) =>
+  rootSelector(state).systemPrompt;
 
-const selectOptionsReceived = createSelector([rootSelector], (state) => {
-  return state.optionsReceived;
-});
+const selectOptionsReceived = (state: RootState) =>
+  rootSelector(state).optionsReceived;
 
-const selectReadyToInteractSent = createSelector([rootSelector], (state) => {
-  return state.readyToInteractSent;
-});
+const selectReadyToInteractSent = (state: RootState) =>
+  rootSelector(state).readyToInteractSent;
 
 export const OverlaySelectors = {
   selectHostDomain,

--- a/apps/chat/src/store/service/service.selectors.ts
+++ b/apps/chat/src/store/service/service.selectors.ts
@@ -1,5 +1,3 @@
-import { createSelector } from '@reduxjs/toolkit';
-
 import { RootState } from '@/src/types/store';
 
 import { ServiceState } from './service.types';

--- a/apps/chat/src/store/service/service.selectors.ts
+++ b/apps/chat/src/store/service/service.selectors.ts
@@ -6,9 +6,7 @@ import { ServiceState } from './service.types';
 
 const rootSelector = (state: RootState): ServiceState => state.service;
 
-const selectIsSuccessfullySent = createSelector(
-  [rootSelector],
-  (state) => state.isSuccessfullySent,
-);
+const selectIsSuccessfullySent = (state: RootState) =>
+  rootSelector(state).isSuccessfullySent;
 
 export const ServiceSelectors = { selectIsSuccessfullySent };

--- a/apps/chat/src/store/share/share.selectors.ts
+++ b/apps/chat/src/store/share/share.selectors.ts
@@ -7,47 +7,30 @@ import { ShareState } from './share.types';
 
 const rootSelector = (state: RootState): ShareState => state.share;
 
-export const selectInvitationId = createSelector([rootSelector], (state) => {
-  return state.invitationId;
-});
+export const selectInvitationId = (state: RootState) =>
+  rootSelector(state).invitationId;
 
-export const selectWriteInvitationId = createSelector(
-  [rootSelector],
-  (state) => {
-    return state.writeInvitationId;
-  },
-);
+export const selectWriteInvitationId = (state: RootState) =>
+  rootSelector(state).writeInvitationId;
 
-export const selectShareModalState = createSelector([rootSelector], (state) => {
-  return state.shareModalState;
-});
-export const selectShareModalOpened = createSelector(
-  [rootSelector],
-  (state) => {
-    return state.shareModalState !== ModalState.CLOSED;
-  },
-);
+export const selectShareModalState = (state: RootState) =>
+  rootSelector(state).shareModalState;
 
-export const selectShareResourceId = createSelector([rootSelector], (state) => {
-  return state.shareResourceId;
-});
+export const selectShareModalOpened = (state: RootState) =>
+  rootSelector(state).shareModalState !== ModalState.CLOSED;
 
-export const selectShareResourceName = createSelector(
-  [rootSelector],
-  (state) => {
-    return state.shareResourceName;
-  },
-);
+export const selectShareResourceId = (state: RootState) =>
+  rootSelector(state).shareResourceId;
 
-export const selectShareFeatureType = createSelector(
-  [rootSelector],
-  (state) => {
-    return state.shareFeatureType;
-  },
-);
-export const selectShareIsFolder = createSelector([rootSelector], (state) => {
-  return state.shareIsFolder;
-});
+export const selectShareResourceName = (state: RootState) =>
+  rootSelector(state).shareResourceName;
+
+export const selectShareFeatureType = (state: RootState) =>
+  rootSelector(state).shareFeatureType;
+
+export const selectShareIsFolder = (state: RootState) =>
+  rootSelector(state).shareIsFolder;
+
 export const selectAcceptedEntityInfo = createSelector(
   [rootSelector],
   (state) => {
@@ -59,14 +42,12 @@ export const selectAcceptedEntityInfo = createSelector(
     };
   },
 );
-export const selectInitialized = createSelector(
-  [rootSelector],
-  (state) => state.initialized,
-);
-export const selectSharePermissions = createSelector(
-  [rootSelector],
-  (state) => state.sharePermissions,
-);
-export const selectUnshareModel = createSelector([rootSelector], (state) => {
-  return state.unshareEntity;
-});
+
+export const selectInitialized = (state: RootState) =>
+  rootSelector(state).initialized;
+
+export const selectSharePermissions = (state: RootState) =>
+  rootSelector(state).sharePermissions;
+
+export const selectUnshareModel = (state: RootState) =>
+  rootSelector(state).unshareEntity;

--- a/apps/chat/src/store/ui/ui.selectors.ts
+++ b/apps/chat/src/store/ui/ui.selectors.ts
@@ -11,78 +11,55 @@ import { Feature } from '@epam/ai-dial-shared';
 
 const rootSelector = (state: RootState): UIState => state.ui;
 
-const selectThemeState = createSelector([rootSelector], (state) => {
-  return state.theme;
-});
-const selectAvailableThemes = createSelector([rootSelector], (state) => {
-  return state.availableThemes;
-});
+const selectThemeState = (state: RootState) => rootSelector(state).theme;
 
-const selectShowChatbar = createSelector([rootSelector], (state) => {
-  return state.showChatbar;
-});
+const selectAvailableThemes = (state: RootState) =>
+  rootSelector(state).availableThemes;
 
-const selectShowPromptbar = createSelector([rootSelector], (state) => {
-  return state.showPromptbar;
-});
+const selectShowChatbar = (state: RootState) => rootSelector(state).showChatbar;
 
-const selectShowMarketplaceFilterbar = createSelector(
-  [rootSelector],
-  (state) => {
-    return state.showMarketplaceFilterbar;
-  },
-);
+const selectShowPromptbar = (state: RootState) =>
+  rootSelector(state).showPromptbar;
 
-const selectIsUserSettingsOpen = createSelector([rootSelector], (state) => {
-  return state.isUserSettingsOpen;
-});
+const selectShowMarketplaceFilterbar = (state: RootState) =>
+  rootSelector(state).showMarketplaceFilterbar;
 
-const selectIsProfileOpen = createSelector([rootSelector], (state) => {
-  return state.isProfileOpen;
-});
+const selectIsUserSettingsOpen = (state: RootState) =>
+  rootSelector(state).isUserSettingsOpen;
 
-const selectIsCompareMode = createSelector([rootSelector], (state) => {
-  return state.isCompareMode;
-});
+const selectIsProfileOpen = (state: RootState) =>
+  rootSelector(state).isProfileOpen;
 
-const selectAllOpenedFoldersIds = createSelector([rootSelector], (state) => {
-  return state.openedFoldersIds;
-});
+const selectIsCompareMode = (state: RootState) =>
+  rootSelector(state).isCompareMode;
 
-const selectOpenedFoldersIds = (featureType: FeatureType) =>
-  createSelector([selectAllOpenedFoldersIds], (openedFoldersIds) => {
-    return openedFoldersIds[featureType];
-  });
+const selectAllOpenedFoldersIds = (state: RootState) =>
+  rootSelector(state).openedFoldersIds;
+
+const selectOpenedFoldersIds =
+  (featureType: FeatureType) => (state: RootState) =>
+    selectAllOpenedFoldersIds(state)[featureType];
+
 const selectIsFolderOpened = (featureType: FeatureType, id: string) =>
   createSelector([selectOpenedFoldersIds(featureType)], (ids): boolean => {
     return ids.includes(id);
   });
-const selectTextOfClosedAnnouncement = createSelector(
-  [rootSelector],
-  (state) => {
-    return state.textOfClosedAnnouncement;
-  },
-);
+const selectTextOfClosedAnnouncement = (state: RootState) =>
+  rootSelector(state).textOfClosedAnnouncement;
 
-const selectChatbarWidth = createSelector([rootSelector], (state) => {
-  return state.chatbarWidth;
-});
+const selectChatbarWidth = (state: RootState) =>
+  rootSelector(state).chatbarWidth;
 
-const selectPromptbarWidth = createSelector([rootSelector], (state) => {
-  return state.promptbarWidth;
-});
-const selectIsChatFullWidth = createSelector([rootSelector], (state) => {
-  return state.isChatFullWidth;
-});
+const selectPromptbarWidth = (state: RootState) =>
+  rootSelector(state).promptbarWidth;
 
-const selectCustomLogo = createSelector([rootSelector], (state) => {
-  return state.customLogo;
-});
+const selectIsChatFullWidth = (state: RootState) =>
+  rootSelector(state).isChatFullWidth;
 
-export const selectShowSelectToMigrateWindow = createSelector(
-  [rootSelector],
-  (state) => state.showSelectToMigrateWindow,
-);
+const selectCustomLogo = (state: RootState) => rootSelector(state).customLogo;
+
+export const selectShowSelectToMigrateWindow = (state: RootState) =>
+  rootSelector(state).showSelectToMigrateWindow;
 
 export const selectIsAnyMenuOpen = createSelector(
   [rootSelector, SettingsSelectors.selectEnabledFeatures],
@@ -92,20 +69,15 @@ export const selectIsAnyMenuOpen = createSelector(
     state.isProfileOpen,
 );
 
-export const selectCollapsedSections = (featureType: FeatureType) =>
-  createSelector([rootSelector], (state) => {
-    return state.collapsedSections[featureType];
-  });
+export const selectCollapsedSections = //TODO: review later how it is used
+  (featureType: FeatureType) => (state: RootState) =>
+    rootSelector(state).collapsedSections[featureType];
 
-export const selectPreviousRoute = createSelector(
-  [rootSelector],
-  (state) => state.previousRoute,
-);
+export const selectPreviousRoute = (state: RootState) =>
+  rootSelector(state).previousRoute;
 
-export const selectInitialized = createSelector(
-  [rootSelector],
-  (state) => state.initialized,
-);
+export const selectInitialized = (state: RootState) =>
+  rootSelector(state).initialized;
 
 export const UISelectors = {
   selectThemeState,


### PR DESCRIPTION
**Description:**

Remove useless createSelector from selectors

Issues:

- Issue #3360

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
