### PR TITLE
fix(chat): disable 'publish to' edit if publication contains at least one unpublish resource (Issue #4286)

### DIFF
--- a/apps/chat/src/components/Chat/Publish/PublicationHandler/PublicationHandler.tsx
+++ b/apps/chat/src/components/Chat/Publish/PublicationHandler/PublicationHandler.tsx
@@ -344,6 +344,10 @@ export function PublicationHandler({ publication }: Props) {
     }, 0);
   }, [publication.resources]);
 
+  const isSomeResourceIsUnpublish = publication.resources.some(
+    (resource) => resource.action === PublishActions.DELETE,
+  );
+
   return (
     <div className="flex size-full justify-center overflow-y-auto p-3 md:px-5 md:pt-5">
       <div
@@ -374,7 +378,7 @@ export function PublicationHandler({ publication }: Props) {
               <div className="flex shrink flex-col divide-y divide-tertiary overflow-auto bg-layer-2 md:py-4">
                 <div className="flex flex-col px-3 pb-4 md:px-5">
                   <h2 className="mb-4 font-semibold">{t('General info')}</h2>
-                  {isEditMode ? (
+                  {isEditMode && !isSomeResourceIsUnpublish ? (
                     <PublishToSection
                       path={publishToUrl}
                       maxDepth={maxPublishToDepth}


### PR DESCRIPTION
**Description:**

disable 'publish to' edit if publication contains at least one unpublish resource

Issues:

- Issue #4286

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
