### PR TITLE
chore(chat): bump @tabler/icons-react from 2.9.0 to 3.31.0

### DIFF
--- a/apps/chat/src/components/Chat/TalkTo/TalkToSlider.tsx
+++ b/apps/chat/src/components/Chat/TalkTo/TalkToSlider.tsx
@@ -289,24 +289,6 @@ export const TalkToSlider = ({ conversation, items, ...restProps }: Props) => {
   }, []);
 
   useEffect(() => {
-    const handleResize = () => {
-      if (sliderRef.current) {
-        setSliderHeight(sliderRef.current.clientHeight);
-      }
-    };
-
-    const resizeObserver = new ResizeObserver(handleResize);
-
-    if (sliderRef.current) {
-      resizeObserver.observe(sliderRef.current);
-    }
-
-    return () => {
-      resizeObserver.disconnect();
-    };
-  }, []);
-
-  useEffect(() => {
     if (!sliderGroups.length) {
       setActiveSlide(0);
     } else if (activeSlide !== 0 && activeSlide > sliderGroups.length - 1) {

--- a/apps/chat/src/components/Common/IconButton.tsx
+++ b/apps/chat/src/components/Common/IconButton.tsx
@@ -1,4 +1,4 @@
-import { TablerIconsProps } from '@tabler/icons-react';
+import { Icon } from '@tabler/icons-react';
 
 import { useTranslation } from 'next-i18next';
 
@@ -10,7 +10,7 @@ interface Props {
   name: string;
   dataQa: string;
   disabled?: boolean;
-  Icon?: (props: TablerIconsProps) => JSX.Element;
+  Icon?: Icon;
   onClick?: (e: React.MouseEvent) => void;
 }
 

--- a/apps/chat/src/components/Markdown/Table.tsx
+++ b/apps/chat/src/components/Markdown/Table.tsx
@@ -1,11 +1,11 @@
 import {
+  Icon,
   IconCheck,
   IconCsv,
   IconMarkdown,
   IconTxt,
-  TablerIconsProps,
 } from '@tabler/icons-react';
-import { FC, ReactNode, useCallback, useEffect, useRef, useState } from 'react';
+import { ReactNode, useCallback, useEffect, useRef, useState } from 'react';
 
 import { useTranslation } from '@/src/hooks/useTranslation';
 
@@ -15,7 +15,7 @@ import { Translation } from '@/src/types/translation';
 import Tooltip from '@/src/components/Common/Tooltip';
 
 interface CopyIconProps {
-  Icon: FC<TablerIconsProps>;
+  Icon: Icon;
   onClick: () => void;
   copied: boolean;
   type: CopyTableType;

--- a/apps/chat/src/components/NavigationWrapper.tsx
+++ b/apps/chat/src/components/NavigationWrapper.tsx
@@ -1,9 +1,10 @@
 import {
+  Icon,
   IconBrowser,
   IconHomeRibbon,
   IconLayoutGrid,
   IconMessage2,
-  TablerIconsProps,
+  IconProps,
 } from '@tabler/icons-react';
 import { JSX, ReactNode, useCallback, useMemo } from 'react';
 
@@ -42,7 +43,7 @@ import { Feature } from '@epam/ai-dial-shared';
 
 interface NavigationButtonProps {
   onClick: () => void;
-  Icon?: (props: TablerIconsProps) => JSX.Element;
+  Icon?: Icon;
   ModelIcon?: () => JSX.Element;
   selected?: boolean;
   tooltip?: ReactNode;
@@ -221,12 +222,10 @@ const UsedWidgets = () => {
   const WidgetBarIcon = useMemo(() => {
     if (areModelsLoading || !isApplicationsInitialised)
       // eslint-disable-next-line react/display-name
-      return ({ height }: TablerIconsProps) => (
-        <Loader size={height as number} />
-      );
+      return ({ height }: IconProps) => <Loader size={height as number} />;
 
     return selectedWidget
-      ? ({ height }: TablerIconsProps) => (
+      ? ({ height }: IconProps) => (
           <ModelIcon
             entity={selectedWidget}
             entityId={selectedWidget.reference}

--- a/apps/chat/src/components/Promptbar/components/ViewPromptButtons.tsx
+++ b/apps/chat/src/components/Promptbar/components/ViewPromptButtons.tsx
@@ -4,6 +4,7 @@ import {
   IconFolderShare,
   IconInfoCircle,
   IconPencilMinus,
+  IconProps,
   IconTrashX,
   IconUserShare,
   IconWorldShare,
@@ -116,7 +117,7 @@ export const ViewPromptButtons: React.FC<Props> = ({ prompt, onEditMode }) => {
         name: 'Unpublish',
         display: isPublic && isPublishingEnabled,
         dataQa: 'publish-prompt',
-        Icon: (props) => (
+        Icon: (props: IconProps) => (
           <UnpublishIcon {...props} style={{ strokeWidth: 1.1 }} />
         ),
         onClick: () => {

--- a/apps/chat/src/types/menu.ts
+++ b/apps/chat/src/types/menu.ts
@@ -1,5 +1,5 @@
 import { Placement } from '@floating-ui/react';
-import { TablerIconsProps } from '@tabler/icons-react';
+import { Icon } from '@tabler/icons-react';
 import { FC, MouseEventHandler, ReactNode } from 'react';
 
 import { FeatureType } from './common';
@@ -17,7 +17,7 @@ export interface DisplayMenuItemProps {
   name: string;
   additionalNameNode?: ReactNode;
   disabled?: boolean;
-  Icon?: (props: TablerIconsProps) => JSX.Element;
+  Icon?: Icon;
   iconClassName?: string;
   dataQa: string;
   onClick?: onClickMenuItemHandler;
@@ -45,7 +45,7 @@ export interface MenuProps {
 }
 
 export interface ContextMenuProps extends MenuProps {
-  TriggerIcon?: (props: TablerIconsProps) => JSX.Element;
+  TriggerIcon?: Icon;
   triggerIconSize?: number;
   triggerIconHighlight?: boolean;
   triggerIconClassName?: string;

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@opentelemetry/sdk-trace-node": "^1.26.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
         "@reduxjs/toolkit": "^1.9.5",
-        "@tabler/icons-react": "^2.9.0",
+        "@tabler/icons-react": "^3.31.0",
         "@tanstack/react-virtual": "^3.13.0",
         "classnames": "^2.3.2",
         "css.escape": "^1.5.1",
@@ -4720,14 +4720,14 @@
       }
     },
     "node_modules/@nx/eslint-plugin/node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.32.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.32.0.tgz",
-      "integrity": "sha512-jc/4IxGNedXkmG4mx4nJTILb6TMjL66D41vyeaPWvDUmeYQzF3lKtN15WsAeTr65ce4mPxwopPSo1yUUAWw0hQ==",
+      "version": "8.32.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.32.1.tgz",
+      "integrity": "sha512-7IsIaIDeZn7kffk7qXC3o6Z4UblZJKV3UBpkvRNpr5NSyLji7tvTcvmnMNYuYLyh26mN8W723xpo3i4MlD33vA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.32.0",
-        "@typescript-eslint/visitor-keys": "8.32.0"
+        "@typescript-eslint/types": "8.32.1",
+        "@typescript-eslint/visitor-keys": "8.32.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4738,14 +4738,14 @@
       }
     },
     "node_modules/@nx/eslint-plugin/node_modules/@typescript-eslint/type-utils": {
-      "version": "8.32.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.32.0.tgz",
-      "integrity": "sha512-t2vouuYQKEKSLtJaa5bB4jHeha2HJczQ6E5IXPDPgIty9EqcJxpr1QHQ86YyIPwDwxvUmLfP2YADQ5ZY4qddZg==",
+      "version": "8.32.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.32.1.tgz",
+      "integrity": "sha512-mv9YpQGA8iIsl5KyUPi+FGLm7+bA4fgXaeRcFKRDRwDMu4iwrSHeDPipwueNXhdIIZltwCJv+NkxftECbIZWfA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "8.32.0",
-        "@typescript-eslint/utils": "8.32.0",
+        "@typescript-eslint/typescript-estree": "8.32.1",
+        "@typescript-eslint/utils": "8.32.1",
         "debug": "^4.3.4",
         "ts-api-utils": "^2.1.0"
       },
@@ -4762,9 +4762,9 @@
       }
     },
     "node_modules/@nx/eslint-plugin/node_modules/@typescript-eslint/types": {
-      "version": "8.32.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.32.0.tgz",
-      "integrity": "sha512-O5Id6tGadAZEMThM6L9HmVf5hQUXNSxLVKeGJYWNhhVseps/0LddMkp7//VDkzwJ69lPL0UmZdcZwggj9akJaA==",
+      "version": "8.32.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.32.1.tgz",
+      "integrity": "sha512-YmybwXUJcgGqgAp6bEsgpPXEg6dcCyPyCSr0CAAueacR/CCBi25G3V8gGQ2kRzQRBNol7VQknxMs9HvVa9Rvfg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4776,14 +4776,14 @@
       }
     },
     "node_modules/@nx/eslint-plugin/node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.32.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.32.0.tgz",
-      "integrity": "sha512-pU9VD7anSCOIoBFnhTGfOzlVFQIA1XXiQpH/CezqOBaDppRwTglJzCC6fUQGpfwey4T183NKhF1/mfatYmjRqQ==",
+      "version": "8.32.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.32.1.tgz",
+      "integrity": "sha512-Y3AP9EIfYwBb4kWGb+simvPaqQoT5oJuzzj9m0i6FCY6SPvlomY2Ei4UEMm7+FXtlNJbor80ximyslzaQF6xhg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.32.0",
-        "@typescript-eslint/visitor-keys": "8.32.0",
+        "@typescript-eslint/types": "8.32.1",
+        "@typescript-eslint/visitor-keys": "8.32.1",
         "debug": "^4.3.4",
         "fast-glob": "^3.3.2",
         "is-glob": "^4.0.3",
@@ -4803,16 +4803,16 @@
       }
     },
     "node_modules/@nx/eslint-plugin/node_modules/@typescript-eslint/utils": {
-      "version": "8.32.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.32.0.tgz",
-      "integrity": "sha512-8S9hXau6nQ/sYVtC3D6ISIDoJzS1NsCK+gluVhLN2YkBPX+/1wkwyUiDKnxRh15579WoOIyVWnoyIf3yGI9REw==",
+      "version": "8.32.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.32.1.tgz",
+      "integrity": "sha512-DsSFNIgLSrc89gpq1LJB7Hm1YpuhK086DRDJSNrewcGvYloWW1vZLHBTIvarKZDcAORIy/uWNx8Gad+4oMpkSA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.7.0",
-        "@typescript-eslint/scope-manager": "8.32.0",
-        "@typescript-eslint/types": "8.32.0",
-        "@typescript-eslint/typescript-estree": "8.32.0"
+        "@typescript-eslint/scope-manager": "8.32.1",
+        "@typescript-eslint/types": "8.32.1",
+        "@typescript-eslint/typescript-estree": "8.32.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4827,13 +4827,13 @@
       }
     },
     "node_modules/@nx/eslint-plugin/node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.32.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.32.0.tgz",
-      "integrity": "sha512-1rYQTCLFFzOI5Nl0c8LUpJT8HxpwVRn9E4CkMsYfuN6ctmQqExjSTzzSk0Tz2apmXy7WU6/6fyaZVVA/thPN+w==",
+      "version": "8.32.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.32.1.tgz",
+      "integrity": "sha512-ar0tjQfObzhSaW3C3QNmTc5ofj0hDoNQ5XWrCy6zDyabdr0TWhCkClp+rywGNj/odAFBVzzJrK4tEq5M4Hmu4w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.32.0",
+        "@typescript-eslint/types": "8.32.1",
         "eslint-visitor-keys": "^4.2.0"
       },
       "engines": {
@@ -9569,9 +9569,9 @@
       }
     },
     "node_modules/@tabler/icons": {
-      "version": "2.47.0",
-      "resolved": "https://registry.npmjs.org/@tabler/icons/-/icons-2.47.0.tgz",
-      "integrity": "sha512-4w5evLh+7FUUiA1GucvGj2ReX2TvOjEr4ejXdwL/bsjoSkof6r1gQmzqI+VHrE2CpJpB3al7bCTulOkFa/RcyA==",
+      "version": "3.31.0",
+      "resolved": "https://registry.npmjs.org/@tabler/icons/-/icons-3.31.0.tgz",
+      "integrity": "sha512-dblAdeKY3+GA1U+Q9eziZ0ooVlZMHsE8dqP0RkwvRtEsAULoKOYaCUOcJ4oW1DjWegdxk++UAt2SlQVnmeHv+g==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -9579,20 +9579,19 @@
       }
     },
     "node_modules/@tabler/icons-react": {
-      "version": "2.47.0",
-      "resolved": "https://registry.npmjs.org/@tabler/icons-react/-/icons-react-2.47.0.tgz",
-      "integrity": "sha512-iqly2FvCF/qUbgmvS8E40rVeYY7laltc5GUjRxQj59DuX0x/6CpKHTXt86YlI2whg4czvd/c8Ce8YR08uEku0g==",
+      "version": "3.31.0",
+      "resolved": "https://registry.npmjs.org/@tabler/icons-react/-/icons-react-3.31.0.tgz",
+      "integrity": "sha512-2rrCM5y/VnaVKnORpDdAua9SEGuJKVqPtWxeQ/vUVsgaUx30LDgBZph7/lterXxDY1IKR6NO//HDhWiifXTi3w==",
       "license": "MIT",
       "dependencies": {
-        "@tabler/icons": "2.47.0",
-        "prop-types": "^15.7.2"
+        "@tabler/icons": "3.31.0"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/codecalm"
       },
       "peerDependencies": {
-        "react": "^16.5.1 || ^17.0.0 || ^18.0.0"
+        "react": ">= 16"
       }
     },
     "node_modules/@tailwindcss/typography": {
@@ -18601,9 +18600,9 @@
       }
     },
     "node_modules/hast-util-from-dom/node_modules/property-information": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.0.0.tgz",
-      "integrity": "sha512-7D/qOz/+Y4X/rzSB6jKxKUsQnphO046ei8qxG59mtM3RG3DHgTK81HrxrmoDVINJb8NKT5ZsRbwHvQ6B68Iyhg==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
+      "integrity": "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -18719,9 +18718,9 @@
       }
     },
     "node_modules/hast-util-from-html/node_modules/property-information": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.0.0.tgz",
-      "integrity": "sha512-7D/qOz/+Y4X/rzSB6jKxKUsQnphO046ei8qxG59mtM3RG3DHgTK81HrxrmoDVINJb8NKT5ZsRbwHvQ6B68Iyhg==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
+      "integrity": "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==",
       "license": "MIT",
       "funding": {
         "type": "github",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@opentelemetry/sdk-trace-node": "^1.26.0",
     "@opentelemetry/semantic-conventions": "^1.27.0",
     "@reduxjs/toolkit": "^1.9.5",
-    "@tabler/icons-react": "^2.9.0",
+    "@tabler/icons-react": "^3.31.0",
     "@tanstack/react-virtual": "^3.13.0",
     "classnames": "^2.3.2",
     "css.escape": "^1.5.1",


### PR DESCRIPTION
**Description:**

bump @tabler/icons-react from 2.9.0 to 3.31.0
https://github.com/tabler/tabler-icons/releases/tag/v3.0.0

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
