### PR TITLE
fix(chat): fix exiting widget mode (Issue #3583)

### DIFF
--- a/apps/chat/src/components/NavigationWrapper.tsx
+++ b/apps/chat/src/components/NavigationWrapper.tsx
@@ -20,7 +20,10 @@ import {
   ApplicationActions,
   ApplicationSelectors,
 } from '@/src/store/application/application.reducers';
-import { ConversationsActions } from '@/src/store/conversations/conversations.reducers';
+import {
+  ConversationsActions,
+  ConversationsSelectors,
+} from '@/src/store/conversations/conversations.reducers';
 import { useAppDispatch, useAppSelector } from '@/src/store/hooks';
 import {
   MarketplaceActions,
@@ -110,13 +113,14 @@ const MarketplaceNavigation = () => {
   const handleChangeTab = useCallback(
     (tab: MarketplaceTabs) => {
       if (!isMarketplace) {
-        router
-          .push(Routes.Marketplace)
-          .then(() => dispatch(MarketplaceActions.setSelectedTab(tab)));
+        router.push(Routes.Marketplace).then(() => {
+          dispatch(MarketplaceActions.setSelectedTab(tab));
+          dispatch(ApplicationActions.selectWidget(undefined));
+        });
       } else {
         dispatch(MarketplaceActions.setSelectedTab(tab));
+        dispatch(ApplicationActions.selectWidget(undefined));
       }
-      dispatch(ApplicationActions.selectWidget(undefined));
     },
     [dispatch, isMarketplace, router],
   );
@@ -226,6 +230,9 @@ const Navigation = () => {
   const selectedWidget = useAppSelector(
     ApplicationSelectors.selectSelectedWidget,
   );
+  const selectedConversationIds = useAppSelector(
+    ConversationsSelectors.selectSelectedConversationsIds,
+  );
 
   const handleChatClick = useCallback(() => {
     if (router.route !== Routes.Chat) {
@@ -233,6 +240,13 @@ const Navigation = () => {
         dispatch(
           ConversationsActions.setIsStartedCustomViewerConversation(false),
         );
+        if (!selectedConversationIds.length) {
+          dispatch(
+            ConversationsActions.createNewConversations({
+              names: [DEFAULT_CONVERSATION_NAME],
+            }),
+          );
+        }
       });
     } else {
       dispatch(
@@ -241,7 +255,7 @@ const Navigation = () => {
         }),
       );
     }
-  }, [dispatch, router]);
+  }, [dispatch, router, selectedConversationIds.length]);
 
   return (
     <div


### PR DESCRIPTION
**Description:**

- create conversation when navigating to chat route after exiting widget view
- fix issue with mobile keyboard popping up when exiting widget view

Issues:

- Issue #3583 

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
