### PR TITLE
fix(chat): disable 'approve selected' button if there are no changes (Issue #4110)

### DIFF
--- a/apps/chat/src/components/Chat/Publish/PublicationHandler/PublicationHandler.tsx
+++ b/apps/chat/src/components/Chat/Publish/PublicationHandler/PublicationHandler.tsx
@@ -444,6 +444,7 @@ export function PublicationHandler({ publication }: Props) {
           onUpdateRequest={handleUpdateRequest}
           publication={publication}
           isFormChanged={isFormChanged}
+          areRulesChanged={hasUserChangedRules}
         />
       </div>
       {isCompareModalOpened && publication.targetFolder && (

--- a/apps/chat/src/components/Chat/Publish/PublicationHandler/PublicationHandlerFooter.tsx
+++ b/apps/chat/src/components/Chat/Publish/PublicationHandler/PublicationHandlerFooter.tsx
@@ -51,6 +51,8 @@ import {
   PublicationSelectors,
 } from '@/src/store/selectors';
 
+import { PUBLIC_URL_PREFIX } from '@/src/constants/publication';
+
 import { IconButton } from '@/src/components/Common/IconButton';
 import { Tooltip } from '@/src/components/Common/Tooltip';
 
@@ -63,14 +65,16 @@ import uniq from 'lodash-es/uniq';
 
 interface Props {
   publication: Publication;
-  onUpdateRequest: () => void;
   isFormChanged: boolean;
+  areRulesChanged: boolean;
+  onUpdateRequest: () => void;
 }
 
 export const PublicationHandlerFooter = ({
   publication,
-  onUpdateRequest,
   isFormChanged,
+  areRulesChanged,
+  onUpdateRequest,
 }: Props) => {
   const { t } = useTranslation(Translation.Chat);
 
@@ -148,7 +152,7 @@ export const PublicationHandlerFooter = ({
     [resourcesToReview],
   );
 
-  const publicationConversationsWithUploadedMessages = useMemo(
+  const uploadedPublicationConversations = useMemo(
     () =>
       conversations.filter(
         (conversation) =>
@@ -330,16 +334,17 @@ export const PublicationHandlerFooter = ({
 
   const isEditInvalid =
     isNamesOrVersionsInvalid || isFoldersInvalid || isDisplayAuthorInvalid;
-  const someReviewedConversationHaveNoMessages =
-    publicationConversationsWithUploadedMessages.some(
-      (conversation) => !conversation.messages.length,
-    );
+  const someReviewedConversationHasNotMessages =
+    uploadedPublicationConversations.some(({ messages }) => !messages.length);
+  const areNoChanges =
+    !itemsToApprove.length &&
+    (publication.targetFolder === `${PUBLIC_URL_PREFIX}/` || !areRulesChanged);
   const isApproveDisabled =
     !isAllResourcesReviewed ||
     !!invalidEntities.length ||
-    someReviewedConversationHaveNoMessages ||
-    isPublicationUpdating;
-
+    someReviewedConversationHasNotMessages ||
+    isPublicationUpdating ||
+    areNoChanges;
   const isEditDisabled = isEditInvalid || !isFormChanged;
 
   return (
@@ -418,11 +423,13 @@ export const PublicationHandlerFooter = ({
               tooltip={t(
                 invalidEntities.length
                   ? "Request can't be approved as some conversations are unpublished"
-                  : someReviewedConversationHaveNoMessages
+                  : someReviewedConversationHasNotMessages
                     ? "Request can't be approved as some conversations have no messages"
                     : isPublicationUpdating
                       ? 'Request is updating'
-                      : "It's required to review all resources",
+                      : areNoChanges
+                        ? 'There are no changes to approve'
+                        : "It's required to review all resources",
               )}
             >
               <button

--- a/apps/chat/src/components/Chat/Publish/PublicationHandler/PublicationHandlerFooter.tsx
+++ b/apps/chat/src/components/Chat/Publish/PublicationHandler/PublicationHandlerFooter.tsx
@@ -334,7 +334,7 @@ export const PublicationHandlerFooter = ({
 
   const isEditInvalid =
     isNamesOrVersionsInvalid || isFoldersInvalid || isDisplayAuthorInvalid;
-  const someReviewedConversationHasNotMessages =
+  const someReviewedConversationHasNoMessages =
     uploadedPublicationConversations.some(({ messages }) => !messages.length);
   const areNoChanges =
     !itemsToApprove.length &&
@@ -342,7 +342,7 @@ export const PublicationHandlerFooter = ({
   const isApproveDisabled =
     !isAllResourcesReviewed ||
     !!invalidEntities.length ||
-    someReviewedConversationHasNotMessages ||
+    someReviewedConversationHasNoMessages ||
     isPublicationUpdating ||
     areNoChanges;
   const isEditDisabled = isEditInvalid || !isFormChanged;
@@ -423,7 +423,7 @@ export const PublicationHandlerFooter = ({
               tooltip={t(
                 invalidEntities.length
                   ? "Request can't be approved as some conversations are unpublished"
-                  : someReviewedConversationHasNotMessages
+                  : someReviewedConversationHasNoMessages
                     ? "Request can't be approved as some conversations have no messages"
                     : isPublicationUpdating
                       ? 'Request is updating'


### PR DESCRIPTION
**Description:**

disable 'approve selected' button if there are no changes

Issues:

- Issue #4110

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
