### PR TITLE
fix(chat): escape special characters before passing to regex creator (Issue #4378, #4413)

### DIFF
--- a/apps/chat/src/components/AppsEditor/GeneralInfoView/form.ts
+++ b/apps/chat/src/components/AppsEditor/GeneralInfoView/form.ts
@@ -1,6 +1,7 @@
 import { Path, RegisterOptions } from 'react-hook-form';
 
 import { safeStringifyApplicationFeatures } from '@/src/utils/app/application';
+import { DefaultsService } from '@/src/utils/app/data/defaults-service';
 import { notAllowedSymbols } from '@/src/utils/app/file';
 import { getNextDefaultName } from '@/src/utils/app/folders';
 import { ApiUtils } from '@/src/utils/server/api';
@@ -19,8 +20,15 @@ import {
   FEATURES_ENDPOINTS_DEFAULT_VALUES,
   FEATURES_ENDPOINTS_NAMES,
 } from '@/src/constants/applications';
-import { DEFAULT_APPLICATION_NAME } from '@/src/constants/default-ui-settings';
+import {
+  DEFAULT_APPLICATION_NAME,
+  DEFAULT_TEMPERATURE,
+} from '@/src/constants/default-ui-settings';
 import { DEFAULT_VERSION } from '@/src/constants/publication';
+import {
+  DEFAULT_QUICK_APPS_MODEL,
+  DEFAULT_QUICK_APPS_SCHEMA_ID,
+} from '@/src/constants/quick-apps';
 
 import { DynamicField } from '@/src/components/Common/Forms/DynamicFormFields';
 
@@ -162,6 +170,11 @@ export const getApplicationData = (
   type: string,
   schema: ApiDetailedApplicationTypeSchema | null,
 ): Omit<CustomApplicationModel, 'id' | 'reference'> => {
+  const quickAppSchemaId = DefaultsService.get(
+    'quickAppsSchemaId',
+    DEFAULT_QUICK_APPS_SCHEMA_ID,
+  );
+
   const preparedData: Omit<CustomApplicationModel, 'id' | 'reference'> = {
     name: formData.name.trim(),
     applicationTypeSchemaId: schema?.$id ?? undefined,
@@ -207,6 +220,17 @@ export const getApplicationData = (
           }),
           {},
         ) ?? {},
+    };
+  }
+
+  if (quickAppSchemaId.endsWith(type) && !preparedData.applicationProperties) {
+    preparedData.applicationProperties = {
+      model: DefaultsService.get('quickAppsModel', DEFAULT_QUICK_APPS_MODEL),
+      document_relative_url: [],
+      instructions: '',
+      temperature: DEFAULT_TEMPERATURE,
+      web_api_toolset: [],
+      mcp_toolset: [],
     };
   }
 

--- a/apps/chat/src/components/Chat/Publish/PublishWizard.tsx
+++ b/apps/chat/src/components/Chat/Publish/PublishWizard.tsx
@@ -83,6 +83,7 @@ import {
 } from './form';
 
 import { PublishActions, ShareEntity } from '@epam/ai-dial-shared';
+import { escapeRegExp } from 'lodash';
 import compact from 'lodash-es/compact';
 import flatMapDeep from 'lodash-es/flatMapDeep';
 import isEqual from 'lodash-es/isEqual';
@@ -251,7 +252,7 @@ export function PublishModal<
   const handlePublish = useCallback(
     (data: PublicationRequestFormData) => {
       const folderOldPathPartsRegExp = new RegExp(
-        getIdWithoutRootPathSegments(entity.folderId),
+        escapeRegExp(getIdWithoutRootPathSegments(entity.folderId)),
       );
 
       const trimmedPath = path.trim();


### PR DESCRIPTION
**Description:**

- escape special characters in folder id before passing to RegEx
- save initial quick app applicationProperties on general step

Issues:

- Issue #4378
- Issue #4413 

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
