### PR TITLE
feat(chat): change regenerating of conversation name behavior (Issue #4122, #1232)

### DIFF
--- a/apps/chat-e2e/src/tests/chatBarConversation.test.ts
+++ b/apps/chat-e2e/src/tests/chatBarConversation.test.ts
@@ -1581,13 +1581,17 @@ dialTest(
     );
 
     await dialTest.step(
-      'Verify conversation name is updated on side bar, header and restricted symbols are removed from the name',
+      'Verify conversation name is not updated neither on side bar nor on the header',
       async () => {
         await conversationAssertion.assertEntityState(
           { name: expectedConversationName },
+          'hidden',
+        );
+        await conversationAssertion.assertEntityState(
+          { name: conversation.name },
           'visible',
         );
-        await chatHeaderAssertion.assertHeaderTitle(expectedConversationName);
+        await chatHeaderAssertion.assertHeaderTitle(conversation.name);
       },
     );
   },

--- a/apps/chat-e2e/src/tests/chatSwitch.test.ts
+++ b/apps/chat-e2e/src/tests/chatSwitch.test.ts
@@ -119,7 +119,6 @@ dialTest(
       );
       await dialHomePage.throttleAPIResponse(API.chatHost);
       await chat.sendRequestWithButton(request, false);
-      firstConversation.name = request;
     });
 
     await dialTest.step(

--- a/apps/chat-e2e/src/tests/compareMode.test.ts
+++ b/apps/chat-e2e/src/tests/compareMode.test.ts
@@ -1639,18 +1639,21 @@ dialTest(
         );
         await page.keyboard.press(keys.ctrlPlusV);
         copiedValue = await dialHomePage.readFromClipboard();
-        const expectedChatId = (modelId: string) =>
-          `${ItemUtil.getEncodedItemId(modelId)}${ItemUtil.entityIdSeparator}${ItemUtil.getEncodedItemId(copiedValue)}`;
+        const expectedChatId = (modelId: string, name: string) =>
+          `${ItemUtil.getEncodedItemId(modelId)}${ItemUtil.entityIdSeparator}${ItemUtil.getEncodedItemId(name)}`;
         await dialHomePage.waitForExpectedResponses(
           () => chatMessages.saveAndSubmit.click(),
           [
             {
               apiMethod: 'PUT',
-              urlPattern: expectedChatId(defaultModel.id),
+              urlPattern: expectedChatId(
+                defaultModel.id,
+                firstConversation.name,
+              ),
             },
             {
               apiMethod: 'PUT',
-              urlPattern: expectedChatId(aModel.id),
+              urlPattern: expectedChatId(aModel.id, secondConversation.name),
             },
           ],
         );
@@ -1663,11 +1666,11 @@ dialTest(
       async () => {
         await baseAssertion.assertElementText(
           leftChatHeader.chatTitle,
-          copiedValue,
+          firstConversation.name,
         );
         await baseAssertion.assertElementText(
           rightChatHeader.chatTitle,
-          copiedValue + ' 1',
+          secondConversation.name,
         );
         await baseAssertion.assertElementsCount(
           chatMessages.compareChatMessages,
@@ -1691,9 +1694,7 @@ dialTest(
       'Edit left chat title and verify it is updated in the header',
       async () => {
         const newLeftChatName = GeneratorUtil.randomString(7);
-        await conversations.openEntityDropdownMenu(updatedRequestContent, {
-          exactMatch: true,
-        });
+        await conversations.openEntityDropdownMenu(firstConversation.name);
         await conversationDropdownMenu.selectMenuOption(MenuOptions.rename);
         await renameConversationModal.editConversationNameWithSaveButton(
           newLeftChatName,
@@ -1708,11 +1709,11 @@ dialTest(
     await dialTest.step(
       'Delete right chat and compare mode closed, left chat is active',
       async () => {
-        await conversations.openEntityDropdownMenu(updatedRequestContent, 1);
+        await conversations.openEntityDropdownMenu(secondConversation.name);
         await conversationDropdownMenu.selectMenuOption(MenuOptions.delete);
         await confirmationDialog.confirm({ triggeredHttpMethod: 'DELETE' });
         await conversationAssertion.assertEntityState(
-          { name: updatedRequestContent, index: 1 },
+          { name: secondConversation.name },
           'hidden',
         );
         await baseAssertion.assertElementState(compare, 'hidden');

--- a/apps/chat-e2e/src/tests/compareMode.test.ts
+++ b/apps/chat-e2e/src/tests/compareMode.test.ts
@@ -1555,7 +1555,6 @@ dialTest(
     const firstConversationRequests = ['1+2', '2+3', '3+4'];
     const secondConversationRequests = ['1+2', '4+5', '5+6'];
     let updatedRequestContent: string;
-    let copiedValue: string;
 
     await dialTest.step(
       'Prepare two conversations for compare mode',
@@ -1636,7 +1635,6 @@ dialTest(
           MockedChatApiResponseBodies.simpleTextBody,
         );
         await page.keyboard.press(keys.ctrlPlusV);
-        copiedValue = await dialHomePage.readFromClipboard();
         const expectedChatId = (modelId: string, name: string) =>
           `${ItemUtil.getEncodedItemId(modelId)}${ItemUtil.entityIdSeparator}${ItemUtil.getEncodedItemId(name)}`;
         await dialHomePage.waitForExpectedResponses(

--- a/apps/chat-e2e/src/ui/webElements/chat.ts
+++ b/apps/chat-e2e/src/ui/webElements/chat.ts
@@ -274,15 +274,15 @@ export class Chat extends BaseElement {
   }
 
   public async saveAndSubmitRequest(waitForAnswer = false) {
-    const moveResponsePromise = this.page.waitForResponse((resp) =>
-      resp.url().includes(API.moveHost),
+    const updateResponsePromise = this.page.waitForResponse(
+      (resp) => resp.request().method() === 'PUT',
     );
     const request = this.sendRequest(
       undefined,
       () => this.getChatMessages().saveAndSubmit.click(),
       waitForAnswer,
     );
-    await moveResponsePromise;
+    await updateResponsePromise;
     return request;
   }
 

--- a/apps/chat/src/components/Chat/RenameConversationModal.tsx
+++ b/apps/chat/src/components/Chat/RenameConversationModal.tsx
@@ -102,7 +102,7 @@ function RenameConversationView() {
       dispatch(
         ConversationsActions.updateConversation({
           id: renamingConversation.id,
-          values: { name: newName, isNameChanged: true },
+          values: { name: newName },
           publicationUrl: renamingConversation.publicationInfo?.publicationUrl,
         }),
       );

--- a/apps/chat/src/store/conversations/conversations.epics.ts
+++ b/apps/chat/src/store/conversations/conversations.epics.ts
@@ -1283,7 +1283,7 @@ const sendMessageEpic: AppEpic = (action$, state$) =>
         const newConversationName =
           isReplayConversation(payload.conversation) ||
           updatedMessages.filter((msg) => msg.role === Role.User).length > 1 ||
-          excludeSystemMessages(payload.conversation.messages).length > 0
+          !isEntityIdLocal(payload.conversation)
             ? payload.conversation.name
             : getNextDefaultName(
                 getNewConversationName(payload.conversation, payload.message),

--- a/apps/chat/src/store/conversations/conversations.epics.ts
+++ b/apps/chat/src/store/conversations/conversations.epics.ts
@@ -1283,7 +1283,7 @@ const sendMessageEpic: AppEpic = (action$, state$) =>
         const newConversationName =
           isReplayConversation(payload.conversation) ||
           updatedMessages.filter((msg) => msg.role === Role.User).length > 1 ||
-          payload.conversation.isNameChanged
+          excludeSystemMessages(payload.conversation.messages).length > 0
             ? payload.conversation.name
             : getNextDefaultName(
                 getNewConversationName(payload.conversation, payload.message),

--- a/apps/chat/src/store/overlay/overlay.epics.ts
+++ b/apps/chat/src/store/overlay/overlay.epics.ts
@@ -624,7 +624,7 @@ const renameConversationEpic: AppEpic = (action$, state$) =>
         of(
           ConversationsActions.updateConversation({
             id: conversation.id,
-            values: { name: payload.newName, isNameChanged: true },
+            values: { name: payload.newName },
             publicationUrl: selectedPublicationUrl,
           }),
         ),

--- a/apps/chat/src/utils/app/__tests__/importExports.test.ts
+++ b/apps/chat/src/utils/app/__tests__/importExports.test.ts
@@ -120,7 +120,6 @@ describe('cleanData Functions', () => {
     assistantModelId: 'gpt-4',
     folderId: getConversationRootId(bucket),
     updatedAt: expect.any(Number),
-    isNameChanged: undefined,
   };
 
   describe('cleaning v1 data', () => {

--- a/apps/chat/src/utils/app/clean.ts
+++ b/apps/chat/src/utils/app/clean.ts
@@ -94,7 +94,6 @@ export const cleanConversation = (
     selectedAddons: conversation.selectedAddons ?? [],
     assistantModelId,
     updatedAt: conversation.updatedAt || conversation.lastActivityDate || 0,
-    isNameChanged: conversation.isNameChanged,
     ...(conversation.playback && {
       playback: {
         ...conversation.playback,

--- a/libs/shared/src/types/chat.ts
+++ b/libs/shared/src/types/chat.ts
@@ -176,5 +176,4 @@ export interface Conversation extends ShareEntity, ConversationInfo {
   assistantModelId?: string;
 
   isMessageStreaming?: boolean;
-  isNameChanged?: boolean;
 }


### PR DESCRIPTION
**Description:**

change regenerating of conversation name behavior

Issues:

- Issue #4122
- Issue #1232

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
