### PR TITLE
fix(chat): add minimum size to select agent modal (Issue #4641)

### DIFF
--- a/apps/chat/src/components/Common/SliderGrid/SliderGrid.tsx
+++ b/apps/chat/src/components/Common/SliderGrid/SliderGrid.tsx
@@ -179,9 +179,9 @@ export const SliderGrid = <T extends { id: string }, P>({
     <div ref={containerRef} className="flex min-h-0 flex-1 flex-col">
       <div
         ref={sliderRef}
-        className="w-full flex-1 overflow-hidden"
+        className="flex w-full flex-1 items-center overflow-hidden"
         style={{
-          height: `${
+          minHeight: `${
             sliderRowsCount * (maxChunksCountConfig.cardHeight + gridGap) -
             gridGap
           }px`,


### PR DESCRIPTION
**Description:**

Select an agent for conversation modal should have minimum size

Issues:

- Issue #4641 

**UI changes**

<img width="620" height="501" alt="Снимок экрана 2025-09-14 в 07 26 45" src="https://github.com/user-attachments/assets/465b62c1-21f1-420c-bf74-01feb89c275f" />
<img width="620" height="382" alt="Снимок экрана 2025-09-14 в 07 26 56" src="https://github.com/user-attachments/assets/0895e535-9048-4acf-aabf-f6fd1e24e5ea" />

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
