### PR TITLE
fix(overlay): fix name of overlay manager method from replay to playback

### DIFF
--- a/apps/overlay-sandbox/app/cases/components/chatOverlayManagerWrapper.tsx
+++ b/apps/overlay-sandbox/app/cases/components/chatOverlayManagerWrapper.tsx
@@ -5,6 +5,8 @@ import { BackToButton } from './backToSelectOverlayMode';
 import {
   ChatOverlayManager,
   ChatOverlayManagerOptions,
+  OverlayConversation,
+  OverlayEvents,
 } from '@epam/ai-dial-overlay';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 
@@ -20,12 +22,95 @@ export const ChatOverlayManagerWrapper: React.FC<
   const [dialogInfo, setDialogInfo] = useState('');
   const [created, setCreated] = useState(false);
   const [conversationIdInputValue, setConversationIdInputValue] = useState('');
+  const [importedConversation, setImportedConversation] = useState('');
+  const [conversations, setConversations] = useState<OverlayConversation[]>([]);
+  const [conversationNewName, setConversationNewName] = useState('');
 
   const handleDisplayInformation = useCallback((textToShow: string) => {
     dialogRef.current?.showModal();
 
     setDialogInfo(textToShow);
   }, []);
+
+  const handleRefreshConversations = useCallback(async () => {
+    const convs = await overlayManager.current?.getConversations(
+      overlayManagerOptions.id,
+    );
+    setConversations(convs?.conversations ?? []);
+  }, [overlayManagerOptions.id]);
+
+  const handleDeleteConversation = useCallback(async () => {
+    await overlayManager.current?.deleteConversation(
+      overlayManagerOptions.id,
+      conversationIdInputValue,
+    );
+  }, [conversationIdInputValue, overlayManagerOptions.id]);
+
+  const handleCreatePlaybackConversation = useCallback(async () => {
+    const replayResult =
+      await overlayManager.current?.createPlaybackConversation(
+        overlayManagerOptions.id,
+        conversationIdInputValue,
+      );
+
+    handleDisplayInformation(
+      JSON.stringify(replayResult?.conversation, null, 2),
+    );
+  }, [
+    conversationIdInputValue,
+    handleDisplayInformation,
+    overlayManagerOptions.id,
+  ]);
+
+  const handleExportConversation = useCallback(async () => {
+    const convObject = await overlayManager.current?.exportConversation(
+      overlayManagerOptions.id,
+      conversationIdInputValue,
+    );
+
+    handleDisplayInformation(JSON.stringify(convObject, null, 2));
+  }, [
+    conversationIdInputValue,
+    handleDisplayInformation,
+    overlayManagerOptions.id,
+  ]);
+
+  const handleImportConversation = useCallback(async () => {
+    let parsedImportedConversation;
+    try {
+      parsedImportedConversation = JSON.parse(importedConversation);
+    } catch (e) {
+      console.warn('Invalid imported conversation', e);
+      return;
+    }
+    const convObject = await overlayManager.current?.importConversation(
+      overlayManagerOptions.id,
+      parsedImportedConversation,
+    );
+
+    handleDisplayInformation(JSON.stringify(convObject, null, 2));
+  }, [
+    handleDisplayInformation,
+    importedConversation,
+    overlayManagerOptions.id,
+  ]);
+
+  const handleRenameConversation = useCallback(async () => {
+    const replayResult = await overlayManager.current?.renameConversation(
+      overlayManagerOptions.id,
+      conversationIdInputValue,
+      conversationNewName,
+    );
+
+    handleDisplayInformation(
+      JSON.stringify(replayResult?.conversation, null, 2),
+    );
+  }, [
+    conversationIdInputValue,
+    conversationNewName,
+    handleDisplayInformation,
+    overlayManagerOptions.id,
+  ]);
 
   useEffect(() => {
     if (!overlayManager.current) {
@@ -59,6 +144,27 @@ export const ChatOverlayManagerWrapper: React.FC<
       () => console.info('START GENERATING'),
     );
 
+    overlayManager.current?.subscribe(
+      overlayManagerOptions.id,
+      '@DIAL_OVERLAY/SELECTED_CONVERSATION_LOADED',
+      async (info) => {
+        console.info('Conversation selected - ');
+        const { messages } = await overlayManager.current!.getMessages(
+          overlayManagerOptions.id,
+        );
+        console.info('messages', messages);
+
+        console.info(JSON.stringify(info, null, 2));
+      },
+    );
+    overlayManager.current?.subscribe(
+      overlayManagerOptions.id,
+      `@DIAL_OVERLAY/${OverlayEvents.conversationsUpdated}`,
+      async () => {
+        console.info('Conversations updated');
+      },
+    );
+
     overlayManager.current
       ?.getMessages(overlayManagerOptions.id)
       .then((messages) => {
@@ -81,102 +187,126 @@ export const ChatOverlayManagerWrapper: React.FC<
         <p className="whitespace-pre-wrap">{dialogInfo}</p>
       </dialog>
 
-      <div className="flex max-w-[300px] flex-col gap-2">
+      <div className="flex max-w-[600px] flex-col gap-2">
         <BackToButton />
-        <details>
+        <details open={true}>
           <summary>Chat actions</summary>
 
-          <div className="flex flex-col gap-2">
-            <button
-              className="button"
-              onClick={() => {
-                overlayManager.current?.sendMessage(
-                  overlayManagerOptions.id,
-                  'Hello',
-                );
-              }}
-            >
-              Send &apos;Hello&apos; to Chat
-            </button>
+          <div className="grid grid-cols-2 gap-2">
+            <div className="flex flex-col gap-2">
+              <button
+                className="button"
+                onClick={() => {
+                  overlayManager.current?.sendMessage(
+                    overlayManagerOptions.id,
+                    'Hello',
+                  );
+                }}
+              >
+                Send &apos;Hello&apos; to Chat
+              </button>
 
-            <button
-              className="button"
-              onClick={() => {
-                overlayManager.current?.setSystemPrompt(
-                  overlayManagerOptions.id,
-                  'End each word with string "!?!?!"',
-                );
-              }}
-            >
-              Set system prompt: End each word with string &quot;!?!?!&quot;
-            </button>
+              <button
+                className="button"
+                onClick={() => {
+                  overlayManager.current?.setSystemPrompt(
+                    overlayManagerOptions.id,
+                    'End each word with string "!?!?!"',
+                  );
+                }}
+              >
+                Set system prompt: End each word with string &quot;!?!?!&quot;
+              </button>
 
-            <button
-              className="button"
-              onClick={async () => {
-                const messages = await overlayManager.current?.getMessages(
-                  overlayManagerOptions.id,
-                );
-
-                handleDisplayInformation(JSON.stringify(messages, null, 2));
-              }}
-            >
-              Get messages
-            </button>
-
-            <button
-              className="button"
-              onClick={async () => {
-                const conversations =
-                  await overlayManager.current?.getConversations(
+              <button
+                className="button"
+                onClick={async () => {
+                  const messages = await overlayManager.current?.getMessages(
                     overlayManagerOptions.id,
                   );
 
-                handleDisplayInformation(
-                  JSON.stringify(conversations, null, 2),
-                );
-              }}
-            >
-              Get conversations
-            </button>
+                  handleDisplayInformation(JSON.stringify(messages, null, 2));
+                }}
+                data-qa="get-messages"
+              >
+                Get messages
+              </button>
 
-            <button
-              className="button"
-              onClick={async () => {
-                const conversation =
-                  await overlayManager.current?.createConversation(
-                    overlayManagerOptions.id,
+              <button
+                className="button"
+                onClick={async () => {
+                  const conversations =
+                    await overlayManager.current?.getConversations(
+                      overlayManagerOptions.id,
+                    );
+
+                  handleDisplayInformation(
+                    JSON.stringify(conversations, null, 2),
                   );
+                }}
+                data-qa="get-conversations"
+              >
+                Get conversations
+              </button>
 
-                handleDisplayInformation(JSON.stringify(conversation, null, 2));
-              }}
-            >
-              Create conversation
-            </button>
+              <button
+                className="button"
+                onClick={async () => {
+                  const conversations =
+                    await overlayManager.current?.getSelectedConversations(
+                      overlayManagerOptions.id,
+                    );
 
-            <button
-              className="button"
-              onClick={async () => {
-                const conversation =
-                  await overlayManager.current?.createConversation(
-                    overlayManagerOptions.id,
-                    'test-inner-folder-root/test-inner-folder-child',
+                  handleDisplayInformation(
+                    JSON.stringify(conversations, null, 2),
                   );
+                }}
+                data-qa="get-selected-conversations"
+              >
+                Get selected conversations
+              </button>
 
-                handleDisplayInformation(JSON.stringify(conversation, null, 2));
-              }}
-            >
-              Create conversation in inner folder
-            </button>
-
-            <div className="flex flex-col gap-1 border p-1">
               <button
                 className="button"
                 onClick={async () => {
                   const conversation =
-                    await overlayManager.current?.selectConversation(
+                    await overlayManager.current?.createLocalConversation(
                       overlayManagerOptions.id,
-                      conversationIdInputValue,
+                    );
+
+                  handleDisplayInformation(
+                    JSON.stringify(conversation, null, 2),
+                  );
+                }}
+                data-qa="create-local-conversation"
+              >
+                Create local conversation
+              </button>
+
+              <button
+                className="button"
+                onClick={async () => {
+                  const conversation =
+                    await overlayManager.current?.createConversation(
+                      overlayManagerOptions.id,
+                    );
+
+                  handleDisplayInformation(
+                    JSON.stringify(conversation, null, 2),
+                  );
+                }}
+                data-qa="create-conversation"
+              >
+                Create conversation
+              </button>
+
+              <button
+                className="button"
+                onClick={async () => {
+                  const conversation =
+                    await overlayManager.current?.createConversation(
+                      overlayManagerOptions.id,
+                      'test-inner-folder-root/test-inner-folder-child',
                     );
 
                   handleDisplayInformation(
@@ -184,14 +314,111 @@ export const ChatOverlayManagerWrapper: React.FC<
                   );
                 }}
               >
-                Select conversation by ID
+                Create conversation in inner folder
               </button>
+
+              <div className="flex flex-col gap-1 border p-1">
+                <button
+                  className="button"
+                  onClick={handleImportConversation}
+                  data-qa="import-conversation"
+                >
+                  Import conversation
+                </button>
+
+                <input
+                  className="border"
+                  placeholder="Imported conversation object"
+                  value={importedConversation}
+                  onChange={(e) => setImportedConversation(e.target.value)}
+                  data-qa="imported-conversation"
+                />
+              </div>
+            </div>
+
+            <div className="flex flex-col gap-1 border p-1">
               <textarea
                 className="border"
                 placeholder="Type conversation ID"
                 value={conversationIdInputValue}
                 onChange={(e) => setConversationIdInputValue(e.target.value)}
               />
+
+              <div className="flex gap-1 overflow-x-hidden">
+                <select
+                  className="max-w-[70%] shrink"
+                  value={conversationIdInputValue}
+                  onChange={(e) =>
+                    setConversationIdInputValue((e.target as any).value)
+                  }
+                >
+                  {conversations.map((conv) => (
+                    <option className="truncate" key={conv.id}>
+                      {conv.id}
+                    </option>
+                  ))}
+                </select>
+                <button className="button" onClick={handleRefreshConversations}>
+                  Refresh
+                </button>
+              </div>
+
+              <div className="flex flex-col gap-1 border p-1">
+                <button
+                  className="button"
+                  onClick={async () => {
+                    const conversation =
+                      await overlayManager.current?.selectConversation(
+                        overlayManagerOptions.id,
+                        conversationIdInputValue,
+                      );
+
+                    handleDisplayInformation(
+                      JSON.stringify(conversation, null, 2),
+                    );
+                  }}
+                >
+                  Select conversation by ID
+                </button>
+
+                <button
+                  className="button"
+                  onClick={handleDeleteConversation}
+                  data-qa="delete-conversation-by-id"
+                >
+                  Delete conversation by ID
+                </button>
+                <button
+                  className="button"
+                  onClick={handleCreatePlaybackConversation}
+                  data-qa="playback-conversation-by-id"
+                >
+                  Create playback conversation by source conversation ID
+                </button>
+                <button
+                  className="button"
+                  onClick={handleExportConversation}
+                  data-qa="export-conversation-by-id"
+                >
+                  Trigger Export conversation by source conversation ID
+                </button>
+                <div>
+                  <button
+                    className="button"
+                    onClick={handleRenameConversation}
+                    data-qa="rename-conversation-by-id"
+                  >
+                    Rename conversation by source conversation ID
+                  </button>
+                  <input
+                    className="border"
+                    placeholder="New name"
+                    value={conversationNewName}
+                    onChange={(e) => setConversationNewName(e.target.value)}
+                    data-qa="conversation-new-name"
+                  />
+                </div>
+              </div>
             </div>
           </div>
         </details>
@@ -209,6 +436,7 @@ export const ChatOverlayManagerWrapper: React.FC<
 
                 newOptions.theme = 'dark';
                 newOptions.modelId = 'stability.stable-diffusion-xl';
+                newOptions.newConversationsFolderId = 'new-folder';
 
                 overlayManager.current?.setOverlayOptions(
                   overlayManagerOptions.id,

--- a/apps/overlay-sandbox/app/cases/components/chatOverlayManagerWrapper.tsx
+++ b/apps/overlay-sandbox/app/cases/components/chatOverlayManagerWrapper.tsx
@@ -436,7 +436,6 @@ export const ChatOverlayManagerWrapper: React.FC<
 
                 newOptions.theme = 'dark';
                 newOptions.modelId = 'stability.stable-diffusion-xl';
-                newOptions.newConversationsFolderId = 'new-folder';
 
                 overlayManager.current?.setOverlayOptions(
                   overlayManagerOptions.id,

--- a/apps/overlay-sandbox/app/cases/components/chatOverlayWrapper.tsx
+++ b/apps/overlay-sandbox/app/cases/components/chatOverlayWrapper.tsx
@@ -328,6 +328,7 @@ export const ChatOverlayWrapper: React.FC<ChatOverlayWrapperProps> = ({
                   Refresh
                 </button>
               </div>
+
               <div className="flex flex-col gap-1 border p-1">
                 <button
                   className="button"

--- a/apps/overlay-sandbox/app/cases/overlay/new-conversations-folder-id-set-sandbox/page.tsx
+++ b/apps/overlay-sandbox/app/cases/overlay/new-conversations-folder-id-set-sandbox/page.tsx
@@ -8,8 +8,7 @@ import {
 import { Feature } from '@epam/ai-dial-shared';
 
 // Use your bucket for testing
-const bucket =
-  '3s5mL6jaqKuWBohoam9sRw7jeqixBDW5QSQezNrvhvu36fKFb8FkRVrpyqx8sQzaSj';
+const bucket = process.env.NEXT_PUBLIC_OVERLAY_USER_BUCKET;
 const overlayOptions = {
   ...commonOverlayProps,
   newConversationsFolderId: `conversations/${bucket}/test-folder`,

--- a/apps/overlay-sandbox/app/cases/overlay/new-conversations-folder-id-set-sandbox/page.tsx
+++ b/apps/overlay-sandbox/app/cases/overlay/new-conversations-folder-id-set-sandbox/page.tsx
@@ -8,7 +8,8 @@ import {
 import { Feature } from '@epam/ai-dial-shared';
 
 // Use your bucket for testing
-const bucket = process.env.NEXT_PUBLIC_OVERLAY_USER_BUCKET;
+const bucket =
+  '3s5mL6jaqKuWBohoam9sRw7jeqixBDW5QSQezNrvhvu36fKFb8FkRVrpyqx8sQzaSj';
 const overlayOptions = {
   ...commonOverlayProps,
   newConversationsFolderId: `conversations/${bucket}/test-folder`,

--- a/libs/overlay/src/lib/ChatOverlay.ts
+++ b/libs/overlay/src/lib/ChatOverlay.ts
@@ -517,6 +517,8 @@ export class ChatOverlay {
 
   /**
    * Create local conversation which will be not visible before first assistant message
+   *
+   * Note: after first assistant message local conversation will be saved in `newConversationsFolderId` option path, or in user Root if it's not defined or null
    * @returns Returns created local conversation info
    */
   public async createLocalConversation(): Promise<CreateLocalConversationResponse> {

--- a/libs/overlay/src/lib/ChatOverlayManager.ts
+++ b/libs/overlay/src/lib/ChatOverlayManager.ts
@@ -496,7 +496,10 @@ export class ChatOverlayManager {
     return overlay.deleteConversation(conversationId);
   }
 
-  public async replayConversation(overlayId: string, conversationId: string) {
+  public async createPlaybackConversation(
+    overlayId: string,
+    conversationId: string,
+  ) {
     const { overlay } = this.getOverlay(overlayId);
 
     return overlay.createPlaybackConversation(conversationId);


### PR DESCRIPTION
**Description:**

Fix issue with incorrect name of method to create playback conversation in chat overlay manager

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
