### PR TITLE
fix(overlay): fix it's impossible to login in browser2 if the user has been logged in browser1 (Issue #4432, #4427)

### DIFF
--- a/apps/chat-e2e/src/tests/overlay/events.test.ts
+++ b/apps/chat-e2e/src/tests/overlay/events.test.ts
@@ -354,6 +354,7 @@ dialOverlayTest(
           const permissions = actualConversation.permissions;
           const isPlayback = conversation.playback?.isPlayback;
           const isReplay = conversation.replay?.isReplay;
+          const bucket = actualConversation.bucket;
           const shortConversation: ConversationInfo = {
             model: isPlayback
               ? { id: PseudoModel.playback }
@@ -373,6 +374,7 @@ dialOverlayTest(
             const expectedSelectedOverlayConversation = {
               ...shortConversation,
               ...(permissions && { permissions }),
+              ...(bucket && { bucket }),
             };
             expectedSelectedConversation = {
               conversation:
@@ -403,8 +405,7 @@ dialOverlayTest(
             //save expectedSelectedConversation for the next test step if it is the last listed one
             if (expectedConversation.id === todayConversation.id) {
               // eslint-disable-next-line @typescript-eslint/no-unused-vars
-              const { bucket, parentPath, ...conversationInfo } =
-                expectedConversation;
+              const { parentPath, ...conversationInfo } = expectedConversation;
               expectedSelectedConversation = {
                 conversation: conversationInfo as OverlayConversation,
               };

--- a/apps/chat/src/components/Chat/Chat.tsx
+++ b/apps/chat/src/components/Chat/Chat.tsx
@@ -116,6 +116,18 @@ const ChatView = memo(() => {
   const enabledFeatures = useAppSelector(
     SettingsSelectors.selectEnabledFeatures,
   );
+  const isEditUserMessageHided = useAppSelector((state) =>
+    SettingsSelectors.isFeatureEnabled(state, Feature.HideEditUserMessage),
+  );
+  const isRegenerateAssistantMessageHided = useAppSelector((state) =>
+    SettingsSelectors.isFeatureEnabled(
+      state,
+      Feature.HideRegenerateAssistantMessage,
+    ),
+  );
+  const isDeleteMessageHided = useAppSelector((state) =>
+    SettingsSelectors.isFeatureEnabled(state, Feature.HideDeleteUserMessage),
+  );
   const isReplay = useAppSelector(
     ConversationsSelectors.selectIsReplaySelectedConversations,
   );
@@ -827,20 +839,28 @@ const ChatView = memo(() => {
                                                 isValidApproveRequiredConversation)
                                             }
                                             editDisabled={
-                                              (!!notAvailableEntityType ||
+                                              ((!!notAvailableEntityType ||
                                                 isReadOnly ||
                                                 isReplay ||
                                                 isPlayback) &&
-                                              (!isValidApproveRequiredConversation ||
-                                                !!notAvailableEntityType)
+                                                (!isValidApproveRequiredConversation ||
+                                                  !!notAvailableEntityType)) ||
+                                              (message.role === Role.User &&
+                                                isEditUserMessageHided)
                                             }
                                             onEdit={handleEditMessage}
                                             onLike={handleLike}
-                                            onDelete={handleDeleteMessage}
+                                            onDelete={
+                                              !isDeleteMessageHided
+                                                ? handleDeleteMessage
+                                                : undefined
+                                            }
                                             onRegenerate={
                                               index ===
                                                 mergedMessages.length - 1 &&
-                                              showLastMessageRegenerate
+                                              showLastMessageRegenerate &&
+                                              (!isRegenerateAssistantMessageHided ||
+                                                message.role !== Role.Assistant)
                                                 ? handleRegenerateMessage
                                                 : undefined
                                             }

--- a/apps/chat/src/components/Chat/ChatMessage/ChatMessage.tsx
+++ b/apps/chat/src/components/Chat/ChatMessage/ChatMessage.tsx
@@ -1,4 +1,4 @@
-import { FC, memo, useCallback, useState } from 'react';
+import { FC, memo, useCallback, useMemo, useState } from 'react';
 
 import { useTranslation } from '@/src/hooks/useTranslation';
 
@@ -23,6 +23,7 @@ import {
   LikeState,
   Message,
   PublishActions,
+  Role,
 } from '@epam/ai-dial-shared';
 
 export interface Props {
@@ -38,7 +39,7 @@ export interface Props {
     conversation: Conversation,
     likeStatus: LikeState,
   ) => void;
-  onDelete: (messageIndex: number, conversation: Conversation) => void;
+  onDelete?: (messageIndex: number, conversation: Conversation) => void;
   onEdit: (
     editedMessage: Message,
     index: number,
@@ -82,6 +83,12 @@ export const ChatMessage: FC<Props> = memo(
     const isMessageTemplatesEnabled = useAppSelector((state) =>
       SettingsSelectors.isFeatureEnabled(state, Feature.MessageTemplates),
     );
+    const isFirstMessageSystem = useMemo(() => {
+      return conversation.messages[0]?.role === Role.System;
+    }, [conversation.messages]);
+    const realMessageIndex = useMemo(() => {
+      return isFirstMessageSystem ? messageIndex + 1 : messageIndex;
+    }, [isFirstMessageSystem, messageIndex]);
 
     const handleLike = useCallback(
       (likeStatus: LikeState) => {
@@ -115,8 +122,14 @@ export const ChatMessage: FC<Props> = memo(
     }, [message.content]);
 
     const handleDeleteMessage = useCallback(() => {
-      onDelete(messageIndex, conversation);
+      onDelete?.(messageIndex, conversation);
     }, [onDelete, messageIndex, conversation]);
+
+    const handleDelete = useCallback(() => {
+      if (!onDelete) return;
+
+      setIsDeleteConfirmationOpened(true);
+    }, [onDelete]);
 
     return (
       <>
@@ -124,10 +137,9 @@ export const ChatMessage: FC<Props> = memo(
           <ChatMessageContent
             isLastMessage={isLastMessage}
             messageIndex={messageIndex}
+            realMessageIndex={realMessageIndex}
             onEdit={onEdit}
-            onDelete={() => {
-              setIsDeleteConfirmationOpened(true);
-            }}
+            onDelete={onDelete && handleDelete}
             onToggleEditing={handleToggleEditing}
             isEditing={isEditing}
             editDisabled={editDisabled}
@@ -167,6 +179,7 @@ export const ChatMessage: FC<Props> = memo(
               <ChatMessageContent
                 isLastMessage={isLastMessage}
                 messageIndex={messageIndex}
+                realMessageIndex={realMessageIndex}
                 conversation={conversation}
                 allMessages={filteredMessages}
                 editDisabled={editDisabled}
@@ -196,13 +209,14 @@ export const ChatMessage: FC<Props> = memo(
             <MessageMobileButtons
               isMessageStreaming={!!conversation.isMessageStreaming}
               isLastMessage={isLastMessage}
+              realMessageIndex={realMessageIndex}
               message={message}
               isLikesEnabled={isLikesEnabled}
               onCopy={handleCopy}
               messageCopied={messageCopied}
               editDisabled={editDisabled}
               onLike={handleLike}
-              onDelete={() => setIsDeleteConfirmationOpened(true)}
+              onDelete={onDelete && handleDelete}
               isEditing={isEditing}
               onToggleEditing={handleToggleEditing}
               onRegenerate={onRegenerate}

--- a/apps/chat/src/components/Chat/ChatMessage/ChatMessageContent/AssistantMessage.tsx
+++ b/apps/chat/src/components/Chat/ChatMessage/ChatMessageContent/AssistantMessage.tsx
@@ -40,9 +40,9 @@ import { isEqual } from 'lodash-es';
 
 interface AssistantMessageProps {
   messageIndex: number;
+  realMessageIndex: number;
   message: Message;
   allMessages: Message[];
-  isFirstMessageSystem: boolean;
   conversation: Conversation;
   isLastMessage: boolean;
   isLikesEnabled: boolean;
@@ -62,9 +62,9 @@ interface AssistantMessageProps {
 
 export const AssistantMessage = memo(function AssistantMessage({
   messageIndex,
+  realMessageIndex,
   message,
   allMessages,
-  isFirstMessageSystem,
   conversation,
   isLastMessage,
   isEditing,
@@ -304,10 +304,7 @@ export const AssistantMessage = memo(function AssistantMessage({
         <ErrorMessage error={message.errorMessage}></ErrorMessage>
 
         {isOverlay && (
-          <OverlayMessageCustomButtons
-            messageIndex={messageIndex}
-            isSystemMessagePresented={isFirstMessageSystem}
-          />
+          <OverlayMessageCustomButtons realMessageIndex={realMessageIndex} />
         )}
       </div>
       {withButtons &&
@@ -317,6 +314,7 @@ export const AssistantMessage = memo(function AssistantMessage({
             copyOnClick={() => onCopy?.()}
             isLikesEnabled={isLikesEnabled}
             message={message}
+            realMessageIndex={realMessageIndex}
             messageCopied={messageCopied}
             onLike={(likeStatus) => onLike?.(likeStatus)}
             onRegenerate={onRegenerate}

--- a/apps/chat/src/components/Chat/ChatMessage/ChatMessageContent/ChatMessageContent.tsx
+++ b/apps/chat/src/components/Chat/ChatMessage/ChatMessageContent/ChatMessageContent.tsx
@@ -1,5 +1,5 @@
 import { IconUser } from '@tabler/icons-react';
-import { MouseEvent, RefObject, useMemo, useRef } from 'react';
+import { MouseEvent, RefObject, useRef } from 'react';
 
 import classNames from 'classnames';
 
@@ -23,6 +23,7 @@ import { LikeState, Message, Role } from '@epam/ai-dial-shared';
 interface Props {
   message: Message;
   messageIndex: number;
+  realMessageIndex: number;
   conversation: Conversation;
   allMessages: Message[];
   isLikesEnabled: boolean;
@@ -55,6 +56,7 @@ const DEFAULT_ICON_SIZE = 28;
 
 export function ChatMessageContent({
   messageIndex,
+  realMessageIndex,
   isLastMessage,
   message,
   allMessages,
@@ -79,10 +81,6 @@ export function ChatMessageContent({
   const isOverlay = useAppSelector(SettingsSelectors.selectIsOverlay);
 
   const messageRef = useRef<HTMLDivElement>(null);
-
-  const isFirstMessageSystem = useMemo(() => {
-    return conversation.messages[0]?.role === Role.System;
-  }, [conversation.messages]);
 
   const isAssistant = message.role === Role.Assistant;
   const isShowResponseLoader: boolean =
@@ -148,10 +146,10 @@ export function ChatMessageContent({
           {isUser ? (
             <UserMessage
               message={message}
-              allMessages={allMessages}
-              isFirstMessageSystem={isFirstMessageSystem}
-              conversation={conversation}
               messageIndex={messageIndex}
+              realMessageIndex={realMessageIndex}
+              allMessages={allMessages}
+              conversation={conversation}
               isEditing={isEditing}
               isEditingTemplates={isEditingTemplates}
               withButtons={withButtons}
@@ -164,9 +162,9 @@ export function ChatMessageContent({
           ) : (
             <AssistantMessage
               messageIndex={messageIndex}
+              realMessageIndex={realMessageIndex}
               message={message}
               allMessages={allMessages}
-              isFirstMessageSystem={isFirstMessageSystem}
               conversation={conversation}
               isEditing={isEditing}
               isLastMessage={isLastMessage}

--- a/apps/chat/src/components/Chat/ChatMessage/ChatMessageContent/OverlayMessageCustomButtons.tsx
+++ b/apps/chat/src/components/Chat/ChatMessage/ChatMessageContent/OverlayMessageCustomButtons.tsx
@@ -1,11 +1,8 @@
-import {
-  CSSProperties,
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
+import { CSSProperties, useCallback, useEffect, useRef, useState } from 'react';
+
+import classNames from 'classnames';
+
+import { isMobile } from '@/src/utils/app/mobile';
 
 import { OverlayActions } from '@/src/store/actions';
 import { useAppDispatch, useAppSelector } from '@/src/store/hooks';
@@ -13,17 +10,38 @@ import { OverlaySelectors } from '@/src/store/selectors';
 
 import { Tooltip } from '@/src/components/Common/Tooltip';
 
-import { MessageButton } from '@epam/ai-dial-shared';
+import { MessageButton, MessageButtonPlacement } from '@epam/ai-dial-shared';
 
 interface ButtonProps {
   button: MessageButton;
-  onEvent: (eventName: keyof WindowEventMap) => void;
+  realMessageIndex: number;
+  defaultClassName?: string;
+  defaultIconClassName?: string;
 }
 
-const OverlayMessageCustomButton = ({ button, onEvent }: ButtonProps) => {
+export const OverlayMessageCustomButton = ({
+  button,
+  defaultClassName,
+  defaultIconClassName,
+  realMessageIndex,
+}: ButtonProps) => {
+  const dispatch = useAppDispatch();
   const ref = useRef<HTMLButtonElement>(null);
   const [isHovered, setIsHovered] = useState(false);
   const [isFocused, setIsFocused] = useState(false);
+
+  const handleOnButtonEvent = useCallback(
+    (eventName: keyof WindowEventMap) => {
+      dispatch(
+        OverlayActions.sendCustomMessageEvent({
+          buttonKey: button.buttonKey,
+          eventName: eventName,
+          messageIndex: realMessageIndex,
+        }),
+      );
+    },
+    [button.buttonKey, dispatch, realMessageIndex],
+  );
 
   const handleMouseEnter = useCallback(() => {
     setIsHovered(true);
@@ -60,7 +78,7 @@ const OverlayMessageCustomButton = ({ button, onEvent }: ButtonProps) => {
       ref.current?.addEventListener(
         event,
         () => {
-          onEvent(event);
+          handleOnButtonEvent(event);
         },
         { signal: abortSignal.signal },
       ),
@@ -69,22 +87,18 @@ const OverlayMessageCustomButton = ({ button, onEvent }: ButtonProps) => {
     return () => {
       abortSignal.abort();
     };
-  }, [button.events, onEvent]);
+  }, [button.events, handleOnButtonEvent]);
 
   if (!button.iconSvg && !button.title) return null;
 
   return (
-    <Tooltip tooltip={button.tooltip}>
+    <Tooltip tooltip={button.tooltip} placement="top" isTriggerClickable>
       <button
         ref={ref}
         disabled={button.disabled}
         onMouseEnter={handleMouseEnter}
         onMouseLeave={handleMouseLeave}
-        className={
-          button.skipDefaultStyles
-            ? undefined
-            : 'button button-secondary flex items-center gap-2 px-2 py-1'
-        }
+        className={classNames(!button.skipDefaultStyles && defaultClassName)}
         style={{
           ...(button.styles as CSSProperties),
           ...(isHovered && !button.disabled
@@ -100,47 +114,33 @@ const OverlayMessageCustomButton = ({ button, onEvent }: ButtonProps) => {
       >
         {button.iconSvg && (
           <span
+            className={classNames(
+              !button.skipDefaultStyles && defaultIconClassName,
+            )}
             dangerouslySetInnerHTML={
               button.iconSvg ? { __html: button.iconSvg } : undefined
             }
           ></span>
         )}
-        {button.title && <span>{button.title}</span>}
+        {button.title &&
+          (button.placement !==
+            MessageButtonPlacement.PREPEND_DEFAULT_BUTTONS ||
+            isMobile()) && <span>{button.title}</span>}
       </button>
     </Tooltip>
   );
 };
 
 interface Props {
-  messageIndex: number;
-  isSystemMessagePresented: boolean;
+  realMessageIndex: number;
 }
 
-export const OverlayMessageCustomButtons = ({
-  messageIndex,
-  isSystemMessagePresented,
-}: Props) => {
-  const dispatch = useAppDispatch();
-
-  const realMessageIndex = useMemo(() => {
-    return isSystemMessagePresented ? messageIndex + 1 : messageIndex;
-  }, [isSystemMessagePresented, messageIndex]);
-
+export const OverlayMessageCustomButtons = ({ realMessageIndex }: Props) => {
   const customMessageButtons = useAppSelector((state) =>
-    OverlaySelectors.selectCustomButtonsForMessage(state, realMessageIndex),
-  );
-
-  const handleOnButtonEvent = useCallback(
-    (eventName: keyof WindowEventMap, button: MessageButton) => {
-      dispatch(
-        OverlayActions.sendCustomMessageEvent({
-          buttonKey: button.buttonKey,
-          eventName: eventName,
-          messageIndex: realMessageIndex,
-        }),
-      );
-    },
-    [dispatch, realMessageIndex],
+    OverlaySelectors.selectContentAppendedButtonsForMessage(
+      state,
+      realMessageIndex,
+    ),
   );
 
   if (!customMessageButtons?.length) return null;
@@ -151,7 +151,8 @@ export const OverlayMessageCustomButtons = ({
         <OverlayMessageCustomButton
           key={button.buttonKey}
           button={button}
-          onEvent={(eventName) => handleOnButtonEvent(eventName, button)}
+          defaultClassName="button button-secondary flex items-center gap-2 px-2 py-1"
+          realMessageIndex={realMessageIndex}
         />
       ))}
     </div>

--- a/apps/chat/src/components/Chat/ChatMessage/ChatMessageContent/UserMessage.tsx
+++ b/apps/chat/src/components/Chat/ChatMessage/ChatMessageContent/UserMessage.tsx
@@ -68,8 +68,8 @@ interface UserMessageProps {
   message: Message;
   conversation: Conversation;
   messageIndex: number;
+  realMessageIndex: number;
   allMessages: Message[];
-  isFirstMessageSystem: boolean;
   isEditing: boolean;
   isEditingTemplates: boolean;
   withButtons?: boolean;
@@ -88,8 +88,8 @@ export const UserMessage = memo(function UserMessage({
   message,
   conversation,
   messageIndex,
+  realMessageIndex,
   allMessages,
-  isFirstMessageSystem,
   isEditing,
   isEditingTemplates,
   withButtons,
@@ -630,10 +630,7 @@ export const UserMessage = memo(function UserMessage({
         <MessageAttachments attachments={message.custom_content?.attachments} />
 
         {isOverlay && (
-          <OverlayMessageCustomButtons
-            messageIndex={messageIndex}
-            isSystemMessagePresented={isFirstMessageSystem}
-          />
+          <OverlayMessageCustomButtons realMessageIndex={realMessageIndex} />
         )}
 
         <div
@@ -643,9 +640,10 @@ export const UserMessage = memo(function UserMessage({
       </div>
       {showUserButtons && !isConversationInvalid && (
         <MessageUserButtons
+          realMessageIndex={realMessageIndex}
           isMessageStreaming={!!conversation.isMessageStreaming}
           isEditAvailable={!!onEdit && !editDisabled}
-          onDelete={() => onDelete?.()}
+          onDelete={onDelete}
           onToggleEditing={handleToggleEditing}
           isEditTemplatesAvailable={
             (!isReadOnly || isApproveRequiredEntitySelected) &&

--- a/apps/chat/src/components/Chat/ChatMessage/MessageButtons.tsx
+++ b/apps/chat/src/components/Chat/ChatMessage/MessageButtons.tsx
@@ -21,11 +21,14 @@ import { Translation } from '@/src/types/translation';
 import { useAppSelector } from '@/src/store/hooks';
 import {
   ConversationsSelectors,
+  OverlaySelectors,
   SettingsSelectors,
 } from '@/src/store/selectors';
 
 import { MenuItem } from '@/src/components/Common/DropdownMenu';
 import { Tooltip } from '@/src/components/Common/Tooltip';
+
+import { OverlayMessageCustomButton } from './ChatMessageContent/OverlayMessageCustomButtons';
 
 import { Feature, LikeState, Message, Role } from '@epam/ai-dial-shared';
 
@@ -50,15 +53,17 @@ const Button: FC<ButtonHTMLAttributes<HTMLButtonElement>> = ({
 };
 
 interface MessageUserButtonsProps {
+  realMessageIndex: number;
   isEditAvailable: boolean;
   isMessageStreaming: boolean;
   isEditTemplatesAvailable: boolean;
   onToggleEditing: () => void;
-  onDelete: () => void;
+  onDelete?: () => void;
   onToggleTemplatesEditing: () => void;
 }
 
 export const MessageUserButtons = ({
+  realMessageIndex,
   isEditAvailable,
   isMessageStreaming,
   isEditTemplatesAvailable,
@@ -72,6 +77,12 @@ export const MessageUserButtons = ({
   const isConversationsWithSchema = useAppSelector(
     ConversationsSelectors.selectIsSelectedConversationsWithSchema,
   );
+  const customMessageButtons = useAppSelector((state) =>
+    OverlaySelectors.selectPrependedDefaultButtonsForMessage(
+      state,
+      realMessageIndex,
+    ),
+  );
 
   return (
     <div
@@ -82,6 +93,14 @@ export const MessageUserButtons = ({
     >
       {!isMessageStreaming && (
         <>
+          {customMessageButtons?.map((item) => (
+            <OverlayMessageCustomButton
+              key={item.buttonKey}
+              button={item}
+              defaultClassName="text-secondary hover:text-accent-primary"
+              realMessageIndex={realMessageIndex}
+            />
+          ))}
           {isEditTemplatesAvailable && !isConversationsWithSchema && (
             <Tooltip
               placement="top"
@@ -106,14 +125,16 @@ export const MessageUserButtons = ({
               </button>
             </Tooltip>
           )}
-          <Tooltip placement="top" isTriggerClickable tooltip={t('Delete')}>
-            <button
-              className="text-secondary hover:text-accent-primary"
-              onClick={onDelete}
-            >
-              <IconTrashX size={18} />
-            </button>
-          </Tooltip>
+          {onDelete && (
+            <Tooltip placement="top" isTriggerClickable tooltip={t('Delete')}>
+              <button
+                className="text-secondary hover:text-accent-primary"
+                onClick={onDelete}
+              >
+                <IconTrashX size={18} />
+              </button>
+            </Tooltip>
+          )}
         </>
       )}
     </div>
@@ -121,6 +142,7 @@ export const MessageUserButtons = ({
 };
 
 interface MessageAssistantButtonsProps {
+  realMessageIndex: number;
   messageCopied?: boolean;
   isLikesEnabled: boolean;
   message: Message;
@@ -133,6 +155,7 @@ interface MessageAssistantButtonsProps {
 export const MessageAssistantButtons = ({
   messageCopied,
   message,
+  realMessageIndex,
   isLikesEnabled,
   copyOnClick,
   onLike,
@@ -142,6 +165,12 @@ export const MessageAssistantButtons = ({
   const { t } = useTranslation(Translation.Chat);
 
   const isOverlay = useAppSelector(SettingsSelectors.selectIsOverlay);
+  const customMessageButtons = useAppSelector((state) =>
+    OverlaySelectors.selectPrependedDefaultButtonsForMessage(
+      state,
+      realMessageIndex,
+    ),
+  );
 
   return (
     <div
@@ -150,6 +179,14 @@ export const MessageAssistantButtons = ({
         isOverlay ? 'mt-3' : 'mt-4',
       )}
     >
+      {customMessageButtons?.map((item) => (
+        <OverlayMessageCustomButton
+          key={item.buttonKey}
+          button={item}
+          defaultClassName="text-secondary hover:text-accent-primary"
+          realMessageIndex={realMessageIndex}
+        />
+      ))}
       {onRegenerate && (
         <Tooltip placement="top" isTriggerClickable tooltip={t('Regenerate')}>
           <Button
@@ -189,73 +226,70 @@ export const MessageAssistantButtons = ({
           </Button>
         </Tooltip>
       )}
-      <div className="flex flex-row gap-2">
-        {isLikesEnabled &&
-          (message.content.trim() || !!getMessageCustomContent(message)) && (
-            <>
-              {message.like !== LikeState.Disliked && (
-                <Tooltip
-                  placement="top"
-                  isTriggerClickable={message.like !== LikeState.Liked}
-                  tooltip={
-                    message.like !== LikeState.Liked ? t('Like') : t('Liked')
+      {isLikesEnabled &&
+        (message.content.trim() || !!getMessageCustomContent(message)) && (
+          <div className="flex flex-row gap-2">
+            {message.like !== LikeState.Disliked && (
+              <Tooltip
+                placement="top"
+                isTriggerClickable={message.like !== LikeState.Liked}
+                tooltip={
+                  message.like !== LikeState.Liked ? t('Like') : t('Liked')
+                }
+              >
+                <Button
+                  onClick={() => {
+                    if (message.like !== LikeState.NoState) {
+                      onLike(LikeState.Liked);
+                    }
+                  }}
+                  className={
+                    message.like !== LikeState.Liked
+                      ? 'text-secondary'
+                      : 'text-accent-primary'
                   }
+                  disabled={message.like === LikeState.Liked}
+                  data-qa="like"
                 >
-                  <Button
-                    onClick={() => {
-                      if (message.like !== LikeState.NoState) {
-                        onLike(LikeState.Liked);
-                      }
-                    }}
-                    className={
-                      message.like !== LikeState.Liked
-                        ? 'text-secondary'
-                        : 'text-accent-primary'
+                  <IconThumbUp size={18} />
+                </Button>
+              </Tooltip>
+            )}
+            {message.like !== LikeState.Liked && (
+              <Tooltip
+                placement="top"
+                isTriggerClickable={message.like !== LikeState.Disliked}
+                tooltip={t(
+                  message.like !== LikeState.Disliked ? 'Dislike' : 'Disliked',
+                )}
+              >
+                <Button
+                  onClick={() => {
+                    if (message.like !== LikeState.NoState) {
+                      onLike(LikeState.Disliked);
                     }
-                    disabled={message.like === LikeState.Liked}
-                    data-qa="like"
-                  >
-                    <IconThumbUp size={18} />
-                  </Button>
-                </Tooltip>
-              )}
-              {message.like !== LikeState.Liked && (
-                <Tooltip
-                  placement="top"
-                  isTriggerClickable={message.like !== LikeState.Disliked}
-                  tooltip={t(
+                  }}
+                  className={
                     message.like !== LikeState.Disliked
-                      ? 'Dislike'
-                      : 'Disliked',
-                  )}
+                      ? 'text-secondary'
+                      : 'text-accent-primary'
+                  }
+                  disabled={message.like === LikeState.Disliked}
+                  data-qa="dislike"
                 >
-                  <Button
-                    onClick={() => {
-                      if (message.like !== LikeState.NoState) {
-                        onLike(LikeState.Disliked);
-                      }
-                    }}
-                    className={
-                      message.like !== LikeState.Disliked
-                        ? 'text-secondary'
-                        : 'text-accent-primary'
-                    }
-                    disabled={message.like === LikeState.Disliked}
-                    data-qa="dislike"
-                  >
-                    <IconThumbDown size={18} />
-                  </Button>
-                </Tooltip>
-              )}
-            </>
-          )}
-      </div>
+                  <IconThumbDown size={18} />
+                </Button>
+              </Tooltip>
+            )}
+          </div>
+        )}
     </div>
   );
 };
 
 interface MessageMobileButtonsProps {
   message: Message;
+  realMessageIndex: number;
   messageCopied: boolean;
   editDisabled: boolean;
   isEditing: boolean;
@@ -265,7 +299,7 @@ interface MessageMobileButtonsProps {
   isMessageStreaming: boolean;
   isConversationInvalid: boolean;
   onLike: (likeStatus: LikeState) => void;
-  onDelete: () => void;
+  onDelete?: () => void;
   onToggleEditing: (value: boolean) => void;
   onToggleTemplatesEditing: () => void;
   onCopy: () => void;
@@ -276,6 +310,7 @@ export const MessageMobileButtons = ({
   messageCopied,
   editDisabled,
   message,
+  realMessageIndex,
   isLikesEnabled,
   isEditing,
   isEditTemplatesAvailable,
@@ -302,12 +337,30 @@ export const MessageMobileButtons = ({
   );
 
   const isAssistant = message.role === Role.Assistant;
+  const customMessageButtons = useAppSelector((state) =>
+    OverlaySelectors.selectPrependedDefaultButtonsForMessage(
+      state,
+      realMessageIndex,
+    ),
+  );
 
   if (isAssistant) {
     return (
       !(isMessageStreaming && isLastMessage) &&
       !isConversationInvalid && (
         <>
+          {customMessageButtons?.map((item) => (
+            <MenuItem
+              key={item.buttonKey}
+              isChildrenButton
+              item={
+                <OverlayMessageCustomButton
+                  button={item}
+                  realMessageIndex={realMessageIndex}
+                />
+              }
+            />
+          ))}
           {message.content.trim() &&
             (messageCopied ? (
               <MenuItem
@@ -429,6 +482,20 @@ export const MessageMobileButtons = ({
     !isMessageStreaming &&
     !isConversationInvalid && (
       <>
+        {customMessageButtons?.map((item) => (
+          <MenuItem
+            key={item.buttonKey}
+            isChildrenButton
+            item={
+              <OverlayMessageCustomButton
+                button={item}
+                defaultClassName="hover:bg-accent-primary-alpha focus:visible disabled:cursor-not-allowed group-hover:visible"
+                defaultIconClassName="text-secondary"
+                realMessageIndex={realMessageIndex}
+              />
+            }
+          />
+        ))}
         {isEditTemplatesAvailable && !isConversationsWithSchema && (
           <MenuItem
             className="hover:bg-accent-primary-alpha focus:visible disabled:cursor-not-allowed group-hover:visible"
@@ -458,16 +525,18 @@ export const MessageMobileButtons = ({
             }
           />
         )}
-        <MenuItem
-          className="hover:bg-accent-primary-alpha focus:visible group-hover:visible"
-          onClick={onDelete}
-          item={
-            <div className="flex items-center gap-3">
-              <IconTrashX className="text-secondary" size={18} />
-              <p>{t('Delete')}</p>
-            </div>
-          }
-        />
+        {onDelete && (
+          <MenuItem
+            className="hover:bg-accent-primary-alpha focus:visible group-hover:visible"
+            onClick={onDelete}
+            item={
+              <div className="flex items-center gap-3">
+                <IconTrashX className="text-secondary" size={18} />
+                <p>{t('Delete')}</p>
+              </div>
+            }
+          />
+        )}
       </>
     )
   );

--- a/apps/chat/src/components/Common/DropdownMenu.tsx
+++ b/apps/chat/src/components/Common/DropdownMenu.tsx
@@ -322,20 +322,31 @@ interface MenuItemProps {
 }
 
 export const MenuItem = forwardRef<
-  HTMLButtonElement,
-  MenuItemProps & ButtonHTMLAttributes<HTMLButtonElement>
+  HTMLButtonElement | HTMLDivElement,
+  MenuItemProps &
+    ButtonHTMLAttributes<HTMLButtonElement | HTMLDivElement> & {
+      isChildrenButton?: boolean;
+    }
 >(function MenuItem(
-  { className, label, item: ItemComponent, disabled, ...props },
+  {
+    className,
+    label,
+    item: ItemComponent,
+    disabled,
+    isChildrenButton,
+    ...props
+  },
   forwardedRef,
 ) {
   const menu = useContext(MenuContext);
   const item = useListItem({ label: disabled ? null : label });
   const tree = useFloatingTree();
   const isActive = item.index === menu.activeIndex;
+  const Tag = isChildrenButton ? 'div' : 'button';
 
   return (
     <div>
-      <button
+      <Tag
         {...props}
         ref={useMergeRefs([item.ref, forwardedRef])}
         type="button"
@@ -349,11 +360,11 @@ export const MenuItem = forwardRef<
         tabIndex={isActive ? 0 : -1}
         disabled={disabled}
         {...menu.getItemProps({
-          onClick(event: MouseEvent<HTMLButtonElement>) {
+          onClick(event: MouseEvent<HTMLDivElement | HTMLButtonElement>) {
             props.onClick?.(event);
             tree?.events.emit('click');
           },
-          onFocus(event: FocusEvent<HTMLButtonElement>) {
+          onFocus(event: FocusEvent<HTMLDivElement | HTMLButtonElement>) {
             props.onFocus?.(event);
             menu.setHasFocusInside(true);
           },
@@ -363,7 +374,7 @@ export const MenuItem = forwardRef<
         {!ItemComponent && label && (
           <span className="inline-block truncate">{label}</span>
         )}
-      </button>
+      </Tag>
     </div>
   );
 });

--- a/apps/chat/src/pages/auth/signin/index.tsx
+++ b/apps/chat/src/pages/auth/signin/index.tsx
@@ -70,19 +70,15 @@ export default function Signin({
 
       if (callbackUrl) {
         try {
-          const allowedUrls = ['/', '/marketplace'];
           const url = new URL(callbackUrl.toString(), window.location.origin);
-          if (
-            url.origin === window.location.origin &&
-            allowedUrls.includes(url.pathname)
-          ) {
+          if (url.origin === window.location.origin) {
             safeUrl = url.href;
           }
         } catch (e) {
           console.error('Invalid callbackUrl:', e);
         }
       }
-      window.location.href = encodeURIComponent(safeUrl);
+      window.location.href = safeUrl;
     }
   }, [defaultAuthProvider, router.query, session, status]);
 
@@ -158,7 +154,8 @@ export const getServerSideProps: GetServerSideProps = async ({
   res,
 }) => {
   const session = await getServerSession(req, res, authOptions);
-  if (session && isServerSessionValid(session)) {
+
+  if (isServerSessionValid(session, true)) {
     return {
       redirect: {
         permanent: false,

--- a/apps/chat/src/store/conversations/conversations.epics.ts
+++ b/apps/chat/src/store/conversations/conversations.epics.ts
@@ -102,6 +102,7 @@ import {
   FilesActions,
   MarketplaceActions,
   ModelsActions,
+  OverlayActions,
   PublicationActions,
   ShareActions,
   UIActions,
@@ -2357,19 +2358,32 @@ const playbackNextMessageEndEpic: AppEpic = (action$, state$) =>
 
       const updatedMessagesWithAssistant =
         messagesDeletedLastMessage.concat(assistantMessage);
+      const playbackState = {
+        ...selectedConversation.playback,
+        activePlaybackIndex: activeIndex + 1,
+      };
 
-      return of(
-        ConversationsActions.updateConversation({
-          id: selectedConversation.id,
-          values: {
-            messages: updatedMessagesWithAssistant,
-            isMessageStreaming: false,
-            playback: {
-              ...selectedConversation.playback,
-              activePlaybackIndex: activeIndex + 1,
+      return concat(
+        of(
+          OverlayActions.sendNextPlaybackEvent({
+            newActiveIndex: activeIndex,
+            playbackState,
+            updatedMessages: updatedMessagesWithAssistant,
+          }),
+        ),
+        of(
+          ConversationsActions.updateConversation({
+            id: selectedConversation.id,
+            values: {
+              messages: updatedMessagesWithAssistant,
+              isMessageStreaming: false,
+              playback: {
+                ...selectedConversation.playback,
+                activePlaybackIndex: activeIndex + 1,
+              },
             },
-          },
-        }),
+          }),
+        ),
       );
     }),
   );
@@ -2406,24 +2420,37 @@ const playbackPrevMessageEpic: AppEpic = (action$, state$) =>
             : conv.model;
           const { prompt, temperature, selectedAddons, assistantModelId } =
             assistantMessage?.settings ? assistantMessage.settings : conv;
+          const playbackState = {
+            ...conv.playback,
+            activePlaybackIndex: activeIndex,
+          };
 
-          return of(
-            ConversationsActions.updateConversation({
-              id: conv.id,
-              values: {
-                messages: updatedMessages,
-                isMessageStreaming: false,
-                model,
-                prompt,
-                temperature: temperature,
-                selectedAddons: selectedAddons,
-                assistantModelId: assistantModelId,
-                playback: {
-                  ...conv.playback,
-                  activePlaybackIndex: activeIndex,
+          return concat(
+            of(
+              OverlayActions.sendPrevPlaybackEvent({
+                newActiveIndex: activeIndex,
+                playbackState,
+                updatedMessages,
+              }),
+            ),
+            of(
+              ConversationsActions.updateConversation({
+                id: conv.id,
+                values: {
+                  messages: updatedMessages,
+                  isMessageStreaming: false,
+                  model,
+                  prompt,
+                  temperature: temperature,
+                  selectedAddons: selectedAddons,
+                  assistantModelId: assistantModelId,
+                  playback: {
+                    ...conv.playback,
+                    activePlaybackIndex: activeIndex,
+                  },
                 },
-              },
-            }),
+              }),
+            ),
           );
         }),
       );

--- a/apps/chat/src/store/overlay/overlay.epics.ts
+++ b/apps/chat/src/store/overlay/overlay.epics.ts
@@ -91,9 +91,11 @@ import {
   GetMessagesResponse,
   ImportConversationRequest,
   ImportConversationResponse,
+  NextMessagePlaybackEventResponse,
   OverlayEvents,
   OverlayRequest,
   OverlayRequests,
+  PrevMessagePlaybackEventResponse,
   RenameConversationRequest,
   RenameConversationResponse,
   Role,
@@ -319,12 +321,14 @@ const getMessagesEpic: AppEpic = (action$, state$) =>
     map(({ requestId, currentConversation, hostDomain }) => {
       const messages = currentConversation?.messages || [];
 
+      const payload: GetMessagesResponse = { messages };
+
       return OverlayActions.sendPMResponse({
         type: OverlayRequests.getMessages,
         requestParams: {
           requestId,
           hostDomain,
-          payload: { messages } as GetMessagesResponse,
+          payload,
         },
       });
     }),
@@ -349,14 +353,16 @@ const getConversationsEpic: AppEpic = (action$, state$) =>
         };
       });
 
+      const payload: GetConversationsResponse = {
+        conversations: resultConversations,
+      };
+
       return OverlayActions.sendPMResponse({
         type: OverlayRequests.getConversations,
         requestParams: {
           requestId,
           hostDomain,
-          payload: {
-            conversations: resultConversations,
-          } as GetConversationsResponse,
+          payload,
         },
       });
     }),
@@ -381,14 +387,16 @@ const getSelectedConversationsEpic: AppEpic = (action$, state$) =>
         };
       });
 
+      const payload: GetConversationsResponse = {
+        conversations: resultConversations,
+      };
+
       return OverlayActions.sendPMResponse({
         type: OverlayRequests.getSelectedConversations,
         requestParams: {
           requestId,
           hostDomain,
-          payload: {
-            conversations: resultConversations,
-          } as GetConversationsResponse,
+          payload,
         },
       });
     }),
@@ -478,6 +486,10 @@ const createConversationEffectEpic: AppEpic = (action$, state$) =>
             parentPath,
           };
 
+          const payloadResponse: CreateConversationResponse = {
+            conversation: resultConversation,
+          };
+
           return concat(
             of(UIActions.setScrollToEntityId(conversation.id)),
             of(
@@ -486,9 +498,7 @@ const createConversationEffectEpic: AppEpic = (action$, state$) =>
                 requestParams: {
                   requestId,
                   hostDomain,
-                  payload: {
-                    conversation: resultConversation,
-                  } as CreateConversationResponse,
+                  payload: payloadResponse,
                 },
               }),
             ),
@@ -519,6 +529,10 @@ const createLocalConversationEffectEpic: AppEpic = (action$, state$) =>
             parentPath,
           };
 
+          const payloadResponse: CreateConversationResponse = {
+            conversation: resultConversation,
+          };
+
           return concat(
             of(UIActions.setScrollToEntityId(conversation.id)),
             of(
@@ -527,9 +541,7 @@ const createLocalConversationEffectEpic: AppEpic = (action$, state$) =>
                 requestParams: {
                   requestId,
                   hostDomain,
-                  payload: {
-                    conversation: resultConversation,
-                  } as CreateConversationResponse,
+                  payload: payloadResponse,
                 },
               }),
             ),
@@ -616,6 +628,10 @@ const createPlaybackConversationEffectEpic: AppEpic = (action$, state$) =>
             parentPath,
           };
 
+          const payloadResponse: CreatePlaybackConversationResponse = {
+            conversation: resultConversation,
+          };
+
           return concat(
             of(UIActions.setScrollToEntityId(newConversation.id)),
             of(
@@ -624,9 +640,7 @@ const createPlaybackConversationEffectEpic: AppEpic = (action$, state$) =>
                 requestParams: {
                   requestId,
                   hostDomain,
-                  payload: {
-                    conversation: resultConversation,
-                  } as CreatePlaybackConversationResponse,
+                  payload: payloadResponse,
                 },
               }),
             ),
@@ -685,6 +699,10 @@ const stopSelectedPlaybackConversationEffectEpic: AppEpic = (action$, state$) =>
             parentPath,
           };
 
+          const payloadResponse: StopSelectedPlaybackConversationResponse = {
+            conversation: resultConversation,
+          };
+
           return concat(
             of(
               OverlayActions.sendPMResponse({
@@ -692,9 +710,7 @@ const stopSelectedPlaybackConversationEffectEpic: AppEpic = (action$, state$) =>
                 requestParams: {
                   requestId,
                   hostDomain,
-                  payload: {
-                    conversation: resultConversation,
-                  } as StopSelectedPlaybackConversationResponse,
+                  payload: payloadResponse,
                 },
               }),
             ),
@@ -779,6 +795,10 @@ const renameConversationEffectEpic: AppEpic = (action$, state$) =>
             parentPath,
           };
 
+          const payloadResponse: RenameConversationResponse = {
+            conversation: resultConversation,
+          };
+
           return concat(
             of(UIActions.setScrollToEntityId(conversation.id)),
             of(
@@ -787,9 +807,7 @@ const renameConversationEffectEpic: AppEpic = (action$, state$) =>
                 requestParams: {
                   requestId,
                   hostDomain,
-                  payload: {
-                    conversation: resultConversation,
-                  } as RenameConversationResponse,
+                  payload: payloadResponse,
                 },
               }),
             ),
@@ -832,15 +850,17 @@ const exportConversationEpic: AppEpic = (action$, state$) =>
         parentFolders,
       );
 
+      const payloadResponse: ExportConversationResponse = {
+        exportConversation: exportedConversation,
+      };
+
       return of(
         OverlayActions.sendPMResponse({
           type: OverlayRequests.exportConversation,
           requestParams: {
             requestId,
             hostDomain,
-            payload: {
-              exportConversation: exportedConversation,
-            } as ExportConversationResponse,
+            payload: payloadResponse,
           },
         }),
       );
@@ -910,6 +930,10 @@ const importConversationEffectEpic: AppEpic = (action$, state$) =>
             parentPath,
           };
 
+          const payloadResponse: ImportConversationResponse = {
+            conversation: resultConversation,
+          };
+
           return concat(
             of(UIActions.setScrollToEntityId(conversation.id)),
             of(
@@ -918,9 +942,7 @@ const importConversationEffectEpic: AppEpic = (action$, state$) =>
                 requestParams: {
                   requestId,
                   hostDomain,
-                  payload: {
-                    conversation: resultConversation,
-                  } as ImportConversationResponse,
+                  payload: payloadResponse,
                 },
               }),
             ),
@@ -948,6 +970,16 @@ const selectConversationEpic: AppEpic = (action$, state$) =>
         getParentFolderIdsFromFolderId(conversation.folderId),
       );
 
+      const { bucket, parentPath } = splitEntityId(conversation.id);
+      const resultConversation = {
+        ...conversation,
+        bucket,
+        parentPath,
+      };
+      const payloadResponse: SelectConversationResponse = {
+        conversation: resultConversation,
+      };
+
       return concat(
         foldersPaths
           ? of(
@@ -969,9 +1001,7 @@ const selectConversationEpic: AppEpic = (action$, state$) =>
             requestParams: {
               requestId,
               hostDomain,
-              payload: {
-                conversation: conversation,
-              } as SelectConversationResponse,
+              payload: payloadResponse,
             },
           }),
         ),
@@ -1042,6 +1072,12 @@ const deleteMessageEffectEpic: AppEpic = (action$, state$) =>
         mergeMap(({ payload: { conversation } }) => {
           const hostDomain = OverlaySelectors.selectHostDomain(state$.value);
 
+          if (!conversation.messages) return EMPTY;
+
+          const payloadResponse: DeleteMessageResponse = {
+            messages: conversation.messages,
+          };
+
           return concat(
             of(
               OverlayActions.sendPMResponse({
@@ -1049,9 +1085,7 @@ const deleteMessageEffectEpic: AppEpic = (action$, state$) =>
                 requestParams: {
                   requestId,
                   hostDomain,
-                  payload: {
-                    messages: conversation.messages,
-                  } as DeleteMessageResponse,
+                  payload: payloadResponse,
                 },
               }),
             ),
@@ -1102,6 +1136,12 @@ const updateMessageEffectEpic: AppEpic = (action$, state$) =>
         mergeMap(({ payload: { conversation } }) => {
           const hostDomain = OverlaySelectors.selectHostDomain(state$.value);
 
+          if (!conversation.messages) return EMPTY;
+
+          const payloadResponse: DeleteMessageResponse = {
+            messages: conversation.messages,
+          };
+
           return concat(
             of(
               OverlayActions.sendPMResponse({
@@ -1109,9 +1149,7 @@ const updateMessageEffectEpic: AppEpic = (action$, state$) =>
                 requestParams: {
                   requestId,
                   hostDomain,
-                  payload: {
-                    messages: conversation.messages,
-                  } as DeleteMessageResponse,
+                  payload: payloadResponse,
                 },
               }),
             ),
@@ -1380,14 +1418,16 @@ const sendSelectedConversationLoaded: AppEpic = (action$, state$) =>
       const currentConvIds =
         ConversationsSelectors.selectSelectedConversationsIds(state);
 
+      const payloadResponse: SelectedConversationLoadedEventResponse = {
+        selectedConversationIds: currentConvIds,
+      };
+
       return of(
         OverlayActions.sendPMEvent({
           type: OverlayEvents.selectedConversationLoaded,
           eventParams: {
             hostDomain,
-            payload: {
-              selectedConversationIds: currentConvIds,
-            } as SelectedConversationLoadedEventResponse,
+            payload: payloadResponse,
           },
         }),
       );
@@ -1401,12 +1441,14 @@ const sendEditMessageEvent: AppEpic = (action$, state$) =>
     switchMap(({ payload }) => {
       const hostDomain = OverlaySelectors.selectHostDomain(state$.value);
 
+      const payloadResponse: EditMessageEventResponse = payload;
+
       return of(
         OverlayActions.sendPMEvent({
           type: OverlayEvents.editMessage,
           eventParams: {
             hostDomain,
-            payload: payload as EditMessageEventResponse,
+            payload: payloadResponse,
           },
         }),
       );
@@ -1429,6 +1471,63 @@ const sendRegenerateLastMessageEvent: AppEpic = (action$, state$) =>
       );
     }),
   );
+const sendStopGeneratingEvent: AppEpic = (action$, state$) =>
+  action$.pipe(
+    filter(() => SettingsSelectors.selectIsOverlay(state$.value)),
+    ofType(ConversationsActions.stopStreamMessage.type),
+    switchMap(() => {
+      const hostDomain = OverlaySelectors.selectHostDomain(state$.value);
+
+      return of(
+        OverlayActions.sendPMEvent({
+          type: OverlayEvents.stopGenerating,
+          eventParams: {
+            hostDomain,
+          },
+        }),
+      );
+    }),
+  );
+
+const sendPrevPlaybackMessageEvent: AppEpic = (action$, state$) =>
+  action$.pipe(
+    filter(() => SettingsSelectors.selectIsOverlay(state$.value)),
+    ofType(OverlayActions.sendPrevPlaybackEvent.type),
+    switchMap(({ payload }) => {
+      const hostDomain = OverlaySelectors.selectHostDomain(state$.value);
+      const payloadResponse: PrevMessagePlaybackEventResponse = payload;
+
+      return of(
+        OverlayActions.sendPMEvent({
+          type: OverlayEvents.prevPlaybackMessage,
+          eventParams: {
+            hostDomain,
+            payload: payloadResponse,
+          },
+        }),
+      );
+    }),
+  );
+
+const sendNextPlaybackMessageEvent: AppEpic = (action$, state$) =>
+  action$.pipe(
+    filter(() => SettingsSelectors.selectIsOverlay(state$.value)),
+    ofType(OverlayActions.sendNextPlaybackEvent.type),
+    switchMap(({ payload }) => {
+      const hostDomain = OverlaySelectors.selectHostDomain(state$.value);
+      const payloadResponse: NextMessagePlaybackEventResponse = payload;
+
+      return of(
+        OverlayActions.sendPMEvent({
+          type: OverlayEvents.nextPlaybackMessage,
+          eventParams: {
+            hostDomain,
+            payload: payloadResponse,
+          },
+        }),
+      );
+    }),
+  );
 
 const sendDeleteMessageEvent: AppEpic = (action$, state$) =>
   action$.pipe(
@@ -1437,12 +1536,14 @@ const sendDeleteMessageEvent: AppEpic = (action$, state$) =>
     switchMap(({ payload }) => {
       const hostDomain = OverlaySelectors.selectHostDomain(state$.value);
 
+      const payloadResponse: DeleteMessageEventResponse = payload;
+
       return of(
         OverlayActions.sendPMEvent({
           type: OverlayEvents.deleteMessage,
           eventParams: {
             hostDomain,
-            payload: payload as DeleteMessageEventResponse,
+            payload: payloadResponse,
           },
         }),
       );
@@ -1585,6 +1686,7 @@ export const OverlayEpics = combineEpics(
   sendPMEventEpic,
   sendPMResponseEpic,
   sendCustomMessageEvent,
+  sendStopGeneratingEvent,
   notifyHostAboutReadyEpic,
   setOverlayOptionsEpic,
   sendMessageEpic,
@@ -1602,4 +1704,6 @@ export const OverlayEpics = combineEpics(
   sendEditMessageEvent,
   sendRegenerateLastMessageEvent,
   sendDeleteMessageEvent,
+  sendPrevPlaybackMessageEvent,
+  sendNextPlaybackMessageEvent,
 );

--- a/apps/chat/src/store/overlay/overlay.reducers.ts
+++ b/apps/chat/src/store/overlay/overlay.reducers.ts
@@ -17,8 +17,10 @@ import {
   ImportConversationRequest,
   MessageButtons,
   MessageCustomButtonEventResponse,
+  NextMessagePlaybackEventResponse,
   OverlayEvents,
   OverlayRequests,
+  PrevMessagePlaybackEventResponse,
   RenameConversationRequest,
   SelectConversationRequest,
   SendMessageRequest,
@@ -140,6 +142,14 @@ export const overlaySlice = createSlice({
     sendMessage: (
       state,
       _action: PayloadAction<WithRequestId<SendMessageRequest>>,
+    ) => state,
+    sendPrevPlaybackEvent: (
+      state,
+      _action: PayloadAction<PrevMessagePlaybackEventResponse>,
+    ) => state,
+    sendNextPlaybackEvent: (
+      state,
+      _action: PayloadAction<NextMessagePlaybackEventResponse>,
     ) => state,
     deleteMessage: (
       state,

--- a/apps/chat/src/store/overlay/overlay.selectors.ts
+++ b/apps/chat/src/store/overlay/overlay.selectors.ts
@@ -2,7 +2,7 @@ import { createSelector } from '@reduxjs/toolkit';
 
 import { RootState } from '@/src/types/store';
 
-import { MessageButton } from '@epam/ai-dial-shared';
+import { MessageButton, MessageButtonPlacement } from '@epam/ai-dial-shared';
 
 const rootSelector = (state: RootState) => state.overlay;
 
@@ -29,11 +29,39 @@ const selectCustomButtonsForMessage = createSelector(
   },
 );
 
+const selectContentAppendedButtonsForMessage = createSelector(
+  [
+    (state, messageIndex: number) =>
+      selectCustomButtonsForMessage(state, messageIndex),
+  ],
+  (customButtons) => {
+    return customButtons?.filter(
+      (button) =>
+        !button.placement ||
+        button.placement === MessageButtonPlacement.CONTENT_APPEND,
+    );
+  },
+);
+
+const selectPrependedDefaultButtonsForMessage = createSelector(
+  [
+    (state, messageIndex: number) =>
+      selectCustomButtonsForMessage(state, messageIndex),
+  ],
+  (customButtons) => {
+    return customButtons?.filter(
+      (button) =>
+        button.placement === MessageButtonPlacement.PREPEND_DEFAULT_BUTTONS,
+    );
+  },
+);
+
 export const OverlaySelectors = {
   selectHostDomain,
   selectOverlaySystemPrompt,
   selectOptionsReceived,
   selectReadyToInteractSent,
   selectCustomButtons,
-  selectCustomButtonsForMessage,
+  selectContentAppendedButtonsForMessage,
+  selectPrependedDefaultButtonsForMessage,
 };

--- a/apps/chat/src/utils/auth/session.ts
+++ b/apps/chat/src/utils/auth/session.ts
@@ -13,8 +13,14 @@ export function isClientSessionValid(session: unknown | null) {
   );
 }
 
-export function isServerSessionValid(session: Session | null) {
-  if (isAuthDisabled || process.env.IS_IFRAME === 'true') {
+export function isServerSessionValid(
+  session: Session | null,
+  checkForOverlay?: boolean,
+) {
+  if (
+    isAuthDisabled ||
+    (!checkForOverlay && process.env.IS_IFRAME === 'true')
+  ) {
     return true;
   }
 

--- a/apps/overlay-sandbox/app/cases/components/chatOverlayManagerWrapper.tsx
+++ b/apps/overlay-sandbox/app/cases/components/chatOverlayManagerWrapper.tsx
@@ -237,6 +237,30 @@ export const ChatOverlayManagerWrapper: React.FC<
         );
       },
     );
+    const subPrevPlaybackMessage = overlayManager.current?.subscribe(
+      overlayManagerOptions.id,
+      `@DIAL_OVERLAY/${OverlayEvents.prevPlaybackMessage}`,
+      async (info) => {
+        console.info(
+          'Previous playback message',
+          JSON.stringify(info, null, 2),
+        );
+      },
+    );
+    const subNextPlaybackMessage = overlayManager.current?.subscribe(
+      overlayManagerOptions.id,
+      `@DIAL_OVERLAY/${OverlayEvents.nextPlaybackMessage}`,
+      async (info) => {
+        console.info('Next playback message', JSON.stringify(info, null, 2));
+      },
+    );
+    const subStopGenerating = overlayManager.current?.subscribe(
+      overlayManagerOptions.id,
+      `@DIAL_OVERLAY/${OverlayEvents.stopGenerating}`,
+      async () => {
+        console.info('Stop generating by user');
+      },
+    );
 
     overlayManager.current
       ?.getMessages(overlayManagerOptions.id)
@@ -253,6 +277,9 @@ export const ChatOverlayManagerWrapper: React.FC<
       editMessageEvent,
       regenerateLastMessageEvent,
       deleteMessageEvent,
+      subPrevPlaybackMessage,
+      subNextPlaybackMessage,
+      subStopGenerating,
     ];
     return () => {
       subs.forEach((sub) => {

--- a/apps/overlay-sandbox/app/cases/components/chatOverlayWrapper.tsx
+++ b/apps/overlay-sandbox/app/cases/components/chatOverlayWrapper.tsx
@@ -197,6 +197,27 @@ export const ChatOverlayWrapper: React.FC<ChatOverlayWrapperProps> = ({
         );
       },
     );
+    const subPrevPlaybackMessage = overlay.current?.subscribe(
+      `@DIAL_OVERLAY/${OverlayEvents.prevPlaybackMessage}`,
+      async (info) => {
+        console.info(
+          'Previous playback message',
+          JSON.stringify(info, null, 2),
+        );
+      },
+    );
+    const subNextPlaybackMessage = overlay.current?.subscribe(
+      `@DIAL_OVERLAY/${OverlayEvents.nextPlaybackMessage}`,
+      async (info) => {
+        console.info('Next playback message', JSON.stringify(info, null, 2));
+      },
+    );
+    const subStopGenerating = overlay.current?.subscribe(
+      `@DIAL_OVERLAY/${OverlayEvents.stopGenerating}`,
+      async () => {
+        console.info('Stop generating by user');
+      },
+    );
 
     overlay.current?.getMessages().then((messages) => {
       console.info(messages);
@@ -211,6 +232,9 @@ export const ChatOverlayWrapper: React.FC<ChatOverlayWrapperProps> = ({
       editMessageEvent,
       regenerateLastMessageEvent,
       deleteMessageEvent,
+      subPrevPlaybackMessage,
+      subNextPlaybackMessage,
+      subStopGenerating,
     ];
     return () => {
       subs.forEach((sub) => {

--- a/apps/overlay-sandbox/app/cases/overlay/custom-message-buttons/page.tsx
+++ b/apps/overlay-sandbox/app/cases/overlay/custom-message-buttons/page.tsx
@@ -5,10 +5,10 @@ import {
   commonOverlayProps,
 } from '../../components/chatOverlayWrapper';
 
-import { MessageButtons } from '@epam/ai-dial-shared';
+import { MessageButtonPlacement, MessageButtons } from '@epam/ai-dial-shared';
 
-const svg = `
-<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+const getSvg = (width: string) => `
+<svg xmlns="http://www.w3.org/2000/svg" width="${width}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
     <path stroke="none" d="M0 0h24v24H0z" fill="none" />
     <path d="M3 3m0 2a2 2 0 0 1 2 -2h14a2 2 0 0 1 2 2v14a2 2 0 0 1 -2 2h-14a2 2 0 0 1 -2 -2z" />
     <path d="M13 10.5v3a1.5 1.5 0 0 0 3 0v-3a1.5 1.5 0 0 0 -3 0z" />
@@ -28,12 +28,12 @@ const overlayOptions = {
           events: ['click'] as (keyof WindowEventMap)[],
           tooltip:
             'Some tooltip with very very long title which should cause scrolls appearing',
-          iconSvg: svg,
+          iconSvg: getSvg('18px'),
         },
         {
           buttonKey: 'custom-button-2',
           events: ['dblclick'] as (keyof WindowEventMap)[],
-          iconSvg: svg,
+          iconSvg: getSvg('18px'),
           title: 'dblclick',
           styles: {
             backgroundColor: 'red',
@@ -51,13 +51,26 @@ const overlayOptions = {
         {
           buttonKey: 'custom-button-3',
           events: ['mousedown'] as (keyof WindowEventMap)[],
-          iconSvg: svg,
+          iconSvg: getSvg('18px'),
           title: 'disabled',
           skipDefaultStyles: true,
           disabled: true,
           disabledStyles: {
             backgroundColor: 'orange',
           },
+        },
+        {
+          buttonKey: 'custom-button-4',
+          events: ['click'] as (keyof WindowEventMap)[],
+          tooltip: 'Some Edit',
+          placement: MessageButtonPlacement.PREPEND_DEFAULT_BUTTONS,
+          iconSvg: getSvg('18px'),
+          styles: {
+            display: 'flex',
+            alignItems: 'center',
+            gap: '12px',
+          },
+          title: 'Some edit',
         },
       ],
     },

--- a/apps/overlay-sandbox/app/cases/overlay/disabled-default-buttons/page.tsx
+++ b/apps/overlay-sandbox/app/cases/overlay/disabled-default-buttons/page.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import {
+  ChatOverlayWrapper,
+  commonOverlayProps,
+} from '../../components/chatOverlayWrapper';
+
+import { Feature } from '@epam/ai-dial-shared';
+
+const overlayOptions = {
+  ...commonOverlayProps,
+  enabledFeatures: [
+    Feature.Header,
+    Feature.ConversationsSection,
+    Feature.HideEditUserMessage,
+    Feature.HideRegenerateAssistantMessage,
+    Feature.HideDeleteUserMessage,
+  ],
+};
+
+export default function Index() {
+  return <ChatOverlayWrapper overlayOptions={overlayOptions} />;
+}

--- a/apps/overlay-sandbox/app/page.tsx
+++ b/apps/overlay-sandbox/app/page.tsx
@@ -25,6 +25,7 @@ enum OverlayCases {
   skipFocusSetSandbox = '/cases/overlay/skip-focus-set-sandbox',
   customMessageButtons = '/cases/overlay/custom-message-buttons',
   editLastAssistantMessage = '/cases/overlay/edit-last-assistant-message',
+  disabledDefaultButtons = '/cases/overlay/disabled-default-buttons',
 }
 
 export default async function Index() {

--- a/libs/overlay/src/index.ts
+++ b/libs/overlay/src/index.ts
@@ -12,6 +12,7 @@ export {
 } from '@epam/ai-dial-shared';
 export type {
   ChatOverlayOptions,
+  MessageButtonPlacement as MessageButtonType,
   MessageButton,
   MessageButtons,
   OverlayConversation,
@@ -28,6 +29,8 @@ export type {
   ImportConversationResponse,
   SelectedConversationLoadedEventResponse as SelectedConversationLoadedResponse,
   MessageCustomButtonEventResponse as MessageCustomButtonResponse,
+  PrevMessagePlaybackEventResponse,
+  NextMessagePlaybackEventResponse,
   EditMessageEventResponse,
   DeleteMessageEventResponse,
   UpdateMessageResponse,
@@ -42,6 +45,7 @@ export type {
   EntityPublicationInfo,
   ShareInterface,
   ShareEntity,
+  SharePermission,
   ConversationInfo,
   TemplateMapping,
   Message,

--- a/libs/shared/src/constants/overlay.ts
+++ b/libs/shared/src/constants/overlay.ts
@@ -55,6 +55,10 @@ export enum OverlayEvents {
    */
   gptEndGenerating = 'GPT_END_GENERATING',
   /**
+   * Chat dispatch this event when user stop streaming explicitly or something happened
+   */
+  stopGenerating = 'STOP_GENERATING',
+  /**
    * Chat dispatch this event when any of conversations updated, added or removed
    */
   conversationsUpdated = 'CONVERSATIONS_UPDATED',
@@ -75,6 +79,14 @@ export enum OverlayEvents {
    * Chat dispatch this event when user message deleted
    */
   deleteMessage = 'DELETE_MESSAGE',
+  /**
+   * Chat dispatch this event when user change playback to previous message
+   */
+  prevPlaybackMessage = 'PREV_PLAYBACK_MESSAGE',
+  /**
+   * Chat dispatch this event when user change playback to next message
+   */
+  nextPlaybackMessage = 'NEXT_PLAYBACK_MESSAGE',
 }
 
 export const overlayLibName = 'ChatOverlay';

--- a/libs/shared/src/types/features.ts
+++ b/libs/shared/src/types/features.ts
@@ -23,9 +23,18 @@ export enum Feature {
   InputLinks = 'input-links', // Allow attach links to conversation
   MessageTemplates = 'message-templates', // message templates
 
-  // Edit assistant
+  // Edit assistant message
   EditLastAssistantContent = 'edit-last-assistant-message', // allow edit last assistant message only
   EditAllAssistantContent = 'edit-all-assistant-message', // allow edit all assistant messages
+
+  // Edit user message
+  HideEditUserMessage = 'hide-edit-user-message', // Hide editing button of user message
+
+  // Regenerate assistant message
+  HideRegenerateAssistantMessage = 'hide-regenerate-assistant-message', // Hide regenerate button of assistant message
+
+  // Delete user message
+  HideDeleteUserMessage = 'hide-delete-user-message', // Hide delete button of user message
 
   // Chat input
   SkipFocusChatInputOnLoad = 'skip-focus-chat-input-onload', // Skip default focusing chat input when on screen onload or after navigation

--- a/libs/shared/src/types/overlay/events.ts
+++ b/libs/shared/src/types/overlay/events.ts
@@ -1,4 +1,4 @@
-import { Message } from '../chat';
+import { Message, Playback } from '../chat';
 
 export interface SelectedConversationLoadedEventResponse {
   selectedConversationIds: string[];
@@ -15,4 +15,14 @@ export interface EditMessageEventResponse {
 }
 export interface DeleteMessageEventResponse {
   index: number;
+}
+export interface PrevMessagePlaybackEventResponse {
+  newActiveIndex: number;
+  updatedMessages: Message[];
+  playbackState: Playback;
+}
+export interface NextMessagePlaybackEventResponse {
+  newActiveIndex: number;
+  updatedMessages: Message[];
+  playbackState: Playback;
 }

--- a/libs/shared/src/types/overlay/overlay.ts
+++ b/libs/shared/src/types/overlay/overlay.ts
@@ -34,6 +34,11 @@ interface OverlaySignInOptions {
   signInInNewWindow?: boolean;
 }
 
+export enum MessageButtonPlacement {
+  PREPEND_DEFAULT_BUTTONS = 'PREPEND_DEFAULT_BUTTONS', // Buttons to show before default buttons
+  CONTENT_APPEND = 'CONTENT_APPEND', // (Default) Buttons to show in separate block after all content, but before default message buttons
+}
+
 export interface MessageButton {
   buttonKey: string; // Unique key which will be exposed to host on click
   events: (keyof WindowEventMap)[];
@@ -45,6 +50,7 @@ export interface MessageButton {
   hoverStyles?: Styles;
   focusStyles?: Styles;
   disabledStyles?: Styles;
+  placement?: MessageButtonPlacement;
   disabled?: boolean;
 }
 


### PR DESCRIPTION
**Description:**

- Fix it's impossible to login in browser2 if the user has been logged in browser1.
- Add an ability to hide edit user message, regenerate assistant answer, delete user message buttons.
- Add playback controls events.
- Add an ability to add custom buttons near default buttons.

Issues:

- Issue #4432 
- Issue #4427 


**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
