### PR TITLE
fix(overlay): fix overlay signout (Issue  #4549)

### DIFF
--- a/apps/chat/src/store/auth/auth.selectors.ts
+++ b/apps/chat/src/store/auth/auth.selectors.ts
@@ -35,13 +35,14 @@ const selectIsShouldLogout = createSelector(
     selectStatus,
     (state: RootState) => state.settings.isAuthDisabled,
     (state: RootState) => state.auth.session?.data?.user.email,
-    (state: RootState, userEmail: string) => userEmail,
+    (state: RootState, userEmail?: string | null) => userEmail,
   ],
   (session, sessionStatus, isAuthDisabled, stateUserEmail, userEmail) => {
     return (
       !isAuthDisabled &&
       sessionStatus === 'authenticated' &&
       isClientSessionValid(session) &&
+      userEmail &&
       userEmail !== stateUserEmail
     );
   },

--- a/apps/chat/src/store/overlay/overlay.epics.ts
+++ b/apps/chat/src/store/overlay/overlay.epics.ts
@@ -1,4 +1,4 @@
-import { signIn } from 'next-auth/react';
+import { signIn, signOut } from 'next-auth/react';
 
 import {
   EMPTY,
@@ -45,7 +45,6 @@ import {
 } from '@/src/utils/app/overlay';
 import { splitEntityId } from '@/src/utils/app/shared-utils';
 import { signInInOverlay } from '@/src/utils/auth/auth-overlay';
-import { customSignOut } from '@/src/utils/auth/signOut';
 
 import { FeatureType } from '@/src/types/common';
 import { AppAction, AppEpic } from '@/src/types/store';
@@ -1327,6 +1326,20 @@ const signInOptionsSet: AppEpic = (action$, state$) =>
   action$.pipe(
     ofType(OverlayActions.signInOptionsSet.type),
     tap(async ({ payload: { signInOptions } }) => {
+      const login = () => {
+        if (signInOptions?.autoSignIn && signInOptions?.signInProvider) {
+          if (signInOptions?.signInInNewWindow) {
+            //will open '/auth/signin?provider=' in a new page
+            signInInOverlay(
+              `/auth/signin?provider=${signInOptions.signInProvider}`,
+            );
+          } else {
+            //will try to signin in the iframe
+            signIn(signInOptions?.signInProvider);
+          }
+        }
+      };
+
       const isShouldLogin = AuthSelectors.selectIsShouldLogin(state$.value);
       const isShouldLogout =
         signInOptions?.validationUserEmail &&
@@ -1336,25 +1349,15 @@ const signInOptionsSet: AppEpic = (action$, state$) =>
         );
 
       if (isShouldLogout) {
-        await customSignOut();
+        await signOut({ redirect: false });
+
+        login();
 
         return;
       }
 
-      if (
-        isShouldLogin &&
-        signInOptions?.autoSignIn &&
-        signInOptions?.signInProvider
-      ) {
-        if (signInOptions?.signInInNewWindow) {
-          //will open '/auth/signin?provider=' in a new page
-          signInInOverlay(
-            `/auth/signin?provider=${signInOptions.signInProvider}`,
-          );
-        } else {
-          //will try to signin in the iframe
-          signIn(signInOptions?.signInProvider);
-        }
+      if (isShouldLogin) {
+        login();
       }
     }),
     ignoreElements(),

--- a/apps/chat/src/utils/auth/signOut.ts
+++ b/apps/chat/src/utils/auth/signOut.ts
@@ -20,8 +20,6 @@ export const customSignOut = async (): Promise<void> => {
     if (url) {
       const parsedUrl = parseUrl(url);
       window.location.href = parsedUrl.href;
-    } else {
-      await signOut({ redirect: true });
     }
   } catch (error) {
     await signOut({ redirect: true });

--- a/apps/chat/src/utils/auth/signOut.ts
+++ b/apps/chat/src/utils/auth/signOut.ts
@@ -15,11 +15,12 @@ export const customSignOut = async (): Promise<void> => {
     const res = await fetch('/api/auth/federated-logout');
     const { url }: { url: string | null } = await res.json();
 
-    await signOut({ redirect: true });
-
     if (url) {
       const parsedUrl = parseUrl(url);
+      await signOut({ redirect: false });
       window.location.href = parsedUrl.href;
+    } else {
+      await signOut({ redirect: true });
     }
   } catch (error) {
     await signOut({ redirect: true });

--- a/apps/chat/src/utils/auth/signOut.ts
+++ b/apps/chat/src/utils/auth/signOut.ts
@@ -15,9 +15,10 @@ export const customSignOut = async (): Promise<void> => {
     const res = await fetch('/api/auth/federated-logout');
     const { url }: { url: string | null } = await res.json();
 
+    await signOut({ redirect: true });
+
     if (url) {
       const parsedUrl = parseUrl(url);
-      await signOut({ redirect: false });
       window.location.href = parsedUrl.href;
     } else {
       await signOut({ redirect: true });


### PR DESCRIPTION
**Description:**

SSO signout not appropriate for overlay signout, because it logged out top app, but should not
We using next auth signout but without redirect, because with redirect it is working in wrong way(for unknown reason) and after logout finish we are doing manual login

Issues:

- Issue #4549 

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
