### PR TITLE
chore(chat): get rid of build warnings (next.js patch) (Issue #4093)

### DIFF
--- a/apps/chat/src/utils/server/chat.ts
+++ b/apps/chat/src/utils/server/chat.ts
@@ -8,7 +8,6 @@ import { errorsMessages } from '@/src/constants/errors';
 import { logger } from './logger';
 
 import { Message, Role } from '@epam/ai-dial-shared';
-import { Blob } from 'buffer';
 import { Tiktoken, TiktokenEncoding, get_encoding } from 'tiktoken';
 
 // This is very conservative calculations of tokens (1 token = 1 byte)

--- a/tools/patch-nextjs.js
+++ b/tools/patch-nextjs.js
@@ -63,6 +63,13 @@ replaceContentInNodeModule(
 
 replaceContentInNodeModule(
   'next',
+  'dist/server/config-schema.js',
+  'basePath: _zod.z.string().optional()',
+  'basePath: _zod.z.string().or(_zod.z.record(_zod.z.any())).optional()',
+);
+
+replaceContentInNodeModule(
+  'next',
   'dist/build/webpack/loaders/next-font-loader/index.js',
   'if (assetPrefix && !/^\\/|https?:\\/\\//.test(assetPrefix))',
   'if (false)',


### PR DESCRIPTION
**Description:**

get rid of build warnings (next.js patch)

**Issues:**
- Issue #4093

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
