### PR TITLE
fix(chat): fix updating of playback attachment titles (Issue #4108)

### DIFF
--- a/apps/chat/src/store/publication/publication.epics.ts
+++ b/apps/chat/src/store/publication/publication.epics.ts
@@ -1783,6 +1783,41 @@ const updatePublicationRequestEpic: AppEpic = (action$, state$) =>
                                   ),
                               },
                             })),
+                            playback: conversation.playback
+                              ? {
+                                  ...conversation.playback,
+                                  messagesStack:
+                                    conversation.playback.messagesStack.map(
+                                      (message) => ({
+                                        ...message,
+                                        custom_content: {
+                                          ...message.custom_content,
+                                          attachments:
+                                            message.custom_content?.attachments?.map(
+                                              (attachment) => {
+                                                const title =
+                                                  ApiUtils.decodeApiUrl(
+                                                    getLastPathSegment(
+                                                      attachment.url ?? '',
+                                                    ),
+                                                  );
+
+                                                return titlesToUpdate.includes(
+                                                  title,
+                                                )
+                                                  ? {
+                                                      ...attachment,
+                                                      title:
+                                                        title ?? 'Attachment',
+                                                    }
+                                                  : attachment;
+                                              },
+                                            ),
+                                        },
+                                      }),
+                                    ),
+                                }
+                              : undefined,
                           },
                         }),
                       );

--- a/apps/chat/src/store/publication/publication.epics.ts
+++ b/apps/chat/src/store/publication/publication.epics.ts
@@ -17,7 +17,10 @@ import {
 import { combineEpics, ofType } from 'redux-observable';
 
 import { getLastPathSegment } from '@/src/utils/app/common';
-import { getConversationInfoFromId } from '@/src/utils/app/conversation';
+import {
+  getConversationInfoFromId,
+  updateAttachmentTitles,
+} from '@/src/utils/app/conversation';
 import { ApplicationService } from '@/src/utils/app/data/application-service';
 import { ApplicationTypesSchemasService } from '@/src/utils/app/data/application-type-schemas-service';
 import { ConversationService } from '@/src/utils/app/data/conversation-service';
@@ -1760,62 +1763,17 @@ const updatePublicationRequestEpic: AppEpic = (action$, state$) =>
                               version: getVersionFromId(conversation.id),
                               publicationUrl: url,
                             },
-                            messages: conversation.messages.map((message) => ({
-                              ...message,
-                              custom_content: {
-                                ...message.custom_content,
-                                attachments:
-                                  message.custom_content?.attachments?.map(
-                                    (attachment) => {
-                                      const title = ApiUtils.decodeApiUrl(
-                                        getLastPathSegment(
-                                          attachment.url ?? '',
-                                        ),
-                                      );
-
-                                      return titlesToUpdate.includes(title)
-                                        ? {
-                                            ...attachment,
-                                            title: title ?? 'Attachment',
-                                          }
-                                        : attachment;
-                                    },
-                                  ),
-                              },
-                            })),
+                            messages: updateAttachmentTitles(
+                              conversation.messages,
+                              titlesToUpdate,
+                            ),
                             playback: conversation.playback
                               ? {
                                   ...conversation.playback,
-                                  messagesStack:
-                                    conversation.playback.messagesStack.map(
-                                      (message) => ({
-                                        ...message,
-                                        custom_content: {
-                                          ...message.custom_content,
-                                          attachments:
-                                            message.custom_content?.attachments?.map(
-                                              (attachment) => {
-                                                const title =
-                                                  ApiUtils.decodeApiUrl(
-                                                    getLastPathSegment(
-                                                      attachment.url ?? '',
-                                                    ),
-                                                  );
-
-                                                return titlesToUpdate.includes(
-                                                  title,
-                                                )
-                                                  ? {
-                                                      ...attachment,
-                                                      title:
-                                                        title ?? 'Attachment',
-                                                    }
-                                                  : attachment;
-                                              },
-                                            ),
-                                        },
-                                      }),
-                                    ),
+                                  messagesStack: updateAttachmentTitles(
+                                    conversation.playback.messagesStack,
+                                    titlesToUpdate,
+                                  ),
                                 }
                               : undefined,
                           },

--- a/apps/chat/src/utils/app/conversation.ts
+++ b/apps/chat/src/utils/app/conversation.ts
@@ -1,4 +1,5 @@
 import {
+  getLastPathSegment,
   isEntityNameOrPathInvalid,
   prepareEntityName,
 } from '@/src/utils/app/common';
@@ -10,6 +11,7 @@ import {
 } from '@/src/utils/app/form-schema';
 import { splitEntityId } from '@/src/utils/app/shared-utils';
 import {
+  ApiUtils,
   getConversationApiKey,
   parseConversationApiKey,
 } from '@/src/utils/server/api';
@@ -381,4 +383,28 @@ export const getQuickAttachmentsSavingPath = () => {
   const date = new Date();
 
   return `${getFileRootId()}/uploads/${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}`;
+};
+
+export const updateAttachmentTitles = (
+  messages: Message[],
+  titlesToUpdate: string[],
+) => {
+  return messages.map((message) => ({
+    ...message,
+    custom_content: {
+      ...message.custom_content,
+      attachments: message.custom_content?.attachments?.map((attachment) => {
+        const title = ApiUtils.decodeApiUrl(
+          getLastPathSegment(attachment.url ?? ''),
+        );
+
+        return titlesToUpdate.includes(title)
+          ? {
+              ...attachment,
+              title: title ?? 'Attachment',
+            }
+          : attachment;
+      }),
+    },
+  }));
 };


### PR DESCRIPTION
**Description:**

fix updating of playback attachment titles

Issues:

- Issue #4108

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
