### PR TITLE
fix(chat): remove unpublish icon button if prompt is on review stage (Issue #3604)

### DIFF
--- a/apps/chat/src/components/Promptbar/components/Prompt.tsx
+++ b/apps/chat/src/components/Promptbar/components/Prompt.tsx
@@ -254,7 +254,12 @@ export const PromptComponent = ({
         )}
         onClick={() => {
           if (!isSelectMode) {
-            dispatch(PromptsActions.selectPrompt({ promptId: prompt.id }));
+            dispatch(
+              PromptsActions.selectPrompt({
+                promptId: prompt.id,
+                isApproveRequiredResource,
+              }),
+            );
           }
 
           if (isSelectMode && !isExternal) {

--- a/apps/chat/src/components/Promptbar/components/ViewPromptButtons.tsx
+++ b/apps/chat/src/components/Promptbar/components/ViewPromptButtons.tsx
@@ -21,7 +21,11 @@ import { FeatureType, ScreenState } from '@/src/types/common';
 import { Prompt } from '@/src/types/prompt';
 
 import { useAppSelector } from '@/src/store/hooks';
-import { PublicationSelectors, SettingsSelectors } from '@/src/store/selectors';
+import {
+  PromptsSelectors,
+  PublicationSelectors,
+  SettingsSelectors,
+} from '@/src/store/selectors';
 
 import { ContextMenu } from '@/src/components/Common/ContextMenu';
 import { IconButton } from '@/src/components/Common/IconButton';
@@ -52,6 +56,9 @@ export const ViewPromptButtons: React.FC<Props> = ({ prompt, onEditMode }) => {
   );
   const isSharingEnabled = useAppSelector((state) =>
     SettingsSelectors.isSharingEnabled(state, FeatureType.Prompt),
+  );
+  const { isSelectedPromptApproveRequiredResource } = useAppSelector(
+    PromptsSelectors.selectSelectedPromptId,
   );
 
   const isApproveRequiredEntitySelected = useAppSelector((state) =>
@@ -111,7 +118,10 @@ export const ViewPromptButtons: React.FC<Props> = ({ prompt, onEditMode }) => {
       },
       {
         name: 'Unpublish',
-        display: isPublic && isPublishingEnabled,
+        display:
+          isPublic &&
+          isPublishingEnabled &&
+          !isSelectedPromptApproveRequiredResource,
         dataQa: 'unpublish-prompt',
         Icon: (props: IconProps) => (
           <UnpublishIcon {...props} style={{ strokeWidth: 1.1 }} />
@@ -134,21 +144,22 @@ export const ViewPromptButtons: React.FC<Props> = ({ prompt, onEditMode }) => {
       },
     ],
     [
-      handleDelete,
+      isMyPrompt,
+      isApproveRequiredEntitySelected,
+      onEditMode,
       handleDuplicate,
       handleExport,
-      handleInfo,
       handleMoveToFolder,
-      handlePublish,
-      handleShare,
-      handleUnpublish,
-      isMyPrompt,
-      isPublic,
-      isPublishingEnabled,
-      isApproveRequiredEntitySelected,
       isSharingEnabled,
-      onEditMode,
+      handleShare,
+      isPublishingEnabled,
+      handlePublish,
+      isPublic,
+      isSelectedPromptApproveRequiredResource,
+      handleUnpublish,
+      handleInfo,
       prompt.sharedWithMe,
+      handleDelete,
     ],
   );
 


### PR DESCRIPTION
**Description:**

remove unpublish icon button if prompt is on review stage

Issues:

- Issue #3604 

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
