### PR TITLE
fix(chat): add toolset remove bookmark confirmation modal (Issue #4669)

### DIFF
--- a/apps/chat/src/components/Marketplace/DeleteMarketplaceEntityDialog.tsx
+++ b/apps/chat/src/components/Marketplace/DeleteMarketplaceEntityDialog.tsx
@@ -82,6 +82,13 @@ const DeleteMarketplaceEntityDialogView = () => {
             action: DeleteType.REMOVE,
           }),
         );
+      } else {
+        dispatch(
+          ToolsetActions.removeInstalledToolsets({
+            references: [entity.reference],
+            action: DeleteType.REMOVE,
+          }),
+        );
       }
     },
     [dispatch],

--- a/apps/chat/src/components/Marketplace/ToolsTabRenderer.tsx
+++ b/apps/chat/src/components/Marketplace/ToolsTabRenderer.tsx
@@ -74,8 +74,8 @@ export function ToolsTabRenderer() {
     (toolset: ToolsetModel) => {
       if (installedToolsetsSet.has(toolset.reference)) {
         dispatch(
-          ToolsetActions.removeInstalledToolsets({
-            references: [toolset.reference],
+          MarketplaceActions.setDeleteEntity({
+            entity: toolset,
             action: DeleteType.REMOVE,
           }),
         );


### PR DESCRIPTION
**Description:**

Need to add confirmation message when user removes a toolset from My workspace

Issues:

- Issue #4669

**UI changes**

<img width="547" height="198" alt="Снимок экрана 2025-09-16 в 18 27 44" src="https://github.com/user-attachments/assets/c2070277-e2f8-4971-8931-8abda34e8b4f" />

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
