### PR TITLE
fix(chat): fix prompt title for create (#3650)

### DIFF
--- a/apps/chat/src/components/Promptbar/components/PromptModal.tsx
+++ b/apps/chat/src/components/Promptbar/components/PromptModal.tsx
@@ -106,7 +106,7 @@ const PromptModalView = () => {
     !isNewPromptCreating && !isPromptInitModeEdit,
   );
 
-  const headingKey = isViewMode
+  const promptModalTitle = isViewMode
     ? 'View prompt'
     : isNewPromptCreating
       ? 'Create prompt'
@@ -138,7 +138,7 @@ const PromptModalView = () => {
           'text-error',
       )}
       state={isLoading ? ModalState.LOADING : ModalState.OPENED}
-      heading={t(headingKey)}
+      heading={t(promptModalTitle)}
       hideClose={!isViewMode}
       onClose={handleClose}
     >

--- a/apps/chat/src/components/Promptbar/components/PromptModal.tsx
+++ b/apps/chat/src/components/Promptbar/components/PromptModal.tsx
@@ -106,6 +106,12 @@ const PromptModalView = () => {
     !isNewPromptCreating && !isPromptInitModeEdit,
   );
 
+  const headingKey = isViewMode
+    ? 'View prompt'
+    : isNewPromptCreating
+      ? 'Create prompt'
+      : 'Edit prompt';
+
   const dispatch = useAppDispatch();
 
   const handleToggleEditMode = useCallback((isOpen: boolean) => {
@@ -132,7 +138,7 @@ const PromptModalView = () => {
           'text-error',
       )}
       state={isLoading ? ModalState.LOADING : ModalState.OPENED}
-      heading={t(isViewMode ? 'View prompt' : 'Edit prompt')}
+      heading={t(headingKey)}
       hideClose={!isViewMode}
       onClose={handleClose}
     >


### PR DESCRIPTION
**Description:**

The name is 'Create prompt'
Be sure to test that if user click on Edit button, the modal is named 'Edit prompt', also we have 'View prompt'

Issues:

- Issue #3650 

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
