### PR TITLE
fix(chat): turn off extended search (Issue #4058)

### DIFF
--- a/apps/chat/src/constants/search.ts
+++ b/apps/chat/src/constants/search.ts
@@ -8,7 +8,7 @@ export const MODELS_SEARCH_OPTIONS: IFuseOptions<DialAIEntityModel> = {
   distance: 100,
   minMatchCharLength: 1,
   ignoreLocation: true,
-  useExtendedSearch: true,
+  useExtendedSearch: false,
   findAllMatches: false,
   isCaseSensitive: false,
   includeScore: false,


### PR DESCRIPTION
**Description:**

- turn off extendedSearch featrue because it's not required for $and, $or operators to work properly

Issues:

- Issue #4058

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
