### PR TITLE
fix(chat): fix only last Plotly attachment rendered if to set all attachments to be open (Issue #3778)

### DIFF
--- a/apps/chat/src/store/conversations/conversations.epics.ts
+++ b/apps/chat/src/store/conversations/conversations.epics.ts
@@ -2882,9 +2882,9 @@ const openFolderEpic: AppEpic = (action$) =>
 const getChartAttachmentEpic: AppEpic = (action$) =>
   action$.pipe(
     ofType(ConversationsActions.getChartAttachment.type),
-    switchMap(({ payload }) =>
+    mergeMap(({ payload }) =>
       FileService.getFileContent<PlotParams>(payload.pathToChart).pipe(
-        switchMap((params) => {
+        mergeMap((params) => {
           return of(
             ConversationsActions.getChartAttachmentSuccess({
               params,


### PR DESCRIPTION
**Description:**

- Fix only last Plotly attachment rendered if to set all attachments to be open.

Issues:

- Issue #3778 

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
