### PR TITLE
fix(chat): hide Edit button for apps from unpublish requests (Issue #4314)

### DIFF
--- a/apps/chat/src/components/Chat/Publish/PublicationHandler/ReviewApplicationDialog/ReviewApplicationDialogView.tsx
+++ b/apps/chat/src/components/Chat/Publish/PublicationHandler/ReviewApplicationDialog/ReviewApplicationDialogView.tsx
@@ -49,10 +49,11 @@ function ReviewApplicationDialogContent() {
     PublicationSelectors.selectSelectedPublicationUrl,
   );
 
-  const isUnpublishRequest = useAppSelector((state) =>
-    PublicationSelectors.selectIsUnpublishRequest(
+  const isResourceUnpublishing = useAppSelector((state) =>
+    PublicationSelectors.selectIsResourceUnpublishing(
       state,
-      selectedPublicationUrl || '',
+      selectedPublicationUrl ?? '',
+      application?.id ?? '',
     ),
   );
 
@@ -203,10 +204,10 @@ function ReviewApplicationDialogContent() {
       <div
         className={classNames(
           'flex w-full items-center border-t border-tertiary px-3 py-4 md:px-5',
-          isUnpublishRequest ? 'justify-end' : 'justify-between',
+          isResourceUnpublishing ? 'justify-end' : 'justify-between',
         )}
       >
-        {!isUnpublishRequest && (
+        {!isResourceUnpublishing && (
           <IconButton
             name={t('Edit application')}
             dataQa="admin-edit-application"

--- a/apps/chat/src/components/Chat/Publish/PublicationHandler/ReviewApplicationDialog/ReviewApplicationDialogView.tsx
+++ b/apps/chat/src/components/Chat/Publish/PublicationHandler/ReviewApplicationDialog/ReviewApplicationDialogView.tsx
@@ -1,6 +1,8 @@
 import { IconPencilMinus } from '@tabler/icons-react';
 import { Fragment, useCallback } from 'react';
 
+import classNames from 'classnames';
+
 import { useTranslation } from '@/src/hooks/useTranslation';
 
 import {
@@ -45,6 +47,13 @@ function ReviewApplicationDialogContent() {
   );
   const selectedPublicationUrl = useAppSelector(
     PublicationSelectors.selectSelectedPublicationUrl,
+  );
+
+  const isUnpublishRequest = useAppSelector((state) =>
+    PublicationSelectors.selectIsUnpublishRequest(
+      state,
+      selectedPublicationUrl || '',
+    ),
   );
 
   const isCodeApp = application && isExecutableApp(application);
@@ -191,13 +200,20 @@ function ReviewApplicationDialogContent() {
 
         <ReviewExternalAppSection application={application} />
       </div>
-      <div className="flex w-full items-center justify-between border-t border-tertiary px-3 py-4 md:px-5">
-        <IconButton
-          name={t('Edit application')}
-          dataQa="admin-edit-application"
-          Icon={IconPencilMinus}
-          onClick={handleEditApplication}
-        />
+      <div
+        className={classNames(
+          'flex w-full items-center border-t border-tertiary px-3 py-4 md:px-5',
+          isUnpublishRequest ? 'justify-end' : 'justify-between',
+        )}
+      >
+        {!isUnpublishRequest && (
+          <IconButton
+            name={t('Edit application')}
+            dataQa="admin-edit-application"
+            Icon={IconPencilMinus}
+            onClick={handleEditApplication}
+          />
+        )}
 
         {controlsEntity && (
           <PublicationControls

--- a/apps/chat/src/store/publication/publication.selectors.ts
+++ b/apps/chat/src/store/publication/publication.selectors.ts
@@ -71,14 +71,6 @@ const selectPublicationByUrl = createSelector(
   },
 );
 
-const selectIsUnpublishRequest = createSelector(
-  [selectPublicationByUrl],
-  (publication) =>
-    !!publication?.resources?.some(
-      (resource) => resource.action === PublishActions.DELETE,
-    ),
-);
-
 const selectResourcesToReview = (state: RootState) =>
   rootSelector(state).resourcesToReview;
 
@@ -334,7 +326,6 @@ export const PublicationSelectors = {
   selectSelectedPublicationUrl,
   selectSelectedPublication,
   selectPublicationByUrl,
-  selectIsUnpublishRequest,
   selectResourcesToReview,
   selectResourceToReviewByReviewUrl,
   selectResourceToReviewByReviewAndPublicationUrls,

--- a/apps/chat/src/store/publication/publication.selectors.ts
+++ b/apps/chat/src/store/publication/publication.selectors.ts
@@ -71,6 +71,14 @@ const selectPublicationByUrl = createSelector(
   },
 );
 
+const selectIsUnpublishRequest = createSelector(
+  [selectPublicationByUrl],
+  (publication) =>
+    !!publication?.resources?.some(
+      (resource) => resource.action === PublishActions.DELETE,
+    ),
+);
+
 const selectResourcesToReview = (state: RootState) =>
   rootSelector(state).resourcesToReview;
 
@@ -326,6 +334,7 @@ export const PublicationSelectors = {
   selectSelectedPublicationUrl,
   selectSelectedPublication,
   selectPublicationByUrl,
+  selectIsUnpublishRequest,
   selectResourcesToReview,
   selectResourceToReviewByReviewUrl,
   selectResourceToReviewByReviewAndPublicationUrls,


### PR DESCRIPTION
**Description:**

Need to hide Edit button for apps from unpublish requests

Issues:

- Issue #4314 

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
