### PR TITLE
fix(chat): fix 'targetFolder' max depth validation (Issue #4480)

### DIFF
--- a/apps/chat/src/components/Chat/Publish/PublicationHandler/PublicationHandler.tsx
+++ b/apps/chat/src/components/Chat/Publish/PublicationHandler/PublicationHandler.tsx
@@ -10,10 +10,7 @@ import {
 } from '@/src/utils/app/common';
 import { getFolderIdFromEntityId } from '@/src/utils/app/folders';
 import { getStringValidationErrors } from '@/src/utils/app/forms';
-import {
-  getIdWithoutFeatureType,
-  getIdWithoutRootPathSegments,
-} from '@/src/utils/app/id';
+import { getIdWithoutFeatureType } from '@/src/utils/app/id';
 import { EnumMapper } from '@/src/utils/app/mappers';
 import {
   getDefaultAllEditEntities,
@@ -61,6 +58,8 @@ import isEqual from 'lodash-es/isEqual';
 interface Props {
   publication: Publication;
 }
+
+const LEADING_SLASH_REGEX = /^\/+/;
 
 const sections = [
   {
@@ -337,12 +336,19 @@ export function PublicationHandler({ publication }: Props) {
 
   const maxPublishToDepth = useMemo(() => {
     return publication.resources.reduce((max, resource) => {
-      return Math.max(
-        max,
-        getIdWithoutRootPathSegments(resource.targetUrl).split('/').length,
+      const targetUrl = getFolderIdFromEntityId(
+        getIdWithoutFeatureType(resource.targetUrl),
       );
+      const cleanTargetUrlPath = targetUrl
+        .replace(publication.targetFolder, '')
+        .replace(LEADING_SLASH_REGEX, '');
+      const cleanTargetUrlPathLength = cleanTargetUrlPath
+        ? cleanTargetUrlPath.split('/').length
+        : 0;
+
+      return Math.max(max, cleanTargetUrlPathLength);
     }, 0);
-  }, [publication.resources]);
+  }, [publication.resources, publication.targetFolder]);
 
   const isSomeResourceIsUnpublish = publication.resources.some(
     (resource) => resource.action === PublishActions.DELETE,


### PR DESCRIPTION
**Description:**

 fix 'targetFolder' max depth validation

Issues:

- Issue #4480

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
