### PR TITLE
fix(chat): enable 'use' button if conversation and publication selected simultaneosely (Issue #4139)

### DIFF
--- a/apps/chat-e2e/src/tests/usePromptNewConversation.test.ts
+++ b/apps/chat-e2e/src/tests/usePromptNewConversation.test.ts
@@ -314,7 +314,7 @@ dialTest(
 
 const publicationsToUnpublish: Publication[] = [];
 
-dialAdminTest(
+dialAdminTest.only(
   'Use prompt not available for chat from Organization\n' +
     'Use prompt not available for chat from Approve required.\n' +
     'Use prompt option is not available when publication request is selected.\n' +

--- a/apps/chat-e2e/src/tests/usePromptNewConversation.test.ts
+++ b/apps/chat-e2e/src/tests/usePromptNewConversation.test.ts
@@ -314,7 +314,7 @@ dialTest(
 
 const publicationsToUnpublish: Publication[] = [];
 
-dialAdminTest.only(
+dialAdminTest(
   'Use prompt not available for chat from Organization\n' +
     'Use prompt not available for chat from Approve required.\n' +
     'Use prompt option is not available when publication request is selected.\n' +

--- a/apps/chat/src/components/Promptbar/components/Prompt.tsx
+++ b/apps/chat/src/components/Promptbar/components/Prompt.tsx
@@ -92,9 +92,6 @@ export const PromptComponent = ({
   const isConversationBlocksInput = useAppSelector(
     ConversationsSelectors.selectIsSelectedConversationBlocksInput,
   );
-  const selectedPublication = useAppSelector(
-    PublicationSelectors.selectSelectedPublication,
-  );
 
   const isExternal = isEntityIdExternal(prompt);
   const isApproveRequiredResource = !!additionalItemData?.publicationUrl;
@@ -218,7 +215,9 @@ export const PromptComponent = ({
   );
 
   const disableUsePrompt =
-    isConversationBlocksInput || !areModelsInstalled || !!selectedPublication;
+    isConversationBlocksInput ||
+    !areModelsInstalled ||
+    !selectedConversations.length;
 
   useEffect(() => {
     if (isSelectMode) {

--- a/apps/chat/src/components/Promptbar/components/ViewPrompt.tsx
+++ b/apps/chat/src/components/Promptbar/components/ViewPrompt.tsx
@@ -16,7 +16,6 @@ import {
   ConversationsSelectors,
   ModelsSelectors,
   PromptsSelectors,
-  PublicationSelectors,
 } from '@/src/store/selectors';
 
 import { TemplateRenderer } from '@/src/components/Chat/ChatMessage/ChatMessageTemplatesModal/TemplateRenderer';
@@ -80,9 +79,6 @@ export const ViewPrompt = ({ prompt, onEditMode }: Props) => {
   const installedModelIds = useAppSelector(
     ModelsSelectors.selectInstalledModelIds,
   );
-  const selectedPublication = useAppSelector(
-    PublicationSelectors.selectSelectedPublication,
-  );
   const { isSelectedPromptApproveRequiredResource } = useAppSelector(
     PromptsSelectors.selectSelectedPromptId,
   );
@@ -102,7 +98,9 @@ export const ViewPrompt = ({ prompt, onEditMode }: Props) => {
     installedModelIds.has(conv.model.id),
   );
   const disableUsePrompt =
-    isConversationBlocksInput || !areModelsInstalled || !!selectedPublication;
+    isConversationBlocksInput ||
+    !areModelsInstalled ||
+    !selectedConversations.length;
 
   const onUse = useMenuItemHandler(handleUse, undefined);
 

--- a/apps/chat/src/store/conversations/conversations.selectors.ts
+++ b/apps/chat/src/store/conversations/conversations.selectors.ts
@@ -780,7 +780,8 @@ const selectIsSelectedConversationBlocksInput = createSelector(
           (isConfigurationBlocksInput || isReplayConversation(conversation))) ||
         notAvailableEntityType ||
         isPlaybackConversation(conversation) ||
-        (areReadOnly && !isReviewEntity) ||
+        areReadOnly ||
+        isReviewEntity ||
         !conversation.messages ||
         isMessageInputDisabled(
           conversation.messages.length,


### PR DESCRIPTION
**Description:**

enable 'use' button if conversation and publication selected simultaneosely

Issues:

- Issue #4139

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
