### PR TITLE
fix(chat): toolsets displayed twice on table view (Issue #4621)

### DIFF
--- a/apps/chat/src/store/toolset/toolset.selectors.ts
+++ b/apps/chat/src/store/toolset/toolset.selectors.ts
@@ -5,6 +5,7 @@ import { ToolsetModel } from '@/src/types/toolsets';
 
 import { UploadStatus } from '@epam/ai-dial-shared';
 import sortBy from 'lodash-es/sortBy';
+import uniq from 'lodash-es/uniq';
 
 const rootSelector = (state: RootState) => state.toolset;
 
@@ -13,7 +14,7 @@ const selectInitialized = (state: RootState) => rootSelector(state).initialized;
 const selectToolsetsMap = (state: RootState) => rootSelector(state).toolsetsMap;
 
 const selectToolsets = createSelector([selectToolsetsMap], (toolsetsMap) => {
-  const toolsets = Object.values(toolsetsMap) as ToolsetModel[];
+  const toolsets = uniq(Object.values(toolsetsMap)) as ToolsetModel[];
 
   return sortBy(toolsets, (toolset) => toolset.name.toLowerCase());
 });


### PR DESCRIPTION
**Description:**

- Fix toolsets displayed twice on table view in Marketplace.

Issues:

- Issue #4621 


**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
