### PR TITLE
fix(chat): highlight starters dots if hidden button has been choosen (Issue #3343)

### DIFF
--- a/apps/chat/src/components/Chat/ChatMessage/MessageSchema/FormSchema.tsx
+++ b/apps/chat/src/components/Chat/ChatMessage/MessageSchema/FormSchema.tsx
@@ -27,6 +27,7 @@ import {
   MessageFormValue,
   MessageFormValueType,
 } from '@epam/ai-dial-shared';
+import intersection from 'lodash-es/intersection';
 
 interface HiddenButtonsPropertyProps {
   options: FormSchemaButtonOption[];
@@ -250,7 +251,15 @@ export const ButtonsProperty = ({
         {hiddenOptions.length > 0 && (
           <button
             onClick={() => setHiddenOptionsModal(true)}
-            className="chat-button"
+            className={classNames(
+              'chat-button',
+              showSelected &&
+                intersection(
+                  Object.values(formValue ?? {}),
+                  hiddenOptions.map((option) => option.const),
+                ).length &&
+                'button-accent-primary',
+            )}
           >
             <IconDotsVertical size={18} />
           </button>


### PR DESCRIPTION
**Description:**

highlight starters dots if hidden button has been choosen

Issues:

- Issue #3343

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
