### PR TITLE
feat(chat): add application type schema icon URL support in ModelIcon and related types (Issue #3975)

### DIFF
--- a/apps/chat/src/components/Chat/TalkTo/__tests__/TalkToSlider.test.tsx
+++ b/apps/chat/src/components/Chat/TalkTo/__tests__/TalkToSlider.test.tsx
@@ -43,7 +43,8 @@ const mockInstalledModelIds = new Set(['model1', 'model2']);
 vi.mock('@/src/store/hooks', async () => {
   return {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    useAppSelector: (selector: any) => selector({}),
+    useAppSelector: (selector: any) =>
+      typeof selector === 'function' ? selector() : selector,
     useAppDispatch: () => (action: AppAction) => action,
   };
 });
@@ -58,6 +59,9 @@ vi.mock('@/src/store/selectors', () => ({
     selectEnabledFeatures: vi.fn(),
     isSharingEnabled: vi.fn(),
     selectIsPublishingEnabled: vi.fn(),
+  },
+  ApplicationTypesSchemasSelectors: {
+    selectApplicationTypesSchemas: vi.fn(),
   },
 }));
 

--- a/apps/chat/src/components/Chatbar/ModelIcon.tsx
+++ b/apps/chat/src/components/Chatbar/ModelIcon.tsx
@@ -53,7 +53,7 @@ const ModelIconTemplate = memo(
     );
 
     const schemaApplicationFallbackUrl = useMemo(() => {
-      const iconUrl = applicationTypeSchemas.find(
+      const iconUrl = applicationTypeSchemas?.find(
         (schema) => schema.id === entity?.applicationTypeSchemaId,
       )?.iconUrl;
       if (!iconUrl) return null;

--- a/apps/chat/src/components/Chatbar/ModelIcon.tsx
+++ b/apps/chat/src/components/Chatbar/ModelIcon.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable jsx-a11y/alt-text */
 
 /* eslint-disable @next/next/no-img-element */
-import { memo, useCallback, useRef } from 'react';
+import { memo, useCallback, useMemo, useRef } from 'react';
 
 import classNames from 'classnames';
 
@@ -13,6 +13,9 @@ import { ApiUtils } from '@/src/utils/server/api';
 
 import { EntityType } from '@/src/types/common';
 import { DialAIEntity } from '@/src/types/models';
+
+import { useAppSelector } from '@/src/store/hooks';
+import { ApplicationTypesSchemasSelectors } from '@/src/store/selectors';
 
 import { Tooltip } from '@/src/components/Common/Tooltip';
 
@@ -45,9 +48,20 @@ const ModelIconTemplate = memo(
         ? getThemeIconUrl('default-addon')
         : getThemeIconUrl('default-model');
     const description = entity ? getOpenAIEntityFullName(entity) : entityId;
+    const applicationTypeSchemas = useAppSelector(
+      ApplicationTypesSchemasSelectors.selectAllSchemas,
+    );
+
+    const schemaApplicationFallbackUrl = useMemo(() => {
+      const iconUrl = applicationTypeSchemas.find(
+        (schema) => schema.id === entity?.applicationTypeSchemaId,
+      )?.iconUrl;
+      if (!iconUrl) return null;
+      return getThemeIconUrl(iconUrl);
+    }, [applicationTypeSchemas, entity?.applicationTypeSchemaId]);
 
     const getIconUrl = (entity: DialAIEntity | undefined) => {
-      if (!entity?.iconUrl) return fallbackUrl;
+      if (!entity?.iconUrl) return schemaApplicationFallbackUrl ?? fallbackUrl;
 
       if (isApplicationId(entity.id)) {
         return constructPath('/api', ApiUtils.encodeApiUrl(entity.iconUrl));

--- a/apps/chat/src/types/application-type-schema.ts
+++ b/apps/chat/src/types/application-type-schema.ts
@@ -4,6 +4,7 @@ export enum ApplicationTypeSchemaProperties {
   applicationTypeDisplayName = 'dial:applicationTypeDisplayName',
   applicationTypeEditorUrl = 'dial:applicationTypeEditorUrl',
   applicationTypeViewerUrl = 'dial:applicationTypeViewerUrl',
+  applicationTypeIconUrl = 'dial:applicationTypeIconUrl',
 }
 
 export interface ApiApplicationTypeSchema {
@@ -11,6 +12,7 @@ export interface ApiApplicationTypeSchema {
   [ApplicationTypeSchemaProperties.applicationTypeDisplayName]: string;
   [ApplicationTypeSchemaProperties.applicationTypeEditorUrl]?: string;
   [ApplicationTypeSchemaProperties.applicationTypeViewerUrl]?: string;
+  [ApplicationTypeSchemaProperties.applicationTypeIconUrl]?: string;
 }
 
 export interface ApplicationTypeSchema {
@@ -18,6 +20,7 @@ export interface ApplicationTypeSchema {
   displayName: string;
   editorUrl?: string;
   viewerUrl?: string;
+  iconUrl?: string;
 }
 
 export interface ApiDetailedApplicationTypeSchema extends JSONSchema7 {

--- a/apps/chat/src/types/models.ts
+++ b/apps/chat/src/types/models.ts
@@ -86,6 +86,7 @@ export interface DialAIEntity {
     encoding?: TiktokenEncoding;
     tokensPerMessage?: number;
   };
+  applicationTypeSchemaId?: string;
 }
 
 export interface DialAIEntityModel

--- a/apps/chat/src/utils/app/application-type-schema.ts
+++ b/apps/chat/src/utils/app/application-type-schema.ts
@@ -13,6 +13,7 @@ export const convertApplicationTypeSchemaFromApi = (
       schema[ApplicationTypeSchemaProperties.applicationTypeDisplayName],
     editorUrl: schema[ApplicationTypeSchemaProperties.applicationTypeEditorUrl],
     viewerUrl: schema[ApplicationTypeSchemaProperties.applicationTypeViewerUrl],
+    iconUrl: schema[ApplicationTypeSchemaProperties.applicationTypeIconUrl],
   };
 };
 


### PR DESCRIPTION
… and related types

**Description:**

add support for default icons from the application schema.

Issues:

- Issue #3975 

**UI changes**

![image](https://github.com/user-attachments/assets/03467bea-0af8-4d65-ac60-1e5693d64657)

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
