### PR TITLE
fix(chat): fix 'use prompt' after new chat creation (Issue #3154)

### DIFF
--- a/apps/chat-e2e/src/testData/expectedConstants.ts
+++ b/apps/chat-e2e/src/testData/expectedConstants.ts
@@ -20,7 +20,7 @@ export const ExpectedConstants = {
     `${ExpectedConstants.newFolderTitle} ${index}`,
   newPromptFolderWithIndexTitle: (index: number) =>
     `${ExpectedConstants.newFolderTitle} ${index}`,
-  promptViewModalTitle: 'View Prompt',
+  promptViewModalTitle: 'View prompt',
   renameConversationModalTitle: 'Rename conversation',
   emptyString: '',
   defaultTemperature: '1',

--- a/apps/chat/src/components/Chatbar/Conversation.tsx
+++ b/apps/chat/src/components/Chatbar/Conversation.tsx
@@ -218,6 +218,9 @@ export const ConversationComponent = ({
   const chosenConversationIds = useAppSelector(
     ConversationsSelectors.selectSelectedItems,
   );
+  const selectedPublicationUrl = useAppSelector(
+    PublicationSelectors.selectSelectedPublicationUrl,
+  );
 
   const [isContextMenu, setIsContextMenu] = useState(false);
 
@@ -226,10 +229,6 @@ export const ConversationComponent = ({
   const isChosen = useMemo(
     () => chosenConversationIds.includes(conversation.id),
     [chosenConversationIds, conversation.id],
-  );
-
-  const selectedPublicationUrl = useAppSelector(
-    PublicationSelectors.selectSelectedPublicationUrl,
   );
 
   const isExternal = isEntityIdExternal(conversation);

--- a/apps/chat/src/components/Header/CreateNewEntity.tsx
+++ b/apps/chat/src/components/Header/CreateNewEntity.tsx
@@ -13,6 +13,7 @@ import {
 } from '@/src/store/conversations/conversations.reducers';
 import { useAppDispatch, useAppSelector } from '@/src/store/hooks';
 import { PromptsActions } from '@/src/store/prompts/prompts.reducers';
+import { PublicationActions } from '@/src/store/publication/publication.reducers';
 
 import { DEFAULT_CONVERSATION_NAME } from '@/src/constants/default-ui-settings';
 
@@ -96,6 +97,7 @@ export const CreateNewConversation: React.FC<Props> = ({ iconSize }) => {
     );
     dispatch(ConversationsActions.resetSearch());
     dispatch(ConversationsActions.setIsStartedCustomViewerConversation(false));
+    dispatch(PublicationActions.selectPublication(null));
   }, [areConversationsLoaded, dispatch]);
 
   return (

--- a/apps/chat/src/components/Promptbar/components/PromptModal.tsx
+++ b/apps/chat/src/components/Promptbar/components/PromptModal.tsx
@@ -136,7 +136,7 @@ const PromptModalView = () => {
           'text-error',
       )}
       state={isLoading ? ModalState.LOADING : ModalState.OPENED}
-      heading={t(isViewMode ? 'View Prompt' : 'Edit Prompt')}
+      heading={t(isViewMode ? 'View prompt' : 'Edit prompt')}
       hideClose={!isViewMode}
       onClose={handleClose}
     >

--- a/apps/chat/src/components/Promptbar/components/ViewPromptButtons.tsx
+++ b/apps/chat/src/components/Promptbar/components/ViewPromptButtons.tsx
@@ -120,7 +120,7 @@ export const ViewPromptButtons: React.FC<Props> = ({ prompt, onEditMode }) => {
         onClick: handleExport,
       },
       {
-        name: 'Move',
+        name: 'Move to',
         display: isMyPrompt,
         dataQa: 'move-prompt',
         Icon: IconFolderShare,


### PR DESCRIPTION
**Description:**

fix 'use prompt' after new chat creation

Issues:

- Issue #3154 

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
