### PR TITLE
fix(overlay): fix new conversation name when conversation folder id (Issue #4049)

### DIFF
--- a/apps/chat/src/store/conversations/conversations.epics.ts
+++ b/apps/chat/src/store/conversations/conversations.epics.ts
@@ -1294,8 +1294,7 @@ const sendMessageEpic: AppEpic = (action$, state$) =>
                     (conv.folderId === payload.conversation.folderId ||
                       (isEntityIdLocal(payload.conversation) &&
                         (isOverlay && overlayNewConversationsFolder
-                          ? conv.folderId ===
-                            overlayNewConversationsFolder
+                          ? conv.folderId === overlayNewConversationsFolder
                           : conv.folderId === conversationRootFolderId))) &&
                     !selectedConversationIds.includes(conv.id),
                 ),

--- a/apps/chat/src/store/conversations/conversations.epics.ts
+++ b/apps/chat/src/store/conversations/conversations.epics.ts
@@ -1293,10 +1293,10 @@ const sendMessageEpic: AppEpic = (action$, state$) =>
                   (conv) =>
                     (conv.folderId === payload.conversation.folderId ||
                       (isEntityIdLocal(payload.conversation) &&
-                        (!isOverlay
-                          ? conv.folderId === conversationRootFolderId
-                          : conv.folderId ===
-                            overlayNewConversationsFolder))) &&
+                        (isOverlay && overlayNewConversationsFolder
+                          ? conv.folderId ===
+                            overlayNewConversationsFolder
+                          : conv.folderId === conversationRootFolderId))) &&
                     !selectedConversationIds.includes(conv.id),
                 ),
                 Math.max(

--- a/apps/chat/src/store/conversations/conversations.epics.ts
+++ b/apps/chat/src/store/conversations/conversations.epics.ts
@@ -1279,6 +1279,8 @@ const sendMessageEpic: AppEpic = (action$, state$) =>
         );
 
         const conversationRootFolderId = getConversationRootId();
+        const overlayNewConversationsFolder =
+          isOverlay && state$.value.overlay.newConversationsFolder;
 
         const newConversationName =
           isReplayConversation(payload.conversation) ||
@@ -1291,7 +1293,10 @@ const sendMessageEpic: AppEpic = (action$, state$) =>
                   (conv) =>
                     (conv.folderId === payload.conversation.folderId ||
                       (isEntityIdLocal(payload.conversation) &&
-                        conv.folderId === conversationRootFolderId)) &&
+                        (!isOverlay
+                          ? conv.folderId === conversationRootFolderId
+                          : conv.folderId ===
+                            overlayNewConversationsFolder))) &&
                     !selectedConversationIds.includes(conv.id),
                 ),
                 Math.max(


### PR DESCRIPTION
**Description:**

Generate conversation name using conversations from folder where conversation created

Issues:

- Issue #4049 


**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [ ] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
