### PR TITLE
fix(chat): fix App Editor indicator displaying (Issue #3369)

### DIFF
--- a/apps/chat-e2e/src/tests/customApplications.test.ts
+++ b/apps/chat-e2e/src/tests/customApplications.test.ts
@@ -425,8 +425,12 @@ dialTest(
         await appEditorHeader.goOnGeneralInfoStep();
         await baseAssertion.assertElementState(appEditorGeneralForm);
         await appEditorHeaderAssertion.assertStepIsCompleted(
-          AppEditSteps.generalInfo,
+          AppEditSteps.appSettings,
           true,
+        );
+        await appEditorHeaderAssertion.assertStepIsCompleted(
+          AppEditSteps.generalInfo,
+          false,
         );
         //need to explicitly click on the form to trigger autosave after fields update
         await appEditorGeneralForm.version.click();

--- a/apps/chat/src/components/AppsEditor/AppsEditorHeader.tsx
+++ b/apps/chat/src/components/AppsEditor/AppsEditorHeader.tsx
@@ -203,7 +203,7 @@ export const AppsEditorHeader: React.FC<AppsEditorHeaderProps> = ({
                       )}
                       onClick={handleTabClick(isDisabled)}
                     >
-                      {tab.key === TabKeys.GENERAL && id ? (
+                      {tab.href.pathname !== pathname && id ? (
                         <IconCircleCheck
                           className="text-accent-primary"
                           data-qa="selected-step-icon"


### PR DESCRIPTION
**Description:**

fix App Editor indicator displaying

Issues:

- Issue #3369

**UI changes**

First step

![Image](https://github.com/user-attachments/assets/4fe7d8d5-706d-4fd1-a15a-8b62ef4f04bb)

Second step

![Image](https://github.com/user-attachments/assets/56309686-7d53-443c-887b-c96595ad3ebc)

Back to first step ( for both Add and edit app flows)

![Image](https://github.com/user-attachments/assets/e9d97722-b7a5-495d-99fe-b7cf1c6d2e61)

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
