### PR TITLE
fix(chat): fix token refresh when multiple requests refreshing it (Issue #3797)

### DIFF
--- a/apps/chat/src/utils/auth/auth-callbacks.ts
+++ b/apps/chat/src/utils/auth/auth-callbacks.ts
@@ -131,7 +131,7 @@ async function refreshAccessToken(token: Token) {
 
       if (!refresh || !refresh.isRefreshing) {
         const localToken: RefreshToken = refresh || {
-          isRefreshing: true,
+          isRefreshing: false,
           token,
         };
         if (
@@ -141,7 +141,10 @@ async function refreshAccessToken(token: Token) {
           return localToken.token;
         }
 
-        NextClient.setIsRefreshTokenStart(token.userId, localToken);
+        NextClient.setIsRefreshTokenStart(token.userId, {
+          token: localToken.token,
+          isRefreshing: true,
+        });
         break;
       }
 


### PR DESCRIPTION
**Description:**

The problem is next - when doing second refresh(after a day or more after previous refresh) the refreshing algo will take previous refresh token and because it's not isRefreshing it goes to refresh, but should set isRefreshing: true and for other requests go to wait 

**Issues:**
- Issue #3797

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
