### PR TITLE
fix(chat): remove confirmation for source folder in not shared apps (Issue #3406)

### DIFF
--- a/apps/chat/src/components/AppsEditor/Settings/CodeAppView/index.tsx
+++ b/apps/chat/src/components/AppsEditor/Settings/CodeAppView/index.tsx
@@ -153,6 +153,10 @@ export const CodeAppView: React.FC<CodeAppViewProps> = ({
     ApplicationSelectors.selectExitAfterSave,
   );
 
+  const confirmSourceFolderValues = oldApplication?.isShared
+    ? CONFIRM_SOURCE_FOLDER_VALUES
+    : undefined;
+
   const handleEdit = useCallback(
     (data: CodeAppFormData) => {
       if (
@@ -326,12 +330,8 @@ export const CodeAppView: React.FC<CodeAppViewProps> = ({
           tooltip={
             isSharedWithMe ? getSharedTooltip('folder with source files') : ''
           }
-          warning={
-            oldApplication?.isShared
-              ? CONFIRM_SOURCE_FOLDER_VALUES.description
-              : ''
-          }
-          confirmDialogValues={CONFIRM_SOURCE_FOLDER_VALUES}
+          warning={confirmSourceFolderValues?.description}
+          confirmDialogValues={confirmSourceFolderValues}
         />
 
         {sources && <FormCodeEditor sourcesFolderId={sources} />}

--- a/apps/chat/src/constants/applications.ts
+++ b/apps/chat/src/constants/applications.ts
@@ -37,7 +37,7 @@ export const CONFIRM_ICON_FILE_VALUES: ConfirmDialogValueTypes = {
 };
 
 export const CONFIRM_DOCUMENT_VALUES: ConfirmDialogValueTypes = {
-  heading: 'Confirm changing source folder',
+  heading: 'Confirm changing document relative url',
   description:
     'Changing of document relative url will stop sharing and other users will no longer see this application.',
 };


### PR DESCRIPTION
Issues:

- Issue #3406

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
