### PR TITLE
fix(chat): fix incorrect mapping of the visualizers (Issue #3613)

### DIFF
--- a/apps/chat/src/store/settings/__tests__/selectors.test.ts
+++ b/apps/chat/src/store/settings/__tests__/selectors.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from 'vitest';
+
+import { FeatureType } from '@/src/types/common';
+import { CustomVisualizer } from '@/src/types/custom-visualizers';
+
+import { SettingsSelectors } from '../settings.selectors';
+
+import { Feature } from '@epam/ai-dial-shared';
+
+describe('SettingsSelectors', () => {
+  const mockState = {
+    settings: {
+      customRenderers: [
+        {
+          title: 'Visualizator 1',
+          contentType: 'application/custom.type1+json',
+          url: 'http://localhost:3000/visualizator1',
+        },
+        {
+          title: 'Visualizator 2',
+          contentType: 'application/custom.type2+json',
+          url: 'http://localhost:3000/visualizator2',
+        },
+        {
+          title: 'Visualizator 3',
+          contentType: 'application/custom.type1+json',
+          url: 'http://localhost:3000/visualizator3',
+        },
+      ] as CustomVisualizer[],
+      enabledFeatures: [
+        Feature.ConversationsSharing,
+        Feature.PromptsSharing,
+        Feature.PromptsPublishing,
+      ],
+    },
+    auth: {
+      session: {
+        data: {
+          user: {
+            isAdmin: false,
+            [Feature.ConversationsSharing]: true,
+            [Feature.PromptsSharing]: true,
+            [Feature.PromptsPublishing]: true,
+          },
+        },
+      },
+    },
+  };
+
+  it('should filter enabled features for the user', () => {
+    const result = SettingsSelectors.selectEnabledFeatures(mockState);
+    expect(result).toEqual(
+      new Set([
+        Feature.ConversationsSharing,
+        Feature.PromptsSharing,
+        Feature.PromptsPublishing,
+      ]),
+    );
+  });
+
+  //TODO make role based check
+  it('should check if feature is enabled', () => {
+    const result = SettingsSelectors.isFeatureEnabled(
+      mockState,
+      Feature.ConversationsSharing,
+    );
+    expect(result).toBe(true);
+  });
+
+  it('should check if conversations publishing is not enabled', () => {
+    const resultChat = SettingsSelectors.selectIsPublishingEnabled(
+      mockState,
+      FeatureType.Chat,
+    );
+    expect(resultChat).toBe(false);
+
+    const resultPrompt = SettingsSelectors.selectIsPublishingEnabled(
+      mockState,
+      FeatureType.Prompt,
+    );
+    expect(resultPrompt).toBe(true);
+  });
+
+  it('should check if feature type is sharing enabled', () => {
+    const result = SettingsSelectors.isSharingEnabled(
+      mockState,
+      FeatureType.Chat,
+    );
+    expect(result).toBe(true);
+  });
+
+  it('should select mapped visualizers', () => {
+    const result = SettingsSelectors.selectMappedVisualizers(mockState);
+
+    expect(result).toEqual({
+      'application/custom.type1+json': [
+        {
+          title: 'Visualizator 1',
+          contentType: 'application/custom.type1+json',
+          url: 'http://localhost:3000/visualizator1',
+        },
+        {
+          title: 'Visualizator 3',
+          contentType: 'application/custom.type1+json',
+          url: 'http://localhost:3000/visualizator3',
+        },
+      ],
+      'application/custom.type2+json': [
+        {
+          title: 'Visualizator 2',
+          contentType: 'application/custom.type2+json',
+          url: 'http://localhost:3000/visualizator2',
+        },
+      ],
+    });
+  });
+
+  it('should check for custom attachment type', () => {
+    const selectIsCustomAttachmentType =
+      SettingsSelectors.selectIsCustomAttachmentType(
+        'application/custom.type1+json',
+      );
+    const result = selectIsCustomAttachmentType(mockState);
+    expect(result).toBe(true);
+  });
+});

--- a/apps/chat/src/store/settings/__tests__/selectors.test.ts
+++ b/apps/chat/src/store/settings/__tests__/selectors.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest';
 import { FeatureType } from '@/src/types/common';
 import { CustomVisualizer } from '@/src/types/custom-visualizers';
 
-import { SettingsSelectors } from '../settings.selectors';
+import { SettingsSelectors } from '../settings.reducers';
 
 import { Feature } from '@epam/ai-dial-shared';
 

--- a/apps/chat/src/store/settings/settings.reducers.ts
+++ b/apps/chat/src/store/settings/settings.reducers.ts
@@ -1,5 +1,6 @@
 import { PayloadAction, createSelector, createSlice } from '@reduxjs/toolkit';
 
+import { parseCommaSeparatedList } from '@/src/utils/app/common';
 import { Defaults } from '@/src/utils/app/data/defaults-service';
 
 import { FeatureType, PageType } from '@/src/types/common';
@@ -284,22 +285,17 @@ const selectMappedVisualizers = createSelector(
   (customVisualizers) => {
     return customVisualizers?.reduce(
       (visualizers: MappedVisualizers, currentVisualizerConfig) => {
-        const contentTypes = currentVisualizerConfig.contentType.split(',');
-
-        visualizers = contentTypes.reduce(
-          (visualizers: MappedVisualizers, contentType) => {
-            visualizers[contentType] = !visualizers[contentType]
-              ? [currentVisualizerConfig]
-              : visualizers[currentVisualizerConfig.contentType].concat(
-                  currentVisualizerConfig,
-                );
-
-            return visualizers;
-          },
-          {} as MappedVisualizers,
+        const contentTypes = parseCommaSeparatedList(
+          currentVisualizerConfig.contentType,
         );
 
-        return visualizers;
+        return contentTypes.reduce((vis: MappedVisualizers, contentType) => {
+          vis[contentType] = !vis[contentType]
+            ? [currentVisualizerConfig]
+            : vis[contentType].concat(currentVisualizerConfig);
+
+          return vis;
+        }, visualizers);
       },
       {} as MappedVisualizers,
     );

--- a/apps/chat/src/utils/app/common.ts
+++ b/apps/chat/src/utils/app/common.ts
@@ -255,6 +255,11 @@ export const groupAllVersions = (versions: PublicVersionOption[]) =>
       : [];
   });
 
+export const parseCommaSeparatedList = (
+  str: string | undefined,
+  defaultValue: string[] = [],
+): string[] => str?.split(',').map((str) => str.trim()) ?? defaultValue;
+
 export const fakeCallback = () => null;
 
 export const castToString = (value: unknown): string => value as string;


### PR DESCRIPTION
**Description:**

- Fix incorrect mapping of the visualizers in the Redux selector.
- Add unit tests for the settings.selectors.ts.

Issues:

- Issue #3613


**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
