### PR TITLE
fix(chat): revert `error.message` and log 429 token limits (Issue #3666)

### DIFF
--- a/apps/chat/src/utils/server/chat.ts
+++ b/apps/chat/src/utils/server/chat.ts
@@ -189,6 +189,10 @@ export const chatErrorHandler = ({
       typeof errorMessage === 'function'
         ? errorMessage('entity')
         : errorMessage;
+
+    if (error.code === '429' && error.message) {
+      console.error(error.message);
+    }
   }
 
   const responseBody = getResponseBody(

--- a/apps/chat/src/utils/server/chat.ts
+++ b/apps/chat/src/utils/server/chat.ts
@@ -193,9 +193,7 @@ export const chatErrorHandler = ({
 
   const responseBody = getResponseBody(
     fieldName,
-    error instanceof DialAIError
-      ? (error.displayMessage ?? error.message)
-      : undefined,
+    error instanceof DialAIError ? error.displayMessage : undefined,
     fallbackErrorMessage,
   );
 


### PR DESCRIPTION
**Description:**

revert `error.message` and log 429 token limits

Issues:

- Issue #3666

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
