### PR TITLE
fix(chat): add space after 'All' in Agents&Toolsets form (Issue #4638)

### DIFF
--- a/apps/chat/src/components/Common/AgentAndToolsetSelector/AgentAndToolsetModal.tsx
+++ b/apps/chat/src/components/Common/AgentAndToolsetSelector/AgentAndToolsetModal.tsx
@@ -274,7 +274,7 @@ const AgentAndToolsetModalView = ({
         {t('Agents & Toolsets')}
       </h3>
       <div className="flex max-h-full min-h-0 w-full flex-1 flex-col px-5 pb-2 pt-6">
-        <div ref={headerRef}>
+        <div ref={headerRef} className="mb-2">
           <EntityTypeTabs currentType={entityType} setType={setEntityType} />
           <div className="relative my-4 flex w-full gap-2 max-sm:flex-col-reverse">
             <div className="relative flex grow">
@@ -345,7 +345,7 @@ const AgentAndToolsetModalView = ({
             )}
           </div>
 
-          <span className="col-span-1 my-2 whitespace-pre-wrap break-words text-xs text-secondary">
+          <span className="col-span-1 whitespace-pre-wrap break-words text-xs text-secondary">
             {t('All')}
           </span>
         </div>


### PR DESCRIPTION
**Description:**

Need to Add space between "All" and card on Agents&Toolsets form

Issues:

- Issue #4638

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
