### PR TITLE
fix(chat): filter attachable files of a chat when being reviewed by admin (Issue #4200)

### DIFF
--- a/apps/chat/src/components/Files/AttachButton.tsx
+++ b/apps/chat/src/components/Files/AttachButton.tsx
@@ -13,18 +13,25 @@ import { useTranslation } from '@/src/hooks/useTranslation';
 import { getQuickAttachmentsSavingPath } from '@/src/utils/app/conversation';
 
 import { FeatureType } from '@/src/types/common';
-import { DialFile, DialLink } from '@/src/types/files';
+import { DialFile, DialLink, FileSourceType } from '@/src/types/files';
 import { DisplayMenuItemProps } from '@/src/types/menu';
 import { Translation } from '@/src/types/translation';
 
 import { useAppSelector } from '@/src/store/hooks';
-import { ConversationsSelectors, ModelsSelectors } from '@/src/store/selectors';
+import {
+  AuthSelectors,
+  ConversationsSelectors,
+  ModelsSelectors,
+  PublicationSelectors,
+} from '@/src/store/selectors';
 
 import { ContextMenu } from '@/src/components/Common/ContextMenu';
 
 import { AttachLinkDialog } from './AttachLinkDialog';
 import { FileManagerModal } from './FileManagerModal';
 import { PreUploadDialog } from './PreUploadModal';
+
+const myFilesFilter = new Set([FileSourceType.MY_FILES]);
 
 interface Props {
   selectedFilesIds?: string[];
@@ -47,6 +54,17 @@ export const AttachButton = ({
   contextMenuPlacement,
 }: Props) => {
   const { t } = useTranslation(Translation.Chat);
+
+  const selectedConversationIds = useAppSelector(
+    ConversationsSelectors.selectSelectedConversationsIds,
+  );
+  const isApproveRequiredEntity = useAppSelector((state) =>
+    PublicationSelectors.selectIsApproveRequiredEntity(
+      state,
+      selectedConversationIds[0] ?? '',
+    ),
+  );
+  const isAdmin = useAppSelector(AuthSelectors.selectIsAdmin);
   const messageIsStreaming = useAppSelector(
     ConversationsSelectors.selectIsConversationsStreaming,
   );
@@ -81,6 +99,9 @@ export const AttachButton = ({
   const handleAttachLink = useCallback(() => {
     setIsAttachLinkDialogOpened(true);
   }, []);
+
+  const sourceFilters =
+    isApproveRequiredEntity && isAdmin ? myFilesFilter : undefined;
 
   const menuItems: DisplayMenuItemProps[] = useMemo(
     () =>
@@ -144,6 +165,7 @@ export const AttachButton = ({
       {isSelectFilesDialogOpened && (
         <FileManagerModal
           isOpen
+          sourceFilters={sourceFilters}
           allowedTypes={availableAttachmentsTypes}
           maximumAttachmentsAmount={maximumAttachmentsAmount}
           headerLabel={t(label)}

--- a/apps/chat/src/components/Files/AttachButton.tsx
+++ b/apps/chat/src/components/Files/AttachButton.tsx
@@ -58,11 +58,8 @@ export const AttachButton = ({
   const selectedConversationIds = useAppSelector(
     ConversationsSelectors.selectSelectedConversationsIds,
   );
-  const isApproveRequiredEntity = useAppSelector((state) =>
-    PublicationSelectors.selectIsApproveRequiredEntity(
-      state,
-      selectedConversationIds[0] ?? '',
-    ),
+  const resourcesToReview = useAppSelector(
+    PublicationSelectors.selectResourcesToReview,
   );
   const isAdmin = useAppSelector(AuthSelectors.selectIsAdmin);
   const messageIsStreaming = useAppSelector(
@@ -99,6 +96,14 @@ export const AttachButton = ({
   const handleAttachLink = useCallback(() => {
     setIsAttachLinkDialogOpened(true);
   }, []);
+
+  const isApproveRequiredEntity = useMemo(
+    () =>
+      resourcesToReview.some((r) =>
+        selectedConversationIds.includes(r.reviewUrl),
+      ),
+    [resourcesToReview, selectedConversationIds],
+  );
 
   const sourceFilters =
     isApproveRequiredEntity && isAdmin ? myFilesFilter : undefined;


### PR DESCRIPTION
**Description:**

- filter attachable files of a chat when being reviewed by admin 

Issues:

- Issue #4200 

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
