### PR TITLE
fix(chat): call getConfigurationSchema only once when change conversation (Issue #4730)

### DIFF
--- a/apps/chat/src/components/Chat/Chat.tsx
+++ b/apps/chat/src/components/Chat/Chat.tsx
@@ -1118,6 +1118,8 @@ export function Chat({ isPreview }: ChatProps) {
     PublicationSelectors.selectIsPublicationUpdating,
   );
 
+  const configurationLoadedRef = useRef(false);
+
   const isNoMessages = selectedConversations.every(
     ({ messages }) => !messages?.length,
   );
@@ -1127,6 +1129,12 @@ export function Chat({ isPreview }: ChatProps) {
   }, [dispatch, selectedConversationsIds]);
 
   useEffect(() => {
+    configurationLoadedRef.current = false;
+  }, [selectedConversationsIds]);
+
+  useEffect(() => {
+    if (configurationLoadedRef.current) return;
+
     const configurationAppReference = selectedConversations.find((conv) =>
       doesModelHaveConfiguration(modelsMap[conv.model.id]),
     )?.model?.id;
@@ -1135,9 +1143,12 @@ export function Chat({ isPreview }: ChatProps) {
       : undefined;
 
     if (configurationAppId && isNoMessages) {
-      dispatch(
-        ChatActions.getConfigurationSchema({ modelId: configurationAppId }),
-      );
+      if (!configurationLoadedRef.current) {
+        configurationLoadedRef.current = true;
+        dispatch(
+          ChatActions.getConfigurationSchema({ modelId: configurationAppId }),
+        );
+      }
     } else {
       dispatch(ChatActions.resetConfigurationSchema());
     }


### PR DESCRIPTION
**Description:**

call getConfigurationSchema only once when change conversation

Issues:

- Issue #4730

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
