### PR TITLE
fix(chat): rename admin duplicate button (Issues #4469, #4470)

### DIFF
--- a/apps/chat/src/components/Chat/ChatInput/ChatExternalControls.tsx
+++ b/apps/chat/src/components/Chat/ChatInput/ChatExternalControls.tsx
@@ -10,7 +10,11 @@ import { Translation } from '@/src/types/translation';
 
 import { ConversationsActions } from '@/src/store/actions';
 import { useAppDispatch, useAppSelector } from '@/src/store/hooks';
-import { PublicationSelectors, SettingsSelectors } from '@/src/store/selectors';
+import {
+  ConversationsSelectors,
+  PublicationSelectors,
+  SettingsSelectors,
+} from '@/src/store/selectors';
 
 import { ScrollDownButton } from '@/src/components/Common/ScrollDownButton';
 
@@ -20,12 +24,14 @@ interface Props {
   conversations: ConversationInfo[];
   showScrollDownButton: boolean;
   onScrollDownClick: () => void;
+  isChatReadyForInput?: boolean;
 }
 
 export function ChatExternalControls({
   conversations,
   showScrollDownButton,
   onScrollDownClick,
+  isChatReadyForInput,
 }: Props) {
   const { t } = useTranslation(Translation.Chat);
 
@@ -39,6 +45,9 @@ export function ChatExternalControls({
   );
   const isOverlayConversationId = useAppSelector(
     SettingsSelectors.selectOverlayConversationId,
+  );
+  const isReadOnly = useAppSelector(
+    ConversationsSelectors.selectAreSelectedConversationsReadOnly,
   );
 
   const conversationsToDuplicate = conversations.filter(
@@ -76,9 +85,11 @@ export function ChatExternalControls({
           <span className="text-secondary">
             <IconCopy width={18} height={18} />
           </span>
-          {t(
-            `Duplicate the conversation${conversationsToDuplicate.length > 1 ? 's' : ''} to be able to edit it`,
-          )}
+          {isChatReadyForInput && !isReadOnly
+            ? t('Duplicate')
+            : t(
+                `Duplicate the conversation${conversationsToDuplicate.length > 1 ? 's' : ''} to be able to edit it`,
+              )}
         </button>
         {showScrollDownButton && (
           <ScrollDownButton

--- a/apps/chat/src/components/Chat/ChatInput/ChatInputControls.tsx
+++ b/apps/chat/src/components/Chat/ChatInput/ChatInputControls.tsx
@@ -38,7 +38,8 @@ export const ChatInputControls = ({
   );
 
   const isPublic =
-    selectedConversations.length && isEntityIdPublic(selectedConversations[0]);
+    selectedConversations.length > 0 &&
+    isEntityIdPublic(selectedConversations[0]);
 
   if (isConversationWithSchema && selectedConversations.length > 1) {
     return <SchemaCompareWarning />;
@@ -46,34 +47,36 @@ export const ChatInputControls = ({
 
   if (showReplayControls && !isNotEmptyConversations) {
     return (
-      <div
-        className={classNames({
-          'mt-10': isWideLayout,
-        })}
-      >
+      <div className={classNames({ 'mt-10': isWideLayout })}>
         <StartReplayButton />
       </div>
     );
   }
 
-  if (isReadOnly || isPublic) {
-    return (
-      <ChatExternalControls
-        conversations={selectedConversations}
-        showScrollDownButton={showScrollDownButton}
-        onScrollDownClick={onScrollDown}
-      />
-    );
+  const shouldShowExternalControls = isPublic || isReadOnly;
+  const shouldShowModelsControl =
+    !isChatReadyForInput && (!isReadOnly || (isPublic && !isReadOnly));
+
+  if (!shouldShowExternalControls && !shouldShowModelsControl) {
+    return null;
   }
 
-  if (!isChatReadyForInput) {
-    return (
-      <AddModelsControl
-        showScrollDownButton={showScrollDownButton}
-        onScrollDown={onScrollDown}
-      />
-    );
-  }
-
-  return null;
+  return (
+    <>
+      {shouldShowExternalControls && (
+        <ChatExternalControls
+          conversations={selectedConversations}
+          showScrollDownButton={showScrollDownButton}
+          onScrollDownClick={onScrollDown}
+          {...(isPublic ? { isChatReadyForInput } : {})}
+        />
+      )}
+      {shouldShowModelsControl && (
+        <AddModelsControl
+          showScrollDownButton={showScrollDownButton}
+          onScrollDown={onScrollDown}
+        />
+      )}
+    </>
+  );
 };


### PR DESCRIPTION
**Description:**

Change text of button "Duplicate the conversation to be able to edit it" is confusing together with message input
"Add agent to my workspace" button should appear

Issues:

- Issue #4469 

**UI changes**

<img width="559" height="206" alt="Снимок экрана 2025-08-08 в 10 12 33" src="https://github.com/user-attachments/assets/cbcac3f0-a004-4e64-b139-dc3906a99315" />
<img width="1101" height="151" alt="Снимок экрана 2025-08-08 в 10 12 43" src="https://github.com/user-attachments/assets/1f1ea4ef-86c9-4a00-b06a-74e017fbd277" />

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
