### PR TITLE
fix(chat): fix "Use prompt" if prompt has variables (Issue #3706)

### DIFF
--- a/apps/chat/src/components/Common/Buttons/ToggleSidebarButtor.tsx
+++ b/apps/chat/src/components/Common/Buttons/ToggleSidebarButtor.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 
 import { useTranslation } from 'next-i18next';
 
@@ -34,10 +34,13 @@ export const ToggleSidebarButton: React.FC<Props> = ({
 }) => {
   const { t } = useTranslation(Translation.Header);
 
-  const handleToggle = (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
-    dispatchMouseLeaveEvent(e);
-    onToggle();
-  };
+  const handleToggle = useCallback(
+    (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+      dispatchMouseLeaveEvent(e);
+      onToggle();
+    },
+    [onToggle],
+  );
 
   const Icon = isOpened ? MoveLeftIcon : MoveRightIcon;
 

--- a/apps/chat/src/components/Common/Buttons/ToggleSidebarButtor.tsx
+++ b/apps/chat/src/components/Common/Buttons/ToggleSidebarButtor.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import React from 'react';
 
 import { useTranslation } from 'next-i18next';
 
@@ -34,13 +34,10 @@ export const ToggleSidebarButton: React.FC<Props> = ({
 }) => {
   const { t } = useTranslation(Translation.Header);
 
-  const handleToggle = useCallback(
-    (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
-      dispatchMouseLeaveEvent(e);
-      onToggle();
-    },
-    [onToggle],
-  );
+  const handleToggle = (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+    dispatchMouseLeaveEvent(e);
+    onToggle();
+  };
 
   const Icon = isOpened ? MoveLeftIcon : MoveRightIcon;
 

--- a/apps/chat/src/components/Promptbar/components/ViewPrompt.tsx
+++ b/apps/chat/src/components/Promptbar/components/ViewPrompt.tsx
@@ -98,6 +98,15 @@ export const ViewPrompt = ({ prompt, onEditMode }: Props) => {
   const disableUsePrompt =
     isConversationBlocksInput || !isModelsInstalled || !!selectedPublication;
 
+  const onUse = useCallback(
+    (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+      e.preventDefault();
+      e.stopPropagation();
+      handleUse();
+    },
+    [handleUse],
+  );
+
   return (
     <>
       <ul className="flex max-h-[435px] flex-col gap-4 overflow-y-auto px-3 pb-4 md:px-6">
@@ -139,7 +148,7 @@ export const ViewPrompt = ({ prompt, onEditMode }: Props) => {
                 />
               )}
               <button
-                onClick={handleUse}
+                onClick={onUse}
                 disabled={disableUsePrompt}
                 className={classNames(
                   'button button-primary flex items-center gap-2',

--- a/apps/chat/src/components/Promptbar/components/ViewPrompt.tsx
+++ b/apps/chat/src/components/Promptbar/components/ViewPrompt.tsx
@@ -2,6 +2,7 @@ import { useCallback } from 'react';
 
 import classNames from 'classnames';
 
+import { useMenuItemHandler } from '@/src/hooks/useHandler';
 import { usePromptActions } from '@/src/hooks/usePromptActions';
 import { usePublicVersionGroupId } from '@/src/hooks/usePublicVersionGroupIdFromPublicEntity';
 import { useTranslation } from '@/src/hooks/useTranslation';
@@ -98,14 +99,7 @@ export const ViewPrompt = ({ prompt, onEditMode }: Props) => {
   const disableUsePrompt =
     isConversationBlocksInput || !isModelsInstalled || !!selectedPublication;
 
-  const onUse = useCallback(
-    (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
-      e.preventDefault();
-      e.stopPropagation();
-      handleUse();
-    },
-    [handleUse],
-  );
+  const onUse = useMenuItemHandler(handleUse, undefined);
 
   return (
     <>


### PR DESCRIPTION
**Description:**

fix "Use prompt" if prompt has variables

Issues:

- Issue #3706

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
