### PR TITLE
fix(chat): reset selected version after close View prompt (Issue #3491)

### DIFF
--- a/apps/chat/src/components/Chat/Publish/PublicationChatControls.tsx
+++ b/apps/chat/src/components/Chat/Publish/PublicationChatControls.tsx
@@ -59,11 +59,10 @@ export function PublicationControlsView<
 
   const unselectPrompt = useCallback(() => {
     dispatch(
-      PromptsActions.setSelectedPrompt({
+      PromptsActions.selectPrompt({
         promptId: undefined,
       }),
     );
-    dispatch(PromptsActions.setIsPromptModalOpen({ isOpen: false }));
     dispatch(
       ConversationsActions.selectConversations({
         conversationIds: [],
@@ -108,12 +107,7 @@ export function PublicationControlsView<
         unselectConversation();
         unselectApplication();
         dispatch(
-          PromptsActions.uploadPrompt({
-            promptId: resourcesToReview[publicationIdx + offset].reviewUrl,
-          }),
-        );
-        dispatch(
-          PromptsActions.setSelectedPrompt({
+          PromptsActions.selectPrompt({
             promptId: resourcesToReview[publicationIdx + offset].reviewUrl,
             isApproveRequiredResource: true,
           }),

--- a/apps/chat/src/components/Chat/Publish/PublicationHandler.tsx
+++ b/apps/chat/src/components/Chat/Publish/PublicationHandler.tsx
@@ -307,14 +307,13 @@ export function PublicationHandler({ publication }: Props) {
         }),
       );
       dispatch(
-        PromptsActions.setSelectedPrompt({
+        PromptsActions.selectPrompt({
           promptId: promptsToReviewIds.length
             ? promptsToReviewIds[0].reviewUrl
             : reviewedPromptsIds[0].reviewUrl,
           isApproveRequiredResource: true,
         }),
       );
-      dispatch(PromptsActions.setIsPromptModalOpen({ isOpen: true }));
     };
 
     if (conversationsToReviewIds.length) {

--- a/apps/chat/src/components/Promptbar/components/PromptModal.tsx
+++ b/apps/chat/src/components/Promptbar/components/PromptModal.tsx
@@ -116,8 +116,7 @@ const PromptModalView = () => {
   }, []);
 
   const handleClose = useCallback(() => {
-    dispatch(PromptsActions.setIsPromptModalOpen({ isOpen: false }));
-    dispatch(PromptsActions.setSelectedPrompt({ promptId: undefined }));
+    dispatch(PromptsActions.selectPrompt({ promptId: undefined }));
   }, [dispatch]);
 
   return (

--- a/apps/chat/src/hooks/usePromptActions.ts
+++ b/apps/chat/src/hooks/usePromptActions.ts
@@ -164,8 +164,7 @@ export const usePromptActions = (prompt: Prompt) => {
       dispatch(PromptsActions.deletePrompt({ prompt }));
     }
 
-    dispatch(PromptsActions.setSelectedPrompt({ promptId: undefined }));
-    dispatch(PromptsActions.setIsPromptModalOpen({ isOpen: false }));
+    dispatch(PromptsActions.selectPrompt({ promptId: undefined }));
   }, [dispatch, prompt]);
 
   const handleInfo = useCallback(() => {
@@ -174,8 +173,7 @@ export const usePromptActions = (prompt: Prompt) => {
 
   const handleUse = useCallback(() => {
     dispatch(PromptsActions.applyPrompt(prompt));
-    dispatch(PromptsActions.setSelectedPrompt({ promptId: undefined }));
-    dispatch(PromptsActions.setIsPromptModalOpen({ isOpen: false }));
+    dispatch(PromptsActions.selectPrompt({ promptId: undefined }));
   }, [dispatch, prompt]);
 
   return {

--- a/apps/chat/src/store/prompts/prompts.epics.ts
+++ b/apps/chat/src/store/prompts/prompts.epics.ts
@@ -579,12 +579,8 @@ const uploadPromptsFromMultipleFoldersEpic: AppEpic = (action$, state$) =>
 
             actions.push(
               concat(
-                of(PromptsActions.setIsPromptModalOpen({ isOpen: true })),
                 of(
-                  PromptsActions.uploadPrompt({ promptId: topLevelPrompt.id }),
-                ),
-                of(
-                  PromptsActions.setSelectedPrompt({
+                  PromptsActions.selectPrompt({
                     promptId: topLevelPrompt.id,
                   }),
                 ),
@@ -923,13 +919,29 @@ const getPromptMetadataEpic: AppEpic = (action$) =>
     ),
   );
 
-const selectPromptEpic: AppEpic = (action$) =>
+const selectPromptEpic: AppEpic = (action$, state$) =>
   action$.pipe(
     ofType(PromptsActions.selectPrompt.type),
     switchMap(({ payload }) => {
       const actions: Observable<AppAction>[] = [];
 
-      if (isEntityIdPublic({ id: payload.promptId })) {
+      if (!payload.promptId) {
+        const selectedPromptInfo = PromptsSelectors.selectSelectedPromptId(
+          state$.value,
+        );
+        if (selectedPromptInfo?.selectedPromptId) {
+          const { versionGroupId } = getVersionGroupFromId(
+            selectedPromptInfo.selectedPromptId,
+          );
+          actions.push(
+            of(
+              PublicationActions.resetSelectedVersionForPublicVersionGroup({
+                versionGroupId,
+              }),
+            ),
+          );
+        }
+      } else if (isEntityIdPublic({ id: payload.promptId })) {
         const { versionGroupId, currentVersion } = getVersionGroupFromId(
           payload.promptId,
         );
@@ -944,13 +956,18 @@ const selectPromptEpic: AppEpic = (action$) =>
         );
       }
 
+      if (payload.promptId) {
+        actions.push(
+          of(
+            PromptsActions.uploadPrompt({
+              promptId: payload.promptId,
+            }),
+          ),
+        );
+      }
+
       return concat(
         ...actions,
-        of(
-          PromptsActions.uploadPrompt({
-            promptId: payload.promptId,
-          }),
-        ),
         of(
           PromptsActions.setSelectedPrompt({
             promptId: payload.promptId,
@@ -959,7 +976,7 @@ const selectPromptEpic: AppEpic = (action$) =>
         ),
         of(
           PromptsActions.setIsPromptModalOpen({
-            isOpen: true,
+            isOpen: !!payload.promptId,
             isInitModeEdit: !!payload.selectInEditMode,
           }),
         ),

--- a/apps/chat/src/store/prompts/prompts.reducers.ts
+++ b/apps/chat/src/store/prompts/prompts.reducers.ts
@@ -457,7 +457,7 @@ export const promptsSlice = createSlice({
     selectPrompt: (
       state,
       _action: PayloadAction<{
-        promptId: string;
+        promptId: string | undefined;
         selectInEditMode?: boolean;
         isApproveRequiredResource?: boolean;
       }>,

--- a/apps/chat/src/store/publication/publication.reducers.ts
+++ b/apps/chat/src/store/publication/publication.reducers.ts
@@ -247,6 +247,20 @@ export const publicationSlice = createSlice({
         versionGroup.selectedVersion = payload.newVersion;
       }
     },
+    resetSelectedVersionForPublicVersionGroup: (
+      state,
+      {
+        payload,
+      }: PayloadAction<{
+        versionGroupId: string;
+      }>,
+    ) => {
+      const versionGroup = state.publicVersionGroups[payload.versionGroupId];
+
+      if (versionGroup) {
+        versionGroup.selectedVersion = versionGroup.allVersions[0];
+      }
+    },
     removePublicVersionGroups: (
       state,
       {

--- a/apps/chat/src/store/share/share.epics.ts
+++ b/apps/chat/src/store/share/share.epics.ts
@@ -830,15 +830,9 @@ const getSharedListingSuccessEpic: AppEpic = (action$, state$) =>
           if (acceptedId && isPrompt) {
             if (!isFolderAccepted) {
               actions.push(
-                PromptsActions.setSelectedPrompt({
+                PromptsActions.selectPrompt({
                   promptId: acceptedId,
                 }),
-              );
-              actions.push(
-                PromptsActions.uploadPrompt({ promptId: acceptedId }),
-              );
-              actions.push(
-                PromptsActions.setIsPromptModalOpen({ isOpen: true }),
               );
             }
 


### PR DESCRIPTION
**Description:**

reset selected version after close View prompt

Issues:

- Issue #3491

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
