### PR TITLE
feat(overlay): add possibility to validate users and logout if they are different

### DIFF
--- a/apps/chat/src/store/auth/auth.selectors.ts
+++ b/apps/chat/src/store/auth/auth.selectors.ts
@@ -28,11 +28,32 @@ const selectIsShouldLogin = createSelector(
     );
   },
 );
+
+const selectIsShouldLogout = createSelector(
+  [
+    selectSession,
+    selectStatus,
+    (state: RootState) => state.settings.isAuthDisabled,
+    (state: RootState) => state.auth.session?.data?.user.email,
+    (state: RootState, userEmail: string) => userEmail,
+  ],
+  (session, sessionStatus, isAuthDisabled, stateUserEmail, userEmail) => {
+    return (
+      !isAuthDisabled &&
+      sessionStatus === 'authenticated' &&
+      isClientSessionValid(session) &&
+      userEmail !== stateUserEmail
+    );
+  },
+);
 const selectIsAdmin = (state: RootState) =>
   isUserAdmin(selectSessionData(state));
 
 const selectUserName = (state: RootState) =>
   selectSessionData(state)?.user?.name ?? '';
+
+const selectUserEmail = (state: RootState) =>
+  selectSessionData(state)?.user?.email ?? '';
 
 export const AuthSelectors = {
   selectIsShouldLogin,
@@ -40,4 +61,6 @@ export const AuthSelectors = {
   selectUserName,
   selectStatus,
   selectIsAdmin,
+  selectUserEmail,
+  selectIsShouldLogout,
 };

--- a/apps/chat/src/store/overlay/overlay.epics.ts
+++ b/apps/chat/src/store/overlay/overlay.epics.ts
@@ -1,4 +1,4 @@
-import { signIn } from 'next-auth/react';
+import { signIn, signOut } from 'next-auth/react';
 
 import {
   EMPTY,
@@ -1180,6 +1180,7 @@ const setOverlayOptionsEpic: AppEpic = (action$, state$) =>
       const _savedOverlayOptions = state$.value.overlay._savedOverlayOptions;
       const isOverlayOptionsReceived = state$.value.overlay.optionsReceived;
       const actions = [];
+      const shouldLogIn = AuthSelectors.selectIsShouldLogin(state$.value);
 
       const isOptionChanged = (optionName: keyof ChatOverlayOptions) => {
         return !isEqual(
@@ -1228,18 +1229,11 @@ const setOverlayOptionsEpic: AppEpic = (action$, state$) =>
         }
 
         if (features.every(validateFeature)) {
-          const isLoginRequired = AuthSelectors.selectIsShouldLogin(
-            state$.value,
-          );
-
           actions.push(
             of(SettingsActions.setEnabledFeatures(features as Feature[])),
           );
 
-          if (
-            !isLoginRequired &&
-            features.includes(Feature.ConversationsSharing)
-          ) {
+          if (!shouldLogIn && features.includes(Feature.ConversationsSharing)) {
             actions.push(
               of(ShareActions.triggerGettingSharedConversationListings()),
             );
@@ -1260,8 +1254,6 @@ const setOverlayOptionsEpic: AppEpic = (action$, state$) =>
           of(SettingsActions.setEnabledFeaturesData(enabledFeaturesData)),
         );
       }
-
-      const shouldLogIn = AuthSelectors.selectIsShouldLogin(state$.value);
 
       if (!shouldLogIn) {
         if (modelId && isOptionChanged('modelId')) {
@@ -1297,6 +1289,14 @@ const setOverlayOptionsEpic: AppEpic = (action$, state$) =>
       }
 
       if (isOptionChanged('signInOptions')) {
+        actions.push(
+          of(
+            OverlayActions.setValidationUserEmail(
+              signInOptions?.validationUserEmail ?? null,
+            ),
+          ),
+        );
+
         actions.push(of(OverlayActions.signInOptionsSet({ signInOptions })));
       }
 
@@ -1325,8 +1325,20 @@ const setOverlayOptionsEpic: AppEpic = (action$, state$) =>
 const signInOptionsSet: AppEpic = (action$, state$) =>
   action$.pipe(
     ofType(OverlayActions.signInOptionsSet.type),
-    tap(({ payload: { signInOptions } }) => {
+    tap(async ({ payload: { signInOptions } }) => {
       const isShouldLogin = AuthSelectors.selectIsShouldLogin(state$.value);
+      const isShouldLogout =
+        signInOptions?.validationUserEmail &&
+        AuthSelectors.selectIsShouldLogout(
+          state$.value,
+          signInOptions?.validationUserEmail,
+        );
+
+      if (isShouldLogout) {
+        await signOut({ redirect: true });
+
+        return;
+      }
 
       if (
         isShouldLogin &&
@@ -1382,8 +1394,14 @@ const checkReadyToInteract: AppEpic = (action$, state$) =>
           const areConvLoaded =
             ConversationsSelectors.selectAreSelectedConversationsLoaded(state);
           const isShouldLogin = AuthSelectors.selectIsShouldLogin(state);
+          const isShouldLogout =
+            state.overlay.validationUserEmail &&
+            AuthSelectors.selectIsShouldLogout(
+              state,
+              state.overlay.validationUserEmail,
+            );
 
-          return areConvLoaded && !isShouldLogin;
+          return areConvLoaded && !isShouldLogin && !isShouldLogout;
         }),
         switchMap(() =>
           !OverlaySelectors.selectReadyToInteractSent(state$.value)

--- a/apps/chat/src/store/overlay/overlay.reducers.ts
+++ b/apps/chat/src/store/overlay/overlay.reducers.ts
@@ -36,6 +36,7 @@ const initialState: OverlayState = {
   customMessageButtons: [],
 
   systemPrompt: null,
+  validationUserEmail: null,
   newConversationsFolder: null,
   readyToInteractSent: false,
 };
@@ -190,6 +191,12 @@ export const overlaySlice = createSlice({
       { payload }: PayloadAction<MessageButtons[]>,
     ) => {
       state.customMessageButtons = payload;
+    },
+    setValidationUserEmail: (
+      state,
+      { payload }: PayloadAction<string | null>,
+    ) => {
+      state.validationUserEmail = payload;
     },
     sendCustomMessageEvent: (
       state,

--- a/apps/chat/src/store/overlay/overlay.types.ts
+++ b/apps/chat/src/store/overlay/overlay.types.ts
@@ -12,6 +12,7 @@ export interface OverlayState {
 
   readyToInteractSent: boolean;
   optionsReceived?: boolean;
+  validationUserEmail: string | null;
 
   customMessageButtons: MessageButtons[];
 }

--- a/apps/overlay-sandbox/app/cases/overlay/sign-in-email/page.tsx
+++ b/apps/overlay-sandbox/app/cases/overlay/sign-in-email/page.tsx
@@ -25,7 +25,7 @@ const overlayOptions = {
     Feature.Marketplace,
   ],
   signInOptions: {
-    validationUserEmail: 'mikita_butsko@epam.com',
+    validationUserEmail: 'someMail',
   },
 } as ChatOverlayOptions;
 

--- a/apps/overlay-sandbox/app/cases/overlay/sign-in-email/page.tsx
+++ b/apps/overlay-sandbox/app/cases/overlay/sign-in-email/page.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import {
+  ChatOverlayWrapper,
+  commonOverlayProps,
+} from '../../components/chatOverlayWrapper';
+
+import { ChatOverlayOptions, Feature } from '@epam/ai-dial-shared';
+
+const overlayOptions = {
+  ...commonOverlayProps,
+  enabledFeatures: [
+    Feature.ConversationsSection,
+    Feature.PromptsSection,
+    Feature.TopSettings,
+    Feature.TopClearConversation,
+    Feature.TopChatInfo,
+    Feature.TopChatModelSettings,
+    Feature.EmptyChatSettings,
+    Feature.Header,
+    Feature.Footer,
+    Feature.RequestApiKey,
+    Feature.ReportAnIssue,
+    Feature.Likes,
+    Feature.Marketplace,
+  ],
+  signInOptions: {
+    validationUserEmail: 'mikita_butsko@epam.com',
+  },
+} as ChatOverlayOptions;
+
+export default function Index() {
+  return <ChatOverlayWrapper overlayOptions={overlayOptions} />;
+}

--- a/apps/overlay-sandbox/app/page.tsx
+++ b/apps/overlay-sandbox/app/page.tsx
@@ -27,6 +27,7 @@ enum OverlayCases {
   editLastAssistantMessage = '/cases/overlay/edit-last-assistant-message',
   disabledDefaultButtons = '/cases/overlay/disabled-default-buttons',
   featuresData = '/cases/overlay/features-data',
+  signInEmail = '/cases/overlay/sign-in-email',
 }
 
 export default async function Index() {

--- a/libs/shared/src/types/overlay/overlay.ts
+++ b/libs/shared/src/types/overlay/overlay.ts
@@ -33,6 +33,7 @@ interface OverlaySignInOptions {
   autoSignIn: boolean;
   signInProvider?: string;
   signInInNewWindow?: boolean;
+  validationUserEmail?: string;
 }
 
 export enum MessageButtonPlacement {


### PR DESCRIPTION
**Description:**

Sometimes we get situation when users are different in overlay and host application, so we want to logout such users

Issues:

- Issue #4549 

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
