### PR TITLE
fix(chat): fix double footer for mindmap custom viewer (Issue #3441)

### DIFF
--- a/apps/chat/src/components/Chat/Chat.tsx
+++ b/apps/chat/src/components/Chat/Chat.tsx
@@ -848,6 +848,7 @@ const ChatView = memo(() => {
                           isShowInput={isInputVisible}
                         >
                           <ChatInputControls
+                            isWideLayout={isWideLayout}
                             isNotEmptyConversations={isNotEmptyConversations}
                             showReplayControls={showReplayControls}
                             isModelsInstalled={
@@ -993,9 +994,6 @@ const CustomViewerChatView: React.FC<CustomChatViewerProps> = ({
                   {` ${customViewer.title}`}
                 </span>
               </button>
-              <div className="p-5 max-md:hidden">
-                <ChatInputFooter />
-              </div>
             </div>
           </div>
         ))}

--- a/apps/chat/src/components/Chat/ChatInput/ChatInputControls.tsx
+++ b/apps/chat/src/components/Chat/ChatInput/ChatInputControls.tsx
@@ -1,3 +1,5 @@
+import classNames from 'classnames';
+
 import { ConversationsSelectors } from '@/src/store/conversations/conversations.reducers';
 import { useAppSelector } from '@/src/store/hooks';
 
@@ -13,6 +15,7 @@ interface Props {
   isModelsInstalled: boolean;
   isConversationWithSchema: boolean;
   showScrollDownButton: boolean;
+  isWideLayout?: boolean;
   onScrollDown: () => void;
 }
 
@@ -22,6 +25,7 @@ export const ChatInputControls = ({
   isModelsInstalled,
   isConversationWithSchema,
   showScrollDownButton,
+  isWideLayout,
   onScrollDown,
 }: Props) => {
   const selectedConversations = useAppSelector(
@@ -36,7 +40,15 @@ export const ChatInputControls = ({
   }
 
   if (showReplayControls && !isNotEmptyConversations) {
-    return <StartReplayButton />;
+    return (
+      <div
+        className={classNames({
+          'mt-10': isWideLayout,
+        })}
+      >
+        <StartReplayButton />
+      </div>
+    );
   }
 
   if (isExternal) {


### PR DESCRIPTION
**Description:**

- fix double footer
- add margin for replay start button in wide layout

Issues:

- Issue #3441 

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
