### PR TITLE
fix(chat): remove manage attachments file limit (Issue #3258)

### DIFF
--- a/apps/chat/src/components/Chatbar/ChatbarSettings.tsx
+++ b/apps/chat/src/components/Chatbar/ChatbarSettings.tsx
@@ -53,9 +53,6 @@ export const ChatbarSettings = () => {
   );
   const [isSelectFilesDialogOpened, setIsSelectFilesDialogOpened] =
     useState(false);
-  const maximumAttachmentsAmount = useAppSelector(
-    ConversationsSelectors.selectMaximumAttachmentsAmount,
-  );
   const isMyItemsExist = useAppSelector(
     ConversationsSelectors.selectDoesAnyMyItemExist,
   );
@@ -226,7 +223,6 @@ export const ChatbarSettings = () => {
         <FileManagerModal
           isOpen
           allowedTypes={['*/*']}
-          maximumAttachmentsAmount={maximumAttachmentsAmount}
           onClose={() => {
             setIsSelectFilesDialogOpened(false);
           }}


### PR DESCRIPTION
**Description:**

On Manage attachments should not be limitation for selecting files

Issues:

- Issue #3258

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
