### PR TITLE
fix(chat): fix "close window" icon overlaps title (Issue #3689)

### DIFF
--- a/apps/chat/src/components/Chat/Publish/PublishWizard.tsx
+++ b/apps/chat/src/components/Chat/Publish/PublishWizard.tsx
@@ -514,7 +514,7 @@ export function PublishModal<
         onSubmit={submitWrapper(handlePublish)}
         className="flex w-full flex-col divide-y divide-tertiary overflow-y-auto"
       >
-        <div className="px-3 pb-4 pt-8 md:pl-4 md:pr-10 md:pt-4">
+        <div className="py-4 pl-3 pr-10 md:pl-4">
           <Field
             className="border-none p-0 text-base font-semibold"
             {...register('publishRequestName', validators.publishRequestName)}

--- a/apps/chat/src/components/Chat/ShareModal.tsx
+++ b/apps/chat/src/components/Chat/ShareModal.tsx
@@ -213,7 +213,7 @@ export function ShareModalView() {
             tooltip={t(`${t('Share')}: ${shareResourceName?.trim()}`)}
           >
             <div
-              className="line-clamp-2 w-full break-words"
+              className="line-clamp-2 w-full break-words pr-6"
               data-qa="modal-entity-name"
             >
               {t(`${t('Share')}: ${shareResourceName?.trim()}`)}


### PR DESCRIPTION
**Description:**

- Fix overlaping of the title for the Share modal and Publish modal

Issues:

- Issue #3689 

**UI changes**

![image](https://github.com/user-attachments/assets/359addda-f1a6-4261-bf22-9a51c5082cce)

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
