### PR TITLE
fix(chat): fix 'Tab' symbol pasted into name's field is treated as restricted symbol (Issue #4240)

### DIFF
--- a/apps/chat/src/components/Chat/Publish/PublicationHandler/PublicationHandler.tsx
+++ b/apps/chat/src/components/Chat/Publish/PublicationHandler/PublicationHandler.tsx
@@ -6,6 +6,7 @@ import {
   extractNameFromEmail,
   formatDate,
   prepareEntityName,
+  replaceSpacesFromString,
 } from '@/src/utils/app/common';
 import { getFolderIdFromEntityId } from '@/src/utils/app/folders';
 import { getStringValidationErrors } from '@/src/utils/app/forms';
@@ -119,10 +120,10 @@ export function PublicationHandler({ publication }: Props) {
   }, [publication.author, t]);
 
   useEffect(() => {
-    if (isEditMode) {
+    if (isEditMode && publication.displayAuthor) {
       setErrors(() =>
         getStringValidationErrors({
-          value: publication.displayAuthor ?? '',
+          value: replaceSpacesFromString(publication.displayAuthor!),
           label: 'Author',
         }),
       );
@@ -219,9 +220,10 @@ export function PublicationHandler({ publication }: Props) {
 
   const handleChangeDisplayAuthor = useCallback(
     (value: string) => {
+      const cleanedValue = replaceSpacesFromString(value);
       setErrors(() =>
         getStringValidationErrors({
-          value: value,
+          value: cleanedValue,
           label: 'Author',
         }),
       );
@@ -229,7 +231,7 @@ export function PublicationHandler({ publication }: Props) {
         value.length <= MAX_ENTITY_LENGTH ||
         value.length < displayAuthorEditState.length
       ) {
-        dispatch(PublicationActions.setDisplayAuthorEditState(value));
+        dispatch(PublicationActions.setDisplayAuthorEditState(cleanedValue));
       }
     },
     [dispatch, displayAuthorEditState.length],

--- a/apps/chat/src/components/Chat/Publish/PublicationHandler/PublicationHandler.tsx
+++ b/apps/chat/src/components/Chat/Publish/PublicationHandler/PublicationHandler.tsx
@@ -120,10 +120,10 @@ export function PublicationHandler({ publication }: Props) {
   }, [publication.author, t]);
 
   useEffect(() => {
-    if (isEditMode && publication.displayAuthor) {
+    if (isEditMode) {
       setErrors(() =>
         getStringValidationErrors({
-          value: replaceSpacesFromString(publication.displayAuthor!),
+          value: replaceSpacesFromString(publication.displayAuthor),
           label: 'Author',
         }),
       );

--- a/apps/chat/src/components/Chat/Publish/PublicationHandler/PublicationHandlerFooter.tsx
+++ b/apps/chat/src/components/Chat/Publish/PublicationHandler/PublicationHandlerFooter.tsx
@@ -12,6 +12,7 @@ import {
   isVersionExists,
   isVersionPartSizeValid,
   isVersionValid,
+  replaceSpacesFromString,
 } from '@/src/utils/app/common';
 import {
   getFolderIdFromEntityId,
@@ -114,7 +115,9 @@ export const PublicationHandlerFooter = ({
       PublicationActions.setEditModeState({
         editState: getDefaultAllEditEntities(publication.resources),
         rules: publication.rules ?? [],
-        displayAuthor: publication.displayAuthor ?? '',
+        displayAuthor: publication.displayAuthor
+          ? replaceSpacesFromString(publication.displayAuthor)
+          : '',
       }),
     );
   }, [

--- a/apps/chat/src/components/Chat/Publish/PublicationHandler/PublicationHandlerFooter.tsx
+++ b/apps/chat/src/components/Chat/Publish/PublicationHandler/PublicationHandlerFooter.tsx
@@ -115,9 +115,7 @@ export const PublicationHandlerFooter = ({
       PublicationActions.setEditModeState({
         editState: getDefaultAllEditEntities(publication.resources),
         rules: publication.rules ?? [],
-        displayAuthor: publication.displayAuthor
-          ? replaceSpacesFromString(publication.displayAuthor)
-          : '',
+        displayAuthor: replaceSpacesFromString(publication.displayAuthor),
       }),
     );
   }, [

--- a/apps/chat/src/components/Chat/Publish/PublicationHandler/ReviewRowItems/PublicationFolderRow.tsx
+++ b/apps/chat/src/components/Chat/Publish/PublicationHandler/ReviewRowItems/PublicationFolderRow.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import classNames from 'classnames';
 
+import { replaceSpacesFromString } from '@/src/utils/app/common';
 import {
   getSelectedEntitiesByFolderId,
   isFolderPartialSelected,
@@ -78,11 +79,12 @@ export const PublicationFolderRow = <T extends PublicationReviewItem>({
   );
 
   useEffect(() => {
-    setInputName(currentFolder.name);
+    const cleanName = replaceSpacesFromString(currentFolder.name);
+    setInputName(cleanName);
     if (isEditMode) {
       setErrors(() =>
         getStringValidationErrors({
-          value: currentFolder.name,
+          value: cleanName,
           label: 'Folder name',
           checkDotsInTheEnd: true,
         }),

--- a/apps/chat/src/components/Chat/Publish/PublicationHandler/ReviewRowItems/PublicationItemRow.tsx
+++ b/apps/chat/src/components/Chat/Publish/PublicationHandler/ReviewRowItems/PublicationItemRow.tsx
@@ -7,7 +7,10 @@ import classNames from 'classnames';
 
 import { usePublicVersionGroupId } from '@/src/hooks/usePublicVersionGroupIdFromPublicEntity';
 
-import { isVersionExists } from '@/src/utils/app/common';
+import {
+  isVersionExists,
+  replaceSpacesFromString,
+} from '@/src/utils/app/common';
 import {
   getStringValidationErrors,
   getVersionValidationErrors,
@@ -213,9 +216,10 @@ export const PublicationItemRow: React.FC<PublicationRowProps> = ({
   const [errors, setErrors] = useState<string[]>([]);
 
   useEffect(() => {
-    setInputName(item.name);
+    const cleanName = replaceSpacesFromString(item.name);
+    setInputName(cleanName);
     const nameErrors = getStringValidationErrors({
-      value: item.name,
+      value: cleanName,
       label: `${itemTypeName} name`,
       checkDotsInTheEnd: true,
     });

--- a/apps/chat/src/components/Common/EditableField.tsx
+++ b/apps/chat/src/components/Common/EditableField.tsx
@@ -1,6 +1,10 @@
+import { ChangeEvent, useCallback } from 'react';
+
 import classNames from 'classnames';
 
 import { useTranslation } from '@/src/hooks/useTranslation';
+
+import { replaceSpacesFromString } from '@/src/utils/app/common';
 
 import { Translation } from '@/src/types/translation';
 
@@ -30,6 +34,14 @@ export const EditableField: React.FC<Props> = ({
 }) => {
   const isErrors = !!errors?.length;
   const { t } = useTranslation(Translation.Chat);
+  const onChangeHandler = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      const cleanName = replaceSpacesFromString(event.target.value);
+      onChange(cleanName);
+    },
+    [onChange],
+  );
+
   if (isEditMode) {
     return (
       <div
@@ -43,7 +55,7 @@ export const EditableField: React.FC<Props> = ({
             inputClassName,
           )}
           value={value}
-          onChange={(e) => onChange(e.target.value)}
+          onChange={onChangeHandler}
           placeholder={placeholder}
         />
 

--- a/apps/chat/src/utils/app/common.ts
+++ b/apps/chat/src/utils/app/common.ts
@@ -127,8 +127,8 @@ export const filterMigratedEntities = <T extends Entity>(
 
 export const trimEndDots = (str: string) => trimEnd(str, '. \t\r\n');
 
-export const replaceSpacesFromString = (valueToClean: string) =>
-  valueToClean.replace(notAllowedSpacesRegex, ' ');
+export const replaceSpacesFromString = (valueToClean: string | undefined) =>
+  valueToClean?.replace(notAllowedSpacesRegex, ' ') ?? '';
 
 export const prepareEntityName = (
   name: string,


### PR DESCRIPTION
**Description:**

- Fix 'Tab' symbol pasted into name's field is treated as restricted symbol.
- Add replacing of the 'Tab' symbol in the name's fields.

Issues:

- Issue #4240 

**UI changes**

**Before:**
![image](https://github.com/user-attachments/assets/b067230d-d83a-4fc3-9895-b27e33786984)

**After:**
![image](https://github.com/user-attachments/assets/b89e6b04-8733-4b90-947b-44c7facb6613)

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
