### PR TITLE
fix(chat): show unshare icon in application footer for sharedWithMe applications (Issue #3857)

### DIFF
--- a/apps/chat/src/components/Marketplace/ApplicationDetails/ApplicationFooter.tsx
+++ b/apps/chat/src/components/Marketplace/ApplicationDetails/ApplicationFooter.tsx
@@ -79,7 +79,7 @@ export const ApplicationDetailsFooter = ({
       disabledActions: {
         copyLink: screenState !== ScreenState.SM,
         share: !showContextMenu,
-        unshare: !showContextMenu,
+        unshare: !entity?.sharedWithMe,
       },
     }),
     [entity, screenState, showContextMenu],


### PR DESCRIPTION
**Description:**

show unshare icon in application footer for sharedWithMe applications

Issues:

- Issue #3857 

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
