### PR TITLE
fix(chat): do not send configuration requests in compare mode and when agent wasn't changed (Issue #4730)

### DIFF
--- a/apps/chat/src/components/Chat/Chat.tsx
+++ b/apps/chat/src/components/Chat/Chat.tsx
@@ -552,9 +552,8 @@ const ChatView = memo(() => {
 
   const isConversationWithSchema = selectedConversations.some(
     (conv) =>
-      selectedConversations.some((conv) =>
-        doesModelHaveConfiguration(modelsMap[conv.model.id]),
-      ) || isConversationWithFormSchema(conv),
+      doesModelHaveConfiguration(modelsMap[conv.model.id]) ||
+      isConversationWithFormSchema(conv),
   );
 
   const isChatReadyForInput =

--- a/apps/chat/src/components/Chat/Chat.tsx
+++ b/apps/chat/src/components/Chat/Chat.tsx
@@ -21,10 +21,7 @@ import {
   excludeSystemMessages,
   getConversationModelParams,
 } from '@/src/utils/app/conversation';
-import {
-  isConversationWithFormSchema,
-  isFormSchemaValid,
-} from '@/src/utils/app/form-schema';
+import { isConversationWithFormSchema } from '@/src/utils/app/form-schema';
 import { isEntityIdExternal } from '@/src/utils/app/id';
 import { is4XLScreen } from '@/src/utils/app/mobile';
 import { doesModelHaveConfiguration } from '@/src/utils/app/models';
@@ -158,12 +155,6 @@ const ChatView = memo(() => {
   );
   const notAvailableEntityType = useAppSelector(
     ChatSelectors.selectNotAvailableEntityType,
-  );
-  const isConfigurationSchemaLoading = useAppSelector(
-    ChatSelectors.selectIsConfigurationSchemaLoading,
-  );
-  const configurationSchema = useAppSelector(
-    ChatSelectors.selectConfigurationSchema,
   );
   const isApproveRequiredEntity = useAppSelector((state) =>
     PublicationSelectors.selectIsApproveRequiredEntity(
@@ -561,10 +552,9 @@ const ChatView = memo(() => {
 
   const isConversationWithSchema = selectedConversations.some(
     (conv) =>
-      (!isConfigurationSchemaLoading &&
-        configurationSchema &&
-        isFormSchemaValid(configurationSchema)) ||
-      isConversationWithFormSchema(conv),
+      selectedConversations.some((conv) =>
+        doesModelHaveConfiguration(modelsMap[conv.model.id]),
+      ) || isConversationWithFormSchema(conv),
   );
 
   const isChatReadyForInput =
@@ -1004,10 +994,14 @@ const CustomViewerChatView: React.FC<CustomChatViewerProps> = ({
   customViewer,
 }) => {
   const dispatch = useAppDispatch();
+
   const { t } = useTranslation(Translation.Chat);
 
   const selectedConversations = useAppSelector(
     ConversationsSelectors.selectSelectedConversations,
+  );
+  const isStartedCustomViewerConversation = useAppSelector(
+    ConversationsSelectors.selectIsStartedCustomViewerConversation,
   );
 
   const handleTalkToConversationId = useCallback(
@@ -1023,9 +1017,6 @@ const CustomViewerChatView: React.FC<CustomChatViewerProps> = ({
     return router.pathname === Routes.AppsEditorSettings;
   }, [router.pathname]);
 
-  const isStartedCustomViewerConversation = useAppSelector(
-    ConversationsSelectors.selectIsStartedCustomViewerConversation,
-  );
   return (
     <>
       {selectedConversations[0].messages.length !== 0 ||
@@ -1118,7 +1109,7 @@ export function Chat({ isPreview }: ChatProps) {
     PublicationSelectors.selectIsPublicationUpdating,
   );
 
-  const configurationLoadedRef = useRef(false);
+  const agentConfigurationLoadedRef = useRef<string | null>(null);
 
   const isNoMessages = selectedConversations.every(
     ({ messages }) => !messages?.length,
@@ -1129,27 +1120,23 @@ export function Chat({ isPreview }: ChatProps) {
   }, [dispatch, selectedConversationsIds]);
 
   useEffect(() => {
-    configurationLoadedRef.current = false;
-  }, [selectedConversationsIds]);
+    const modelId = selectedConversations.at(0)?.model.id;
 
-  useEffect(() => {
-    if (configurationLoadedRef.current) return;
+    if (modelId === agentConfigurationLoadedRef.current) {
+      return;
+    }
 
-    const configurationAppReference = selectedConversations.find((conv) =>
-      doesModelHaveConfiguration(modelsMap[conv.model.id]),
-    )?.model?.id;
-    const configurationAppId = configurationAppReference
-      ? modelsMap[configurationAppReference]?.id
-      : undefined;
+    if (!modelId || selectedConversations.length > 1) {
+      dispatch(ChatActions.resetConfigurationSchema());
+      agentConfigurationLoadedRef.current = null;
+      return;
+    }
 
-    if (configurationAppId && isNoMessages) {
-      if (!configurationLoadedRef.current) {
-        configurationLoadedRef.current = true;
-        dispatch(
-          ChatActions.getConfigurationSchema({ modelId: configurationAppId }),
-        );
-      }
+    if (doesModelHaveConfiguration(modelsMap[modelId]) && isNoMessages) {
+      agentConfigurationLoadedRef.current = modelId;
+      dispatch(ChatActions.getConfigurationSchema({ modelId }));
     } else {
+      agentConfigurationLoadedRef.current = null;
       dispatch(ChatActions.resetConfigurationSchema());
     }
   }, [dispatch, isNoMessages, modelsMap, selectedConversations]);


### PR DESCRIPTION
**Description:**

do not send configuration requests in compare mode and when agent wasn't changed

Issues:

- Issue #4730

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
