### PR TITLE
fix(chat): fix editing unpublish request with nested folders (Issue #4144, #4103)

### DIFF
--- a/apps/chat/src/components/Chat/Publish/PublicationHandler/PublicationFilters.tsx
+++ b/apps/chat/src/components/Chat/Publish/PublicationHandler/PublicationFilters.tsx
@@ -85,7 +85,7 @@ export function PublicationFilters({
       {isNewRules && !isEditMode && (
         <RuleListItem path={publication.targetFolder} rules={newRules} />
       )}
-      {isNewRules && isEditMode && (
+      {isEditMode && (
         <RulesInput
           isOpen={isRulesSetterVisible}
           filters={filters}

--- a/apps/chat/src/components/Chat/Publish/PublicationHandler/PublicationHandler.tsx
+++ b/apps/chat/src/components/Chat/Publish/PublicationHandler/PublicationHandler.tsx
@@ -48,6 +48,7 @@ import {
   PromptPublicationResources,
 } from './ReviewResources';
 
+import { PublishActions } from '@epam/ai-dial-shared';
 import isEqual from 'lodash-es/isEqual';
 
 interface Props {
@@ -171,7 +172,8 @@ export function PublicationHandler({ publication }: Props) {
                     : currentFolder[EDITED_FOLDER_NAME_KEY],
                 );
               });
-              newFolderSegments[1] = publication.targetFolder;
+              if (action !== PublishActions.DELETE)
+                newFolderSegments[1] = publication.targetFolder;
               const newFolderId = newFolderSegments.join('/');
 
               // get new api key

--- a/apps/chat/src/components/Chat/Publish/PublicationHandler/PublicationHandler.tsx
+++ b/apps/chat/src/components/Chat/Publish/PublicationHandler/PublicationHandler.tsx
@@ -172,8 +172,9 @@ export function PublicationHandler({ publication }: Props) {
                     : currentFolder[EDITED_FOLDER_NAME_KEY],
                 );
               });
-              if (action !== PublishActions.DELETE)
+              if (action !== PublishActions.DELETE) {
                 newFolderSegments[1] = publication.targetFolder;
+              }
               const newFolderId = newFolderSegments.join('/');
 
               // get new api key

--- a/apps/chat/src/store/publication/publication.epics.ts
+++ b/apps/chat/src/store/publication/publication.epics.ts
@@ -1599,7 +1599,7 @@ const updatePublicationRequestEpic: AppEpic = (action$, state$) =>
               ...resource,
               sourceUrl: ApiUtils.decodeApiUrl(resource.sourceUrl ?? ''),
               targetUrl: ApiUtils.decodeApiUrl(resource.targetUrl),
-              reviewUrl: ApiUtils.decodeApiUrl(resource.reviewUrl),
+              reviewUrl: ApiUtils.decodeApiUrl(resource.reviewUrl ?? ''),
             }),
           );
 


### PR DESCRIPTION
**Description:**

- fix new folder id generation when unpublishing resources with nested folders
- allow editing rules on unpublish request modal

Issues:

- Issue #4144 
- Issue #4103 

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
