### PR TITLE
fix(chat): disable publication navigation and 'Back to publication request' while streaming (Issue #4191)

### DIFF
--- a/apps/chat/src/components/Chat/Publish/ApproveRequiredSection.tsx
+++ b/apps/chat/src/components/Chat/Publish/ApproveRequiredSection.tsx
@@ -54,11 +54,18 @@ const PublicationItem = ({ publication, featureTypes }: PublicationProps) => {
     ),
   );
 
+  const isMessageStreaming = useAppSelector(
+    ConversationsSelectors.selectIsConversationsStreaming,
+  );
+
   const [isOpen, setIsOpen] = useState(
     selectedPublicationUrl === publication.url,
   );
 
   const handlePublicationSelect = useCallback(() => {
+    if (isMessageStreaming) {
+      return;
+    }
     setIsOpen((value) => !value);
 
     if (publication.uploadStatus !== UploadStatus.LOADED) {
@@ -72,7 +79,7 @@ const PublicationItem = ({ publication, featureTypes }: PublicationProps) => {
         conversationIds: [],
       }),
     );
-  }, [dispatch, publication]);
+  }, [dispatch, publication, isMessageStreaming]);
 
   const showCaretIcon = featureTypesWithCaretIcon.some((type) =>
     publication.resourceTypes.includes(
@@ -104,7 +111,15 @@ const PublicationItem = ({ publication, featureTypes }: PublicationProps) => {
         )}
         data-qa="folder"
       >
-        <div className="group/button flex size-full cursor-pointer items-center gap-1 py-2 pr-3">
+        <div
+          className={classNames(
+            'group/button flex size-full items-center gap-1 py-2 pr-3',
+            {
+              'cursor-pointer': !isMessageStreaming,
+              'cursor-not-allowed': isMessageStreaming,
+            },
+          )}
+        >
           <CaretIconComponent hidden={!showCaretIcon} isOpen={isOpen} />
           <div className="relative">
             <IconClipboard

--- a/apps/chat/src/components/Chat/Publish/PublicationControls/PublicationControls.tsx
+++ b/apps/chat/src/components/Chat/Publish/PublicationControls/PublicationControls.tsx
@@ -17,7 +17,10 @@ import {
   PublicationActions,
 } from '@/src/store/actions';
 import { useAppDispatch, useAppSelector } from '@/src/store/hooks';
-import { PublicationSelectors } from '@/src/store/selectors';
+import {
+  ConversationsSelectors,
+  PublicationSelectors,
+} from '@/src/store/selectors';
 
 import { TEntity } from './view-props';
 
@@ -40,6 +43,10 @@ function PublicationControlsView({
   const { t } = useTranslation(Translation.Chat);
 
   const dispatch = useAppDispatch();
+
+  const isMessageStreaming = useAppSelector(
+    ConversationsSelectors.selectIsConversationsStreaming,
+  );
 
   const resourcesToReview = useAppSelector((state) =>
     PublicationSelectors.selectResourcesToReviewByPublicationUrl(
@@ -186,7 +193,13 @@ function PublicationControlsView({
       <button
         onClick={handleBackToPublication}
         data-qa="back-to-publication"
-        className="button button-primary flex max-h-[38px] items-center"
+        disabled={isMessageStreaming}
+        className={classNames(
+          'button button-primary flex max-h-[38px] items-center',
+          {
+            'cursor-not-allowed': isMessageStreaming,
+          },
+        )}
       >
         {t('Back to publication request')}
       </button>


### PR DESCRIPTION
**Description:**

"Back to publication request" button and publication requests should be not available when response is generating

Issues:

- Issue #4191

**UI changes**

<img width="427" height="67" alt="Снимок экрана 2025-07-10 в 19 25 15" src="https://github.com/user-attachments/assets/3c893a82-7819-4701-86e1-92a120f4a4f5" />

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
