### PR TITLE
fix(chat): disable drop files in playback, replay and external chats, fix drop area blinking (Issue #3790, #3785, #3787)

### DIFF
--- a/apps/chat/src/components/Chat/Chat.tsx
+++ b/apps/chat/src/components/Chat/Chat.tsx
@@ -597,346 +597,361 @@ const ChatView = memo(() => {
   }, [enabledFeatures]);
 
   return (
-    <div
-      className="relative size-full min-w-0 overflow-y-auto"
-      data-qa="chat"
-      id="chat"
-    >
-      {modelError ? (
-        <ErrorMessageDiv error={modelError} />
-      ) : customViewer ? (
-        <CustomViewerChatView
-          customViewer={customViewer}
-          setShowSettings={setIsShowChatSettings}
-        />
-      ) : (
-        <>
-          <div
-            className={classNames(
-              'flex size-full',
-              isCompareMode ? 'landscape:hidden' : 'hidden',
-            )}
-          >
-            <ChatCompareRotate />
-          </div>
-          <div
-            className={classNames(
-              'relative size-full',
-              isCompareMode && 'portrait:hidden',
-            )}
-          >
-            <div className="flex h-full">
-              <div
-                className={classNames(
-                  'flex h-full flex-col',
-                  isCompareMode && selectedConversations.length < 2
-                    ? 'w-1/2'
-                    : 'w-full',
-                )}
-                data-qa={
-                  isCompareMode ? 'compare-mode' : 'app-settings-chat-mode'
-                }
-              >
+    <ChatDropArea isSettingsModalOpen={isShowChatSettings}>
+      <div
+        className="relative size-full min-w-0 overflow-y-auto"
+        data-qa="chat"
+        id="chat"
+      >
+        {modelError ? (
+          <ErrorMessageDiv error={modelError} />
+        ) : customViewer ? (
+          <CustomViewerChatView
+            customViewer={customViewer}
+            setShowSettings={setIsShowChatSettings}
+          />
+        ) : (
+          <>
+            <div
+              className={classNames(
+                'flex size-full',
+                isCompareMode ? 'landscape:hidden' : 'hidden',
+              )}
+            >
+              <ChatCompareRotate />
+            </div>
+            <div
+              className={classNames(
+                'relative size-full',
+                isCompareMode && 'portrait:hidden',
+              )}
+            >
+              <div className="flex h-full">
                 <div
                   className={classNames(
                     'flex h-full flex-col',
-                    areSelectedConversationsEmpty
-                      ? 'justify-center'
-                      : 'justify-between',
+                    isCompareMode && selectedConversations.length < 2
+                      ? 'w-1/2'
+                      : 'w-full',
                   )}
+                  data-qa={
+                    isCompareMode ? 'compare-mode' : 'app-settings-chat-mode'
+                  }
                 >
-                  <div className="flex w-full">
-                    {selectedConversations.map((conv) => (
-                      <div
-                        key={conv.id}
-                        className={classNames(
-                          isCompareMode && selectedConversations.length > 1
-                            ? 'w-1/2'
-                            : 'w-full',
-                        )}
-                      >
-                        {conv.messages.length !== 0 &&
-                          enabledFeatures.has(Feature.TopSettings) &&
-                          !isApplicationPreviewChat && (
-                            <div className="z-10 flex flex-col">
-                              <ChatHeader
-                                conversation={conv}
-                                isCompareMode={isCompareMode}
-                                isShowChatInfo={enabledFeatures.has(
-                                  Feature.TopChatInfo,
-                                )}
-                                isShowClearConversation={
-                                  enabledFeatures.has(
-                                    Feature.TopClearConversation,
-                                  ) &&
-                                  !isPlayback &&
-                                  !isReplay &&
-                                  !isExternal
-                                }
-                                isShowSettings={isShowChatSettings}
-                                setShowSettings={setIsShowChatSettings}
-                                selectedConversationIds={
-                                  selectedConversationsIds
-                                }
-                                onClearConversation={() =>
-                                  handleClearConversation(conv)
-                                }
-                                onUnselectConversation={(id) => {
-                                  dispatch(
-                                    ConversationsActions.unselectConversations({
-                                      conversationIds: [id],
-                                    }),
-                                  );
-                                }}
-                                onModelClick={handleTalkToConversationId}
-                              />
-                            </div>
-                          )}
-                      </div>
-                    ))}
-                  </div>
                   <div
-                    onScroll={() => {
-                      if (
-                        selectedConversations.some(
-                          (conv) =>
-                            !!conv.messages.find(
-                              (m) => m.role !== Role.Assistant,
-                            ),
-                        )
-                      ) {
-                        handleScroll();
-                      }
-                    }}
-                    ref={setChatContainerRef}
-                    className={classNames('overflow-x-hidden', {
-                      'content-center': areSelectedConversationsEmpty,
-                      'h-full': !isWideLayout,
-                    })}
-                    data-qa="scrollable-area"
+                    className={classNames(
+                      'flex h-full flex-col',
+                      areSelectedConversationsEmpty
+                        ? 'justify-center'
+                        : 'justify-between',
+                    )}
                   >
-                    <div className="flex max-h-full w-full">
-                      {selectedConversations.map(
-                        (conv) =>
-                          conv.messages.length === 0 && (
-                            <div
-                              key={conv.id}
-                              className={classNames(
-                                'flex h-full flex-col justify-between',
-                                selectedConversations.length > 1
-                                  ? 'w-1/2'
-                                  : 'w-full',
-                              )}
-                            >
-                              <div
-                                className="shrink-0"
-                                style={{
-                                  height: `calc(100% - ${inputHeight}px)`,
-                                }}
-                              >
-                                <EmptyChatDescription
+                    <div className="flex w-full">
+                      {selectedConversations.map((conv) => (
+                        <div
+                          key={conv.id}
+                          className={classNames(
+                            isCompareMode && selectedConversations.length > 1
+                              ? 'w-1/2'
+                              : 'w-full',
+                          )}
+                        >
+                          {conv.messages.length !== 0 &&
+                            enabledFeatures.has(Feature.TopSettings) &&
+                            !isApplicationPreviewChat && (
+                              <div className="z-10 flex flex-col">
+                                <ChatHeader
                                   conversation={conv}
-                                  isApplicationPreviewChat={
-                                    isApplicationPreviewChat
+                                  isCompareMode={isCompareMode}
+                                  isShowChatInfo={enabledFeatures.has(
+                                    Feature.TopChatInfo,
+                                  )}
+                                  isShowClearConversation={
+                                    enabledFeatures.has(
+                                      Feature.TopClearConversation,
+                                    ) &&
+                                    !isPlayback &&
+                                    !isReplay &&
+                                    !isExternal
                                   }
-                                  onShowChangeModel={handleTalkToConversationId}
-                                  onShowSettings={setIsShowChatSettings}
+                                  isShowSettings={isShowChatSettings}
+                                  setShowSettings={setIsShowChatSettings}
+                                  selectedConversationIds={
+                                    selectedConversationsIds
+                                  }
+                                  onClearConversation={() =>
+                                    handleClearConversation(conv)
+                                  }
+                                  onUnselectConversation={(id) => {
+                                    dispatch(
+                                      ConversationsActions.unselectConversations(
+                                        {
+                                          conversationIds: [id],
+                                        },
+                                      ),
+                                    );
+                                  }}
+                                  onModelClick={handleTalkToConversationId}
                                 />
                               </div>
-                            </div>
-                          ),
-                      )}
+                            )}
+                        </div>
+                      ))}
                     </div>
-                    <div ref={chatMessagesRef}>
-                      {mergedMessages?.length > 0 && (
-                        <div className="flex flex-col" data-qa="chat-messages">
-                          {mergedMessages.map(
-                            (
-                              mergedStr: [
-                                Conversation,
-                                Message,
-                                number,
-                                Message[],
-                              ][],
-                              i: number,
-                            ) => (
+                    <div
+                      onScroll={() => {
+                        if (
+                          selectedConversations.some(
+                            (conv) =>
+                              !!conv.messages.find(
+                                (m) => m.role !== Role.Assistant,
+                              ),
+                          )
+                        ) {
+                          handleScroll();
+                        }
+                      }}
+                      ref={setChatContainerRef}
+                      className={classNames('overflow-x-hidden', {
+                        'content-center': areSelectedConversationsEmpty,
+                        'h-full': !isWideLayout,
+                      })}
+                      data-qa="scrollable-area"
+                    >
+                      <div className="flex max-h-full w-full">
+                        {selectedConversations.map(
+                          (conv) =>
+                            conv.messages.length === 0 && (
                               <div
-                                key={i}
-                                className="flex w-full"
-                                data-qa={
-                                  isCompareMode
-                                    ? 'compare-message-row'
-                                    : 'message-row'
-                                }
-                              >
-                                {mergedStr.map(
-                                  ([conv, message, index, filteredMessages]: [
-                                    Conversation,
-                                    Message,
-                                    number,
-                                    Message[],
-                                  ]) => (
-                                    <div
-                                      key={conv.id}
-                                      className={classNames(
-                                        isCompareMode &&
-                                          selectedConversations.length > 1
-                                          ? 'w-1/2'
-                                          : 'w-full',
-                                      )}
-                                    >
-                                      <div className="size-full">
-                                        <MemoizedChatMessage
-                                          key={conv.id}
-                                          message={message}
-                                          messageIndex={index}
-                                          filteredMessages={filteredMessages}
-                                          conversation={conv}
-                                          isLikesEnabled={
-                                            enabledFeatures.has(
-                                              Feature.Likes,
-                                            ) && !isEntityIdExternal(conv)
-                                          }
-                                          editDisabled={
-                                            !!notAvailableEntityType ||
-                                            isExternal ||
-                                            isReplay ||
-                                            isPlayback
-                                          }
-                                          onEdit={onEditMessage}
-                                          onLike={onLikeHandler(index, conv)}
-                                          onDelete={() => {
-                                            handleDeleteMessage(index, conv);
-                                          }}
-                                          onRegenerate={
-                                            index ===
-                                              mergedMessages.length - 1 &&
-                                            showLastMessageRegenerate
-                                              ? onRegenerateMessage
-                                              : undefined
-                                          }
-                                          messagesLength={mergedMessages.length}
-                                        />
-                                      </div>
-                                    </div>
-                                  ),
+                                key={conv.id}
+                                className={classNames(
+                                  'flex h-full flex-col justify-between',
+                                  selectedConversations.length > 1
+                                    ? 'w-1/2'
+                                    : 'w-full',
                                 )}
+                              >
+                                <div
+                                  className="shrink-0"
+                                  style={{
+                                    height: `calc(100% - ${inputHeight}px)`,
+                                  }}
+                                >
+                                  <EmptyChatDescription
+                                    conversation={conv}
+                                    isApplicationPreviewChat={
+                                      isApplicationPreviewChat
+                                    }
+                                    onShowChangeModel={
+                                      handleTalkToConversationId
+                                    }
+                                    onShowSettings={setIsShowChatSettings}
+                                  />
+                                </div>
                               </div>
                             ),
-                          )}
-                        </div>
-                      )}
+                        )}
+                      </div>
+                      <div ref={chatMessagesRef}>
+                        {mergedMessages?.length > 0 && (
+                          <div
+                            className="flex flex-col"
+                            data-qa="chat-messages"
+                          >
+                            {mergedMessages.map(
+                              (
+                                mergedStr: [
+                                  Conversation,
+                                  Message,
+                                  number,
+                                  Message[],
+                                ][],
+                                i: number,
+                              ) => (
+                                <div
+                                  key={i}
+                                  className="flex w-full"
+                                  data-qa={
+                                    isCompareMode
+                                      ? 'compare-message-row'
+                                      : 'message-row'
+                                  }
+                                >
+                                  {mergedStr.map(
+                                    ([conv, message, index, filteredMessages]: [
+                                      Conversation,
+                                      Message,
+                                      number,
+                                      Message[],
+                                    ]) => (
+                                      <div
+                                        key={conv.id}
+                                        className={classNames(
+                                          isCompareMode &&
+                                            selectedConversations.length > 1
+                                            ? 'w-1/2'
+                                            : 'w-full',
+                                        )}
+                                      >
+                                        <div className="size-full">
+                                          <MemoizedChatMessage
+                                            key={conv.id}
+                                            message={message}
+                                            messageIndex={index}
+                                            filteredMessages={filteredMessages}
+                                            conversation={conv}
+                                            isLikesEnabled={
+                                              enabledFeatures.has(
+                                                Feature.Likes,
+                                              ) && !isEntityIdExternal(conv)
+                                            }
+                                            editDisabled={
+                                              !!notAvailableEntityType ||
+                                              isExternal ||
+                                              isReplay ||
+                                              isPlayback
+                                            }
+                                            onEdit={onEditMessage}
+                                            onLike={onLikeHandler(index, conv)}
+                                            onDelete={() => {
+                                              handleDeleteMessage(index, conv);
+                                            }}
+                                            onRegenerate={
+                                              index ===
+                                                mergedMessages.length - 1 &&
+                                              showLastMessageRegenerate
+                                                ? onRegenerateMessage
+                                                : undefined
+                                            }
+                                            messagesLength={
+                                              mergedMessages.length
+                                            }
+                                          />
+                                        </div>
+                                      </div>
+                                    ),
+                                  )}
+                                </div>
+                              ),
+                            )}
+                          </div>
+                        )}
+                      </div>
                     </div>
-                  </div>
-                  {!isPlayback &&
-                  notAvailableEntityType &&
-                  !selectedPublicationUrl ? (
-                    <NotAllowedModel
-                      showScrollDownButton={showScrollDownButton}
-                      onScrollDownClick={handleScrollDown}
-                      type={notAvailableEntityType}
-                    />
-                  ) : (
-                    <>
-                      {isExternal && selectedConversations.length === 1 && (
-                        <PublicationControls
-                          showScrollDownButton={showScrollDownButton}
-                          entity={selectedConversations[0]}
-                          onScrollDownClick={handleScrollDown}
-                          controlsClassNames="mx-2 mb-2 mt-5 w-full flex-row md:mx-4 md:mb-0 md:last:mb-6 lg:mx-auto lg:w-[768px] lg:max-w-3xl"
-                        />
-                      )}
-
-                      {!isWideLayout && <ChatStarters />}
-
-                      {!isPlayback && (
-                        <ChatInput
-                          isWideLayout={isWideLayout}
-                          showReplayControls={showReplayControls}
-                          textareaRef={textareaRef}
-                          showScrollDownButton={showScrollDownButton}
-                          onSend={onSendMessage}
-                          onScrollDownClick={handleScrollDown}
-                          onRegenerate={onRegenerateMessage}
-                          isLastMessageError={isLastMessageError}
-                          onStopConversation={() => {
-                            dispatch(ConversationsActions.stopStreamMessage());
-                          }}
-                          onResize={onChatInputResize}
-                          isShowInput={isInputVisible}
-                        >
-                          <ChatInputControls
-                            isWideLayout={isWideLayout}
-                            isNotEmptyConversations={isNotEmptyConversations}
-                            showReplayControls={showReplayControls}
-                            areModelsInstalled={
-                              areModelsInstalled || isIsolatedView
-                            }
-                            isConversationWithSchema={isConversationWithSchema}
+                    {!isPlayback &&
+                    notAvailableEntityType &&
+                    !selectedPublicationUrl ? (
+                      <NotAllowedModel
+                        showScrollDownButton={showScrollDownButton}
+                        onScrollDownClick={handleScrollDown}
+                        type={notAvailableEntityType}
+                      />
+                    ) : (
+                      <>
+                        {isExternal && selectedConversations.length === 1 && (
+                          <PublicationControls
                             showScrollDownButton={showScrollDownButton}
-                            onScrollDown={handleScrollDown}
+                            entity={selectedConversations[0]}
+                            onScrollDownClick={handleScrollDown}
+                            controlsClassNames="mx-2 mb-2 mt-5 w-full flex-row md:mx-4 md:mb-0 md:last:mb-6 lg:mx-auto lg:w-[768px] lg:max-w-3xl"
                           />
-                        </ChatInput>
-                      )}
+                        )}
 
-                      {isPlayback && (
-                        <PlaybackControls
-                          nextMessageBoxRef={nextMessageBoxRef}
-                          showScrollDownButton={showScrollDownButton}
-                          onScrollDownClick={handleScrollDown}
-                          onResize={onChatInputResize}
-                        />
-                      )}
+                        {!isWideLayout && <ChatStarters />}
 
-                      {isWideLayout && <ChatStarters />}
-                    </>
-                  )}
+                        {!isPlayback && (
+                          <ChatInput
+                            isWideLayout={isWideLayout}
+                            showReplayControls={showReplayControls}
+                            textareaRef={textareaRef}
+                            showScrollDownButton={showScrollDownButton}
+                            onSend={onSendMessage}
+                            onScrollDownClick={handleScrollDown}
+                            onRegenerate={onRegenerateMessage}
+                            isLastMessageError={isLastMessageError}
+                            onStopConversation={() => {
+                              dispatch(
+                                ConversationsActions.stopStreamMessage(),
+                              );
+                            }}
+                            onResize={onChatInputResize}
+                            isShowInput={isInputVisible}
+                          >
+                            <ChatInputControls
+                              isWideLayout={isWideLayout}
+                              isNotEmptyConversations={isNotEmptyConversations}
+                              showReplayControls={showReplayControls}
+                              areModelsInstalled={
+                                areModelsInstalled || isIsolatedView
+                              }
+                              isConversationWithSchema={
+                                isConversationWithSchema
+                              }
+                              showScrollDownButton={showScrollDownButton}
+                              onScrollDown={handleScrollDown}
+                            />
+                          </ChatInput>
+                        )}
+
+                        {isPlayback && (
+                          <PlaybackControls
+                            nextMessageBoxRef={nextMessageBoxRef}
+                            showScrollDownButton={showScrollDownButton}
+                            onScrollDownClick={handleScrollDown}
+                            onResize={onChatInputResize}
+                          />
+                        )}
+
+                        {isWideLayout && <ChatStarters />}
+                      </>
+                    )}
+                  </div>
                 </div>
-              </div>
-              {isShowChatSettings && (
-                <ChatSettings
-                  conversations={selectedConversations}
-                  onChangeSettings={handleTemporarySettingsSave}
-                  onApplySettings={handleApplyChatSettings}
-                  onClose={() => setIsShowChatSettings(false)}
-                  isOpen={isShowChatSettings}
-                  isCompareMode={isCompareMode}
-                />
-              )}
-              {isCompareMode && selectedConversations.length < 2 && (
-                <div className="flex h-full w-1/2 items-center">
-                  <ChatCompareSelect
-                    conversations={conversations}
-                    selectedConversations={selectedConversations}
-                    onConversationSelect={(conversation) => {
-                      dispatch(
-                        ConversationsActions.selectForCompare(conversation),
-                      );
-                    }}
+                {isShowChatSettings && (
+                  <ChatSettings
+                    conversations={selectedConversations}
+                    onChangeSettings={handleTemporarySettingsSave}
+                    onApplySettings={handleApplyChatSettings}
+                    onClose={() => setIsShowChatSettings(false)}
+                    isOpen={isShowChatSettings}
+                    isCompareMode={isCompareMode}
                   />
-                </div>
-              )}
+                )}
+                {isCompareMode && selectedConversations.length < 2 && (
+                  <div className="flex h-full w-1/2 items-center">
+                    <ChatCompareSelect
+                      conversations={conversations}
+                      selectedConversations={selectedConversations}
+                      onConversationSelect={(conversation) => {
+                        dispatch(
+                          ConversationsActions.selectForCompare(conversation),
+                        );
+                      }}
+                    />
+                  </div>
+                )}
+              </div>
             </div>
-          </div>
-        </>
-      )}
-      {talkToConversationId &&
-        selectedConversations.map((conversation, i) => {
-          if (conversation.id !== talkToConversationId) {
-            return null;
-          }
+          </>
+        )}
+        {talkToConversationId &&
+          selectedConversations.map((conversation, i) => {
+            if (conversation.id !== talkToConversationId) {
+              return null;
+            }
 
-          return (
-            <TalkToModal
-              key={conversation.id}
-              onClose={handleTalkToClose}
-              conversation={conversation}
-              isCompareMode={selectedConversations.length > 1}
-              isRight={i === 1}
-            />
-          );
-        })}
-    </div>
+            return (
+              <TalkToModal
+                key={conversation.id}
+                onClose={handleTalkToClose}
+                conversation={conversation}
+                isCompareMode={selectedConversations.length > 1}
+                isRight={i === 1}
+              />
+            );
+          })}
+      </div>
+    </ChatDropArea>
   );
 });
 
@@ -1134,9 +1149,7 @@ export function Chat({ isPreview }: ChatProps) {
 
   return (
     <>
-      <ChatDropArea>
-        <ChatView />
-      </ChatDropArea>
+      <ChatView />
       {!isPreview && <ChatInputFooter />}
     </>
   );

--- a/apps/chat/src/components/Chat/ChatDropArea.tsx
+++ b/apps/chat/src/components/Chat/ChatDropArea.tsx
@@ -4,25 +4,64 @@ import { useChatUploadFiles } from '@/src/hooks/useChatUploadFiles';
 
 import { ConversationsSelectors } from '@/src/store/conversations/conversations.selectors';
 import { useAppSelector } from '@/src/store/hooks';
+import { ModelsSelectors } from '@/src/store/models/models.selectors';
 
 import { FileDropArea } from '@/src/components/Files/FIleDropArea';
 
 interface ChatDropAreaProps {
   children: ReactNode;
+  isSettingsModalOpen?: boolean;
 }
 
-export const ChatDropArea = ({ children }: ChatDropAreaProps) => {
+export const ChatDropArea = ({
+  children,
+  isSettingsModalOpen = false,
+}: ChatDropAreaProps) => {
   const canAttachFiles = useAppSelector(
     ConversationsSelectors.selectCanAttachFile,
   );
+  const isReplay = useAppSelector(
+    ConversationsSelectors.selectIsReplaySelectedConversations,
+  );
+  const isPlayback = useAppSelector(
+    ConversationsSelectors.selectIsPlaybackSelectedConversations,
+  );
+  const isExternal = useAppSelector(
+    ConversationsSelectors.selectAreSelectedConversationsExternal,
+  );
+  const isConversationBlocksInput = useAppSelector(
+    ConversationsSelectors.selectIsSelectedConversationBlocksInput,
+  );
+  const installedModelIds = useAppSelector(
+    ModelsSelectors.selectInstalledModelIds,
+  );
+  const selectedConversations = useAppSelector(
+    ConversationsSelectors.selectSelectedConversations,
+  );
+  const talkToConversationId = useAppSelector(
+    ConversationsSelectors.selectTalkToConversationId,
+  );
 
   const handleUploadFiles = useChatUploadFiles();
+
+  const areModelsInstalled = selectedConversations.every((conv) =>
+    installedModelIds.has(conv.model.id),
+  );
+
+  const isDroppable =
+    canAttachFiles &&
+    !isReplay &&
+    !isPlayback &&
+    !isExternal &&
+    !isConversationBlocksInput &&
+    areModelsInstalled;
 
   return (
     <FileDropArea
       className="min-w-0 shrink grow basis-0 overflow-hidden"
       onDrop={handleUploadFiles}
-      droppable={canAttachFiles}
+      droppable={isDroppable}
+      disabled={!!talkToConversationId || isSettingsModalOpen}
     >
       {children}
     </FileDropArea>

--- a/apps/chat/src/components/Chat/ChatDropArea.tsx
+++ b/apps/chat/src/components/Chat/ChatDropArea.tsx
@@ -20,15 +20,6 @@ export const ChatDropArea = ({
   const canAttachFiles = useAppSelector(
     ConversationsSelectors.selectCanAttachFile,
   );
-  const isReplay = useAppSelector(
-    ConversationsSelectors.selectIsReplaySelectedConversations,
-  );
-  const isPlayback = useAppSelector(
-    ConversationsSelectors.selectIsPlaybackSelectedConversations,
-  );
-  const isExternal = useAppSelector(
-    ConversationsSelectors.selectAreSelectedConversationsExternal,
-  );
   const isConversationBlocksInput = useAppSelector(
     ConversationsSelectors.selectIsSelectedConversationBlocksInput,
   );
@@ -49,12 +40,7 @@ export const ChatDropArea = ({
   );
 
   const isDroppable =
-    canAttachFiles &&
-    !isReplay &&
-    !isPlayback &&
-    !isExternal &&
-    !isConversationBlocksInput &&
-    areModelsInstalled;
+    canAttachFiles && isConversationBlocksInput && areModelsInstalled;
 
   return (
     <FileDropArea

--- a/apps/chat/src/components/Chat/ChatDropArea.tsx
+++ b/apps/chat/src/components/Chat/ChatDropArea.tsx
@@ -6,7 +6,7 @@ import { ConversationsSelectors } from '@/src/store/conversations/conversations.
 import { useAppSelector } from '@/src/store/hooks';
 import { ModelsSelectors } from '@/src/store/models/models.selectors';
 
-import { FileDropArea } from '@/src/components/Files/FIleDropArea';
+import { FileDropArea } from '@/src/components/Files/FileDropArea';
 
 interface ChatDropAreaProps {
   children: ReactNode;

--- a/apps/chat/src/components/Chat/ChatDropArea.tsx
+++ b/apps/chat/src/components/Chat/ChatDropArea.tsx
@@ -40,7 +40,7 @@ export const ChatDropArea = ({
   );
 
   const isDroppable =
-    canAttachFiles && isConversationBlocksInput && areModelsInstalled;
+    canAttachFiles && !isConversationBlocksInput && areModelsInstalled;
 
   return (
     <FileDropArea

--- a/apps/chat/src/components/Files/FIleDropArea.tsx
+++ b/apps/chat/src/components/Files/FIleDropArea.tsx
@@ -69,12 +69,17 @@ export const FileDropArea = ({
     >
       {isDraggingOver && (
         <div
-          onDragLeave={handleDragLeave}
           className={classNames(
             'absolute z-50 flex size-full items-center justify-center bg-overlay backdrop-blur-sm',
-            droppable ? 'cursor-copy' : 'cursor-not-allowed',
           )}
         >
+          <div
+            className={classNames(
+              'absolute z-50 size-full',
+              droppable ? 'cursor-copy' : 'cursor-not-allowed',
+            )}
+            onDragLeave={handleDragLeave}
+          />
           <div className="flex flex-col items-center">
             {droppable ? (
               <>

--- a/apps/chat/src/components/Files/FIleDropArea.tsx
+++ b/apps/chat/src/components/Files/FIleDropArea.tsx
@@ -30,11 +30,11 @@ export const FileDropArea = ({
 
   const handleDragOver = useCallback(
     (e: DragEvent) => {
-      e.preventDefault();
-      e.stopPropagation();
       if (disabled || !e.dataTransfer?.types?.includes('Files')) {
         return;
       }
+      e.preventDefault();
+      e.stopPropagation();
       setIsDraggingOver(true);
     },
     [disabled],

--- a/apps/chat/src/components/Files/FIleDropArea.tsx
+++ b/apps/chat/src/components/Files/FIleDropArea.tsx
@@ -13,12 +13,14 @@ interface FileDropAreaProps {
   children: ReactNode;
   onDrop: (files: File[]) => void;
   droppable?: boolean;
+  disabled?: boolean;
   className?: string;
 }
 
 export const FileDropArea = ({
   children,
   droppable = true,
+  disabled = false,
   className,
   onDrop,
 }: FileDropAreaProps) => {
@@ -26,14 +28,17 @@ export const FileDropArea = ({
 
   const [isDraggingOver, setIsDraggingOver] = useState(false);
 
-  const handleDragOver = useCallback((e: DragEvent) => {
-    e.preventDefault();
-    e.stopPropagation();
-    if (!e.dataTransfer?.types?.includes('Files')) {
-      return;
-    }
-    setIsDraggingOver(true);
-  }, []);
+  const handleDragOver = useCallback(
+    (e: DragEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+      if (disabled || !e.dataTransfer?.types?.includes('Files')) {
+        return;
+      }
+      setIsDraggingOver(true);
+    },
+    [disabled],
+  );
 
   const handleDragLeave = useCallback((e: DragEvent) => {
     e.preventDefault();

--- a/apps/chat/src/components/Files/FileDropArea.tsx
+++ b/apps/chat/src/components/Files/FileDropArea.tsx
@@ -9,6 +9,8 @@ import { getFileNameExtension } from '@/src/utils/app/file';
 
 import { Translation } from '@/src/types/translation';
 
+const containerId = 'file-drop-area';
+
 interface FileDropAreaProps {
   children: ReactNode;
   onDrop: (files: File[]) => void;
@@ -30,7 +32,15 @@ export const FileDropArea = ({
 
   const handleDragOver = useCallback(
     (e: DragEvent) => {
-      if (disabled || !e.dataTransfer?.types?.includes('Files')) {
+      const isModalOverlayOpened = (e.target as HTMLElement)?.closest(
+        '[data-floating-overlay]',
+      );
+
+      if (
+        disabled ||
+        !e.dataTransfer?.types?.includes('Files') ||
+        isModalOverlayOpened
+      ) {
         return;
       }
       e.preventDefault();
@@ -63,19 +73,20 @@ export const FileDropArea = ({
 
   return (
     <div
-      onDragOver={handleDragOver}
+      id={containerId}
+      onDragOverCapture={handleDragOver}
       onDrop={handleDrop}
       className={classNames('relative', className)}
     >
       {isDraggingOver && (
         <div
           className={classNames(
-            'absolute z-50 flex size-full items-center justify-center bg-overlay backdrop-blur-sm',
+            'absolute z-10 flex size-full items-center justify-center bg-overlay backdrop-blur-sm',
           )}
         >
           <div
             className={classNames(
-              'absolute z-50 size-full',
+              'absolute z-10 size-full',
               droppable ? 'cursor-copy' : 'cursor-not-allowed',
             )}
             onDragLeave={handleDragLeave}

--- a/apps/chat/src/utils/app/conversation.ts
+++ b/apps/chat/src/utils/app/conversation.ts
@@ -363,5 +363,5 @@ export const isReplayAsIsConversation = (conversation: ConversationInfo) =>
 export const getQuickAttachmentsSavingPath = () => {
   const date = new Date();
 
-  return `${getFileRootId()}/${date.getFullYear()}-${date.getMonth() + 1}`;
+  return `${getFileRootId()}/${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}`;
 };

--- a/apps/chat/src/utils/app/conversation.ts
+++ b/apps/chat/src/utils/app/conversation.ts
@@ -361,5 +361,7 @@ export const isReplayAsIsConversation = (conversation: ConversationInfo) =>
   (conversation as Conversation).replay?.replayAsIs ?? false;
 
 export const getQuickAttachmentsSavingPath = () => {
-  return `${getFileRootId()}/temp`;
+  const date = new Date();
+
+  return `${getFileRootId()}/${date.getFullYear()}-${date.getMonth() + 1}`;
 };


### PR DESCRIPTION
**Description:**

- forbid drop files in playback, replay, external chats and when input disabled by buttons
- fix blinking drop area overlay
- skip drag over handler if disabled or not dragging files
- update pasted/dropped attachemts saving path to fit yyyy-m date format (default path will be changed in other issue)

Issues:

- Issue #3790 
- Issue #3785 
- Issue #3787 

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
