### PR TITLE
fix(chat): fix displaying of env variables on review (Issue #3679)

### DIFF
--- a/apps/chat/src/components/Chat/Publish/ReviewApplicationDialog/ReviewApplicationPropsSection.tsx
+++ b/apps/chat/src/components/Chat/Publish/ReviewApplicationDialog/ReviewApplicationPropsSection.tsx
@@ -33,7 +33,7 @@ export const ReviewApplicationPropsSection = ({
   return (
     <div className="flex gap-4">
       <span className="w-[122px] shrink-0 text-secondary">{t(label)}:</span>
-      <div className="shrink grow">
+      <div className="flex shrink grow flex-col gap-1">
         {Object.entries(appProps).map(([key, value]) => {
           return (
             <ReviewApplicationPropsItem


### PR DESCRIPTION
**Description:**

fix displaying of env variables on review

Issues:

- Issue #3679 

**UI changes**
![image](https://github.com/user-attachments/assets/9a2e6d9d-bb26-455c-88c5-d1c5dcc9b4ee)
->
<img width="675" alt="image" src="https://github.com/user-attachments/assets/b1a2df01-fbfc-4a0b-a9d3-10b6e0a580cb" />

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
