### PR TITLE
chore(chat): set useLegacyTypescriptPlugin to false to use the official @rollup/plugin-typescript

### DIFF
--- a/apps/chat/project.json
+++ b/apps/chat/project.json
@@ -9,7 +9,8 @@
       "outputs": ["{options.outputPath}"],
       "defaultConfiguration": "production",
       "options": {
-        "outputPath": "dist/apps/chat"
+        "outputPath": "dist/apps/chat",
+        "useLegacyTypescriptPlugin": false
       },
       "configurations": {
         "development": {

--- a/libs/chat-visualizer-connector/project.json
+++ b/libs/chat-visualizer-connector/project.json
@@ -29,7 +29,8 @@
             "input": ".",
             "output": "."
           }
-        ]
+        ],
+        "useLegacyTypescriptPlugin": false
       }
     },
     "publish": {

--- a/libs/modulify-ui/project.json
+++ b/libs/modulify-ui/project.json
@@ -30,7 +30,8 @@
             "output": "."
           }
         ],
-        "buildableProjectDepsInPackageJsonType": true
+        "buildableProjectDepsInPackageJsonType": true,
+        "useLegacyTypescriptPlugin": false
       }
     },
     "publish": {

--- a/libs/overlay/project.json
+++ b/libs/overlay/project.json
@@ -29,7 +29,8 @@
             "input": ".",
             "output": "."
           }
-        ]
+        ],
+        "useLegacyTypescriptPlugin": false
       }
     },
     "publish": {

--- a/libs/shared/project.json
+++ b/libs/shared/project.json
@@ -30,7 +30,8 @@
             "output": "."
           }
         ],
-        "buildableProjectDepsInPackageJsonType": true
+        "buildableProjectDepsInPackageJsonType": true,
+        "useLegacyTypescriptPlugin": false
       }
     },
     "publish": {

--- a/libs/visualizer-connector/project.json
+++ b/libs/visualizer-connector/project.json
@@ -29,7 +29,8 @@
             "input": ".",
             "output": "."
           }
-        ]
+        ],
+        "useLegacyTypescriptPlugin": false
       }
     },
     "publish": {


### PR DESCRIPTION
**Description:**

set useLegacyTypescriptPlugin to false to use the official @rollup/plugin-typescript

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
