### PR TITLE
fix(chat): hide thin white border for agent icon in dark theme (Issue #4195)

### DIFF
--- a/apps/chat/src/components/Chatbar/ModelIcon.tsx
+++ b/apps/chat/src/components/Chatbar/ModelIcon.tsx
@@ -91,7 +91,7 @@ const ModelIconTemplate = memo(
     return (
       <span
         className={classNames(
-          'relative inline-block shrink-0 bg-model-icon leading-none',
+          'relative inline-block shrink-0 leading-none',
           entity?.type !== EntityType.Addon && 'overflow-hidden rounded-full',
           animate && 'animate-bounce',
           enableShrinking && 'shrink',
@@ -99,6 +99,10 @@ const ModelIconTemplate = memo(
         style={{ height: `${size}px`, width: `${size}px` }}
         data-qa="entity-icon"
       >
+        <div
+          className="absolute z-0 size-full rounded-full border border-secondary bg-model-icon"
+          style={{ height: `${size}px`, width: `${size}px` }}
+        ></div>
         <img
           key={entityId}
           src={getIconUrl(entity)}
@@ -107,6 +111,7 @@ const ModelIconTemplate = memo(
           onError={handleError}
           data-image-name={description}
           ref={ref}
+          className="absolute left-0 top-0 z-10 size-full"
           style={{ height: `${size}px`, width: `${size}px` }}
           id={entityId}
         />

--- a/apps/chat/src/components/Common/ShareIcon.tsx
+++ b/apps/chat/src/components/Common/ShareIcon.tsx
@@ -75,7 +75,7 @@ export function ShareIcon({
       {children}
       <div
         className={classNames(
-          'absolute bg-layer-3',
+          'absolute z-50 bg-layer-3',
           isPublished && 'rounded-md',
           isApplication
             ? 'bottom-0 left-0 rounded-none rounded-tr-[4px] stroke-[0.6]'


### PR DESCRIPTION
**Description:**

hide thin white border for agent icon in dark theme

Issues:

- Issue #4195

**UI changes**
![image](https://github.com/user-attachments/assets/234adf95-45d1-48a2-9864-1ae1235f444f)
->
![image](https://github.com/user-attachments/assets/5f054fac-d7fd-455a-aecd-4e0be0dffce8)

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
