### PR TITLE
fix(chat): fix context menu displaying for folders and prompts (Issue #3612)

### DIFF
--- a/apps/chat/src/components/Folder/Folder.tsx
+++ b/apps/chat/src/components/Folder/Folder.tsx
@@ -1159,6 +1159,7 @@ const Folder = <T extends ConversationInfo | PromptInfo | DialFile>({
                 'relative max-h-5 flex-1 select-none truncate text-left',
                 isNameOrPathInvalid && 'text-secondary',
                 !hideContextMenu && 'group-hover/button:pr-5',
+                isContextMenu && 'pr-5',
               )}
               data-qa="folder-name"
             >

--- a/apps/chat/src/components/Promptbar/components/Prompt.tsx
+++ b/apps/chat/src/components/Promptbar/components/Prompt.tsx
@@ -296,6 +296,7 @@ export const PromptComponent = ({
         className={classNames(
           'group relative flex size-full shrink-0 items-center rounded border-l-2 pr-3 hover:bg-accent-primary-alpha disabled:cursor-not-allowed',
           !isSelectMode && '[&:not(:disabled)]:hover:pr-9',
+          isContextMenu && 'pr-9',
           !isSelectMode && isHighlighted
             ? 'border-l-accent-primary '
             : 'border-l-transparent',
@@ -409,7 +410,7 @@ export const PromptComponent = ({
             {...getFloatingProps()}
             className={classNames(
               'absolute right-0 z-50 flex justify-end group-hover:visible',
-              isSelected ? 'visible' : 'invisible',
+              isSelected || isContextMenu ? 'visible' : 'invisible',
             )}
             onClick={stopBubbling}
           >


### PR DESCRIPTION
**Description:**

fix context menu displaying for folders and prompts

Issues:

- Issue #3612

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
