### PR TITLE
fix(chat): disable 'approve' button  if there is conversation with no messages (Issue #4176)

### DIFF
--- a/apps/chat-e2e/src/tests/marketplaceSearch.test.ts
+++ b/apps/chat-e2e/src/tests/marketplaceSearch.test.ts
@@ -739,9 +739,9 @@ dialTest(
     applicationApiHelper,
   }) => {
     setTestIds('EPMRTC-6448');
-    const firstTerm = '7.7.7';
-    const secondTerm = '3.3.3';
-    const thirdTerm = '7.7.8';
+    const firstTerm = '72.73.7';
+    const secondTerm = '36.37.3';
+    const thirdTerm = '72.73.8';
     const firstAppName = `${GeneratorUtil.randomApplicationName()} ${firstTerm}`;
     const secondAppName = `${GeneratorUtil.randomApplicationName()} ${secondTerm}`;
     const thirdAppName = GeneratorUtil.randomApplicationName();
@@ -827,10 +827,10 @@ dialTest(
     );
 
     await dialTest.step(
-      'Type "5.5.5155" in the search field and verify no results are found',
+      'Type "72.73.71555" in the search field and verify no results are found',
       async () => {
         await marketplaceHeader.searchInput.fillInInput(
-          firstTerm.concat('155'),
+          firstTerm.concat('1555'),
         );
         await baseAssertion.assertElementState(
           marketplace.noResultsFound,

--- a/apps/chat/src/components/Chat/Publish/PublicationHandler/PublicationHandlerFooter.tsx
+++ b/apps/chat/src/components/Chat/Publish/PublicationHandler/PublicationHandlerFooter.tsx
@@ -48,7 +48,7 @@ import { NA_VERSION } from '@/src/constants/publication';
 import { IconButton } from '@/src/components/Common/IconButton';
 import { Tooltip } from '@/src/components/Common/Tooltip';
 
-import { FeatureType } from '@epam/ai-dial-shared';
+import { Conversation, FeatureType } from '@epam/ai-dial-shared';
 import uniq from 'lodash-es/uniq';
 
 interface Props {
@@ -120,6 +120,21 @@ export const PublicationHandlerFooter = ({
         (entity) => entity.publicationInfo?.isNotExist,
       ),
     [conversations, files, prompts, applications],
+  );
+
+  const resourcesToReviewIds = useMemo(
+    () => resourcesToReview.map((resource) => resource.reviewUrl),
+    [resourcesToReview],
+  );
+
+  const publicationConversationsWithUploadedMessages = useMemo(
+    () =>
+      conversations.filter(
+        (conversation) =>
+          resourcesToReviewIds.includes(conversation.id) &&
+          (conversation as Conversation).messages !== undefined,
+      ) as Conversation[],
+    [conversations, resourcesToReviewIds],
   );
 
   const expandFoldersByFeatureType = useCallback(
@@ -276,6 +291,10 @@ export const PublicationHandlerFooter = ({
     displayAuthorEditState.length > MAX_ENTITY_LENGTH;
   const isEditDisabled =
     isNamesOrVersionsInvalid || isFoldersInvalid || isDisplayAuthorInvalid;
+  const someReviewedConversationHaveNoMessages =
+    publicationConversationsWithUploadedMessages.some(
+      (conversation) => !conversation.messages.length,
+    );
 
   return (
     <div
@@ -350,12 +369,18 @@ export const PublicationHandlerFooter = ({
               tooltip={t(
                 invalidEntities.length
                   ? "Request can't be approved as some conversations are unpublished"
-                  : "It's required to review all resources",
+                  : someReviewedConversationHaveNoMessages
+                    ? "Request can't be approved as some conversations have no messages"
+                    : "It's required to review all resources",
               )}
             >
               <button
                 className="button button-primary disabled:cursor-not-allowed disabled:text-controls-disable"
-                disabled={!isAllResourcesReviewed || !!invalidEntities.length}
+                disabled={
+                  !isAllResourcesReviewed ||
+                  !!invalidEntities.length ||
+                  someReviewedConversationHaveNoMessages
+                }
                 onClick={handleApprovePublication}
                 data-qa="approve"
               >


### PR DESCRIPTION
**Description:**

disable 'approve' button  if there is conversation with no messages

Issues:

- Issue #4176

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
