### PR TITLE
feat(chat): add possibility to customize default banners (Issue #4367)

### DIFF
--- a/apps/chat/src/components/Marketplace/MarketplaceBanner.tsx
+++ b/apps/chat/src/components/Marketplace/MarketplaceBanner.tsx
@@ -37,6 +37,17 @@ const getBannerSrc = (theme: string, tab: MarketplaceTabs) => {
     : lightBanner.src;
 };
 
+const getBannerCssVariable = (theme: string, tab: MarketplaceTabs) => {
+  const fallbackBannerSrc = getBannerSrc(theme, tab);
+  const tabBannerCssVariableName =
+    tab === MarketplaceTabs.MY_WORKSPACE
+      ? '--my-workspace-banner'
+      : '--marketplace-banner';
+
+  const bannerCssVariable = `var(${tabBannerCssVariableName}, url(${fallbackBannerSrc}))`;
+  return bannerCssVariable;
+};
+
 export const MarketplaceBanner = () => {
   const { t } = useTranslation(Translation.Marketplace);
 
@@ -47,7 +58,7 @@ export const MarketplaceBanner = () => {
     <div
       className="hidden rounded-md bg-cover bg-center bg-no-repeat py-6 md:block"
       style={{
-        backgroundImage: `url(${getBannerSrc(selectedTheme, selectedTab)})`,
+        backgroundImage: getBannerCssVariable(selectedTheme, selectedTab),
       }}
     >
       <h1 className="text-center text-xl font-semibold">

--- a/apps/chat/src/pages/api/themes/styles.ts
+++ b/apps/chat/src/pages/api/themes/styles.ts
@@ -129,6 +129,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
           generateColorsCssVariables(theme.topicColors),
           generateColorsCssVariables(theme.authColors),
           generateUrlsCssVariables({ 'app-logo': theme['app-logo'] }),
+          generateUrlsCssVariables(theme.banners),
           generateFontCssVariables({
             'theme-font': theme['font-family'],
             'codeblock-font':

--- a/apps/chat/src/types/themes.ts
+++ b/apps/chat/src/types/themes.ts
@@ -3,6 +3,7 @@ export interface Theme {
   colors: Record<string, string>;
   topicColors: Record<string, string>;
   authColors: Record<string, string>;
+  banners?: Record<string, string>;
   'code-editor-theme'?: string;
   'app-logo': string;
   'font-family'?: string;


### PR DESCRIPTION
**Description:**

- Add possibility to customize default banners by adding variables to the `Themes` config

Issues:

- Issue #4367

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
