### PR TITLE
fix(chat): add click to tablet preview text (Issue #3929)

### DIFF
--- a/apps/chat/src/components/AppsEditor/GeneralInfoView/GeneralInfoView.tsx
+++ b/apps/chat/src/components/AppsEditor/GeneralInfoView/GeneralInfoView.tsx
@@ -86,9 +86,7 @@ export const GeneralInfoView: React.FC<Props> = ({
     setPreviewMode(mode);
   };
 
-  const handleFullModeClick = (
-    e: React.MouseEvent<HTMLButtonElement, MouseEvent>,
-  ) => {
+  const handleFullModeClick = (e: React.MouseEvent<HTMLElement>) => {
     e.stopPropagation();
     handlePreviewModeChange(PreviewMode.full);
   };
@@ -160,11 +158,11 @@ export const GeneralInfoView: React.FC<Props> = ({
         </div>
 
         {isPreviewClosed && (
-          <div className="hidden h-full w-10 flex-col items-center space-y-3 border-l border-primary pt-4 hover:cursor-pointer md:flex">
-            <button
-              className="text-secondary hover:text-accent-primary"
-              onClick={handleFullModeClick}
-            >
+          <div
+            className="hidden h-full w-10 flex-col items-center space-y-3 border-l border-primary pt-4 hover:cursor-pointer md:flex"
+            onClick={handleFullModeClick}
+          >
+            <button className="text-secondary hover:text-accent-primary">
               <Tooltip tooltip={t('Expand preview')}>
                 <IconArrowsMaximize size={24} />
               </Tooltip>
@@ -178,25 +176,6 @@ export const GeneralInfoView: React.FC<Props> = ({
           </div>
         )}
       </div>
-
-      {isPreviewClosed && (
-        <div className="hidden h-full w-10 flex-col items-center space-y-3 border-l border-primary pt-4 hover:cursor-pointer xl:flex">
-          <button
-            className="text-secondary hover:text-accent-primary"
-            onClick={handleFullModeClick}
-          >
-            <Tooltip tooltip={t('Expand preview')}>
-              <IconArrowsMaximize size={24} />
-            </Tooltip>
-          </button>
-          <span
-            className="select-none text-primary"
-            style={{ writingMode: 'vertical-rl' }}
-          >
-            {t('Preview')}
-          </span>
-        </div>
-      )}
     </div>
   );
 };

--- a/apps/chat/src/components/AppsEditor/Settings/index.tsx
+++ b/apps/chat/src/components/AppsEditor/Settings/index.tsx
@@ -123,7 +123,7 @@ export const ApplicationSettings: React.FC<Props> = ({
     setPreviewMode(mode);
   };
 
-  const handlePreviewClick = () => {
+  const handleOpenPreview = () => {
     if (screenState > ScreenState.MD) {
       handlePreviewModeChange(PreviewMode.half);
     } else {
@@ -444,7 +444,7 @@ export const ApplicationSettings: React.FC<Props> = ({
         {isPreviewClosed && (
           <div
             className="flex h-full w-10 flex-col items-center space-y-3 border-l border-primary pt-4 transition-all duration-300 ease-in-out hover:cursor-pointer max-md:hidden xl:pt-5"
-            onClick={handlePreviewClick}
+            onClick={handleOpenPreview}
           >
             <button
               className="text-secondary hover:text-accent-primary"

--- a/apps/chat/src/components/AppsEditor/Settings/index.tsx
+++ b/apps/chat/src/components/AppsEditor/Settings/index.tsx
@@ -123,9 +123,11 @@ export const ApplicationSettings: React.FC<Props> = ({
     setPreviewMode(mode);
   };
 
-  const handleHalfModeClick = () => {
+  const handlePreviewClick = () => {
     if (screenState > ScreenState.MD) {
       handlePreviewModeChange(PreviewMode.half);
+    } else {
+      handlePreviewModeChange(PreviewMode.full);
     }
   };
 
@@ -442,7 +444,7 @@ export const ApplicationSettings: React.FC<Props> = ({
         {isPreviewClosed && (
           <div
             className="flex h-full w-10 flex-col items-center space-y-3 border-l border-primary pt-4 transition-all duration-300 ease-in-out hover:cursor-pointer max-md:hidden xl:pt-5"
-            onClick={handleHalfModeClick}
+            onClick={handlePreviewClick}
           >
             <button
               className="text-secondary hover:text-accent-primary"


### PR DESCRIPTION
**Description:**

[Tablet][App editor]: click on text "Preview <app's name> <app's version>" does not open preview

Issues:

- Issue #3929

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
