### PR TITLE
fix(chat): fix quick app 2.0 remove all collapse, x functionality, tooltips for not available (Issues #4582, #4586, #4602)

### DIFF
--- a/apps/chat/src/components/Chat/Publish/PublicationHandler/ReviewApplicationDialog/ReviewQuickApp2Section.tsx
+++ b/apps/chat/src/components/Chat/Publish/PublicationHandler/ReviewApplicationDialog/ReviewQuickApp2Section.tsx
@@ -163,6 +163,7 @@ const ReviewQuickApp2SectionView = ({
           <span className="flex gap-2 text-primary">
             {agents.map((agent) => (
               <AgentAndToolsetChip
+                id={agent.deployment.name}
                 key={agent.deployment.name}
                 item={
                   modelsMap[agent.deployment.name] ?? {
@@ -189,6 +190,7 @@ const ReviewQuickApp2SectionView = ({
           <span className="flex gap-2 text-primary">
             {toolsets.map((toolset) => (
               <AgentAndToolsetChip
+                id={toolset.name}
                 key={toolset.name}
                 item={
                   toolsetsMap[toolset.name] ?? {

--- a/apps/chat/src/components/Common/AgentAndToolsetSelector/AgentAndToolsetChip.tsx
+++ b/apps/chat/src/components/Common/AgentAndToolsetSelector/AgentAndToolsetChip.tsx
@@ -15,26 +15,26 @@ import { EntityMarkdownDescription } from '@/src/components/Common/MarkdownDescr
 import { Tooltip } from '@/src/components/Common/Tooltip';
 import { TopicsList } from '@/src/components/Marketplace/TopicsList';
 
-interface AgentAndToolsetChipProps {
+interface ChipViewProps {
   id: string;
   item?: MarketplaceEntity;
-  onRemove?: (id: string) => void;
+  name: string;
+  version?: string;
+  isInvalid: boolean;
   readonly?: boolean;
+  onRemove?: (id: string) => void;
 }
 
-export const AgentAndToolsetChip: React.FC<AgentAndToolsetChipProps> = ({
+const ChipView: React.FC<ChipViewProps> = ({
   id,
   item,
-  onRemove,
+  name,
+  version,
+  isInvalid,
   readonly,
+  onRemove,
 }) => {
-  const { t } = useTranslation(Translation.Common);
-  const isInvalid = !item;
-
-  const name = isInvalid ? getEntityNameFromId(id) : item.name;
-  const version = isInvalid ? getVersionFromId(id) : item.version;
-
-  const chipContent = (
+  return (
     <div
       className={classNames(
         'flex h-[34px] cursor-pointer items-center gap-2 rounded px-2 py-1.5',
@@ -63,52 +63,105 @@ export const AgentAndToolsetChip: React.FC<AgentAndToolsetChipProps> = ({
       )}
     </div>
   );
+};
+
+interface ChipTooltipContentProps {
+  id: string;
+  item?: MarketplaceEntity;
+  name: string;
+  version?: string;
+  isInvalid: boolean;
+}
+
+const ChipTooltipContent: React.FC<ChipTooltipContentProps> = ({
+  id,
+  item,
+  name,
+  version,
+  isInvalid,
+}) => {
+  const { t } = useTranslation(Translation.Common);
+
+  return (
+    <div className="flex w-[440px] max-w-full flex-col gap-3 p-3">
+      <div className="flex items-center gap-3">
+        <div className="shrink-0">
+          <ModelIcon entityId={id} entity={item} size={96} />
+        </div>
+        <div className="flex min-w-0 flex-1 flex-col">
+          <span className="text-xs text-secondary">
+            {t('Version {{version}}', { version })}
+          </span>
+          <span className="w-full truncate text-base font-bold">{name}</span>
+          {isInvalid ? (
+            <div className="flex items-center gap-2 text-error">
+              <span className="text-sm">
+                {t(
+                  'Not available toolset selected. Please, change or remove toolset to proceed',
+                )}
+              </span>
+            </div>
+          ) : (
+            item?.description && (
+              <EntityMarkdownDescription
+                className="line-clamp-3 text-sm leading-4 text-secondary"
+                isShortDescription
+              >
+                {item.description}
+              </EntityMarkdownDescription>
+            )
+          )}
+        </div>
+      </div>
+      {item?.topics && item.topics.length > 0 && (
+        <div className="shrink-0">
+          <TopicsList topics={item.topics} />
+        </div>
+      )}
+    </div>
+  );
+};
+
+interface AgentAndToolsetChipProps {
+  id: string;
+  item?: MarketplaceEntity;
+  onRemove?: (id: string) => void;
+  readonly?: boolean;
+}
+
+export const AgentAndToolsetChip: React.FC<AgentAndToolsetChipProps> = ({
+  id,
+  item,
+  onRemove,
+  readonly,
+}) => {
+  const isInvalid = !item;
+
+  const name = isInvalid ? getEntityNameFromId(id) : item.name;
+  const version = isInvalid ? getVersionFromId(id) : item.version;
 
   return (
     <Tooltip
       isTriggerClickable
       tooltip={
-        <div className="flex w-[440px] max-w-full flex-col gap-3 p-3">
-          <div className="flex items-center gap-3">
-            <div className="shrink-0">
-              <ModelIcon entityId={id} entity={item} size={96} />
-            </div>
-            <div className="flex min-w-0 flex-1 flex-col">
-              <span className="text-xs text-secondary">
-                {t('Version {{version}}', { version })}
-              </span>
-              <span className="w-full truncate text-base font-bold">
-                {name}
-              </span>
-              {isInvalid ? (
-                <div className="flex items-center gap-2 text-error">
-                  <span className="text-sm">
-                    {t(
-                      'Not available toolset selected. Please, change or remove toolset to proceed',
-                    )}
-                  </span>
-                </div>
-              ) : (
-                item.description && (
-                  <EntityMarkdownDescription
-                    className="line-clamp-3 text-sm leading-4 text-secondary"
-                    isShortDescription
-                  >
-                    {item.description}
-                  </EntityMarkdownDescription>
-                )
-              )}
-            </div>
-          </div>
-          {item?.topics && item.topics.length > 0 && (
-            <div className="shrink-0">
-              <TopicsList topics={item.topics} />
-            </div>
-          )}
-        </div>
+        <ChipTooltipContent
+          id={id}
+          item={item}
+          name={name}
+          version={version}
+          isInvalid={isInvalid}
+        />
       }
     >
-      {chipContent}
+      <ChipView
+        id={id}
+        item={item}
+        name={name}
+        version={version}
+        isInvalid={isInvalid}
+        readonly={readonly}
+        onRemove={onRemove}
+      />
     </Tooltip>
   );
 };

--- a/apps/chat/src/components/Common/AgentAndToolsetSelector/AgentAndToolsetChip.tsx
+++ b/apps/chat/src/components/Common/AgentAndToolsetSelector/AgentAndToolsetChip.tsx
@@ -1,72 +1,114 @@
 import { IconX } from '@tabler/icons-react';
 import React from 'react';
 
+import { useTranslation } from 'next-i18next';
+
+import classNames from 'classnames';
+
+import { getEntityNameFromId, getVersionFromId } from '@/src/utils/server/api';
+
 import { MarketplaceEntity } from '@/src/types/marketplace';
+import { Translation } from '@/src/types/translation';
 
 import { ModelIcon } from '@/src/components/Chatbar/ModelIcon';
 import { EntityMarkdownDescription } from '@/src/components/Common/MarkdownDescription';
 import { Tooltip } from '@/src/components/Common/Tooltip';
 import { TopicsList } from '@/src/components/Marketplace/TopicsList';
 
-const AgentTooltipContent = ({ item }: { item: MarketplaceEntity }) => {
-  return (
-    <div className="flex max-h-[166px] w-full max-w-[440px] flex-col gap-3 p-3">
-      <div className="flex min-h-0 items-center gap-3">
-        <div className="shrink-0">
-          <ModelIcon entityId={item.id} entity={item} size={96} />
-        </div>
-
-        <div className="flex min-w-0 flex-1 flex-col gap-1">
-          <span className="truncate text-base font-bold">{item.name}</span>
-          {item.description && (
-            <EntityMarkdownDescription
-              className="line-clamp-3 text-sm leading-4 text-secondary"
-              isShortDescription
-            >
-              {item.description}
-            </EntityMarkdownDescription>
-          )}
-        </div>
-      </div>
-
-      {item.topics && item.topics.length > 0 && (
-        <div className="shrink-0">
-          <TopicsList topics={item.topics} />
-        </div>
-      )}
-    </div>
-  );
-};
-
 interface AgentAndToolsetChipProps {
-  item: MarketplaceEntity;
+  id: string;
+  item?: MarketplaceEntity;
+  onRemove: (id: string) => void;
   readonly?: boolean;
-  onRemove?: (id: string) => void;
 }
+
 export const AgentAndToolsetChip: React.FC<AgentAndToolsetChipProps> = ({
+  id,
   item,
-  readonly,
   onRemove,
+  readonly,
 }) => {
-  return (
-    <Tooltip
-      isTriggerClickable
-      triggerClassName="flex h-[34px] cursor-pointer items-center gap-2 rounded bg-accent-primary-alpha px-2 py-1.5 text-primary"
-      tooltip={<AgentTooltipContent item={item} />}
+  const { t } = useTranslation(Translation.Common);
+  const isInvalid = !item;
+
+  const name = isInvalid ? getEntityNameFromId(id) : item.name;
+  const version = isInvalid ? getVersionFromId(id) : item.version;
+
+  const chipContent = (
+    <div
+      className={classNames(
+        'flex h-[34px] cursor-pointer items-center gap-2 rounded px-2 py-1.5',
+        isInvalid
+          ? 'bg-error text-error'
+          : 'bg-accent-primary-alpha text-primary',
+      )}
     >
-      <ModelIcon entityId={item.id} entity={item} size={18} />
-      <span className="max-w-[200px] truncate">{item.name}</span>
+      <ModelIcon entityId={id} entity={item} size={18} />
+      <span className="max-w-[220px] truncate">
+        {name} {version}
+      </span>
       {!readonly && (
         <button
-          className="text-secondary hover:text-primary"
+          className={classNames(
+            'text-secondary',
+            isInvalid ? 'hover:text-error' : 'hover:text-primary',
+          )}
           onClick={(e) => {
             e.stopPropagation();
-            onRemove?.(item.id);
+            onRemove(id);
           }}
         >
           <IconX size={14} />
         </button>
       )}
+    </div>
+  );
+
+  return (
+    <Tooltip
+      isTriggerClickable
+      tooltip={
+        <div className="flex w-[440px] max-w-full flex-col gap-3 p-3">
+          <div className="flex items-center gap-3">
+            <div className="shrink-0">
+              <ModelIcon entityId={id} entity={item} size={96} />
+            </div>
+            <div className="flex min-w-0 flex-1 flex-col">
+              <span className="text-xs text-secondary">
+                {t('Version {{version}}', { version })}
+              </span>
+              <span className="w-full truncate text-base font-bold">
+                {name}
+              </span>
+              {isInvalid ? (
+                <div className="flex items-center gap-2 text-error">
+                  <span className="text-sm">
+                    {t(
+                      'Not available toolset selected. Please, change or remove toolset to proceed',
+                    )}
+                  </span>
+                </div>
+              ) : (
+                item.description && (
+                  <EntityMarkdownDescription
+                    className="line-clamp-3 text-sm leading-4 text-secondary"
+                    isShortDescription
+                  >
+                    {item.description}
+                  </EntityMarkdownDescription>
+                )
+              )}
+            </div>
+          </div>
+          {item?.topics && item.topics.length > 0 && (
+            <div className="shrink-0">
+              <TopicsList topics={item.topics} />
+            </div>
+          )}
+        </div>
+      }
+    >
+      {chipContent}
     </Tooltip>
   );
 };

--- a/apps/chat/src/components/Common/AgentAndToolsetSelector/AgentAndToolsetChip.tsx
+++ b/apps/chat/src/components/Common/AgentAndToolsetSelector/AgentAndToolsetChip.tsx
@@ -18,7 +18,7 @@ import { TopicsList } from '@/src/components/Marketplace/TopicsList';
 interface AgentAndToolsetChipProps {
   id: string;
   item?: MarketplaceEntity;
-  onRemove: (id: string) => void;
+  onRemove?: (id: string) => void;
   readonly?: boolean;
 }
 
@@ -55,7 +55,7 @@ export const AgentAndToolsetChip: React.FC<AgentAndToolsetChipProps> = ({
           )}
           onClick={(e) => {
             e.stopPropagation();
-            onRemove(id);
+            onRemove?.(id);
           }}
         >
           <IconX size={14} />

--- a/apps/chat/src/components/Common/AgentAndToolsetSelector/AgentAndToolsetChip.tsx
+++ b/apps/chat/src/components/Common/AgentAndToolsetSelector/AgentAndToolsetChip.tsx
@@ -5,7 +5,8 @@ import { useTranslation } from 'next-i18next';
 
 import classNames from 'classnames';
 
-import { getEntityNameFromId, getVersionFromId } from '@/src/utils/server/api';
+import { getEntityNameFromId } from '@/src/utils/app/id';
+import { getVersionFromId } from '@/src/utils/server/api';
 
 import { MarketplaceEntity } from '@/src/types/marketplace';
 import { Translation } from '@/src/types/translation';

--- a/apps/chat/src/components/Common/AgentAndToolsetSelector/AgentAndToolsetModal.tsx
+++ b/apps/chat/src/components/Common/AgentAndToolsetSelector/AgentAndToolsetModal.tsx
@@ -108,20 +108,20 @@ function ScopeTabButton({
     </TabButton>
   );
 }
-
 interface AgentAndToolsetModalViewProps {
   onClose: () => void;
   onConfirm: (selectedItems: MarketplaceEntity[]) => void;
-  defaultSelectedItems: MarketplaceEntity[];
+  initialSelectedIds: string[];
+  allItemsMap: Record<string, MarketplaceEntity | undefined>;
 }
 
 const AgentAndToolsetModalView = ({
   onClose,
   onConfirm,
-  defaultSelectedItems,
+  initialSelectedIds,
+  allItemsMap,
 }: AgentAndToolsetModalViewProps) => {
   const { t } = useTranslation(Translation.Chat);
-
   const headerRef = useRef<HTMLDivElement>(null);
   const footerRef = useRef<HTMLDivElement>(null);
 
@@ -135,8 +135,9 @@ const AgentAndToolsetModalView = ({
     MarketplaceTabs | MarketplaceEntitiesTabs
   >(MarketplaceTabs.MY_WORKSPACE);
   const [searchTerm, setSearchTerm] = useState('');
-  const [selectedItems, setSelectedItems] =
-    useState<MarketplaceEntity[]>(defaultSelectedItems);
+  const [selectedIds, setSelectedIds] = useState<string[]>(
+    initialSelectedIds ?? [],
+  );
 
   const isMyWorkspace = scopeTab === MarketplaceTabs.MY_WORKSPACE;
 
@@ -157,7 +158,7 @@ const AgentAndToolsetModalView = ({
     if (headerRef.current) {
       setHeaderHeight(headerRef.current.offsetHeight);
     }
-  }, [selectedItems]);
+  }, [selectedIds]);
 
   const installedAgentsSet = useAppSelector(
     ModelsSelectors.selectInstalledModelIds,
@@ -178,29 +179,19 @@ const AgentAndToolsetModalView = ({
 
   const handleToggleSelectItem = useCallback(
     (itemToToggle: MarketplaceEntity) => {
-      setSelectedItems((prevSelected) => {
-        const isAlreadySelected = prevSelected.some(
-          (item) => item.id === itemToToggle.id,
-        );
-        if (isAlreadySelected) {
-          return prevSelected.filter((item) => item.id !== itemToToggle.id);
-        } else {
-          return [...prevSelected, itemToToggle];
+      setSelectedIds((prevIds) => {
+        if (prevIds.includes(itemToToggle.id)) {
+          return prevIds.filter((id) => id !== itemToToggle.id);
         }
+        return [...prevIds, itemToToggle.id];
       });
     },
     [],
   );
 
-  const handleRemoveItem = useCallback(
-    (idToRemove: string) => {
-      const itemToRemove = selectedItems.find((item) => item.id === idToRemove);
-      if (itemToRemove) {
-        handleToggleSelectItem(itemToRemove);
-      }
-    },
-    [selectedItems, handleToggleSelectItem],
-  );
+  const handleRemoveItem = useCallback((idToRemove: string) => {
+    setSelectedIds((prevIds) => prevIds.filter((id) => id !== idToRemove));
+  }, []);
 
   const searchedAgents = useFuseSearch(
     allAgents,
@@ -255,18 +246,27 @@ const AgentAndToolsetModalView = ({
     installedToolsetsSet,
   ]);
 
+  const selectedIdsSet = useMemo(() => new Set(selectedIds), [selectedIds]);
+
   const sliderItemProps = useMemo(
     () => ({
-      selectedItems,
+      selectedIdsSet,
       onToggleSelectItem: handleToggleSelectItem,
     }),
-    [selectedItems, handleToggleSelectItem],
+    [selectedIdsSet, handleToggleSelectItem],
   );
 
   const sliderResetDependencies = useMemo(
-    () => [isMyWorkspace, searchTerm],
-    [isMyWorkspace, searchTerm],
+    () => [isMyWorkspace, searchTerm, entityType],
+    [isMyWorkspace, searchTerm, entityType],
   );
+
+  const handleConfirm = useCallback(() => {
+    const itemsToConfirm = selectedIds
+      .map((id) => allItemsMap[id])
+      .filter((item): item is MarketplaceEntity => !!item);
+    onConfirm(itemsToConfirm);
+  }, [selectedIds, allItemsMap, onConfirm]);
 
   return (
     <>
@@ -329,11 +329,12 @@ const AgentAndToolsetModalView = ({
             {t('Selected')}
           </span>
           <div className="my-2 flex  flex-wrap gap-2">
-            {selectedItems.length ? (
-              selectedItems.map((item) => (
+            {selectedIds.length ? (
+              selectedIds.map((id) => (
                 <AgentAndToolsetChip
-                  key={item.id}
-                  item={item}
+                  key={id}
+                  id={id}
+                  item={allItemsMap[id]}
                   onRemove={handleRemoveItem}
                 />
               ))
@@ -371,10 +372,7 @@ const AgentAndToolsetModalView = ({
         <button className="button button-secondary" onClick={onClose}>
           {t('Cancel')}
         </button>
-        <button
-          className="button button-primary"
-          onClick={() => onConfirm(selectedItems)}
-        >
+        <button className="button button-primary" onClick={handleConfirm}>
           {t('Confirm')}
         </button>
       </div>
@@ -385,13 +383,15 @@ const AgentAndToolsetModalView = ({
 interface Props {
   onClose: () => void;
   onConfirm: (selectedItems: MarketplaceEntity[]) => void;
-  defaultSelectedItems: MarketplaceEntity[];
+  initialSelectedIds: string[];
+  allItemsMap: Record<string, MarketplaceEntity | undefined>;
 }
 
 export const AgentAndToolsetModal = ({
   onClose,
   onConfirm,
-  defaultSelectedItems,
+  initialSelectedIds,
+  allItemsMap,
 }: Props) => {
   return (
     <Modal
@@ -405,7 +405,8 @@ export const AgentAndToolsetModal = ({
       <AgentAndToolsetModalView
         onClose={onClose}
         onConfirm={onConfirm}
-        defaultSelectedItems={defaultSelectedItems}
+        initialSelectedIds={initialSelectedIds}
+        allItemsMap={allItemsMap}
       />
     </Modal>
   );

--- a/apps/chat/src/components/Common/AgentAndToolsetSelector/AgentAndToolsetSelectItem.tsx
+++ b/apps/chat/src/components/Common/AgentAndToolsetSelector/AgentAndToolsetSelectItem.tsx
@@ -6,19 +6,15 @@ import { DialAIEntityModel } from '@/src/types/models';
 import { ItemCardView } from '@/src/components/Chat/TalkTo/ItemCardView';
 
 export interface AgentAndToolsetSelectItemProps {
-  selectedItems: MarketplaceEntity[];
-  onToggleSelectItem: (item: MarketplaceEntity) => void;
   groupItem: MarketplaceEntity;
+  selectedIdsSet: Set<string>;
+  onToggleSelectItem: (item: MarketplaceEntity) => void;
 }
 
-export const AgentAndToolsetSelectItem = ({
-  groupItem,
-  selectedItems,
-  onToggleSelectItem,
-}: AgentAndToolsetSelectItemProps) => {
-  const isSelected = selectedItems.some(
-    (selected) => selected.id === groupItem.id,
-  );
+export const AgentAndToolsetSelectItem: React.FC<
+  AgentAndToolsetSelectItemProps
+> = ({ groupItem, selectedIdsSet, onToggleSelectItem }) => {
+  const isSelected = selectedIdsSet.has(groupItem.id);
 
   return (
     <ItemCardView

--- a/apps/chat/src/components/Common/AgentAndToolsetSelector/AgentAndToolsetSelector.tsx
+++ b/apps/chat/src/components/Common/AgentAndToolsetSelector/AgentAndToolsetSelector.tsx
@@ -1,5 +1,5 @@
 import { IconLayoutGrid, IconPlus } from '@tabler/icons-react';
-import { MouseEvent, useCallback, useMemo, useState } from 'react';
+import { MouseEvent, useCallback, useState } from 'react';
 
 import { useTranslation } from 'next-i18next';
 
@@ -46,14 +46,6 @@ export const AgentAndToolsetSelector: React.FC<
 
   const [isSelectModalOpen, setSelectModalOpen] = useState(false);
 
-  const selectedItems = useMemo(
-    () =>
-      value
-        .map((id) => allItemsMap[id])
-        .filter((item): item is MarketplaceEntity => !!item),
-    [value, allItemsMap],
-  );
-
   const handleOpenSelectModal = (e: MouseEvent<HTMLButtonElement>) => {
     e.preventDefault();
     setSelectModalOpen(true);
@@ -95,11 +87,13 @@ export const AgentAndToolsetSelector: React.FC<
             <NoAgentsAndToolsets />
           ) : (
             <div className="flex flex-wrap gap-2 rounded border border-primary p-2">
-              {selectedItems.map((item) => (
+              {value.map((id) => (
                 <AgentAndToolsetChip
-                  key={item.id}
-                  item={item}
+                  key={id}
+                  id={id}
+                  item={allItemsMap[id]}
                   onRemove={handleRemoveItem}
+                  readonly={readonly}
                 />
               ))}
             </div>
@@ -108,7 +102,8 @@ export const AgentAndToolsetSelector: React.FC<
 
         {isSelectModalOpen && !readonly && (
           <AgentAndToolsetModal
-            defaultSelectedItems={selectedItems}
+            initialSelectedIds={value}
+            allItemsMap={allItemsMap}
             onClose={handleCloseModal}
             onConfirm={handleConfirmSelection}
           />

--- a/apps/chat/src/utils/app/id.ts
+++ b/apps/chat/src/utils/app/id.ts
@@ -1,4 +1,5 @@
 import { splitEntityId } from '@/src/utils/app/shared-utils';
+import { pathKeySeparator } from '@/src/utils/server/api';
 
 import { ApiKeys, FeatureType } from '@/src/types/common';
 
@@ -8,8 +9,6 @@ import { LOCAL_BUCKET } from '@/src/constants/chat';
 import { BucketService } from './data/bucket-service';
 import { constructPath } from './file';
 import { EnumMapper } from './mappers';
-
-export const pathKeySeparator = '__';
 
 export const getRootId = ({
   featureType,

--- a/apps/chat/src/utils/app/id.ts
+++ b/apps/chat/src/utils/app/id.ts
@@ -9,6 +9,8 @@ import { BucketService } from './data/bucket-service';
 import { constructPath } from './file';
 import { EnumMapper } from './mappers';
 
+export const pathKeySeparator = '__';
+
 export const getRootId = ({
   featureType,
   id,
@@ -120,4 +122,17 @@ export const areEntitiesBucketsTheSame = (
   secondId: string,
 ) => {
   return getEntityBucket({ id: firstId }) === getEntityBucket({ id: secondId });
+};
+
+export const getEntityNameFromId = (
+  id: string,
+  options?: { removeVersion?: boolean },
+): string => {
+  const name = id.split('/').at(-1) ?? id;
+
+  if (options?.removeVersion) {
+    return name.split(pathKeySeparator).at(0) ?? name;
+  }
+
+  return name;
 };

--- a/apps/chat/src/utils/server/api.ts
+++ b/apps/chat/src/utils/server/api.ts
@@ -301,18 +301,17 @@ export const getModelIdWithoutVersion = (id: string) => {
   return name;
 };
 
-export const getEntityNameFromId = (id: string): string => {
-  const versionSeparatorIndex = id.lastIndexOf(pathKeySeparator);
-  let baseId = id;
-  if (versionSeparatorIndex !== -1) {
-    baseId = id.substring(0, versionSeparatorIndex);
+export const getEntityNameFromId = (
+  id: string,
+  options?: { removeVersion?: boolean },
+): string => {
+  const name = id.split('/').at(-1) ?? id;
+
+  if (options?.removeVersion) {
+    return name.split(pathKeySeparator).at(0) ?? name;
   }
 
-  const pathSeparatorIndex = baseId.lastIndexOf('/');
-  if (pathSeparatorIndex !== -1) {
-    return baseId.substring(pathSeparatorIndex + 1);
-  }
-  return baseId;
+  return name;
 };
 
 export const getPublicItemIdWithoutVersion = (version: string, id: string) => {

--- a/apps/chat/src/utils/server/api.ts
+++ b/apps/chat/src/utils/server/api.ts
@@ -301,19 +301,6 @@ export const getModelIdWithoutVersion = (id: string) => {
   return name;
 };
 
-export const getEntityNameFromId = (
-  id: string,
-  options?: { removeVersion?: boolean },
-): string => {
-  const name = id.split('/').at(-1) ?? id;
-
-  if (options?.removeVersion) {
-    return name.split(pathKeySeparator).at(0) ?? name;
-  }
-
-  return name;
-};
-
 export const getPublicItemIdWithoutVersion = (version: string, id: string) => {
   if (version === NA_VERSION) {
     return id;

--- a/apps/chat/src/utils/server/api.ts
+++ b/apps/chat/src/utils/server/api.ts
@@ -301,6 +301,20 @@ export const getModelIdWithoutVersion = (id: string) => {
   return name;
 };
 
+export const getEntityNameFromId = (id: string): string => {
+  const versionSeparatorIndex = id.lastIndexOf(pathKeySeparator);
+  let baseId = id;
+  if (versionSeparatorIndex !== -1) {
+    baseId = id.substring(0, versionSeparatorIndex);
+  }
+
+  const pathSeparatorIndex = baseId.lastIndexOf('/');
+  if (pathSeparatorIndex !== -1) {
+    return baseId.substring(pathSeparatorIndex + 1);
+  }
+  return baseId;
+};
+
 export const getPublicItemIdWithoutVersion = (version: string, id: string) => {
   if (version === NA_VERSION) {
     return id;


### PR DESCRIPTION
**Description:**

- Need to fix collapse in Agents & Toolsets field when remove all values
- x-icon click should remove value for "Agents & Toolsets" field
- tooltip should have the same width
- add not available toolset logic and design

Issues:

- Issue #4582 
- Issue #4586 
- Issue #4602 

**UI changes**

<img width="505" height="213" alt="Снимок экрана 2025-09-09 в 07 16 35" src="https://github.com/user-attachments/assets/8bb8305e-d5e2-48bd-80cd-0ce227dd658b" />
<img width="275" height="121" alt="Снимок экрана 2025-09-09 в 07 16 46" src="https://github.com/user-attachments/assets/75cd2cbb-dd61-472d-9f4c-66ba9ca75ed8" />

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
