### PR TITLE
fix(chat): fix agents and toolsets icons overlap (Issue #4682)

### DIFF
--- a/apps/chat/src/components/Common/Combobox.tsx
+++ b/apps/chat/src/components/Common/Combobox.tsx
@@ -208,7 +208,7 @@ export const Combobox = <T,>({
       </div>
       <ul
         className={classNames(
-          'z-10 max-h-80 overflow-auto rounded bg-layer-3 shadow',
+          'z-50 max-h-80 overflow-auto rounded bg-layer-3 shadow',
           panelClassName,
           !isOpen && 'hidden',
         )}


### PR DESCRIPTION
**Description:**

Icons from "Agents&Toolsets" should not overlap Model drop-down

Issues:

- Issue #4682

**UI changes**

Before:
<img width="941" height="176" alt="Снимок экрана 2025-09-17 в 14 00 56" src="https://github.com/user-attachments/assets/67053a60-6fa5-4188-95ca-1e248409dded" />

Afore:
<img width="932" height="386" alt="Снимок экрана 2025-09-17 в 14 01 11" src="https://github.com/user-attachments/assets/eec92849-549b-4921-8e10-a27f15e40531" />

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
