### PR TITLE
fix(chat): hide prompt panel after click on Use (Issue #3607, #3664)

### DIFF
--- a/apps/chat/src/components/Common/Buttons/ToggleSidebarButtor.tsx
+++ b/apps/chat/src/components/Common/Buttons/ToggleSidebarButtor.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 
 import { useTranslation } from 'next-i18next';
 
@@ -34,10 +34,13 @@ export const ToggleSidebarButton: React.FC<Props> = ({
 }) => {
   const { t } = useTranslation(Translation.Header);
 
-  const handleToggle = (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
-    dispatchMouseLeaveEvent(e);
-    onToggle();
-  };
+  const handleToggle = useCallback(
+    (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+      dispatchMouseLeaveEvent(e);
+      onToggle();
+    },
+    [onToggle],
+  );
 
   const Icon = isOpened ? MoveLeftIcon : MoveRightIcon;
 

--- a/apps/chat/src/components/Common/Buttons/ToggleSidebarButtor.tsx
+++ b/apps/chat/src/components/Common/Buttons/ToggleSidebarButtor.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import React from 'react';
 
 import { useTranslation } from 'next-i18next';
 
@@ -34,13 +34,10 @@ export const ToggleSidebarButton: React.FC<Props> = ({
 }) => {
   const { t } = useTranslation(Translation.Header);
 
-  const handleToggle = useCallback(
-    (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
-      dispatchMouseLeaveEvent(e);
-      onToggle();
-    },
-    [onToggle],
-  );
+  const handleToggle = (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+    dispatchMouseLeaveEvent(e);
+    onToggle();
+  };
 
   const Icon = isOpened ? MoveLeftIcon : MoveRightIcon;
 

--- a/apps/chat/src/components/Promptbar/components/ViewPrompt.tsx
+++ b/apps/chat/src/components/Promptbar/components/ViewPrompt.tsx
@@ -104,7 +104,7 @@ export const ViewPrompt = ({ prompt, onEditMode }: Props) => {
   return (
     <>
       <ul className="flex max-h-[435px] flex-col gap-4 overflow-y-auto px-3 pb-4 md:px-6">
-        <PromptField valueClassName="line-clamp-2" label="Name" dataQa="name">
+        <PromptField valueClassName="line-clamp-3" label="Name" dataQa="name">
           {prompt.name}
         </PromptField>
         {prompt.description && (

--- a/apps/chat/src/components/Promptbar/components/ViewPrompt.tsx
+++ b/apps/chat/src/components/Promptbar/components/ViewPrompt.tsx
@@ -98,6 +98,15 @@ export const ViewPrompt = ({ prompt, onEditMode }: Props) => {
   const disableUsePrompt =
     isConversationBlocksInput || !isModelsInstalled || !!selectedPublication;
 
+  const onUse = useCallback(
+    (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+      e.preventDefault();
+      e.stopPropagation();
+      handleUse();
+    },
+    [handleUse],
+  );
+
   return (
     <>
       <ul className="flex max-h-[435px] flex-col gap-4 overflow-y-auto px-3 pb-4 md:px-6">
@@ -139,7 +148,7 @@ export const ViewPrompt = ({ prompt, onEditMode }: Props) => {
                 />
               )}
               <button
-                onClick={handleUse}
+                onClick={onUse}
                 disabled={disableUsePrompt}
                 className={classNames(
                   'button button-primary flex items-center gap-2',

--- a/apps/chat/src/components/Promptbar/components/ViewPrompt.tsx
+++ b/apps/chat/src/components/Promptbar/components/ViewPrompt.tsx
@@ -2,6 +2,7 @@ import { useCallback } from 'react';
 
 import classNames from 'classnames';
 
+import { useMenuItemHandler } from '@/src/hooks/useHandler';
 import { usePromptActions } from '@/src/hooks/usePromptActions';
 import { usePublicVersionGroupId } from '@/src/hooks/usePublicVersionGroupIdFromPublicEntity';
 import { useTranslation } from '@/src/hooks/useTranslation';
@@ -98,14 +99,7 @@ export const ViewPrompt = ({ prompt, onEditMode }: Props) => {
   const disableUsePrompt =
     isConversationBlocksInput || !isModelsInstalled || !!selectedPublication;
 
-  const onUse = useCallback(
-    (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
-      e.preventDefault();
-      e.stopPropagation();
-      handleUse();
-    },
-    [handleUse],
-  );
+  const onUse = useMenuItemHandler(handleUse, undefined);
 
   return (
     <>

--- a/apps/chat/src/store/prompts/prompts.epics.ts
+++ b/apps/chat/src/store/prompts/prompts.epics.ts
@@ -58,6 +58,7 @@ import { PromptsActions, PromptsSelectors } from './prompts.reducers';
 import { UploadStatus } from '@epam/ai-dial-shared';
 import omit from 'lodash-es/omit';
 import uniq from 'lodash-es/uniq';
+import { isTabletScreen } from '@/src/utils/app/mobile';
 
 const initEpic: AppEpic = (action$, state$) =>
   action$.pipe(
@@ -980,6 +981,18 @@ const selectPromptEpic: AppEpic = (action$) =>
     }),
   );
 
+  const hidePromptbarEpic: AppEpic = (action$) =>
+    action$.pipe(
+      filter(
+        (action) =>
+          (PromptsActions.selectPrompt.match(action) ||
+          PromptsActions.applyPrompt.match(action))
+      ),
+      switchMap(() =>
+        isTabletScreen() ? of(UIActions.setShowPromptbar(false)) : EMPTY,
+      ),
+    );
+
 export const PromptsEpics = combineEpics(
   initEpic,
   uploadPromptsFromMultipleFoldersEpic,
@@ -1006,4 +1019,5 @@ export const PromptsEpics = combineEpics(
   applyPromptEpic,
   getPromptMetadataEpic,
   selectPromptEpic,
+  hidePromptbarEpic
 );

--- a/apps/chat/src/store/prompts/prompts.epics.ts
+++ b/apps/chat/src/store/prompts/prompts.epics.ts
@@ -985,8 +985,7 @@ const selectPromptEpic: AppEpic = (action$) =>
     action$.pipe(
       filter(
         (action) =>
-          (PromptsActions.selectPrompt.match(action) ||
-          PromptsActions.applyPrompt.match(action))
+          (PromptsActions.applyPrompt.match(action))
       ),
       switchMap(() =>
         isTabletScreen() ? of(UIActions.setShowPromptbar(false)) : EMPTY,

--- a/apps/chat/src/store/prompts/prompts.epics.ts
+++ b/apps/chat/src/store/prompts/prompts.epics.ts
@@ -29,6 +29,7 @@ import {
   updateChildFoldersIds,
 } from '@/src/utils/app/folders';
 import { getPromptRootId, isEntityIdExternal } from '@/src/utils/app/id';
+import { isTabletScreen } from '@/src/utils/app/mobile';
 import {
   getPromptInfoFromId,
   parseVariablesFromContent,
@@ -58,7 +59,6 @@ import { PromptsActions, PromptsSelectors } from './prompts.reducers';
 import { UploadStatus } from '@epam/ai-dial-shared';
 import omit from 'lodash-es/omit';
 import uniq from 'lodash-es/uniq';
-import { isTabletScreen } from '@/src/utils/app/mobile';
 
 const initEpic: AppEpic = (action$, state$) =>
   action$.pipe(
@@ -981,16 +981,13 @@ const selectPromptEpic: AppEpic = (action$) =>
     }),
   );
 
-  const hidePromptbarEpic: AppEpic = (action$) =>
-    action$.pipe(
-      filter(
-        (action) =>
-          (PromptsActions.applyPrompt.match(action))
-      ),
-      switchMap(() =>
-        isTabletScreen() ? of(UIActions.setShowPromptbar(false)) : EMPTY,
-      ),
-    );
+const hidePromptbarEpic: AppEpic = (action$) =>
+  action$.pipe(
+    filter(PromptsActions.applyPrompt.match),
+    switchMap(() =>
+      isTabletScreen() ? of(UIActions.setShowPromptbar(false)) : EMPTY,
+    ),
+  );
 
 export const PromptsEpics = combineEpics(
   initEpic,
@@ -1018,5 +1015,5 @@ export const PromptsEpics = combineEpics(
   applyPromptEpic,
   getPromptMetadataEpic,
   selectPromptEpic,
-  hidePromptbarEpic
+  hidePromptbarEpic,
 );


### PR DESCRIPTION
**Description:**

hide prompt panel after  click on Use

Issues:

- Issue #3607
- Issue #3664

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
