### PR TITLE
fix(chat): fix 'Back to publication request' button disappearing if update prompt through the 'Edit modal' (Issue #4213)

### DIFF
--- a/apps/chat/src/components/Promptbar/components/EditPrompt.tsx
+++ b/apps/chat/src/components/Promptbar/components/EditPrompt.tsx
@@ -20,7 +20,7 @@ import {
   trimEndDots,
 } from '@/src/utils/app/common';
 import { notAllowedSymbolsRegex } from '@/src/utils/app/file';
-import { arePromptsFieldsTheSame } from '@/src/utils/app/prompts';
+import { areSomePromptsFieldsChanged } from '@/src/utils/app/prompts';
 import { onBlur } from '@/src/utils/app/style-helpers';
 
 import { Prompt } from '@/src/types/prompt';
@@ -162,7 +162,7 @@ export const EditPrompt: FC<Props> = ({ prompt, onEdit, onClose }) => {
   );
 
   const handleEditClose = useCallback(() => {
-    if (arePromptsFieldsTheSame(prompt, { name, description, content })) {
+    if (areSomePromptsFieldsChanged(prompt, { name, description, content })) {
       setConfirmClose(true);
     } else {
       onClose();

--- a/apps/chat/src/components/Promptbar/components/PromptModal.tsx
+++ b/apps/chat/src/components/Promptbar/components/PromptModal.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from 'next-i18next';
 import classNames from 'classnames';
 
 import {
-  arePromptsFieldsTheSame,
+  areSomePromptsFieldsChanged,
   regeneratePromptId,
 } from '@/src/utils/app/prompts';
 
@@ -58,7 +58,7 @@ const PromptModalContent: React.FC<PromptModalViewProps> = ({
         );
         dispatch(PromptsActions.uploadPromptSuccess({ prompt: null }));
       } else {
-        if (arePromptsFieldsTheSame(editedPrompt, prompt)) {
+        if (areSomePromptsFieldsChanged(editedPrompt, prompt)) {
           dispatch(
             PromptsActions.updatePrompt({
               id: prompt.id,

--- a/apps/chat/src/store/publication/publication.epics.ts
+++ b/apps/chat/src/store/publication/publication.epics.ts
@@ -1479,18 +1479,19 @@ const updatePublicationRequestAndEntityEpic: AppEpic = (action$, state$) =>
 
           const isConversationResource = isConversationId(payload.newEntity.id);
 
-          const updateEntityAction$: Observable<AppAction>[] = [
+          const updateEntityActions: Observable<AppAction>[] = [
             of(
               isConversationResource
                 ? ConversationsActions.updateConversation(updateEntityPayload)
                 : PromptsActions.updatePrompt(updateEntityPayload),
             ),
           ];
+
           if (isConversationResource) {
             const selectedConversationIds =
               ConversationsSelectors.selectSelectedConversationsIds(state);
             if (selectedConversationIds.includes(payload.resourceToUpdateUrl)) {
-              updateEntityAction$.push(
+              updateEntityActions.push(
                 of(
                   ConversationsActions.selectConversations({
                     conversationIds: selectedConversationIds.map((id) =>
@@ -1503,6 +1504,20 @@ const updatePublicationRequestAndEntityEpic: AppEpic = (action$, state$) =>
                 ),
               );
             }
+          } else {
+            updateEntityActions.push(
+              of(
+                PromptsActions.uploadPrompt({
+                  promptId: payload.newEntity.id,
+                }),
+              ),
+              of(
+                PromptsActions.selectPrompt({
+                  promptId: payload.newEntity.id,
+                  isApproveRequiredResource: true,
+                }),
+              ),
+            );
           }
 
           return concat(
@@ -1511,7 +1526,7 @@ const updatePublicationRequestAndEntityEpic: AppEpic = (action$, state$) =>
                 url: payload.publicationUrl,
               }),
             ),
-            ...updateEntityAction$,
+            ...updateEntityActions,
           );
         }),
         catchError((err) => {

--- a/apps/chat/src/utils/app/prompts.ts
+++ b/apps/chat/src/utils/app/prompts.ts
@@ -129,7 +129,7 @@ export const replaceTemplates = (
     .join(value.trim());
 };
 
-export const arePromptsFieldsTheSame = (
+export const areSomePromptsFieldsChanged = (
   firstPrompt: Pick<Prompt, 'name' | 'content' | 'description'>,
   secondPrompt: Pick<Prompt, 'name' | 'content' | 'description'>,
 ) => {


### PR DESCRIPTION
**Description:**

fix 'Back to publication request' button disappearing if update prompt through the 'Edit modal' 

Issues:

- Issue #4213

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
