### PR TITLE
fix(chat): long touch on nested item triggers parent context menu open (Issue #3606)

### DIFF
--- a/apps/chat/src/hooks/useContextMenuTrigger.ts
+++ b/apps/chat/src/hooks/useContextMenuTrigger.ts
@@ -22,6 +22,8 @@ export const useContextMenuTrigger = (
 
   const handleTouchStart = useCallback(
     (e: TouchEvent<HTMLElement>) => {
+      e.preventDefault();
+      e.stopPropagation();
       if (timeoutRef.current) clearTimeout(timeoutRef.current);
 
       timer.current = new Date().valueOf();


### PR DESCRIPTION
**Description:**

- prevent default and stop propagation on touch start

Issues:

- Issue #3606 

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
