### PR TITLE
fix(chat): fix renaming in folder selector modal (Issue #3189)

### DIFF
--- a/apps/chat-e2e/src/tests/selectUploadFolder.test.ts
+++ b/apps/chat-e2e/src/tests/selectUploadFolder.test.ts
@@ -560,10 +560,6 @@ dialTest(
         await selectFolders.renameEmptyFolderWithTick(newParentFolderName, {
           isHttpMethodTriggered: false,
         });
-        //TODO: remove next line when fixed https://github.com/epam/ai-dial-chat/issues/1551
-        await selectFolders.expandCollapseFolder(newParentFolderName, {
-          isHttpMethodTriggered: true,
-        });
         await expect
           .soft(
             selectFolders.getNestedFolder(

--- a/apps/chat/src/components/Files/SelectFolderModal.tsx
+++ b/apps/chat/src/components/Files/SelectFolderModal.tsx
@@ -5,6 +5,7 @@ import { useHandleFileFolders } from '@/src/hooks/useHandleFileFolders';
 import {
   getParentFolderIdsFromFolderId,
   splitEntityId,
+  updateMovedFolderId,
 } from '@/src/utils/app/folders';
 
 import { FilesActions, FilesSelectors } from '@/src/store/files/files.reducers';
@@ -69,6 +70,9 @@ export const SelectFolderModal = ({
   const loadingFolderIds = useAppSelector(
     FilesSelectors.selectLoadingFolderIds,
   );
+  const lastRenamedParentFolder = useAppSelector(
+    FilesSelectors.selectLastRenamedParentFolder,
+  );
 
   const {
     handleRenameFolder,
@@ -84,6 +88,42 @@ export const SelectFolderModal = ({
     setIsAllFilesOpened,
   );
   const showSpinner = folders.length === 0 && areFoldersLoading;
+
+  useEffect(() => {
+    if (lastRenamedParentFolder?.newId) {
+      setOpenedFoldersIds((prev) =>
+        prev.map((id) => {
+          if (id === lastRenamedParentFolder.oldId)
+            return lastRenamedParentFolder.newId;
+          if (id.startsWith(`${lastRenamedParentFolder.oldId}/`))
+            return updateMovedFolderId(
+              lastRenamedParentFolder.oldId,
+              lastRenamedParentFolder.newId,
+              id,
+            );
+          return id;
+        }),
+      );
+      setSelectedFolderId((id) => {
+        if (!id) return id;
+
+        if (id === lastRenamedParentFolder.oldId)
+          return lastRenamedParentFolder.newId;
+        if (id.startsWith(`${lastRenamedParentFolder.oldId}/`))
+          return updateMovedFolderId(
+            lastRenamedParentFolder.oldId,
+            lastRenamedParentFolder.newId,
+            id,
+          );
+        return id;
+      });
+      dispatch(FilesActions.resetLastRenamedParentFolder());
+    }
+  }, [
+    dispatch,
+    lastRenamedParentFolder?.newId,
+    lastRenamedParentFolder?.oldId,
+  ]);
 
   useEffect(() => {
     if (isOpen) {

--- a/apps/chat/src/components/Folder/Folder.tsx
+++ b/apps/chat/src/components/Folder/Folder.tsx
@@ -425,8 +425,8 @@ const Folder = <T extends ConversationInfo | PromptInfo | DialFile>({
     }
   }, [newAddedFolderId, dispatch, currentFolder]);
 
-  const scrollIntoView = useCallback(() => {
-    dragDropElement.current?.scrollIntoView({
+  const scrollIntoView = useCallback((elem: HTMLDivElement | null) => {
+    elem?.scrollIntoView({
       behavior: 'smooth',
       block: 'center',
     });
@@ -488,7 +488,7 @@ const Folder = <T extends ConversationInfo | PromptInfo | DialFile>({
     setRenameValue('');
     setIsRenaming(false);
     setIsContextMenu(false);
-    scrollIntoView();
+    scrollIntoView(dragDropElement.current);
   }, [
     onRenameFolder,
     renameValue,


### PR DESCRIPTION
**Description:**

- keep selected folder on rename
- keep opened folder on rename

Issues:

- Issue #3189 

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
