### PR TITLE
fix(chat): folder & files long touch issues on mobile (Issue #3641)

### DIFF
--- a/apps/chat/src/components/Chatbar/Conversation.tsx
+++ b/apps/chat/src/components/Chatbar/Conversation.tsx
@@ -340,6 +340,7 @@ export const ConversationComponent = ({
             'absolute right-0 z-50 flex cursor-pointer justify-end group-hover:visible',
             (conversation.status === UploadStatus.LOADED || !isContextMenu) &&
               'invisible',
+            isContextMenu && 'md:visible',
           )}
         >
           <ConversationContextMenu

--- a/apps/chat/src/components/Common/FolderContextMenu.tsx
+++ b/apps/chat/src/components/Common/FolderContextMenu.tsx
@@ -4,6 +4,7 @@ import {
   IconFolderPlus,
   IconPencilMinus,
   IconSquareCheck,
+  IconSquareOff,
   IconTrashX,
   IconUpload,
   IconUserShare,
@@ -53,6 +54,7 @@ interface FolderContextMenuProps {
   onPublishUpdate?: MouseEventHandler<unknown>;
   onUpload?: MouseEventHandler<unknown>;
   onSelect?: MouseEventHandler<unknown>;
+  isSelected?: boolean;
 }
 
 export const FolderContextMenu = ({
@@ -73,6 +75,7 @@ export const FolderContextMenu = ({
   isOpen,
   isEmpty,
   additionalItemData,
+  isSelected,
 }: FolderContextMenuProps) => {
   const { t } = useTranslation(Translation.SideBar);
 
@@ -103,13 +106,13 @@ export const FolderContextMenu = ({
   const menuItems: DisplayMenuItemProps[] = useMemo(
     () => [
       {
-        name: t('Select'),
+        name: t(isSelected ? 'Unselect' : 'Select'),
         display:
           !isExternal &&
           !!onSelect &&
           (featureType !== FeatureType.File || !!canSelectFolders),
         dataQa: 'select',
-        Icon: IconSquareCheck,
+        Icon: isSelected ? IconSquareOff : IconSquareCheck,
         onClick: onSelect,
       },
       {
@@ -227,6 +230,7 @@ export const FolderContextMenu = ({
       additionalItemData?.isChangePathFolder,
       onDelete,
       onAddFolder,
+      isSelected,
     ],
   );
 

--- a/apps/chat/src/components/Files/AttachButton.tsx
+++ b/apps/chat/src/components/Files/AttachButton.tsx
@@ -147,6 +147,7 @@ export const AttachButton = ({
           headerLabel={t(label)}
           customButtonLabel={t('Attach')}
           initialSelectedFilesIds={selectedFilesIds}
+          showTooltip
           onClose={(result: unknown) => {
             onSelectAlreadyUploaded(result);
             setIsSelectFilesDialogOpened(false);

--- a/apps/chat/src/components/Files/FileItem.tsx
+++ b/apps/chat/src/components/Files/FileItem.tsx
@@ -18,6 +18,8 @@ import classNames from 'classnames';
 import { useContextMenuTrigger } from '@/src/hooks/useContextMenuTrigger';
 import { useTranslation } from '@/src/hooks/useTranslation';
 
+import { isTabletScreen } from '@/src/utils/app/mobile';
+
 import { AdditionalItemData, FeatureType } from '@/src/types/common';
 import { DialFile } from '@/src/types/files';
 import { Translation } from '@/src/types/translation';
@@ -140,10 +142,13 @@ export const FileItem = ({
     item.id,
   ]);
 
+  const isMobileCheckboxVisible =
+    canAttachFiles && isContextMenu && isTabletScreen();
+
   return (
     <div
       className={classNames(
-        'group/file-item flex justify-between gap-3 rounded px-3 py-1.5 hover:bg-accent-primary-alpha',
+        'group/file-item flex select-none justify-between gap-3 rounded px-3 py-1.5 hover:bg-accent-primary-alpha',
         (isHighlighted || isContextMenu) && 'bg-accent-primary-alpha',
         wrapperClassNames,
       )}
@@ -167,6 +172,7 @@ export const FileItem = ({
                 item.status !== UploadStatus.LOADING &&
                   canAttachFiles &&
                   'group-hover/file-item:hidden',
+                isMobileCheckboxVisible && 'hidden',
               )}
               featureType={FeatureType.Chat}
               isHighlighted={isSelected}
@@ -200,7 +206,7 @@ export const FileItem = ({
               <div
                 className={classNames(
                   'relative size-[18px] group-hover/file-item:flex',
-                  isSelected ? 'flex' : 'hidden',
+                  isSelected || isMobileCheckboxVisible ? 'flex' : 'hidden',
                 )}
                 data-qa={isSelected ? 'selected' : null}
               >
@@ -219,6 +225,7 @@ export const FileItem = ({
             )}
         </div>
         <Tooltip
+          hideTooltip={isContextMenu}
           tooltip={item.name}
           isTriggerClickable={isContextMenu}
           triggerClassName="block max-h-5 flex-1 truncate whitespace-pre text-left"
@@ -264,6 +271,7 @@ export const FileItem = ({
           </button>
         ) : (
           <FileItemContextMenu
+            isSelected={isSelected}
             file={item}
             onDelete={handleDelete}
             onUnshare={handleUnshare}

--- a/apps/chat/src/components/Files/FileItemContextMenu.tsx
+++ b/apps/chat/src/components/Files/FileItemContextMenu.tsx
@@ -3,6 +3,7 @@ import {
   IconDots,
   IconDownload,
   IconSquareCheck,
+  IconSquareOff,
   IconTrashX,
   IconUserX,
 } from '@tabler/icons-react';
@@ -42,6 +43,7 @@ interface ContextMenuProps {
   onUnpublish?: MouseEventHandler<unknown>;
   onSave?: (fileId: string) => void | MouseEventHandler<unknown>;
   onSelect?: MouseEventHandler<unknown>;
+  isSelected?: boolean;
 }
 
 export function FileItemContextMenu({
@@ -55,6 +57,7 @@ export function FileItemContextMenu({
   onUnpublish,
   onSave,
   onSelect,
+  isSelected,
 }: ContextMenuProps) {
   const { t } = useTranslation(Translation.SideBar);
 
@@ -78,10 +81,10 @@ export function FileItemContextMenu({
   const menuItems: DisplayMenuItemProps[] = useMemo(
     () => [
       {
-        name: t('Select'),
+        name: t(isSelected ? 'Unselect' : 'Select'),
         dataQa: 'select',
         display: !!onSelect && !isOverlay,
-        Icon: IconSquareCheck,
+        Icon: isSelected ? IconSquareOff : IconSquareCheck,
         onClick: onSelect,
       },
       {
@@ -160,6 +163,7 @@ export function FileItemContextMenu({
       onDelete,
       isOverlay,
       onSelect,
+      isSelected,
     ],
   );
 

--- a/apps/chat/src/components/Folder/Folder.tsx
+++ b/apps/chat/src/components/Folder/Folder.tsx
@@ -37,6 +37,7 @@ import {
   sortByName,
 } from '@/src/utils/app/folders';
 import { isEntityIdExternal, isRootId } from '@/src/utils/app/id';
+import { isTabletScreen } from '@/src/utils/app/mobile';
 import {
   hasParentWithAttribute,
   hasParentWithFloatingOverlay,
@@ -894,6 +895,9 @@ const Folder = <T extends ConversationInfo | PromptInfo | DialFile>({
     (selectedPublicationUrl && additionalItemData?.publicationUrl) ||
     (!selectedPublicationUrl && !additionalItemData?.publicationUrl);
 
+  const isMobileCheckboxVisible =
+    canSelectFolders && isContextMenu && isTabletScreen();
+
   return (
     <div
       id="folder"
@@ -974,6 +978,7 @@ const Folder = <T extends ConversationInfo | PromptInfo | DialFile>({
                       (!isExternal || !additionalItemData?.isSidePanelItem) &&
                         canSelectFolders &&
                         'group-hover:hidden',
+                      isMobileCheckboxVisible && 'hidden',
                     )}
                   >
                     {hasResourcesToReview &&
@@ -989,6 +994,7 @@ const Folder = <T extends ConversationInfo | PromptInfo | DialFile>({
                         (!isExternal || !additionalItemData?.isSidePanelItem) &&
                           canSelectFolders &&
                           'group-hover:hidden',
+                        isMobileCheckboxVisible && 'hidden',
                       )}
                     />
                   </ShareIcon>
@@ -1003,7 +1009,9 @@ const Folder = <T extends ConversationInfo | PromptInfo | DialFile>({
                         additionalItemData?.isSidePanelItem
                           ? 'size-[24px] items-center justify-center'
                           : 'size-[18px]',
-                        isSelected ? 'flex' : 'hidden',
+                        isSelected || isMobileCheckboxVisible
+                          ? 'flex'
+                          : 'hidden',
                       )}
                       data-item-checkbox
                     >
@@ -1073,7 +1081,10 @@ const Folder = <T extends ConversationInfo | PromptInfo | DialFile>({
                         additionalItemData?.isSidePanelItem
                           ? 'size-[24px] items-center justify-center'
                           : 'size-[18px]',
-                        isSelected || isPartialSelected || isSelectAlwaysVisible
+                        isSelected ||
+                          isPartialSelected ||
+                          isSelectAlwaysVisible ||
+                          isMobileCheckboxVisible
                           ? 'flex'
                           : 'hidden',
                       )}
@@ -1116,13 +1127,13 @@ const Folder = <T extends ConversationInfo | PromptInfo | DialFile>({
                     {...currentFolder}
                     isHighlighted={isContextMenu}
                     featureType={featureType}
-                    containerClassName={
+                    containerClassName={classNames(
                       (!isExternal || !additionalItemData?.isSidePanelItem) &&
-                      canSelectFolders &&
-                      !isSelectAlwaysVisible
-                        ? 'group-hover/folder-item:hidden'
-                        : ''
-                    }
+                        canSelectFolders &&
+                        !isSelectAlwaysVisible &&
+                        'group-hover/folder-item:hidden',
+                      isMobileCheckboxVisible && 'hidden',
+                    )}
                   >
                     {hasResourcesToReview &&
                       additionalItemData?.isSidePanelItem &&

--- a/apps/chat/src/components/Folder/Folder.tsx
+++ b/apps/chat/src/components/Folder/Folder.tsx
@@ -898,6 +898,7 @@ const Folder = <T extends ConversationInfo | PromptInfo | DialFile>({
     <div
       id="folder"
       className={classNames(
+        'select-none',
         isDraggingOver && 'bg-accent-primary-alpha',
         currentFolder.temporary && 'text-primary',
       )}
@@ -1151,6 +1152,7 @@ const Folder = <T extends ConversationInfo | PromptInfo | DialFile>({
               data-qa="folder-name"
             >
               <Tooltip
+                hideTooltip={isContextMenu}
                 tooltip={
                   showTooltip && !isNameOrPathInvalid
                     ? currentFolder.name
@@ -1194,10 +1196,11 @@ const Folder = <T extends ConversationInfo | PromptInfo | DialFile>({
                   {...getFloatingProps()}
                   className={classNames(
                     'invisible absolute right-0 z-50 flex justify-end group-hover/button:visible',
-                    isContextMenu && 'max-md:visible',
+                    isContextMenu && 'md:visible',
                   )}
                 >
                   <FolderContextMenu
+                    isSelected={isSelected}
                     folder={currentFolder}
                     featureType={featureType}
                     onRename={


### PR DESCRIPTION
**Description:**

- dont show ellipsis on long touch on mobile
- show unselect checkbox in context menu
- disable folder text selection
- hide tooltip when context menu is open
- show folder tooltip in attach folder modal
- show checkbox input on long touch when selecting attachments on mobile

Issues:

- Issue #3641 

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
