### PR TITLE
feat(chat): split `advanced-view` feature flag into 2 separated ones (Issue #3333)

### DIFF
--- a/apps/chat/src/store/ui/ui.epics.ts
+++ b/apps/chat/src/store/ui/ui.epics.ts
@@ -46,19 +46,23 @@ const initEpic: AppEpic = (action$, state$) =>
       const isThemesDefined = SettingsSelectors.selectThemeHostDefined(
         state$.value,
       );
-      const isAdvancedView = SettingsSelectors.isFeatureEnabled(
+      const enabledFeatures = SettingsSelectors.selectEnabledFeatures(
         state$.value,
-        Feature.AdvancedView,
       );
-      const showPanelsByDefault = isAdvancedView && !isTabletScreenOrMobile();
 
       return forkJoin({
         theme: DataService.getTheme(),
         availableThemes: isThemesDefined
           ? DataService.getAvailableThemes()
           : of([]),
-        showChatbar: DataService.getShowChatbar(showPanelsByDefault),
-        showPromptbar: DataService.getShowPromptbar(showPanelsByDefault),
+        showChatbar: DataService.getShowChatbar(
+          enabledFeatures.has(Feature.ShowConversationsSectionByDefault) &&
+            !isTabletScreenOrMobile(),
+        ),
+        showPromptbar: DataService.getShowPromptbar(
+          enabledFeatures.has(Feature.ShowPromptsSectionByDefault) &&
+            !isTabletScreenOrMobile(),
+        ),
         showMarketplaceFilterbar: DataService.getShowMarketplaceFilterbar(),
         textOfClosedAnnouncement: DataService.getClosedAnnouncement(),
         chatbarWidth: DataService.getChatbarWidth(),

--- a/libs/shared/src/types/features.ts
+++ b/libs/shared/src/types/features.ts
@@ -1,71 +1,55 @@
 export enum Feature {
+  // Layout
+  Header = 'header', // Display app header
+  Footer = 'footer', // Display app footer
   ConversationsSection = 'conversations-section', // Display conversations sidebar
   PromptsSection = 'prompts-section', // Display prompts sidebar
+  ShowConversationsSectionByDefault = 'showConversationsSectionByDefault', // show conversations sidebar by default on desktop
+  ShowPromptsSectionByDefault = 'showPromptsSectionByDefault', // show prompts sidebar by default on desktop
+  AttachmentsManager = 'attachments-manager', // Display attachments manager in conversation
+
+  // Conversation Header
+  HideNewConversation = 'hide-new-conversation', // hide "New conversation" button
   TopSettings = 'top-settings', // Display conversation top header
   TopClearConversation = 'top-clear-conversation', // Display clear conversations button in chat top settings
   TopChatInfo = 'top-chat-info', // Display conversation info in top chat settings
   TopChatModelSettings = 'top-chat-model-settings', // Display change model settings button
   HideTopContextMenu = 'hide-top-context-menu', // Hide top context menu button
+  DisallowChangeAgent = 'disallow-change-agent', // Disallow "Change agent" button
+
+  // Conversation functions
+  Likes = 'likes', // Display likes
+  InputFiles = 'input-files', // Allow attach files to conversation
+  InputLinks = 'input-links', // Allow attach links to conversation
+  MessageTemplates = 'message-templates', // message templates
+
+  // Conversation First Screen
   EmptyChatSettings = 'empty-chat-settings', // Display settings for empty chat
   HideEmptyChatChangeAgent = 'hide-empty-chat-change-agent', // Hide empty chat "Change agent" button
-  Header = 'header', // Display app header
-  Footer = 'footer', // Display app footer
-  RequestApiKey = 'request-api-key', // Display request API Key modal
-  ReportAnIssue = 'report-an-issue', // Display report issue modal
-  Likes = 'likes', // Display likes
+
+  // Sharing
   ConversationsSharing = 'conversations-sharing', // Display conversation sharing
   PromptsSharing = 'prompts-sharing', // Display prompts sharing
   ApplicationsSharing = 'applications-sharing', // Display applications sharing
-  InputFiles = 'input-files', // Allow attach files to conversation
-  InputLinks = 'input-links', // Allow attach links to conversation
-  AttachmentsManager = 'attachments-manager', // Display attachments manager in conversation sidebar
+
+  // Publishing
   ConversationsPublishing = 'conversations-publishing',
   PromptsPublishing = 'prompts-publishing',
+
+  // Special dialogs
+  RequestApiKey = 'request-api-key', // Display request API Key modal
+  ReportAnIssue = 'report-an-issue', // Display report issue modal
+
+  // User settings
+  HideUserSettings = 'hide-user-settings', // Hide user settings
   CustomLogo = 'custom-logo', // Enable setting for custom logo feature
-  HideNewConversation = 'hide-new-conversation', // hide "New conversation" button
+
+  // Applications
   CustomApplications = 'custom-applications', // custom applications
-  MessageTemplates = 'message-templates', // message templates
-  Marketplace = 'marketplace', // Enable Marketplace
   QuickApps = 'quick-apps', // Enable Quick apps
   CodeApps = 'code-apps', // Enable Code apps
-  DisallowChangeAgent = 'disallow-change-agent', // Disallow "Change agent" button
-  MarketplaceTableView = 'marketplace-table-view', // Enable table view in Marketplace
-  HideUserSettings = 'hide-user-settings', // Hide user settings
-  AdvancedView = 'advanced-view', // Enable advanced view: show chat and prompt sidebars by default on descktop
-}
 
-export const availableFeatures: Record<Feature, boolean> = {
-  [Feature.ConversationsSection]: true,
-  [Feature.PromptsSection]: true,
-  [Feature.TopSettings]: true,
-  [Feature.TopClearConversation]: true,
-  [Feature.TopChatInfo]: true,
-  [Feature.TopChatModelSettings]: true,
-  [Feature.HideTopContextMenu]: false,
-  [Feature.EmptyChatSettings]: true,
-  [Feature.HideEmptyChatChangeAgent]: false,
-  [Feature.Header]: true,
-  [Feature.Footer]: true,
-  [Feature.RequestApiKey]: true,
-  [Feature.ReportAnIssue]: true,
-  [Feature.Likes]: true,
-  [Feature.ConversationsSharing]: true,
-  [Feature.PromptsSharing]: true,
-  [Feature.ApplicationsSharing]: true,
-  [Feature.InputFiles]: true,
-  [Feature.InputLinks]: true,
-  [Feature.AttachmentsManager]: true,
-  [Feature.ConversationsPublishing]: true,
-  [Feature.PromptsPublishing]: true,
-  [Feature.CustomLogo]: true,
-  [Feature.HideNewConversation]: true,
-  [Feature.CustomApplications]: true,
-  [Feature.MessageTemplates]: true,
-  [Feature.Marketplace]: true,
-  [Feature.QuickApps]: true,
-  [Feature.CodeApps]: true,
-  [Feature.DisallowChangeAgent]: true,
-  [Feature.MarketplaceTableView]: true,
-  [Feature.HideUserSettings]: true,
-  [Feature.AdvancedView]: true,
-};
+  // Marketplace
+  Marketplace = 'marketplace', // Enable Marketplace
+  MarketplaceTableView = 'marketplace-table-view', // Enable table view in Marketplace
+}

--- a/libs/shared/src/utils/features.ts
+++ b/libs/shared/src/utils/features.ts
@@ -1,5 +1,5 @@
-import { availableFeatures } from '../types/features';
+import { Feature } from '../types/features';
 
 export const validateFeature = (feature: string) => {
-  return feature in availableFeatures;
+  return Object.values(Feature).includes(feature as Feature);
 };


### PR DESCRIPTION
**Description:**

split `advanced-view` feature flag into 2 separated ones 

Issues:

- Issue #3333 

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
