### PR TITLE
chore(ci): handle multi-arch image cleanup

### DIFF
--- a/.github/workflows/cleanup-untagged-images.yml
+++ b/.github/workflows/cleanup-untagged-images.yml
@@ -11,10 +11,8 @@ jobs:
     permissions:
       packages: write
     steps:
-      - uses: snok/container-retention-policy@4f22ef80902ad409ed55a99dc5133cc1250a0d03 # v3.0.0
+      - uses: dataaxiom/ghcr-cleanup-action@cd0cdb900b5dbf3a6f2cc869f0dbb0b8211f50c4 # v1.0.16
         with:
-          account: ${{ github.repository_owner }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-          image-names: ${{ github.event.repository.name }}
-          tag-selection: "untagged"
-          cut-off: "1d"
+          owner: ${{ github.repository_owner }}
+          package: ${{ github.event.repository.name }}
+          delete-untagged: true

--- a/.github/workflows/cleanup-untagged-images.yml
+++ b/.github/workflows/cleanup-untagged-images.yml
@@ -13,6 +13,4 @@ jobs:
     steps:
       - uses: dataaxiom/ghcr-cleanup-action@cd0cdb900b5dbf3a6f2cc869f0dbb0b8211f50c4 # v1.0.16
         with:
-          owner: ${{ github.repository_owner }}
-          package: ${{ github.event.repository.name }}
           delete-untagged: true


### PR DESCRIPTION
**Description:**

Use `dataaxiom/ghcr-cleanup-action` to properly handle untagged image cleanup for multi-arch images.
