### PR TITLE
fix(chat): fix 'next' button when return to the first step of toolset editor (Issue #4606)

### DIFF
--- a/apps/chat/src/components/ToolsetEditor/ToolsetEditor.tsx
+++ b/apps/chat/src/components/ToolsetEditor/ToolsetEditor.tsx
@@ -117,9 +117,15 @@ export const ToolsetEditor = () => {
   const handleNextClick = useCallback(
     (e: React.FormEvent<HTMLFormElement>) => {
       e.preventDefault();
-      handleSubmit();
+      if (!isDirty && toolsetDetails) {
+        handleSubmit(() =>
+          dispatch(ToolsetActions.setEditorStep(ToolsetEditorSteps.Settings)),
+        );
+      } else {
+        handleSubmit();
+      }
     },
-    [handleSubmit],
+    [dispatch, handleSubmit, isDirty, toolsetDetails],
   );
 
   return (


### PR DESCRIPTION
**Description:**

fix 'next' button when return to the first step of toolset editor

Issues:

- Issue #4606

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
