### PR TITLE
fix(chat): update button behavior based on applicationTypeEditorUrl presence (Issue #3392)

### DIFF
--- a/apps/chat/src/components/AppsEditor/AppsEditorHeader.tsx
+++ b/apps/chat/src/components/AppsEditor/AppsEditorHeader.tsx
@@ -37,11 +37,13 @@ enum TabKeys {
 interface AppsEditorHeaderProps {
   applicationTypeDisplayName: string;
   isEditApplication?: boolean;
+  hasCustomEditor?: boolean;
 }
 
 export const AppsEditorHeader: React.FC<AppsEditorHeaderProps> = ({
   applicationTypeDisplayName,
   isEditApplication,
+  hasCustomEditor,
 }) => {
   const dispatch = useAppDispatch();
   const {
@@ -171,7 +173,7 @@ export const AppsEditorHeader: React.FC<AppsEditorHeaderProps> = ({
         </div>
 
         <div className="flex h-full items-center space-x-2">
-          {isEditApplication && applicationTypeDisplayName !== 'Mindmap' ? (
+          {isEditApplication && !hasCustomEditor ? (
             <button
               className="button flex items-center space-x-1 text-accent-primary md:flex"
               onClick={handleSaveAndRedirect}

--- a/apps/chat/src/pages/apps-editor/[slug]/index.tsx
+++ b/apps/chat/src/pages/apps-editor/[slug]/index.tsx
@@ -77,6 +77,7 @@ export default function AppsEditor() {
                 : decode(slug.toString())
             }
             isEditApplication={!!id}
+            hasCustomEditor={!!schema?.['dial:applicationTypeEditorUrl']}
           />
           <div className="flex size-full">
             <GeneralInfoView

--- a/apps/chat/src/pages/apps-editor/[slug]/settings/index.tsx
+++ b/apps/chat/src/pages/apps-editor/[slug]/settings/index.tsx
@@ -92,6 +92,7 @@ export default function AppsSettings() {
                 ? (schema?.['dial:applicationTypeDisplayName'] ?? '')
                 : decode(slug.toString())
             }
+            hasCustomEditor={!!schema?.['dial:applicationTypeEditorUrl']}
           />
           <div className="flex size-full grow overflow-hidden">
             {applicationData && (

--- a/apps/chat/src/types/application-type-schema.ts
+++ b/apps/chat/src/types/application-type-schema.ts
@@ -3,7 +3,7 @@ import { JSONSchema7 } from 'json-schema';
 export interface ApiApplicationTypeSchema {
   $id: string;
   'dial:applicationTypeDisplayName': string;
-  'dial:applicationTypeEditorUrl': string;
+  'dial:applicationTypeEditorUrl'?: string;
   'dial:applicationTypeViewerUrl'?: string;
 }
 
@@ -17,6 +17,6 @@ export interface ApplicationTypeSchema {
 export interface ApiDetailedApplicationTypeSchema extends JSONSchema7 {
   $id: string;
   'dial:applicationTypeDisplayName': string;
-  'dial:applicationTypeEditorUrl': string;
+  'dial:applicationTypeEditorUrl'?: string;
   'dial:applicationTypeViewerUrl'?: string;
 }

--- a/apps/chat/src/types/application-type-schema.ts
+++ b/apps/chat/src/types/application-type-schema.ts
@@ -10,7 +10,7 @@ export interface ApiApplicationTypeSchema {
 export interface ApplicationTypeSchema {
   id: string;
   displayName: string;
-  editorUrl: string;
+  editorUrl?: string;
   viewerUrl?: string;
 }
 


### PR DESCRIPTION
**Description:**

Refactored button behavior logic to determine whether to display "Exit" or "Save and Exit" based on the presence of `dial:applicationTypeEditorUrl`. Updated UI logic, added tests, and revised documentation accordingly.  


Issues:

- Issue #3392 

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
