### PR TITLE
fix(chat): can not type space in the end of string in Request name and author fields (Issue #3450)

### DIFF
--- a/apps/chat/src/components/Chat/Publish/PublishWizard.tsx
+++ b/apps/chat/src/components/Chat/Publish/PublishWizard.tsx
@@ -239,18 +239,16 @@ export function PublishModal<
 
   const onChangePublicationRequestName = useCallback(
     (e: ChangeEvent<HTMLInputElement>) => {
-      const cleanName = prepareEntityName(e.target.value);
-      setPublishRequestName(cleanName);
+      if (e.target.value.length > 160) return;
+      setPublishRequestName(e.target.value);
     },
     [],
   );
 
   const onChangePublicationAuthor = useCallback(
     (e: ChangeEvent<HTMLInputElement>) => {
-      const cleanAuthor = prepareEntityName(e.target.value, {
-        maxNameLength: 50,
-      });
-      setPublicationAuthor(cleanAuthor);
+      if (e.target.value.length > 50) return;
+      setPublicationAuthor(e.target.value);
     },
     [],
   );
@@ -265,6 +263,10 @@ export function PublishModal<
       );
 
       const trimmedPath = path.trim();
+      const cleanPublishRequestName = prepareEntityName(publishRequestName);
+      const cleanPublicationAuthor = prepareEntityName(publicationAuthor, {
+        maxNameLength: 50,
+      });
       const notEmptyFilters = otherTargetAudienceFilters.filter(
         (filter) =>
           // TODO: uncomment when it will be supported on core
@@ -320,8 +322,8 @@ export function PublishModal<
 
       dispatch(
         PublicationActions.publish({
-          name: publishRequestName,
-          displayAuthor: publicationAuthor,
+          name: cleanPublishRequestName,
+          displayAuthor: cleanPublicationAuthor,
           targetFolder: constructPath(PUBLIC_URL_PREFIX, trimmedPath),
           resources: [
             ...(publishAction === PublishActions.DELETE


### PR DESCRIPTION
**Description:**

Fix can not type space in the end of string in Request name and author fields. 
Clean functions moved to the `handlePublish` function.

Issues:

- Issue #3450 

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
