### PR TITLE
fix(chat): fix 'next' button for toolset update (Issue #4606)

### DIFF
--- a/apps/chat/src/store/toolset/toolset.epics.ts
+++ b/apps/chat/src/store/toolset/toolset.epics.ts
@@ -244,6 +244,9 @@ const updateToolsetEpic: AppEpic = (action$) =>
                 switchMap((updatedToolset) => {
                   return concat(
                     of(
+                      ToolsetActions.setEditorStep(ToolsetEditorSteps.Settings),
+                    ),
+                    of(
                       ToolsetActions.updateToolsetSuccess({
                         oldToolset: payload.oldToolset,
                         newToolset: updatedToolset,


### PR DESCRIPTION
**Description:**

fix 'next' button for toolset update

Issues:

- Issue #4606

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
