### PR TITLE
fix(chat): display "Add app" only for desktop (1280px) (Issue #3729)

### DIFF
--- a/apps/chat/src/components/Marketplace/SearchHeader.tsx
+++ b/apps/chat/src/components/Marketplace/SearchHeader.tsx
@@ -59,7 +59,7 @@ const AddAppButton = ({ menuItems }: AddAppButtonProps) => {
     return (
       <button
         onClick={visibleActions[0].onClick}
-        className="button button-primary hidden items-center gap-2 py-2 sm:flex"
+        className="button button-primary hidden items-center gap-2 py-2 xl:flex"
       >
         <IconPlus size={18} />
         <span>{t('Add app')}</span>
@@ -73,7 +73,7 @@ const AddAppButton = ({ menuItems }: AddAppButtonProps) => {
       isOpen={isOpen}
       onOpenChange={setIsOpen}
       placement="bottom"
-      triggerIconClassName="max-sm:hidden"
+      triggerIconClassName="max-xl:hidden"
       TriggerCustomRenderer={
         <button
           className="button button-primary flex items-center gap-2 py-2"


### PR DESCRIPTION
**Description:**

display "Add app" only for desktop (1280px)

Issues:

- Issue #3729

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
