### PR TITLE
fix(chat): enable input of conversation that is edited by admin (Issue #4135)

### DIFF
--- a/apps/chat/src/store/conversations/conversations.selectors.ts
+++ b/apps/chat/src/store/conversations/conversations.selectors.ts
@@ -52,6 +52,7 @@ import { DialAIEntityModel } from '@/src/types/models';
 import { EntityFilter, EntityFilters, SearchFilters } from '@/src/types/search';
 import { RootState } from '@/src/types/store';
 
+import { AuthSelectors } from '@/src/store/auth/auth.selectors';
 import { ChatSelectors } from '@/src/store/chat/chat.selectors';
 import { ModelsSelectors } from '@/src/store/models/models.selectors';
 import { PublicationSelectors } from '@/src/store/publication/publication.selectors';
@@ -759,6 +760,7 @@ const selectIsSelectedConversationBlocksInput = createSelector(
     ChatSelectors.selectIsConfigurationBlocksInput,
     ChatSelectors.selectNotAvailableEntityType,
     selectAreSelectedConversationsReadOnly,
+    AuthSelectors.selectIsAdmin,
   ],
   (
     conversations,
@@ -766,6 +768,7 @@ const selectIsSelectedConversationBlocksInput = createSelector(
     isConfigurationBlocksInput,
     notAvailableEntityType,
     areReadOnly,
+    isAdmin,
   ) => {
     const isReviewEntity = conversations.some((conversation) =>
       resourcesToReview.some(
@@ -780,8 +783,8 @@ const selectIsSelectedConversationBlocksInput = createSelector(
           (isConfigurationBlocksInput || isReplayConversation(conversation))) ||
         notAvailableEntityType ||
         isPlaybackConversation(conversation) ||
-        areReadOnly ||
-        isReviewEntity ||
+        (areReadOnly && !isReviewEntity) ||
+        (isReviewEntity && !isAdmin) ||
         !conversation.messages ||
         isMessageInputDisabled(
           conversation.messages.length,


### PR DESCRIPTION
**Description:**

- update IsSelectedConversationBlocksInput logic

Issues:

- Issue #4135

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
