### PR TITLE
fix(chat): fix displaying of publication resource after changing agent or renaming (Issue #4108)

### DIFF
--- a/apps/chat/src/components/Chat/Publish/PublicationHandler/PublicationHandler.tsx
+++ b/apps/chat/src/components/Chat/Publish/PublicationHandler/PublicationHandler.tsx
@@ -230,7 +230,7 @@ export function PublicationHandler({ publication }: Props) {
     !isEqual(publication.rules, rules[publication.targetFolder] || []);
 
   return (
-    <div className="size-full justify-center overflow-y-auto p-0 md:px-5 md:pt-5">
+    <div className="flex size-full justify-center overflow-y-auto p-0 md:px-5 md:pt-5">
       <div
         className="relative flex size-full flex-col justify-center gap-px rounded 2xl:max-w-[1000px]"
         data-qa="publish-approval-modal"

--- a/apps/chat/src/store/publication/publication.epics.ts
+++ b/apps/chat/src/store/publication/publication.epics.ts
@@ -1463,19 +1463,41 @@ const updatePublicationRequestAndEntityEpic: AppEpic = (action$, state$) =>
             values: payload.newEntity,
           };
 
-          const updateEntityAction$ = of(
-            isConversationId(payload.newEntity.id)
-              ? ConversationsActions.updateConversation(updateEntityPayload)
-              : PromptsActions.updatePrompt(updateEntityPayload),
-          );
+          const isConversationResource = isConversationId(payload.newEntity.id);
+
+          const updateEntityAction$: Observable<AppAction>[] = [
+            of(
+              isConversationResource
+                ? ConversationsActions.updateConversation(updateEntityPayload)
+                : PromptsActions.updatePrompt(updateEntityPayload),
+            ),
+          ];
+          if (isConversationResource) {
+            const selectedConversationIds =
+              ConversationsSelectors.selectSelectedConversationsIds(state);
+            if (selectedConversationIds.includes(payload.resourceToUpdateUrl)) {
+              updateEntityAction$.push(
+                of(
+                  ConversationsActions.selectConversations({
+                    conversationIds: selectedConversationIds.map((id) =>
+                      id === payload.resourceToUpdateUrl
+                        ? payload.newEntity.id
+                        : id,
+                    ),
+                    suspendHideSidebar: false,
+                  }),
+                ),
+              );
+            }
+          }
 
           return concat(
-            updateEntityAction$,
             of(
               PublicationActions.uploadPublication({
                 url: payload.publicationUrl,
               }),
             ),
+            ...updateEntityAction$,
           );
         }),
         catchError((err) => {


### PR DESCRIPTION
**Description:**

fix displaying of publication resource after changing agent or renaming

Issues:

- Issue #4108

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
