### PR TITLE
fix(chat): disable name and version during deployment (Issue #3726)

### DIFF
--- a/apps/chat/src/components/AppsEditor/GeneralInfoView/GeneralInfoEditor.tsx
+++ b/apps/chat/src/components/AppsEditor/GeneralInfoView/GeneralInfoEditor.tsx
@@ -116,10 +116,8 @@ export const GeneralInfoEditor: React.FC<Props> = ({
     oldApplication?.functionStatus === ApplicationStatus.DEPLOYING ||
     oldApplication?.functionStatus === ApplicationStatus.REDEPLOYING;
 
-  const isFieldDisabled = useMemo(
-    () => isAppDeployed || isSharedWithMe || isAppPublic || isDeploying,
-    [isAppDeployed, isSharedWithMe, isAppPublic, isDeploying],
-  );
+  const isFieldDisabled =
+    isAppDeployed || isSharedWithMe || isAppPublic || isDeploying;
 
   const nameTooltip = useMemo(() => {
     if (isAppPublic) return PUBLIC_APP_TOOLTIP;

--- a/apps/chat/src/components/AppsEditor/GeneralInfoView/GeneralInfoEditor.tsx
+++ b/apps/chat/src/components/AppsEditor/GeneralInfoView/GeneralInfoEditor.tsx
@@ -15,6 +15,7 @@ import { getRouteForSlug } from '@/src/utils/app/route';
 
 import { ApiDetailedApplicationTypeSchema } from '@/src/types/application-type-schema';
 import {
+  ApplicationStatus,
   ApplicationType,
   CustomApplicationModel,
 } from '@/src/types/applications';
@@ -110,6 +111,10 @@ export const GeneralInfoEditor: React.FC<Props> = ({
         'After you add or change an icon, other users will see the default one immediately after confirmation. Share the link again so they can see the new icon.',
       )
     : '';
+
+  const isDeploying =
+    oldApplication?.functionStatus === ApplicationStatus.DEPLOYING ||
+    oldApplication?.functionStatus === ApplicationStatus.REDEPLOYING;
 
   useEffect(() => {
     if (isFormChanged && isValid) {
@@ -262,7 +267,9 @@ export const GeneralInfoEditor: React.FC<Props> = ({
             placeholder={t('Type name')}
             id="name"
             error={errors.name?.message}
-            disabled={isAppDeployed || isSharedWithMe || isAppPublic}
+            disabled={
+              isAppDeployed || isSharedWithMe || isAppPublic || isDeploying
+            }
             tooltip={
               (isAppPublic && PUBLIC_APP_TOOLTIP) ||
               (isSharedWithMe && getSharedTooltip('name')) ||
@@ -280,7 +287,9 @@ export const GeneralInfoEditor: React.FC<Props> = ({
             control={control}
             name="version"
             rules={validators['version']}
-            disabled={isAppDeployed || isSharedWithMe || isAppPublic}
+            disabled={
+              isAppDeployed || isSharedWithMe || isAppPublic || isDeploying
+            }
             tooltip={
               (isAppPublic && PUBLIC_APP_TOOLTIP) ||
               (isSharedWithMe && getSharedTooltip('version')) ||

--- a/apps/chat/src/components/AppsEditor/GeneralInfoView/GeneralInfoEditor.tsx
+++ b/apps/chat/src/components/AppsEditor/GeneralInfoView/GeneralInfoEditor.tsx
@@ -116,6 +116,31 @@ export const GeneralInfoEditor: React.FC<Props> = ({
     oldApplication?.functionStatus === ApplicationStatus.DEPLOYING ||
     oldApplication?.functionStatus === ApplicationStatus.REDEPLOYING;
 
+  const isFieldDisabled = useMemo(
+    () => isAppDeployed || isSharedWithMe || isAppPublic || isDeploying,
+    [isAppDeployed, isSharedWithMe, isAppPublic, isDeploying],
+  );
+
+  const nameTooltip = useMemo(() => {
+    if (isAppPublic) return PUBLIC_APP_TOOLTIP;
+    if (isSharedWithMe) return getSharedTooltip('name');
+    if (isAppDeployed) return t('Undeploy application to edit name');
+    return '';
+  }, [isAppPublic, isSharedWithMe, isAppDeployed, t]);
+
+  const versionTooltip = useMemo(() => {
+    if (isAppPublic) return PUBLIC_APP_TOOLTIP;
+    if (isSharedWithMe) return getSharedTooltip('version');
+    if (isAppDeployed) return t('Undeploy application to edit version');
+    return '';
+  }, [isAppPublic, isSharedWithMe, isAppDeployed, t]);
+
+  const iconTooltip = useMemo(() => {
+    if (isAppPublic) return PUBLIC_APP_TOOLTIP;
+    if (isSharedWithMe) return getSharedTooltip('icon');
+    return '';
+  }, [isAppPublic, isSharedWithMe]);
+
   useEffect(() => {
     if (isFormChanged && isValid) {
       dispatch(ApplicationActions.setHasUnsavedChanges(isFormChanged));
@@ -267,15 +292,8 @@ export const GeneralInfoEditor: React.FC<Props> = ({
             placeholder={t('Type name')}
             id="name"
             error={errors.name?.message}
-            disabled={
-              isAppDeployed || isSharedWithMe || isAppPublic || isDeploying
-            }
-            tooltip={
-              (isAppPublic && PUBLIC_APP_TOOLTIP) ||
-              (isSharedWithMe && getSharedTooltip('name')) ||
-              (isAppDeployed && t('Undeploy application to edit name')) ||
-              ''
-            }
+            disabled={isFieldDisabled}
+            tooltip={nameTooltip}
           />
 
           <ControlledField
@@ -287,15 +305,8 @@ export const GeneralInfoEditor: React.FC<Props> = ({
             control={control}
             name="version"
             rules={validators['version']}
-            disabled={
-              isAppDeployed || isSharedWithMe || isAppPublic || isDeploying
-            }
-            tooltip={
-              (isAppPublic && PUBLIC_APP_TOOLTIP) ||
-              (isSharedWithMe && getSharedTooltip('version')) ||
-              (isAppDeployed && t('Undeploy application to edit version')) ||
-              ''
-            }
+            disabled={isFieldDisabled}
+            tooltip={versionTooltip}
           />
 
           <Controller
@@ -314,11 +325,7 @@ export const GeneralInfoEditor: React.FC<Props> = ({
                 allowedTypes={IMAGE_TYPES}
                 error={errors.iconUrl?.message}
                 disabled={isSharedWithMe || isAppPublic}
-                tooltip={
-                  (isAppPublic && PUBLIC_APP_TOOLTIP) ||
-                  (isSharedWithMe && getSharedTooltip('icon')) ||
-                  ''
-                }
+                tooltip={iconTooltip}
                 confirmDialogValues={confirmIconValues}
                 warningMessage={iconWarning}
                 sourceFilters={sourceFilters}


### PR DESCRIPTION
**Description:**

Need to disable Name and version fields for edit for code app in deploying state

Issues:

- Issue #3726

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
