### PR TITLE
fix(chat): hide `display_author` field for publications with unpublish resources only (Issue #3461)

### DIFF
--- a/apps/chat/src/components/Chat/Publish/PublicationHandler/PublicationHandler.tsx
+++ b/apps/chat/src/components/Chat/Publish/PublicationHandler/PublicationHandler.tsx
@@ -160,6 +160,14 @@ export function PublicationHandler({ publication }: Props) {
     [publication.rules],
   );
 
+  const isPublicationHasOnlyUnpublishEntities = useMemo(
+    () =>
+      publication.resources.every(
+        (resource) => resource.action === PublishActions.DELETE,
+      ),
+    [publication.resources],
+  );
+
   const handleUpdateRequest = useCallback(() => {
     dispatch(
       PublicationActions.updatePublicationRequest({
@@ -339,19 +347,21 @@ export function PublicationHandler({ publication }: Props) {
                     valueToDisplay={publicationAuthor}
                   />
 
-                  <PublicationInfoSection
-                    labelDataQa="publication-display-author-label"
-                    label={t("Author's public name: ")}
-                    valueDataQa="publication-display-author"
-                    valueToDisplay={publication.displayAuthor ?? ''}
-                    infoTooltip={t(
-                      `This name will be displayed instead of the author's name for this publication.`,
-                    )}
-                    editValue={displayAuthorEditState}
-                    onChangeValue={handleChangeDisplayAuthor}
-                    isEditMode={isEditMode}
-                    errors={errors}
-                  />
+                  {!isPublicationHasOnlyUnpublishEntities && (
+                    <PublicationInfoSection
+                      labelDataQa="publication-display-author-label"
+                      label={t("Author's public name: ")}
+                      valueDataQa="publication-display-author"
+                      valueToDisplay={publication.displayAuthor ?? ''}
+                      infoTooltip={t(
+                        `This name will be displayed instead of the author's name for this publication.`,
+                      )}
+                      editValue={displayAuthorEditState}
+                      onChangeValue={handleChangeDisplayAuthor}
+                      isEditMode={isEditMode}
+                      errors={errors}
+                    />
+                  )}
 
                   <PublicationInfoSection
                     labelDataQa="creation-date-label"


### PR DESCRIPTION
**Description:**

hide `display_author` field for publications with unpublish resources only

Issues:

- Issue #3461 

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
