### PR TITLE
fix(chat): fix infinity PublicationFolderRow component rerender (Issue #4170)

### DIFF
--- a/apps/chat/src/components/Chat/Publish/PublicationHandler/ReviewRowItems/PublicationFolderRow.tsx
+++ b/apps/chat/src/components/Chat/Publish/PublicationHandler/ReviewRowItems/PublicationFolderRow.tsx
@@ -62,12 +62,16 @@ export const PublicationFolderRow = <T extends PublicationReviewItem>({
   const selectedPublication = useAppSelector(
     PublicationSelectors.selectSelectedPublication,
   );
+
+  const collapsedSectionsSelector = useMemo(
+    () => PublicationSelectors.selectChosenFolderIds(allFolders, allItems),
+    [allFolders, allItems],
+  );
   const {
     fullyChosenFolderIds: selectedFolderIds,
     partialChosenFolderIds: partialSelectedFolderIds,
-  } = useAppSelector((state) =>
-    PublicationSelectors.selectChosenFolderIds(state, allFolders, allItems),
-  );
+  } = useAppSelector(collapsedSectionsSelector);
+
   const chosenItemsIds = useAppSelector(
     PublicationSelectors.selectSelectedItemsToPublish,
   );

--- a/apps/chat/src/components/Chat/Publish/PublicationItemsList.tsx
+++ b/apps/chat/src/components/Chat/Publish/PublicationItemsList.tsx
@@ -94,13 +94,12 @@ export const PublicationItemsList = memo(
       [conversationFolders, promptFolders],
     );
 
+    const collapsedSectionsSelector = useMemo(
+      () => PublicationSelectors.selectChosenFolderIds(memoizedItems, entities),
+      [memoizedItems, entities],
+    );
     const { fullyChosenFolderIds, partialChosenFolderIds } = useAppSelector(
-      (state) =>
-        PublicationSelectors.selectChosenFolderIds(
-          state,
-          memoizedItems,
-          entities,
-        ),
+      collapsedSectionsSelector,
     );
     const chosenItemsIds = useAppSelector(
       PublicationSelectors.selectSelectedItemsToPublish,

--- a/apps/chat/src/store/publication/publication.selectors.ts
+++ b/apps/chat/src/store/publication/publication.selectors.ts
@@ -127,7 +127,7 @@ const selectIsAllItemsUploaded = (state: RootState, featureType: FeatureType) =>
 const selectSelectedItemsToPublish = (state: RootState) =>
   rootSelector(state).selectedItemsToPublish;
 
-const selectChosenFolderIds = createSelector(
+const _selectChosenFolderIds = createSelector(
   [
     selectSelectedItemsToPublish,
     (_state, folders: FolderInterface[]) => folders,
@@ -165,6 +165,10 @@ const selectChosenFolderIds = createSelector(
     return { partialChosenFolderIds, fullyChosenFolderIds };
   },
 );
+
+const selectChosenFolderIds =
+  (folders: FolderInterface[], items: ShareEntity[]) => (state: RootState) =>
+    _selectChosenFolderIds(state, folders, items);
 
 const selectPublicationsToReviewCount = createSelector(
   [


### PR DESCRIPTION
**Description:**

fix infinity PublicationFolderRow component rerender

Issues:

- Issue #4170

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
