### PR TITLE
fix(chat): prevent saving application when navigating to app editor (Issue #3334)

### DIFF
--- a/apps/chat-e2e/src/testData/publishing/publishRequestBuilder.ts
+++ b/apps/chat-e2e/src/testData/publishing/publishRequestBuilder.ts
@@ -26,6 +26,7 @@ export class PublishRequestBuilder {
 
   private reset(): PublicationRequestModel {
     this.publishRequest = {
+      displayAuthor: '',
       name: '',
       targetFolder: ExpectedConstants.rootPublicationFolder,
       resources: [],

--- a/apps/chat-e2e/src/tests/agentSelection.test.ts
+++ b/apps/chat-e2e/src/tests/agentSelection.test.ts
@@ -36,6 +36,7 @@ dialTest(
     marketplaceAgentsSection,
     toast,
   }) => {
+    dialTest.slow();
     setTestIds('EPMRTC-4878', 'EPMRTC-4880', 'EPMRTC-4356', 'EPMRTC-5168');
     const models = GeneratorUtil.randomArrayElements(
       ModelsUtil.getLatestModels().filter((m) => m.iconUrl !== undefined),

--- a/apps/chat-e2e/src/tests/playBack.test.ts
+++ b/apps/chat-e2e/src/tests/playBack.test.ts
@@ -739,6 +739,7 @@ dialTest(
     chatMessages,
     sendMessage,
     playbackControl,
+    baseAssertion,
     setTestIds,
   }) => {
     setTestIds('EPMRTC-1427', 'EPMRTC-1470', 'EPMRTC-1473', 'EPMRTC-1428');
@@ -766,7 +767,6 @@ dialTest(
       await dialHomePage.openHomePage();
       await dialHomePage.waitForPageLoaded();
       await conversations.selectConversation(playbackConversation.name);
-      await conversations.getEntityByName(playbackConversation.name).waitFor();
       await chat.playNextChatMessage();
       const isPlaybackNextMessageScrollable = await playbackControl
         .getPlaybackMessage()
@@ -782,16 +782,18 @@ dialTest(
       async () => {
         await dialHomePage.throttleAPIResponse('**/*');
         await chat.playNextChatMessage(false);
-        await expect(
-          chatMessages.loadingCursor.getElementLocator(),
-          ExpectedMessages.playbackNextMessageIsScrollable,
-        ).toBeVisible();
-        await expect(
-          playbackControl.playbackNextButton.getElementLocator(),
-          ExpectedMessages.playbackNextMessageIsScrollable,
-        ).toBeDisabled();
-
-        await sendMessage.waitForMessageInputLoaded();
+        await baseAssertion.assertElementState(
+          chatMessages.loadingCursor,
+          'visible',
+        );
+        await baseAssertion.assertElementActionabilityState(
+          playbackControl.playbackNextButton,
+          'disabled',
+        );
+        await baseAssertion.assertElementState(
+          sendMessage.messageInputSpinner,
+          'hidden',
+        );
         await chatMessages.waitForResponseReceived();
 
         const playedBackResponse = chatMessages.getChatMessage(

--- a/apps/chat-e2e/src/tests/publishConversationWithAttachment.test.ts
+++ b/apps/chat-e2e/src/tests/publishConversationWithAttachment.test.ts
@@ -69,6 +69,7 @@ dialAdminTest(
     fileApiHelper,
     setTestIds,
   }) => {
+    dialAdminTest.slow();
     setTestIds(
       'EPMRTC-3463',
       'EPMRTC-3213',

--- a/apps/chat-e2e/src/tests/unpublishFolderWithConversations.test.ts
+++ b/apps/chat-e2e/src/tests/unpublishFolderWithConversations.test.ts
@@ -54,6 +54,7 @@ dialAdminTest(
     organizationFolderConversationAssertions,
     setTestIds,
   }) => {
+    dialAdminTest.slow();
     setTestIds('EPMRTC-3386', 'EPMRTC-3802', 'EPMRTC-3389');
     let firstConversation: Conversation;
     let secondConversation: Conversation;

--- a/apps/chat-e2e/src/tests/workWithModels.test.ts
+++ b/apps/chat-e2e/src/tests/workWithModels.test.ts
@@ -492,59 +492,35 @@ dialTest(
 );
 
 dialTest(
-  'Send button in new message is available for Model if previous response is partly received when Stop generating was used.\n' +
-    'Compare mode button is not available while response is being generated',
+  'Compare mode button is not available while response is being generated.\n' +
+    '"Talk to" item icon is jumping while generating an answer',
   async ({
     dialHomePage,
     chat,
     setTestIds,
     chatMessages,
-    sendMessage,
     localStorageManager,
+    baseAssertion,
     chatBar,
   }) => {
     dialTest.skip(simpleRequestModel === undefined, noSimpleModelSkipReason);
-    setTestIds('EPMRTC-1533', 'EPMRTC-538');
+    setTestIds('EPMRTC-538', 'EPMRTC-386');
     await dialTest.step(
-      'Send request, verify Compare button is disabled while generating the response and stop generation immediately',
+      'Send request, verify Compare button is disabled while generating the response, model icon is jumping',
       async () => {
         const width = SIDEBAR_MIN_WIDTH + SIDEBAR_MIN_WIDTH / 3;
         await localStorageManager.setChatbarWidth(width.toFixed());
         await localStorageManager.setRecentModelsIds(simpleRequestModel!);
         await dialHomePage.openHomePage();
         await dialHomePage.waitForPageLoaded();
+        await dialHomePage.throttleAPIResponse(API.chatHost);
         await chat.sendRequestWithButton(request, false);
-        await expect
-          .soft(
-            chatBar.compareButton.getElementLocator(),
-            ExpectedMessages.compareButtonIsDisabled,
-          )
-          .toBeDisabled();
-
-        await chatMessages.waitForPartialMessageReceived(2);
-        // eslint-disable-next-line playwright/no-force-option
-        await sendMessage.stopGenerating.click({ force: true });
-        await expect
-          .soft(
-            sendMessage.stopGenerating.getElementLocator(),
-            ExpectedMessages.stopGeneratingIsNotVisible,
-          )
-          .toBeHidden();
-      },
-    );
-
-    await dialTest.step(
-      'Type a new message and verify Send button is enabled',
-      async () => {
-        await sendMessage.messageInput.fillInInput(
-          GeneratorUtil.randomString(10),
+        await baseAssertion.assertElementActionabilityState(
+          chatBar.compareButton,
+          'disabled',
         );
-        await expect
-          .soft(
-            sendMessage.sendMessageButton.getElementLocator(),
-            ExpectedMessages.sendMessageButtonEnabled,
-          )
-          .toBeEnabled();
+        const jumpingIcon = await chatMessages.getMessageJumpingIcon();
+        await baseAssertion.assertElementState(jumpingIcon, 'visible');
       },
     );
   },

--- a/apps/chat/src/components/Marketplace/SearchHeader.tsx
+++ b/apps/chat/src/components/Marketplace/SearchHeader.tsx
@@ -16,6 +16,7 @@ import { FeatureType } from '@/src/types/common';
 import { DisplayMenuItemProps } from '@/src/types/menu';
 import { Translation } from '@/src/types/translation';
 
+import { ApplicationActions } from '@/src/store/application/application.reducers';
 import {
   ApplicationTypesSchemasActions,
   ApplicationTypesSchemasSelectors,
@@ -133,6 +134,7 @@ export const SearchHeader = () => {
           display: isCustomApplicationsEnabled,
           onClick: (e: React.MouseEvent) => {
             e.stopPropagation();
+            dispatch(ApplicationActions.setShouldSaveApplication(false));
             router.push(getAppEditorRoute(ApplicationType.CUSTOM_APP));
           },
         },
@@ -143,6 +145,7 @@ export const SearchHeader = () => {
           display: isCodeAppsEnabled && canCreateCodeApps,
           onClick: (e: React.MouseEvent) => {
             e.stopPropagation();
+            dispatch(ApplicationActions.setShouldSaveApplication(false));
             router.push(getAppEditorRoute(ApplicationType.CODE_APP));
           },
         },
@@ -153,6 +156,7 @@ export const SearchHeader = () => {
           display: true,
           onClick: (e: React.MouseEvent) => {
             e.stopPropagation();
+            dispatch(ApplicationActions.setShouldSaveApplication(false));
             if (detailedApplicationTypeSchema?.$id !== schema.id) {
               dispatch(
                 ApplicationTypesSchemasActions.fetchDetailedApplicationTypeSchema(


### PR DESCRIPTION
**Description:**

prevent saving application when navigating to app editor

Copy of #3341 into 0.26

Issues:

- Issue #3334

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
