### PR TITLE
fix(chat): fix 'next' button for toolset update (Issue #4606)

### DIFF
--- a/apps/chat/src/components/ToolsetEditor/ToolsetEditor.tsx
+++ b/apps/chat/src/components/ToolsetEditor/ToolsetEditor.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useRef } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 
 import { useRouter } from 'next/router';
@@ -31,6 +31,8 @@ export const ToolsetEditor = () => {
   const toolsetDetails = useAppSelector(ToolsetSelectors.selectToolsetDetails);
   const toolsets = useAppSelector(ToolsetSelectors.selectToolsets);
   const editorStep = useAppSelector(ToolsetSelectors.selectEditorStep);
+
+  const changeEditorTabRef = useRef<ToolsetEditorSteps | null>(null);
 
   const formMethods = useForm<ToolsetEditorForm>({
     defaultValues: getDefaultFormData(toolsetDetails, toolsets),
@@ -72,6 +74,7 @@ export const ToolsetEditor = () => {
           ToolsetActions.updateToolset({
             oldToolset: toolsetDetails,
             newToolset: payloadToolset,
+            tabToOpen: changeEditorTabRef.current ?? undefined,
           }),
         );
       } else {
@@ -81,6 +84,8 @@ export const ToolsetEditor = () => {
           }),
         );
       }
+
+      changeEditorTabRef.current = null;
       formMethods.reset(getDefaultFormData(payloadToolset));
     },
     [dispatch, formMethods, toolsetDetails],
@@ -89,13 +94,17 @@ export const ToolsetEditor = () => {
   const handleSubmit = useCallback(
     (cb?: () => void) => {
       formMethods.trigger().then((isValid) => {
-        if (!isValid) return;
+        if (!isValid) {
+          changeEditorTabRef.current = null;
+          return;
+        }
 
         if (isDirty || !toolsetDetails) {
           void formMethods
             .handleSubmit(submitHandler)()
             .then(() => cb?.());
         } else {
+          changeEditorTabRef.current = null;
           cb?.();
         }
       });
@@ -114,9 +123,14 @@ export const ToolsetEditor = () => {
   const handleTabClick = useCallback(
     (tab: ToolsetEditorSteps) => {
       if (tab === editorStep) return;
-      handleSubmit(() => dispatch(ToolsetActions.setEditorStep(tab)));
+      if (!isDirty && toolsetDetails) {
+        handleSubmit(() => dispatch(ToolsetActions.setEditorStep(tab)));
+      } else {
+        changeEditorTabRef.current = tab;
+        handleSubmit();
+      }
     },
-    [editorStep, handleSubmit, dispatch],
+    [editorStep, isDirty, toolsetDetails, handleSubmit, dispatch],
   );
 
   const handleNextClick = useCallback(
@@ -127,6 +141,7 @@ export const ToolsetEditor = () => {
           dispatch(ToolsetActions.setEditorStep(ToolsetEditorSteps.Settings)),
         );
       } else {
+        changeEditorTabRef.current = ToolsetEditorSteps.Settings;
         handleSubmit();
       }
     },

--- a/apps/chat/src/store/toolset/toolset.epics.ts
+++ b/apps/chat/src/store/toolset/toolset.epics.ts
@@ -244,13 +244,15 @@ const updateToolsetEpic: AppEpic = (action$) =>
                 switchMap((updatedToolset) => {
                   return concat(
                     of(
-                      ToolsetActions.setEditorStep(ToolsetEditorSteps.Settings),
-                    ),
-                    of(
                       ToolsetActions.updateToolsetSuccess({
                         oldToolset: payload.oldToolset,
                         newToolset: updatedToolset,
                       }),
+                    ),
+                    iif(
+                      () => !!payload.tabToOpen,
+                      of(ToolsetActions.setEditorStep(payload.tabToOpen!)),
+                      EMPTY,
                     ),
                     iif(
                       () => !!payload.auth,

--- a/apps/chat/src/store/toolset/toolset.reducer.ts
+++ b/apps/chat/src/store/toolset/toolset.reducer.ts
@@ -100,6 +100,7 @@ export const toolsetSlice = createSlice({
       }: PayloadAction<{
         oldToolset: ToolsetModel;
         newToolset: ToolsetModel;
+        tabToOpen?: ToolsetEditorSteps;
         auth?: {
           apiKey?: string;
         };


### PR DESCRIPTION
**Description:**

fix 'next' button for toolset update

Issues:

- Issue #4606

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
