### PR TITLE
chore(chat): upgrade NX from 20.6.2 to 21.0.3 for e2e-tests (Issue #3890)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -141,7 +141,7 @@
         "npm": ">=10.7.0"
       },
       "optionalDependencies": {
-        "@nx/playwright": "^20.6.2",
+        "@nx/playwright": "21.0.3",
         "@playwright/test": "^1.52.0",
         "@types/tinycolor2": "^1.4.6",
         "allure-playwright": "^3.2.0",
@@ -2228,7 +2228,7 @@
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
       "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "0.3.9"
@@ -2241,7 +2241,7 @@
       "version": "0.3.9",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
       "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
@@ -5309,15 +5309,15 @@
       ]
     },
     "node_modules/@nx/playwright": {
-      "version": "20.6.2",
-      "resolved": "https://registry.npmjs.org/@nx/playwright/-/playwright-20.6.2.tgz",
-      "integrity": "sha512-x7VPlqcDX4RLNvuEpqV6vCLUnmny2r97KOdDcSis7rm5Uoc22bSAHohWsUeb9Czxei4UaXVZyxdYwWm9mevxOw==",
+      "version": "21.0.3",
+      "resolved": "https://registry.npmjs.org/@nx/playwright/-/playwright-21.0.3.tgz",
+      "integrity": "sha512-ynbazFN87wZILIEzLi3wznFz0/ybt55auZm9jrCsvet7FKuXGXdMDmI0iXed1mm+U3NzDFRJX1+0kS7sAhgDDA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@nx/devkit": "20.6.2",
-        "@nx/eslint": "20.6.2",
-        "@nx/js": "20.6.2",
+        "@nx/devkit": "21.0.3",
+        "@nx/eslint": "21.0.3",
+        "@nx/js": "21.0.3",
         "@phenomnomnominal/tsquery": "~5.0.1",
         "minimatch": "9.0.3",
         "tslib": "^2.3.0"
@@ -5329,359 +5329,6 @@
         "@playwright/test": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@nx/playwright/node_modules/@nx/devkit": {
-      "version": "20.6.2",
-      "resolved": "https://registry.npmjs.org/@nx/devkit/-/devkit-20.6.2.tgz",
-      "integrity": "sha512-n36iECrNrrRugh7Jfpe9A3PS6vjil57iLyJ9fE8plylWSHPJmsXRp5K6HH7q3hBu6UG3my1HgdproJwvF34a5A==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "ejs": "^3.1.7",
-        "enquirer": "~2.3.6",
-        "ignore": "^5.0.4",
-        "minimatch": "9.0.3",
-        "semver": "^7.5.3",
-        "tmp": "~0.2.1",
-        "tslib": "^2.3.0",
-        "yargs-parser": "21.1.1"
-      },
-      "peerDependencies": {
-        "nx": ">= 19 <= 21"
-      }
-    },
-    "node_modules/@nx/playwright/node_modules/@nx/eslint": {
-      "version": "20.6.2",
-      "resolved": "https://registry.npmjs.org/@nx/eslint/-/eslint-20.6.2.tgz",
-      "integrity": "sha512-cWP+ayiP3WY2xyAPXPDxEQG38Vh+NqwUACrgzkswqo7F1zpFMEwoTFY36USoMr7+nfqnIy6haMYVtoezj+9MxA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@nx/devkit": "20.6.2",
-        "@nx/js": "20.6.2",
-        "semver": "^7.5.3",
-        "tslib": "^2.3.0",
-        "typescript": "~5.7.2"
-      },
-      "peerDependencies": {
-        "@zkochan/js-yaml": "0.0.7",
-        "eslint": "^8.0.0 || ^9.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@zkochan/js-yaml": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@nx/playwright/node_modules/@nx/js": {
-      "version": "20.6.2",
-      "resolved": "https://registry.npmjs.org/@nx/js/-/js-20.6.2.tgz",
-      "integrity": "sha512-h6r1bPHL5u6IZHKYm+fdAgup5G5YOWjtbTddCP5TVWnKU7ume/5P8cpYch4jvc4T7+/PKJQxikdUz7isDztyJg==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@babel/core": "^7.23.2",
-        "@babel/plugin-proposal-decorators": "^7.22.7",
-        "@babel/plugin-transform-class-properties": "^7.22.5",
-        "@babel/plugin-transform-runtime": "^7.23.2",
-        "@babel/preset-env": "^7.23.2",
-        "@babel/preset-typescript": "^7.22.5",
-        "@babel/runtime": "^7.22.6",
-        "@nx/devkit": "20.6.2",
-        "@nx/workspace": "20.6.2",
-        "@zkochan/js-yaml": "0.0.7",
-        "babel-plugin-const-enum": "^1.0.1",
-        "babel-plugin-macros": "^3.1.0",
-        "babel-plugin-transform-typescript-metadata": "^0.3.1",
-        "chalk": "^4.1.0",
-        "columnify": "^1.6.0",
-        "detect-port": "^1.5.1",
-        "enquirer": "~2.3.6",
-        "ignore": "^5.0.4",
-        "js-tokens": "^4.0.0",
-        "jsonc-parser": "3.2.0",
-        "npm-package-arg": "11.0.1",
-        "npm-run-path": "^4.0.1",
-        "ora": "5.3.0",
-        "picocolors": "^1.1.0",
-        "picomatch": "4.0.2",
-        "semver": "^7.5.3",
-        "source-map-support": "0.5.19",
-        "tinyglobby": "^0.2.12",
-        "ts-node": "10.9.1",
-        "tsconfig-paths": "^4.1.2",
-        "tslib": "^2.3.0"
-      },
-      "peerDependencies": {
-        "verdaccio": "^6.0.5"
-      },
-      "peerDependenciesMeta": {
-        "verdaccio": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@nx/playwright/node_modules/@nx/nx-darwin-arm64": {
-      "version": "20.6.2",
-      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-arm64/-/nx-darwin-arm64-20.6.2.tgz",
-      "integrity": "sha512-ap7DJPx7goc0iXOaVETOmeTrQdWQfVVhM8rrjteARycJf7+kirEYPg9V/3ePA/lome7PudLVe2qGlOCaQbXbHw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@nx/playwright/node_modules/@nx/nx-darwin-x64": {
-      "version": "20.6.2",
-      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-x64/-/nx-darwin-x64-20.6.2.tgz",
-      "integrity": "sha512-xtOsd5Wh5J3/wzw0BVMNbzSjVEfc1IkgB53ofoEqBd80/dqqI/WIh8qkt+5oQjJwE2CHaZ+4UkVlwSylaHguPg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@nx/playwright/node_modules/@nx/nx-freebsd-x64": {
-      "version": "20.6.2",
-      "resolved": "https://registry.npmjs.org/@nx/nx-freebsd-x64/-/nx-freebsd-x64-20.6.2.tgz",
-      "integrity": "sha512-tSHAcIoSR4grW2uJNE+8ipHkB1PyGikYHBoy6iGu4upbLH0d3RqZVpiXS5qCY030XWo16yo4gXyMMyp84cjdDw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@nx/playwright/node_modules/@nx/nx-linux-arm-gnueabihf": {
-      "version": "20.6.2",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-20.6.2.tgz",
-      "integrity": "sha512-x4EK2ydPcKAu8/DlesoWx/hfnK/CYp6BEjss/lsffLLMXNmzhCMulxqYhjwE5m38hauHQFSVrkHq6gSZeGkB8Q==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@nx/playwright/node_modules/@nx/nx-linux-arm64-gnu": {
-      "version": "20.6.2",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-20.6.2.tgz",
-      "integrity": "sha512-OjJ6UA/varsVfhuKAV/GLVkPZk7CzRKeTW0xEB6Ik9XjllXruYmNvMhtBuD+MNWqkKld9aIjAQhnJ3YI8hjMRA==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@nx/playwright/node_modules/@nx/nx-linux-arm64-musl": {
-      "version": "20.6.2",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-musl/-/nx-linux-arm64-musl-20.6.2.tgz",
-      "integrity": "sha512-+Vq8STTtJi+o2BR2JmPf0CvZEotkMHYOlgzcFox8HBIRel3vXW2rJpISSExEtocb/qDj5+pRoiRf07vGY7utjg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@nx/playwright/node_modules/@nx/nx-linux-x64-gnu": {
-      "version": "20.6.2",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-gnu/-/nx-linux-x64-gnu-20.6.2.tgz",
-      "integrity": "sha512-PzZvYuYhD5JBddVN5l/VukW2Ju/BubKqrH0P3ndgh1atH/eBljJegSHryAMHhR9wNygwLTvbpVQzU5jOBX2HDQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@nx/playwright/node_modules/@nx/nx-linux-x64-musl": {
-      "version": "20.6.2",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-musl/-/nx-linux-x64-musl-20.6.2.tgz",
-      "integrity": "sha512-CZoWa6CY7fDHah49cnLSThbkvLoXkYtQ/2uEV7AzYm7k47VAOK191ymuEIRQKl4gw60e0BHr7T9UFsJoiJNohA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@nx/playwright/node_modules/@nx/nx-win32-arm64-msvc": {
-      "version": "20.6.2",
-      "resolved": "https://registry.npmjs.org/@nx/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-20.6.2.tgz",
-      "integrity": "sha512-D9HFGyzqy6JqqokxoHAzsGmR6D+Y962ldcUrfaQWvBQSDDJRaDG0iL2crnj85pOh7NDMGF8avv2gv39oUxATaw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@nx/playwright/node_modules/@nx/nx-win32-x64-msvc": {
-      "version": "20.6.2",
-      "resolved": "https://registry.npmjs.org/@nx/nx-win32-x64-msvc/-/nx-win32-x64-msvc-20.6.2.tgz",
-      "integrity": "sha512-WlSGOpt6lUC9NujVAi3Ky3wp/Ys+qAbxmrU5YKhuXhjVsuqPKw97OwptjXAdEt71Wxvdp4Ghlw12Pn9YScN0kw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@nx/playwright/node_modules/@nx/workspace": {
-      "version": "20.6.2",
-      "resolved": "https://registry.npmjs.org/@nx/workspace/-/workspace-20.6.2.tgz",
-      "integrity": "sha512-sZc1UnmuiMJWCa23ycYX4h5NaxRTj+q8iqIOd5zjwLQ/LxY4gkaUpWJJIG8zwl4EF+PIjHPtbnIj78G4ZM2FJw==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@nx/devkit": "20.6.2",
-        "@zkochan/js-yaml": "0.0.7",
-        "chalk": "^4.1.0",
-        "enquirer": "~2.3.6",
-        "nx": "20.6.2",
-        "picomatch": "4.0.2",
-        "tslib": "^2.3.0",
-        "yargs-parser": "21.1.1"
-      }
-    },
-    "node_modules/@nx/playwright/node_modules/@nx/workspace/node_modules/nx": {
-      "version": "20.6.2",
-      "resolved": "https://registry.npmjs.org/nx/-/nx-20.6.2.tgz",
-      "integrity": "sha512-FvdDpBRgTdlTO0ixFjtZnMsp25MMBUzHcylVphekVY4vdFOnJ54f9Y64oncqcj70gyKX6Qn9g9+hEzV4bomYeQ==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@napi-rs/wasm-runtime": "0.2.4",
-        "@yarnpkg/lockfile": "^1.1.0",
-        "@yarnpkg/parsers": "3.0.2",
-        "@zkochan/js-yaml": "0.0.7",
-        "axios": "^1.8.3",
-        "chalk": "^4.1.0",
-        "cli-cursor": "3.1.0",
-        "cli-spinners": "2.6.1",
-        "cliui": "^8.0.1",
-        "dotenv": "~16.4.5",
-        "dotenv-expand": "~11.0.6",
-        "enquirer": "~2.3.6",
-        "figures": "3.2.0",
-        "flat": "^5.0.2",
-        "front-matter": "^4.0.2",
-        "ignore": "^5.0.4",
-        "jest-diff": "^29.4.1",
-        "jsonc-parser": "3.2.0",
-        "lines-and-columns": "2.0.3",
-        "minimatch": "9.0.3",
-        "node-machine-id": "1.1.12",
-        "npm-run-path": "^4.0.1",
-        "open": "^8.4.0",
-        "ora": "5.3.0",
-        "resolve.exports": "2.0.3",
-        "semver": "^7.5.3",
-        "string-width": "^4.2.3",
-        "tar-stream": "~2.2.0",
-        "tmp": "~0.2.1",
-        "tsconfig-paths": "^4.1.2",
-        "tslib": "^2.3.0",
-        "yaml": "^2.6.0",
-        "yargs": "^17.6.2",
-        "yargs-parser": "21.1.1"
-      },
-      "bin": {
-        "nx": "bin/nx.js",
-        "nx-cloud": "bin/nx-cloud.js"
-      },
-      "optionalDependencies": {
-        "@nx/nx-darwin-arm64": "20.6.2",
-        "@nx/nx-darwin-x64": "20.6.2",
-        "@nx/nx-freebsd-x64": "20.6.2",
-        "@nx/nx-linux-arm-gnueabihf": "20.6.2",
-        "@nx/nx-linux-arm64-gnu": "20.6.2",
-        "@nx/nx-linux-arm64-musl": "20.6.2",
-        "@nx/nx-linux-x64-gnu": "20.6.2",
-        "@nx/nx-linux-x64-musl": "20.6.2",
-        "@nx/nx-win32-arm64-msvc": "20.6.2",
-        "@nx/nx-win32-x64-msvc": "20.6.2"
-      },
-      "peerDependencies": {
-        "@swc-node/register": "^1.8.0",
-        "@swc/core": "^1.3.85"
-      },
-      "peerDependenciesMeta": {
-        "@swc-node/register": {
-          "optional": true
-        },
-        "@swc/core": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@nx/playwright/node_modules/picomatch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/@nx/react": {
@@ -9663,6 +9310,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -9679,6 +9327,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -9695,6 +9344,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -9711,6 +9361,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -9727,6 +9378,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -9743,6 +9395,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -9759,6 +9412,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -9775,6 +9429,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -9791,6 +9446,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -9807,6 +9463,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -10170,28 +9827,28 @@
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
       "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@tsconfig/node12": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
       "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@tsconfig/node14": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
       "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@tsconfig/node16": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@turf/area": {
@@ -11710,7 +11367,7 @@
       "version": "8.3.4",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
       "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.11.0"
@@ -13847,7 +13504,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/cron-parser": {
@@ -15367,7 +15024,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
       "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
@@ -23347,7 +23004,7 @@
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/makeerror": {
@@ -32221,7 +31878,7 @@
       "version": "10.9.1",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
       "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
@@ -32265,7 +31922,7 @@
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
       "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/tsconfig-paths": {
@@ -32981,7 +32638,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/v8-to-istanbul": {
@@ -34109,7 +33766,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
       "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"

--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "koa": "2.16.1"
   },
   "optionalDependencies": {
-    "@nx/playwright": "^20.6.2",
+    "@nx/playwright": "21.0.3",
     "@playwright/test": "^1.52.0",
     "@types/tinycolor2": "^1.4.6",
     "allure-playwright": "^3.2.0",


### PR DESCRIPTION
**Description:**

upgrade NX from 20.6.2 to 21.0.3 for e2e-tests

Issues:

- Issue #3890

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
