### PR TITLE
fix(chat): adjust padding to align 'Expand Preview' button height in both tabs (Issue #3955)

### DIFF
--- a/apps/chat/src/components/AppsEditor/Settings/index.tsx
+++ b/apps/chat/src/components/AppsEditor/Settings/index.tsx
@@ -374,7 +374,7 @@ export const ApplicationSettings: React.FC<Props> = ({
           )}
           data-qa="app-preview-settings"
         >
-          <div className="flex max-w-full items-center justify-between px-0 py-3 max-md:self-end md:px-5 md:py-4 xl:p-2">
+          <div className="flex max-w-full items-center justify-between px-0 py-3 max-md:self-end md:px-5 md:py-4 xl:px-5 xl:py-4">
             <div className="mr-2 hidden min-w-0 shrink grow gap-2 text-primary md:flex">
               <span>{t('Preview')}:</span>
               <span
@@ -443,7 +443,7 @@ export const ApplicationSettings: React.FC<Props> = ({
         </div>
         {isPreviewClosed && (
           <div
-            className="flex h-full w-10 flex-col items-center space-y-3 border-l border-primary pt-4 transition-all duration-300 ease-in-out hover:cursor-pointer max-md:hidden xl:pt-5"
+            className="flex h-full w-10 flex-col items-center space-y-3 border-l border-primary pt-4 transition-all duration-300 ease-in-out hover:cursor-pointer max-md:hidden xl:pt-4"
             onClick={handleOpenPreview}
           >
             <button


### PR DESCRIPTION
**Description:**

Aligns padding in the application editor so the "Expand Preview" button has consistent height across Settings and Preview tabs. Improves visual consistency when toggling tabs.

Issues:

- Issue #3955 

**UI changes**

Before: 
<img width="151" alt="Снимок экрана 2025-05-23 в 13 52 10" src="https://github.com/user-attachments/assets/95dfaebe-6356-44e9-acf5-f4f237354438" />
<img width="139" alt="Снимок экрана 2025-05-23 в 13 52 17" src="https://github.com/user-attachments/assets/43103b1d-c1bd-4937-9a74-8e04ba24cc72" />

After: 
<img width="354" alt="Снимок экрана 2025-05-23 в 14 08 16" src="https://github.com/user-attachments/assets/d43bf90a-e3de-40e1-869c-da3112044c7a" />
<img width="334" alt="Снимок экрана 2025-05-23 в 14 08 24" src="https://github.com/user-attachments/assets/9869ce96-d987-43ae-b33f-d2e7d22c93c3" />


**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
