### PR TITLE
fix(chat): fix editing assistant message when system message presented (Issue #4299)

### DIFF
--- a/apps/chat/src/components/Chat/Chat.tsx
+++ b/apps/chat/src/components/Chat/Chat.tsx
@@ -460,10 +460,15 @@ const ChatView = memo(() => {
         return;
       }
 
+      let finalIndex = index;
+      const conv = selectedConversations.find((conv) => conv.id === convId);
+      if (conv?.messages.at(0)?.role === Role.System) {
+        finalIndex += 1;
+      }
       dispatch(
         ConversationsActions.updateMessage({
           conversationId: convId,
-          messageIndex: index,
+          messageIndex: finalIndex,
           values: editedMessage,
         }),
       );

--- a/apps/overlay-sandbox/app/cases/overlay/edit-last-assistant-message/page.tsx
+++ b/apps/overlay-sandbox/app/cases/overlay/edit-last-assistant-message/page.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import {
+  ChatOverlayWrapper,
+  commonOverlayProps,
+} from '../../components/chatOverlayWrapper';
+
+import { Feature } from '@epam/ai-dial-shared';
+
+const overlayOptions = {
+  ...commonOverlayProps,
+  enabledFeatures: [
+    Feature.EditLastAssistantContent,
+    Feature.Header,
+    Feature.ConversationsSection,
+  ],
+};
+
+export default function Index() {
+  return <ChatOverlayWrapper overlayOptions={overlayOptions} />;
+}

--- a/apps/overlay-sandbox/app/page.tsx
+++ b/apps/overlay-sandbox/app/page.tsx
@@ -24,6 +24,7 @@ enum OverlayCases {
   loaderHideEventSetSandbox = '/cases/overlay/loader-hide-event-set-sandbox',
   skipFocusSetSandbox = '/cases/overlay/skip-focus-set-sandbox',
   customMessageButtons = '/cases/overlay/custom-message-buttons',
+  editLastAssistantMessage = '/cases/overlay/edit-last-assistant-message',
 }
 
 export default async function Index() {


### PR DESCRIPTION
**Description:**

When editing assistant message during saving it updated user message but should assistant message - this is because system message presented in messages

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
