### PR TITLE
fix(chat): do not hide button on the last line if it's a single button (Issue #3343)

### DIFF
--- a/apps/chat/src/components/Chat/ChatMessage/MessageSchema/FormSchema.tsx
+++ b/apps/chat/src/components/Chat/ChatMessage/MessageSchema/FormSchema.tsx
@@ -123,7 +123,7 @@ const HiddenButtonsProperty = ({
       if (buttonsContentWidth >= containerContentWidth) {
         const lastItem = visible.pop();
 
-        if (lastItem?.option) {
+        if (lastItem) {
           hidden.unshift(lastItem);
         }
       }

--- a/apps/chat/src/components/Chat/ChatMessage/MessageSchema/FormSchema.tsx
+++ b/apps/chat/src/components/Chat/ChatMessage/MessageSchema/FormSchema.tsx
@@ -38,8 +38,23 @@ interface HiddenButtonsPropertyProps {
   onCloseModal: () => void;
 }
 
+interface HTMLSchemaButtonType {
+  option: FormSchemaButtonOption;
+  line: number;
+  btn: HTMLElement;
+}
+
 const buttonsWrapperClassName = 'flex flex-wrap items-center gap-2';
 const MAX_LINES = 3;
+
+const getContainerStyles = (element: HTMLElement) => {
+  const style = window.getComputedStyle(element);
+
+  return {
+    gap: parseFloat(style.gap),
+    paddingX: parseFloat(style.paddingRight) + parseFloat(style.paddingLeft),
+  };
+};
 
 const HiddenButtonsProperty = ({
   options,
@@ -65,12 +80,8 @@ const HiddenButtonsProperty = ({
       return;
     }
 
-    const visible: {
-      option: FormSchemaButtonOption;
-      line: number;
-      btn: HTMLElement;
-    }[] = [];
-    const hidden: FormSchemaButtonOption[] = [];
+    const visible: HTMLSchemaButtonType[] = [];
+    const hidden: HTMLSchemaButtonType[] = [];
     let currentLine = 1;
     let lastOffsetTop = hiddenButtons[0].offsetTop;
     let currentOptionIdx = 0;
@@ -91,7 +102,7 @@ const HiddenButtonsProperty = ({
       if (currentLine <= MAX_LINES) {
         visible.push({ option, line: currentLine, btn });
       } else {
-        hidden.push(option);
+        hidden.push({ option, line: currentLine, btn });
       }
 
       currentOptionIdx++;
@@ -99,24 +110,34 @@ const HiddenButtonsProperty = ({
 
     const maxLineItems = visible.filter((item) => item.line === MAX_LINES);
     if (maxLineItems.length) {
-      const style = window.getComputedStyle(hiddenContainerRef.current);
-      const gap = parseFloat(style.gap);
-      const paddingsWidth =
-        parseFloat(style.paddingLeft) + parseFloat(style.paddingRight);
-      const allBtnsWidth = maxLineItems.reduce<number>(
+      const { gap, paddingX } = getContainerStyles(hiddenContainerRef.current);
+      const allBtnsWidth = maxLineItems.reduce(
         (acc, item) => (item.btn.offsetWidth ?? 0) + gap + acc,
         0,
       );
+      const containerContentWidth =
+        hiddenContainerRef.current.clientWidth - paddingX;
+      const buttonsContentWidth =
+        allBtnsWidth + (dotsButtonRef.current?.clientWidth ?? 0) + gap;
 
-      if (
-        allBtnsWidth + (dotsButtonRef.current?.clientWidth ?? 0) + gap >=
-        hiddenContainerRef.current.clientWidth - paddingsWidth
-      ) {
+      if (buttonsContentWidth >= containerContentWidth) {
         const lastItem = visible.pop();
 
         if (lastItem?.option) {
-          hidden.unshift(lastItem?.option);
+          hidden.unshift(lastItem);
         }
+      }
+    }
+
+    const isSomethingVisibleOnLastLine = visible.some(
+      ({ line }) => line === MAX_LINES,
+    );
+
+    if (hidden.length === 1 && !isSomethingVisibleOnLastLine) {
+      const hiddenOption = hidden.pop();
+
+      if (hiddenOption) {
+        visible.push(hiddenOption);
       }
     }
 
@@ -125,7 +146,7 @@ const HiddenButtonsProperty = ({
     }
 
     onSetVisibleOptions(visible.map((item) => item.option));
-    onSetHiddenOptions(hidden);
+    onSetHiddenOptions(hidden.map((item) => item.option));
   }, [onCloseModal, onSetHiddenOptions, onSetVisibleOptions, options]);
 
   useEffect(() => {


### PR DESCRIPTION
**Description:**

do not hide button on the last line if it's a single button

Issues:

- Issue #3343

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
