### PR TITLE
fix(chat): improve validation behavior with ability to save draft state (Issue #4766, #4672)

### DIFF
--- a/apps/chat/src/components/Header/EditorHeader.tsx
+++ b/apps/chat/src/components/Header/EditorHeader.tsx
@@ -1,7 +1,9 @@
 import {
+  IconAlertCircle,
   IconChevronDown,
   IconCircleCheck,
   IconCircleDot,
+  IconCircleDotFilled,
   IconLogout,
 } from '@tabler/icons-react';
 import { useCallback, useState } from 'react';
@@ -29,19 +31,27 @@ const getTabIcon = <T extends string>(
   isDisabled?: boolean,
   isNotValid?: boolean,
 ) => {
-  const iconColor =
-    isNotValid && tab !== activeTab ? 'text-error' : 'text-accent-primary';
-  return tab !== activeTab && isEditing ? (
-    <IconCircleCheck
-      className={iconColor}
-      data-qa="selected-step-icon"
-      width={24}
-      height={24}
-    />
-  ) : (
-    <IconCircleDot
-      className={isDisabled ? 'text-secondary' : iconColor}
-      data-qa="not-selected-step-icon"
+  const selected = tab === activeTab;
+
+  const Icon = selected
+    ? IconCircleDotFilled
+    : isNotValid
+      ? IconAlertCircle
+      : isEditing
+        ? IconCircleCheck
+        : IconCircleDot;
+  const color = isDisabled
+    ? 'text-secondary'
+    : isNotValid
+      ? 'text-error'
+      : isEditing || selected
+        ? 'text-accent-primary'
+        : 'text-secondary';
+
+  return (
+    <Icon
+      className={color}
+      data-qa={selected ? 'selected-step-icon' : 'not-selected-step-icon'}
       width={24}
       height={24}
     />

--- a/apps/chat/src/components/Header/EditorHeader.tsx
+++ b/apps/chat/src/components/Header/EditorHeader.tsx
@@ -27,17 +27,20 @@ const getTabIcon = <T extends string>(
   activeTab: T,
   isEditing?: boolean,
   isDisabled?: boolean,
+  isNotValid?: boolean,
 ) => {
+  const iconColor =
+    isNotValid && tab !== activeTab ? 'text-error' : 'text-accent-primary';
   return tab !== activeTab && isEditing ? (
     <IconCircleCheck
-      className="text-accent-primary"
+      className={iconColor}
       data-qa="selected-step-icon"
       width={24}
       height={24}
     />
   ) : (
     <IconCircleDot
-      className={isDisabled ? 'text-secondary' : 'text-accent-primary'}
+      className={isDisabled ? 'text-secondary' : iconColor}
       data-qa="not-selected-step-icon"
       width={24}
       height={24}
@@ -55,6 +58,7 @@ interface EditorHeaderProps<T extends string> {
   dataQa?: string;
   tabs: EditorHeaderTab<T>[];
   activeTab: T;
+  errorTabsSet?: Set<T>;
   onTabClick: (e: PartialBy<EditorHeaderTab<T>, 'label'>) => void;
   title: string;
 
@@ -68,6 +72,7 @@ export const EditorHeader = <T extends string>({
   dataQa,
   tabs,
   activeTab,
+  errorTabsSet,
   onTabClick,
   title,
 
@@ -165,6 +170,7 @@ export const EditorHeader = <T extends string>({
           >
             {tabs.map((tab, index) => {
               const isDisabled = tab.disabled;
+              const isNotValid = errorTabsSet?.has(tab.key) ?? false;
               return (
                 <div key={tab.key} className="flex items-center">
                   <div
@@ -178,7 +184,13 @@ export const EditorHeader = <T extends string>({
                     )}
                     onClick={() => onTabClick(tab)}
                   >
-                    {getTabIcon(tab.key, activeTab, isEditing, isDisabled)}
+                    {getTabIcon(
+                      tab.key,
+                      activeTab,
+                      isEditing,
+                      isDisabled,
+                      isNotValid,
+                    )}
 
                     <span className="grow truncate" data-qa="single-step-title">
                       {tab.label}

--- a/apps/chat/src/components/Marketplace/ToolsetLoginDialog.tsx
+++ b/apps/chat/src/components/Marketplace/ToolsetLoginDialog.tsx
@@ -1,4 +1,5 @@
 import { useCallback } from 'react';
+import { FormProvider, useForm } from 'react-hook-form';
 
 import { useTranslation } from 'next-i18next';
 
@@ -15,7 +16,13 @@ import { MarketplaceSelectors } from '@/src/store/selectors';
 import { Modal } from '@/src/components/Common/Modal';
 import { withRenderWhen } from '@/src/components/Common/RenderWhen';
 import { ToolsetLoginForm } from '@/src/components/ToolsetEditor/ToolsetLoginForm';
-import { ToolsetLoginFormType } from '@/src/components/ToolsetEditor/form';
+import {
+  ToolsetLoginFormSchema,
+  ToolsetLoginFormType,
+  getDefaultLoginFormData,
+} from '@/src/components/ToolsetEditor/form';
+
+import { zodResolver } from '@hookform/resolvers/zod';
 
 export const ToolsetLoginDialogView = () => {
   const { t } = useTranslation(Translation.Marketplace);
@@ -24,6 +31,16 @@ export const ToolsetLoginDialogView = () => {
   const entity = useAppSelector(
     MarketplaceSelectors.selectLoginEntity,
   ) as ToolsetModel;
+
+  const formMethods = useForm<ToolsetLoginFormType>({
+    defaultValues: getDefaultLoginFormData(
+      entity.authSettings.authenticationType,
+      entity,
+    ),
+    mode: 'onChange',
+    reValidateMode: 'onChange',
+    resolver: zodResolver(ToolsetLoginFormSchema),
+  });
 
   const isSignedIn = isToolsetSignedIn(entity);
 
@@ -79,13 +96,15 @@ export const ToolsetLoginDialogView = () => {
         </h4>
       </div>
 
-      <ToolsetLoginForm
-        type={entity.authSettings.authenticationType}
-        toolset={entity}
-        buttonClassName="ml-auto"
-        onLogin={handleLogin}
-        onLogout={handleLogout}
-      />
+      <FormProvider {...formMethods}>
+        <ToolsetLoginForm
+          type={entity.authSettings.authenticationType}
+          toolset={entity}
+          buttonClassName="ml-auto"
+          onLogin={handleLogin}
+          onLogout={handleLogout}
+        />
+      </FormProvider>
     </Modal>
   );
 };

--- a/apps/chat/src/components/ToolsetEditor/EditorForm/AuthField.tsx
+++ b/apps/chat/src/components/ToolsetEditor/EditorForm/AuthField.tsx
@@ -10,7 +10,6 @@ import {
   ForwardRefExoticComponent,
   RefAttributes,
   useCallback,
-  useEffect,
   useState,
 } from 'react';
 import { Controller, useFormContext, useWatch } from 'react-hook-form';
@@ -70,44 +69,32 @@ interface AuthTypeSectionProps {
   type: ToolsetAuthTypes;
   isSelected: boolean;
   onClick: (type: ToolsetAuthTypes) => void;
+  onWithLoginChange: (e: ChangeEvent<HTMLInputElement>) => void;
   onLogout?: () => void;
   onLogin?: (data: ToolsetLoginFormType) => void;
+  withLogin?: WithLogin;
 }
 
 const AuthTypeSection = ({
   type,
   isSelected,
   onClick,
+  onWithLoginChange,
   onLogout,
   onLogin,
+  withLogin = WithLogin.WithoutLogin,
 }: AuthTypeSectionProps) => {
   const { t } = useTranslation(Translation.Common);
-  const { setValue } = useFormContext<ToolsetEditorForm>();
 
   const toolsetDetails = useAppSelector(ToolsetSelectors.selectToolsetDetails);
 
-  const [withLogin, setWithLogin] = useState(WithLogin.WithLogin);
   const isSignedIn = toolsetDetails && isToolsetSignedIn(toolsetDetails);
-
-  const handleWithLoginChange = (e: ChangeEvent<HTMLInputElement>) => {
-    setWithLogin(e.currentTarget.value as WithLogin);
-    setValue(
-      'includeOAuthFields',
-      e.currentTarget.value === WithLogin.WithConfig,
-    );
-  };
 
   const { Icon, name } = authTypeOptions[type];
 
   const handleOnClick = useCallback(() => {
     if (!isSignedIn) onClick(type);
   }, [isSignedIn, onClick, type]);
-
-  useEffect(() => {
-    if (type !== ToolsetAuthTypes.OAUTH && isSelected) {
-      setValue('includeOAuthFields', false);
-    }
-  }, [isSelected, setValue, type]);
 
   return (
     <Tooltip
@@ -148,7 +135,7 @@ const AuthTypeSection = ({
                 id={WithLogin.WithLogin}
                 name="with-auth"
                 caption={t(WithLogin.WithLogin)}
-                onChange={handleWithLoginChange}
+                onChange={onWithLoginChange}
                 value={WithLogin.WithLogin}
                 checked={withLogin === WithLogin.WithLogin}
               />
@@ -158,7 +145,7 @@ const AuthTypeSection = ({
                   id={WithLogin.WithConfig}
                   name="with-auth"
                   caption={t(WithLogin.WithConfig)}
-                  onChange={handleWithLoginChange}
+                  onChange={onWithLoginChange}
                   value={WithLogin.WithConfig}
                   checked={withLogin === WithLogin.WithConfig}
                   disabled={isSignedIn}
@@ -169,7 +156,7 @@ const AuthTypeSection = ({
                 id={WithLogin.WithoutLogin}
                 name="with-auth"
                 caption={t(WithLogin.WithoutLogin)}
-                onChange={handleWithLoginChange}
+                onChange={onWithLoginChange}
                 value={WithLogin.WithoutLogin}
                 checked={withLogin === WithLogin.WithoutLogin}
                 disabled={isSignedIn}
@@ -191,18 +178,58 @@ const AuthTypeSection = ({
   );
 };
 
+const getWithLoginInitialValue = (formData: ToolsetEditorForm) => {
+  if (
+    formData.authenticationType === ToolsetAuthTypes.OAUTH &&
+    formData.includeOAuthFields
+  ) {
+    return WithLogin.WithConfig;
+  }
+  return WithLogin.WithLogin;
+};
+
 export const AuthField = () => {
   const { t } = useTranslation(Translation.Common);
   const dispatch = useAppDispatch();
 
   const toolsetDetails = useAppSelector(ToolsetSelectors.selectToolsetDetails);
-  const { control, trigger } = useFormContext<ToolsetEditorForm>();
+  const { control, trigger, clearErrors, setValue, getValues } =
+    useFormContext<ToolsetEditorForm>();
   const [endpoint, transport, allowedTools] = useWatch({
     name: ['endpoint', 'protocol', 'allowedTools'],
     control,
   });
 
   const [logoutModal, setLogoutModal] = useState(false);
+  const [withLogin, setWithLogin] = useState(
+    getWithLoginInitialValue(getValues()),
+  );
+
+  const updateWithLogin = useCallback(
+    (value: WithLogin) => {
+      setWithLogin(value);
+      if (value !== WithLogin.WithConfig) {
+        clearErrors(['clientId', 'clientSecret']);
+      }
+      setValue('includeOAuthFields', value === WithLogin.WithConfig);
+    },
+    [clearErrors, setValue],
+  );
+
+  const handleWithLoginChange = useCallback(
+    (e: ChangeEvent<HTMLInputElement>) => {
+      updateWithLogin(e.currentTarget.value as WithLogin);
+    },
+    [updateWithLogin],
+  );
+
+  const handleSelectAuthType = useCallback(
+    (type: ToolsetAuthTypes) => {
+      setValue('authenticationType', type);
+      updateWithLogin(WithLogin.WithLogin);
+    },
+    [setValue, updateWithLogin],
+  );
 
   const handleLogoutClick = useCallback(() => {
     setLogoutModal(true);
@@ -273,21 +300,26 @@ export const AuthField = () => {
             <AuthTypeSection
               type={ToolsetAuthTypes.OAUTH}
               isSelected={field.value === ToolsetAuthTypes.OAUTH}
-              onClick={field.onChange}
+              onClick={handleSelectAuthType}
+              onWithLoginChange={handleWithLoginChange}
               onLogout={handleLogoutClick}
               onLogin={handleLogIn}
+              withLogin={withLogin}
             />
             <AuthTypeSection
               type={ToolsetAuthTypes.API_KEY}
               isSelected={field.value === ToolsetAuthTypes.API_KEY}
-              onClick={field.onChange}
+              onClick={handleSelectAuthType}
+              onWithLoginChange={handleWithLoginChange}
               onLogout={handleLogoutClick}
               onLogin={handleLogIn}
+              withLogin={withLogin}
             />
             <AuthTypeSection
               type={ToolsetAuthTypes.NONE}
               isSelected={field.value === ToolsetAuthTypes.NONE}
-              onClick={field.onChange}
+              onClick={handleSelectAuthType}
+              onWithLoginChange={handleWithLoginChange}
             />
           </>
         )}

--- a/apps/chat/src/components/ToolsetEditor/EditorForm/AuthField.tsx
+++ b/apps/chat/src/components/ToolsetEditor/EditorForm/AuthField.tsx
@@ -211,7 +211,9 @@ export const AuthField = () => {
       if (value !== WithLogin.WithConfig) {
         clearErrors(['clientId', 'clientSecret']);
       }
-      setValue('includeOAuthFields', value === WithLogin.WithConfig);
+      setValue('includeOAuthFields', value === WithLogin.WithConfig, {
+        shouldDirty: false,
+      });
     },
     [clearErrors, setValue],
   );
@@ -225,7 +227,7 @@ export const AuthField = () => {
 
   const handleSelectAuthType = useCallback(
     (type: ToolsetAuthTypes) => {
-      setValue('authenticationType', type);
+      setValue('authenticationType', type, { shouldDirty: true });
       updateWithLogin(WithLogin.WithLogin);
     },
     [setValue, updateWithLogin],

--- a/apps/chat/src/components/ToolsetEditor/EditorForm/AuthField.tsx
+++ b/apps/chat/src/components/ToolsetEditor/EditorForm/AuthField.tsx
@@ -10,6 +10,7 @@ import {
   ForwardRefExoticComponent,
   RefAttributes,
   useCallback,
+  useEffect,
   useState,
 } from 'react';
 import { Controller, useFormContext, useWatch } from 'react-hook-form';
@@ -81,6 +82,7 @@ const AuthTypeSection = ({
   onLogin,
 }: AuthTypeSectionProps) => {
   const { t } = useTranslation(Translation.Common);
+  const { setValue } = useFormContext<ToolsetEditorForm>();
 
   const toolsetDetails = useAppSelector(ToolsetSelectors.selectToolsetDetails);
 
@@ -89,6 +91,10 @@ const AuthTypeSection = ({
 
   const handleWithLoginChange = (e: ChangeEvent<HTMLInputElement>) => {
     setWithLogin(e.currentTarget.value as WithLogin);
+    setValue(
+      'includeOAuthFields',
+      e.currentTarget.value === WithLogin.WithConfig,
+    );
   };
 
   const { Icon, name } = authTypeOptions[type];
@@ -96,6 +102,12 @@ const AuthTypeSection = ({
   const handleOnClick = useCallback(() => {
     if (!isSignedIn) onClick(type);
   }, [isSignedIn, onClick, type]);
+
+  useEffect(() => {
+    if (type !== ToolsetAuthTypes.OAUTH && isSelected) {
+      setValue('includeOAuthFields', false);
+    }
+  }, [isSelected, setValue, type]);
 
   return (
     <Tooltip
@@ -170,7 +182,6 @@ const AuthTypeSection = ({
                 type={type}
                 toolset={toolsetDetails}
                 onLogout={onLogout}
-                includeOAuthFields={withLogin === WithLogin.WithConfig}
               />
             )}
           </div>
@@ -224,7 +235,7 @@ export const AuthField = () => {
               transport,
               allowedTools,
               authSettings: {
-                authenticationType: data.type,
+                authenticationType: data.authenticationType,
                 apiKeyHeader: data.keyHeader,
                 ...(data.includeOAuthFields && {
                   clientId: data.clientId,

--- a/apps/chat/src/components/ToolsetEditor/EditorForm/GeneralForm.tsx
+++ b/apps/chat/src/components/ToolsetEditor/EditorForm/GeneralForm.tsx
@@ -23,6 +23,7 @@ import { Field } from '@/src/components/Common/Forms/Field';
 import { withErrorMessage } from '@/src/components/Common/Forms/FieldErrorMessage';
 import { FieldTextArea } from '@/src/components/Common/Forms/FieldTextArea';
 import { withLabel } from '@/src/components/Common/Forms/Label';
+import { Tooltip } from '@/src/components/Common/Tooltip';
 import { CustomLogoSelect } from '@/src/components/Settings/CustomLogoSelect';
 import { ToolsetEditorForm } from '@/src/components/ToolsetEditor/form';
 
@@ -136,13 +137,18 @@ export const GeneralForm = ({ onNextClick }: GeneralFormProps) => {
         />
       </div>
       <div className="mt-auto flex justify-end gap-2 border-t border-tertiary px-3 py-4 md:px-5 xl:px-6">
-        <button
-          className="button button-primary py-2"
-          type="submit"
-          disabled={!isValid || isToolsetDetailsLoading}
+        <Tooltip
+          tooltip={t('Fill in all required fields')}
+          hideTooltip={isValid}
         >
-          {t('Next')}
-        </button>
+          <button
+            className="button button-primary py-2"
+            type="submit"
+            disabled={!isValid || isToolsetDetailsLoading}
+          >
+            {t('Next')}
+          </button>
+        </Tooltip>
       </div>
     </form>
   );

--- a/apps/chat/src/components/ToolsetEditor/ToolsetEditor.tsx
+++ b/apps/chat/src/components/ToolsetEditor/ToolsetEditor.tsx
@@ -104,22 +104,26 @@ export const ToolsetEditor = () => {
 
       changeEditorTabRef.current = null;
       saveAndExitRef.current = false;
+      formMethods.reset(formMethods.getValues(), {
+        keepIsValid: true,
+        keepErrors: true,
+      });
       lastSubmittedValuesRef.current = getDefaultFormData(payloadToolset);
     },
-    [dispatch, toolsetDetails],
+    [dispatch, formMethods, toolsetDetails],
   );
 
   const handleSubmit = useCallback(
     (cb?: () => void, forceSave = false) => {
       formMethods.trigger().then((isValid) => {
-        if (!isValid) {
+        if (!isValid && isDirty) {
           if (!forceSave) {
             changeEditorTabRef.current = null;
           } else {
             const data = formMethods.getValues();
             submitHandler({
-              ...getValidFormFields(data, formMethods.getFieldState),
               ...lastSubmittedValuesRef.current,
+              ...getValidFormFields(data, formMethods.getFieldState),
             });
           }
           return;
@@ -139,17 +143,20 @@ export const ToolsetEditor = () => {
     [formMethods, isDirty, submitHandler, toolsetDetails],
   );
 
-  const handleSaveAndExit = useCallback(() => {
-    if ((!isDirty && toolsetDetails) || !toolsetDetails) {
-      void router.push(
-        router.query.publicationUrl ? Routes.Chat : marketplaceRoute,
-      );
-      return;
-    }
+  const handleSaveAndExit = useCallback(
+    (saveDraft = false) => {
+      if ((!isDirty && toolsetDetails) || !toolsetDetails) {
+        void router.push(
+          router.query.publicationUrl ? Routes.Chat : marketplaceRoute,
+        );
+        return;
+      }
 
-    saveAndExitRef.current = true;
-    handleSubmit();
-  }, [handleSubmit, isDirty, router, toolsetDetails]);
+      saveAndExitRef.current = true;
+      handleSubmit(undefined, saveDraft);
+    },
+    [handleSubmit, isDirty, router, toolsetDetails],
+  );
 
   const handleTabClick = useCallback(
     (tab: ToolsetEditorSteps) => {
@@ -183,6 +190,7 @@ export const ToolsetEditor = () => {
     if (toolsetDetails) {
       formMethods.resetField('authenticationType', {
         defaultValue: toolsetDetails.authSettings.authenticationType,
+        keepDirty: false,
       });
     }
   }, [formMethods, toolsetDetails]);

--- a/apps/chat/src/components/ToolsetEditor/ToolsetEditor.tsx
+++ b/apps/chat/src/components/ToolsetEditor/ToolsetEditor.tsx
@@ -3,6 +3,7 @@ import { FormProvider, useForm } from 'react-hook-form';
 
 import { useRouter } from 'next/router';
 
+import { getValidFormFields } from '@/src/utils/app/forms';
 import { getToolsetPayload } from '@/src/utils/app/toolsets';
 
 import { ToolsetEditorSteps } from '@/src/types/toolsets';
@@ -54,6 +55,9 @@ export const ToolsetEditor = () => {
     reValidateMode: 'onChange',
     resolver: zodResolver(ToolsetEditorFormSchema),
   });
+  const lastSubmittedValuesRef = useRef<ToolsetEditorForm>(
+    getDefaultFormData(toolsetDetails, toolsets),
+  );
 
   const isDirty = formMethods.formState.isDirty;
 
@@ -71,7 +75,11 @@ export const ToolsetEditor = () => {
           version: data.version,
           authSettings: {
             authenticationType: data.authenticationType,
-            apiKeyHeader: toolsetDetails?.authSettings?.apiKeyHeader,
+            apiKeyHeader: data.keyHeader,
+            clientId: data.clientId,
+            clientSecret: data.clientSecret,
+            authorizationEndpoint: data.authorizationEndpoint,
+            tokenEndpoint: data.tokenEndpoint,
           },
         },
         toolsetDetails,
@@ -96,16 +104,24 @@ export const ToolsetEditor = () => {
 
       changeEditorTabRef.current = null;
       saveAndExitRef.current = false;
-      formMethods.reset(getDefaultFormData(payloadToolset));
+      lastSubmittedValuesRef.current = getDefaultFormData(payloadToolset);
     },
-    [dispatch, formMethods, toolsetDetails],
+    [dispatch, toolsetDetails],
   );
 
   const handleSubmit = useCallback(
-    (cb?: () => void) => {
+    (cb?: () => void, forceSave = false) => {
       formMethods.trigger().then((isValid) => {
         if (!isValid) {
-          changeEditorTabRef.current = null;
+          if (!forceSave) {
+            changeEditorTabRef.current = null;
+          } else {
+            const data = formMethods.getValues();
+            submitHandler({
+              ...getValidFormFields(data, formMethods.getFieldState),
+              ...lastSubmittedValuesRef.current,
+            });
+          }
           return;
         }
 
@@ -124,7 +140,6 @@ export const ToolsetEditor = () => {
   );
 
   const handleSaveAndExit = useCallback(() => {
-    // todo: handle redirect
     if ((!isDirty && toolsetDetails) || !toolsetDetails) {
       void router.push(
         router.query.publicationUrl ? Routes.Chat : marketplaceRoute,
@@ -140,13 +155,13 @@ export const ToolsetEditor = () => {
     (tab: ToolsetEditorSteps) => {
       if (tab === editorStep) return;
       if (!isDirty && toolsetDetails) {
-        handleSubmit(() => dispatch(ToolsetActions.setEditorStep(tab)));
+        handleSubmit(() => dispatch(ToolsetActions.setEditorStep(tab)), true);
       } else {
         changeEditorTabRef.current = tab;
-        handleSubmit();
+        handleSubmit(undefined, true);
       }
     },
-    [editorStep, isDirty, toolsetDetails, handleSubmit, dispatch],
+    [dispatch, editorStep, handleSubmit, isDirty, toolsetDetails],
   );
 
   const handleNextClick = useCallback(

--- a/apps/chat/src/components/ToolsetEditor/ToolsetEditorHeader.tsx
+++ b/apps/chat/src/components/ToolsetEditor/ToolsetEditorHeader.tsx
@@ -94,9 +94,9 @@ export const ToolsetEditorHeader = ({
   }, [onSave, trigger]);
 
   const handleCloseConfirmDialog = useCallback(
-    async (result: boolean) => {
+    (result: boolean) => {
       setSaveDraftDialog(false);
-      if (result) {
+      if (!result) {
         onSave(true);
         return;
       }
@@ -125,10 +125,13 @@ export const ToolsetEditorHeader = ({
 
       <ConfirmDialog
         isOpen={saveDraftDialog}
-        heading={t('Some fields need your attention')}
-        description={t('You can save your changes as a draft and finish later')}
-        confirmLabel={t('Save draft')}
-        cancelLabel={t('Resolve now')}
+        heading={t('Invalid fields will not be saved')}
+        description={t(
+          'Some fields are filled in incorrectly, or required fields are missing. Any invalid fields will not be saved.\n' +
+            'Are you sure you want to exit?',
+        )}
+        confirmLabel={t('Continue editing')}
+        cancelLabel={t('Exit')}
         onClose={handleCloseConfirmDialog}
       />
     </>

--- a/apps/chat/src/components/ToolsetEditor/ToolsetEditorHeader.tsx
+++ b/apps/chat/src/components/ToolsetEditor/ToolsetEditorHeader.tsx
@@ -1,17 +1,34 @@
-import { useCallback, useMemo } from 'react';
+import { useCallback, useMemo, useState } from 'react';
+import { useFormContext } from 'react-hook-form';
 
 import { useTranslation } from '@/src/hooks/useTranslation';
 
 import { ToolsetEditorSteps, ToolsetModel } from '@/src/types/toolsets';
 import { Translation } from '@/src/types/translation';
 
+import { useAppDispatch } from '@/src/store/hooks';
+import { ToolsetActions } from '@/src/store/toolset/toolset.reducer';
+
+import { ConfirmDialog } from '@/src/components/Common/ConfirmDialog';
 import { EditorHeader } from '@/src/components/Header/EditorHeader';
+import { ToolsetEditorForm } from '@/src/components/ToolsetEditor/form';
+
+const stepFields: {
+  step: ToolsetEditorSteps;
+  fields: (keyof ToolsetEditorForm)[];
+}[] = [
+  { step: ToolsetEditorSteps.General, fields: ['name', 'version'] },
+  {
+    step: ToolsetEditorSteps.Settings,
+    fields: ['endpoint', 'clientId', 'clientSecret'],
+  },
+];
 
 interface ToolsetEditorHeaderProps {
   currentToolset?: ToolsetModel;
   currentStep: ToolsetEditorSteps;
   onTabClick: (tab: ToolsetEditorSteps) => void;
-  onSave: () => void;
+  onSave: (saveDraft?: boolean) => void;
 }
 
 export const ToolsetEditorHeader = ({
@@ -21,8 +38,26 @@ export const ToolsetEditorHeader = ({
   onSave,
 }: ToolsetEditorHeaderProps) => {
   const { t } = useTranslation(Translation.Chat);
+  const dispatch = useAppDispatch();
 
   const isEditing = !!currentToolset;
+
+  const [saveDraftDialog, setSaveDraftDialog] = useState(false);
+
+  const { formState, trigger } = useFormContext<ToolsetEditorForm>();
+  const errors = formState.errors;
+
+  const errorSteps = useMemo(() => {
+    return stepFields.reduce<Set<ToolsetEditorSteps>>(
+      (steps, { step, fields }) => {
+        if (fields.some((field) => errors[field])) {
+          steps.add(step);
+        }
+        return steps;
+      },
+      new Set(),
+    );
+  }, [errors]);
 
   const tabs = useMemo(
     () => [
@@ -48,15 +83,54 @@ export const ToolsetEditorHeader = ({
     [onTabClick],
   );
 
+  const handleSaveClick = useCallback(async () => {
+    const isValid = await trigger();
+
+    if (!isValid) {
+      setSaveDraftDialog(true);
+      return;
+    }
+    onSave();
+  }, [onSave, trigger]);
+
+  const handleCloseConfirmDialog = useCallback(
+    async (result: boolean) => {
+      setSaveDraftDialog(false);
+      if (result) {
+        onSave(true);
+        return;
+      }
+
+      const invalidStep = Array.from(errorSteps)[0];
+
+      if (invalidStep) {
+        dispatch(ToolsetActions.setEditorStep(invalidStep));
+      }
+    },
+    [dispatch, errorSteps, onSave],
+  );
+
   return (
-    <EditorHeader
-      tabs={tabs}
-      activeTab={currentStep}
-      isEditing={isEditing}
-      onTabClick={handleTabClick}
-      title={t(isEditing ? 'Edit toolset' : 'Add toolset')}
-      saveLabel={isEditing ? 'Save and exit' : 'Exit'}
-      onSave={onSave}
-    />
+    <>
+      <EditorHeader
+        tabs={tabs}
+        activeTab={currentStep}
+        errorTabsSet={errorSteps}
+        isEditing={isEditing}
+        onTabClick={handleTabClick}
+        title={t(isEditing ? 'Edit toolset' : 'Add toolset')}
+        saveLabel={isEditing ? 'Save and exit' : 'Exit'}
+        onSave={handleSaveClick}
+      />
+
+      <ConfirmDialog
+        isOpen={saveDraftDialog}
+        heading={t('Some fields need your attention')}
+        description={t('You can save your changes as a draft and finish later')}
+        confirmLabel={t('Save draft')}
+        cancelLabel={t('Resolve now')}
+        onClose={handleCloseConfirmDialog}
+      />
+    </>
   );
 };

--- a/apps/chat/src/components/ToolsetEditor/ToolsetLoginForm.tsx
+++ b/apps/chat/src/components/ToolsetEditor/ToolsetLoginForm.tsx
@@ -1,6 +1,6 @@
 import { IconLogin, IconLogout } from '@tabler/icons-react';
-import { useCallback, useEffect } from 'react';
-import { useForm } from 'react-hook-form';
+import { useCallback } from 'react';
+import { useFormContext, useWatch } from 'react-hook-form';
 
 import classNames from 'classnames';
 
@@ -13,44 +13,9 @@ import { Translation } from '@/src/types/translation';
 
 import { Field } from '@/src/components/Common/Forms/Field';
 
-import { ToolsetLoginFormSchema, ToolsetLoginFormType } from './form';
+import { ToolsetLoginFormType } from './form';
 
 import { ToolsetAuthTypes } from '@epam/ai-dial-shared';
-import { zodResolver } from '@hookform/resolvers/zod';
-
-const getDefaultFormData = ({
-  type,
-  toolset,
-  prevData,
-}: {
-  type: ToolsetAuthTypes;
-  toolset?: ToolsetModel;
-  prevData?: ToolsetLoginFormType;
-}): ToolsetLoginFormType => {
-  switch (type) {
-    case ToolsetAuthTypes.API_KEY:
-      return {
-        type,
-        keyHeader: toolset?.authSettings?.apiKeyHeader ?? 'api_key',
-        apiKey: prevData?.apiKey ?? '',
-      };
-    case ToolsetAuthTypes.OAUTH:
-      return {
-        type,
-        clientId: toolset?.authSettings?.clientId ?? '',
-        clientSecret: toolset?.authSettings?.clientSecret ?? '',
-        authorizationEndpoint:
-          toolset?.authSettings?.authorizationEndpoint ?? '',
-        tokenEndpoint: toolset?.authSettings?.tokenEndpoint ?? '',
-        includeOAuthFields: prevData?.includeOAuthFields ?? false,
-      };
-    case ToolsetAuthTypes.NONE:
-    default:
-      return {
-        type,
-      };
-  }
-};
 
 interface ToolsetLoginFormProps {
   type: ToolsetAuthTypes;
@@ -61,7 +26,6 @@ interface ToolsetLoginFormProps {
   disabled?: boolean;
   className?: string;
   buttonClassName?: string;
-  includeOAuthFields?: boolean;
 }
 
 export const ToolsetLoginForm = ({
@@ -73,47 +37,34 @@ export const ToolsetLoginForm = ({
   disabled = false,
   className,
   buttonClassName,
-  includeOAuthFields = false,
 }: ToolsetLoginFormProps) => {
   const { t } = useTranslation(Translation.Common);
 
   const isSignedIn = toolset && isToolsetSignedIn(toolset, credentialsLevel);
 
-  const { reset, register, formState, getValues, trigger } =
-    useForm<ToolsetLoginFormType>({
-      defaultValues: getDefaultFormData({
-        type,
-        toolset,
-        prevData: { includeOAuthFields, type },
-      }),
-      mode: 'onChange',
-      reValidateMode: 'onChange',
-      resolver: zodResolver(ToolsetLoginFormSchema),
-    });
+  const { register, formState, getValues, trigger, control } =
+    useFormContext<ToolsetLoginFormType>();
   const isValid = formState.isValid;
   const errors = formState.errors;
+
+  const includeOAuthFields = useWatch({
+    name: 'includeOAuthFields',
+    control,
+  });
 
   const handleSubmit = useCallback(() => {
     if (isSignedIn) {
       onLogout?.();
     } else {
-      trigger().then((isValid) => {
-        if (!isValid) return;
-        const data = getValues();
-        onLogin?.(data);
-      });
+      trigger(['keyHeader', 'apiKey', 'clientId', 'clientSecret']).then(
+        (isValid) => {
+          if (!isValid) return;
+          const data = getValues();
+          onLogin?.(data);
+        },
+      );
     }
   }, [isSignedIn, onLogout, trigger, getValues, onLogin]);
-
-  useEffect(() => {
-    reset(
-      getDefaultFormData({
-        type,
-        toolset,
-        prevData: { ...getValues(), includeOAuthFields },
-      }),
-    );
-  }, [getValues, reset, toolset, type, includeOAuthFields]);
 
   return (
     <div className={classNames('flex flex-col gap-4', className)}>

--- a/apps/chat/src/components/ToolsetEditor/ToolsetLoginForm.tsx
+++ b/apps/chat/src/components/ToolsetEditor/ToolsetLoginForm.tsx
@@ -17,6 +17,13 @@ import { ToolsetLoginFormType } from './form';
 
 import { ToolsetAuthTypes } from '@epam/ai-dial-shared';
 
+const fields = [
+  'keyHeader',
+  'apiKey',
+  'clientId',
+  'clientSecret',
+] as (keyof ToolsetLoginFormType)[];
+
 interface ToolsetLoginFormProps {
   type: ToolsetAuthTypes;
   onLogout?: () => void;
@@ -44,7 +51,6 @@ export const ToolsetLoginForm = ({
 
   const { register, formState, getValues, trigger, control } =
     useFormContext<ToolsetLoginFormType>();
-  const isValid = formState.isValid;
   const errors = formState.errors;
 
   const includeOAuthFields = useWatch({
@@ -56,13 +62,11 @@ export const ToolsetLoginForm = ({
     if (isSignedIn) {
       onLogout?.();
     } else {
-      trigger(['keyHeader', 'apiKey', 'clientId', 'clientSecret']).then(
-        (isValid) => {
-          if (!isValid) return;
-          const data = getValues();
-          onLogin?.(data);
-        },
-      );
+      trigger(fields).then((isValid) => {
+        if (!isValid) return;
+        const data = getValues();
+        onLogin?.(data);
+      });
     }
   }, [isSignedIn, onLogout, trigger, getValues, onLogin]);
 
@@ -99,6 +103,7 @@ export const ToolsetLoginForm = ({
             placeholder={t('Enter client ID')}
             id="clientId"
             disabled={disabled}
+            error={errors.clientId?.message}
             mandatory
           />
           <Field
@@ -107,6 +112,7 @@ export const ToolsetLoginForm = ({
             placeholder={t('Enter client secret')}
             id="clientSecret"
             disabled={disabled}
+            error={errors.clientSecret?.message}
             mandatory
             type="password"
           />
@@ -133,7 +139,7 @@ export const ToolsetLoginForm = ({
           buttonClassName,
           isSignedIn ? 'button-secondary' : 'button-primary',
         )}
-        disabled={disabled || (!isValid && !isSignedIn)}
+        disabled={disabled}
         onClick={handleSubmit}
       >
         {isSignedIn ? (

--- a/apps/chat/src/components/ToolsetEditor/form.ts
+++ b/apps/chat/src/components/ToolsetEditor/form.ts
@@ -17,76 +17,10 @@ import { z as zodValidation } from 'zod';
 
 export const ENDPOINT_PLACEHOLDER = 'ENDPOINT_PLACEHOLDER';
 
-export const ToolsetEditorFormSchema = zodValidation.object({
-  name: zodValidation
-    .string()
-    .nonempty(formErrors.required)
-    .min(2, formErrors.tooShort('Name', 2))
-    .max(160, formErrors.tooLong('Name', 160))
-    .refine(
-      (str) => !doesHaveNotAllowedSymbols(str),
-      formErrors.hasSpecialCharacters(),
-    ),
-  endpoint: zodValidation
-    .string()
-    .nonempty(formErrors.required)
-    .regex(/^(https?|sse):\/\//, {
-      error: urlErrors.notValidProtocol,
-    })
-    .refine(
-      (str) => !str.endsWith('.') && !str.endsWith('//'),
-      urlErrors.notValidEnding,
-    )
-    .refine((str) => {
-      try {
-        const url = new URL(str);
-        return !!url;
-      } catch {
-        return false;
-      }
-    }, urlErrors.notValidUrl)
-    .or(zodValidation.literal(ENDPOINT_PLACEHOLDER)),
-  protocol: zodValidation.enum(ToolsetTransportType),
-  version: zodValidation
-    .string()
-    .nonempty(versionsErrors.required)
-    .refine(isVersionValid, versionsErrors.notValid)
-    .refine(isVersionPartSizeValid, versionsErrors.tooLongPart),
-  description: zodValidation.string(),
-  allowedTools: zodValidation.array(zodValidation.string()),
-  iconUrl: zodValidation.string(),
-  topics: zodValidation.array(zodValidation.string()),
-  authenticationType: zodValidation.enum(ToolsetAuthTypes),
-});
-
-export type ToolsetEditorForm = zodValidation.infer<
-  typeof ToolsetEditorFormSchema
->;
-
-export const getDefaultFormData = (
-  toolset?: ToolsetModel,
-  toolsets?: ToolsetModel[],
-): ToolsetEditorForm => {
-  return {
-    name:
-      toolset?.name ??
-      getNextDefaultName(DEFAULT_TOOLSET_NAME, toolsets ?? [], 0, true),
-    endpoint: toolset?.endpoint ?? ENDPOINT_PLACEHOLDER,
-    protocol: toolset?.transport ?? ToolsetTransportType.SSE,
-    authenticationType:
-      toolset?.authSettings?.authenticationType ?? ToolsetAuthTypes.NONE,
-    description: toolset?.description ?? '',
-    allowedTools: toolset?.allowedTools ?? [],
-    iconUrl: toolset?.iconUrl ?? '',
-    version: toolset?.version ?? DEFAULT_VERSION,
-    topics: toolset?.topics ?? [],
-  };
-};
-
 export const ToolsetLoginFormSchema = zodValidation
   .object({
     includeOAuthFields: zodValidation.boolean().optional(),
-    type: zodValidation.enum(ToolsetAuthTypes),
+    authenticationType: zodValidation.enum(ToolsetAuthTypes),
     // API_KEY
     keyHeader: zodValidation.string().optional(),
     apiKey: zodValidation.string().optional(),
@@ -97,7 +31,7 @@ export const ToolsetLoginFormSchema = zodValidation
     tokenEndpoint: zodValidation.string().optional(),
   })
   .superRefine((data, ctx) => {
-    if (data.type === ToolsetAuthTypes.API_KEY) {
+    if (data.authenticationType === ToolsetAuthTypes.API_KEY) {
       if (!data.keyHeader?.trim()) {
         ctx.addIssue({
           code: 'custom',
@@ -113,7 +47,7 @@ export const ToolsetLoginFormSchema = zodValidation
         });
       }
     }
-    if (data.type === ToolsetAuthTypes.OAUTH) {
+    if (data.authenticationType === ToolsetAuthTypes.OAUTH) {
       if (!data.clientId && data.includeOAuthFields) {
         ctx.addIssue({
           code: 'custom',
@@ -133,3 +67,105 @@ export const ToolsetLoginFormSchema = zodValidation
 export type ToolsetLoginFormType = zodValidation.infer<
   typeof ToolsetLoginFormSchema
 >;
+
+export const ToolsetEditorFormSchema = zodValidation
+  .object({
+    name: zodValidation
+      .string()
+      .nonempty(formErrors.required)
+      .min(2, formErrors.tooShort('Name', 2))
+      .max(160, formErrors.tooLong('Name', 160))
+      .refine(
+        (str) => !doesHaveNotAllowedSymbols(str),
+        formErrors.hasSpecialCharacters(),
+      ),
+    endpoint: zodValidation
+      .string()
+      .nonempty(formErrors.required)
+      .regex(/^(https?|sse):\/\//, {
+        error: urlErrors.notValidProtocol,
+      })
+      .refine(
+        (str) => !str.endsWith('.') && !str.endsWith('//'),
+        urlErrors.notValidEnding,
+      )
+      .refine((str) => {
+        try {
+          const url = new URL(str);
+          return !!url;
+        } catch {
+          return false;
+        }
+      }, urlErrors.notValidUrl)
+      .or(zodValidation.literal(ENDPOINT_PLACEHOLDER)),
+    protocol: zodValidation.enum(ToolsetTransportType),
+    version: zodValidation
+      .string()
+      .nonempty(versionsErrors.required)
+      .refine(isVersionValid, versionsErrors.notValid)
+      .refine(isVersionPartSizeValid, versionsErrors.tooLongPart),
+    description: zodValidation.string(),
+    allowedTools: zodValidation.array(zodValidation.string()),
+    iconUrl: zodValidation.string(),
+    topics: zodValidation.array(zodValidation.string()),
+  })
+  .and(ToolsetLoginFormSchema);
+
+export type ToolsetEditorForm = zodValidation.infer<
+  typeof ToolsetEditorFormSchema
+>;
+
+export const getDefaultLoginFormData = (
+  authenticationType: ToolsetAuthTypes,
+  toolset?: ToolsetModel,
+  prevData?: ToolsetLoginFormType,
+): ToolsetLoginFormType => {
+  switch (authenticationType) {
+    case ToolsetAuthTypes.API_KEY:
+      return {
+        authenticationType,
+        keyHeader: toolset?.authSettings?.apiKeyHeader ?? 'api_key',
+        apiKey: prevData?.apiKey ?? '',
+      };
+    case ToolsetAuthTypes.OAUTH:
+      return {
+        authenticationType,
+        clientId: toolset?.authSettings?.clientId ?? '',
+        clientSecret: toolset?.authSettings?.clientSecret ?? '',
+        authorizationEndpoint:
+          toolset?.authSettings?.authorizationEndpoint ?? '',
+        tokenEndpoint: toolset?.authSettings?.tokenEndpoint ?? '',
+        includeOAuthFields: prevData?.includeOAuthFields ?? false,
+      };
+    case ToolsetAuthTypes.NONE:
+    default:
+      return {
+        authenticationType,
+      };
+  }
+};
+
+export const getDefaultFormData = (
+  toolset?: ToolsetModel,
+  toolsets?: ToolsetModel[],
+  prevData?: ToolsetEditorForm,
+): ToolsetEditorForm => {
+  return {
+    name:
+      toolset?.name ??
+      getNextDefaultName(DEFAULT_TOOLSET_NAME, toolsets ?? [], 0, true),
+    endpoint: toolset?.endpoint ?? ENDPOINT_PLACEHOLDER,
+    protocol: toolset?.transport ?? ToolsetTransportType.SSE,
+    description: toolset?.description ?? '',
+    allowedTools: toolset?.allowedTools ?? [],
+    iconUrl: toolset?.iconUrl ?? '',
+    version: toolset?.version ?? DEFAULT_VERSION,
+    topics: toolset?.topics ?? [],
+
+    ...getDefaultLoginFormData(
+      toolset?.authSettings?.authenticationType ?? ToolsetAuthTypes.NONE,
+      toolset,
+      prevData,
+    ),
+  };
+};

--- a/apps/chat/src/utils/app/toolsets.ts
+++ b/apps/chat/src/utils/app/toolsets.ts
@@ -208,6 +208,18 @@ export const getToolsetPayload = (
     ...(authType === ToolsetAuthTypes.OAUTH && {
       redirectUri: getToolsetRedirectUri(),
     }),
+    ...(newToolset.authSettings.clientId && {
+      clientId: newToolset.authSettings.clientId,
+    }),
+    ...(newToolset.authSettings.clientSecret && {
+      clientSecret: newToolset.authSettings.clientSecret,
+    }),
+    ...(newToolset.authSettings.authorizationEndpoint && {
+      authorizationEndpoint: newToolset.authSettings.authorizationEndpoint,
+    }),
+    ...(newToolset.authSettings.tokenEndpoint && {
+      tokenEndpoint: newToolset.authSettings.tokenEndpoint,
+    }),
   };
 
   return {


### PR DESCRIPTION
**Description:**

- validate all fields including ones for login when exitting editor
- allow to swtich between tabs even if some fields are not valid
- add ***Save draft*** option when exitting with not valid fields

Issues:

- Issue #4766 
- Issue #4672

**UI changes**

<img width="1440" height="713" alt="Screenshot 2025-09-28 at 17 24 45" src="https://github.com/user-attachments/assets/6b7035c3-4266-4f2a-8a6f-179a6bd5ac14" />

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
