### PR TITLE
fix(chat): revert send configuration model request based on modelId (Issue #4730)

### DIFF
--- a/apps/chat/src/components/Chat/Chat.tsx
+++ b/apps/chat/src/components/Chat/Chat.tsx
@@ -21,7 +21,10 @@ import {
   excludeSystemMessages,
   getConversationModelParams,
 } from '@/src/utils/app/conversation';
-import { isConversationWithFormSchema } from '@/src/utils/app/form-schema';
+import {
+  isConversationWithFormSchema,
+  isFormSchemaValid,
+} from '@/src/utils/app/form-schema';
 import { isEntityIdExternal } from '@/src/utils/app/id';
 import { is4XLScreen } from '@/src/utils/app/mobile';
 import { doesModelHaveConfiguration } from '@/src/utils/app/models';
@@ -155,6 +158,12 @@ const ChatView = memo(() => {
   );
   const notAvailableEntityType = useAppSelector(
     ChatSelectors.selectNotAvailableEntityType,
+  );
+  const isConfigurationSchemaLoading = useAppSelector(
+    ChatSelectors.selectIsConfigurationSchemaLoading,
+  );
+  const configurationSchema = useAppSelector(
+    ChatSelectors.selectConfigurationSchema,
   );
   const isApproveRequiredEntity = useAppSelector((state) =>
     PublicationSelectors.selectIsApproveRequiredEntity(
@@ -552,7 +561,9 @@ const ChatView = memo(() => {
 
   const isConversationWithSchema = selectedConversations.some(
     (conv) =>
-      doesModelHaveConfiguration(modelsMap[conv.model.id]) ||
+      (!isConfigurationSchemaLoading &&
+        configurationSchema &&
+        isFormSchemaValid(configurationSchema)) ||
       isConversationWithFormSchema(conv),
   );
 
@@ -993,14 +1004,10 @@ const CustomViewerChatView: React.FC<CustomChatViewerProps> = ({
   customViewer,
 }) => {
   const dispatch = useAppDispatch();
-
   const { t } = useTranslation(Translation.Chat);
 
   const selectedConversations = useAppSelector(
     ConversationsSelectors.selectSelectedConversations,
-  );
-  const isStartedCustomViewerConversation = useAppSelector(
-    ConversationsSelectors.selectIsStartedCustomViewerConversation,
   );
 
   const handleTalkToConversationId = useCallback(
@@ -1016,6 +1023,9 @@ const CustomViewerChatView: React.FC<CustomChatViewerProps> = ({
     return router.pathname === Routes.AppsEditorSettings;
   }, [router.pathname]);
 
+  const isStartedCustomViewerConversation = useAppSelector(
+    ConversationsSelectors.selectIsStartedCustomViewerConversation,
+  );
   return (
     <>
       {selectedConversations[0].messages.length !== 0 ||
@@ -1108,7 +1118,7 @@ export function Chat({ isPreview }: ChatProps) {
     PublicationSelectors.selectIsPublicationUpdating,
   );
 
-  const agentConfigurationLoadedRef = useRef<string | null>(null);
+  const configurationLoadedRef = useRef(false);
 
   const isNoMessages = selectedConversations.every(
     ({ messages }) => !messages?.length,
@@ -1119,24 +1129,27 @@ export function Chat({ isPreview }: ChatProps) {
   }, [dispatch, selectedConversationsIds]);
 
   useEffect(() => {
-    const modelReference = selectedConversations.at(0)?.model.id;
+    configurationLoadedRef.current = false;
+  }, [selectedConversationsIds]);
 
-    if (modelReference === agentConfigurationLoadedRef.current) {
-      return;
-    }
+  useEffect(() => {
+    if (configurationLoadedRef.current) return;
 
-    if (!modelReference || selectedConversations.length > 1) {
-      dispatch(ChatActions.resetConfigurationSchema());
-      agentConfigurationLoadedRef.current = null;
-      return;
-    }
+    const configurationAppReference = selectedConversations.find((conv) =>
+      doesModelHaveConfiguration(modelsMap[conv.model.id]),
+    )?.model?.id;
+    const configurationAppId = configurationAppReference
+      ? modelsMap[configurationAppReference]?.id
+      : undefined;
 
-    const model = modelsMap[modelReference];
-    if (model && doesModelHaveConfiguration(model) && isNoMessages) {
-      agentConfigurationLoadedRef.current = modelReference;
-      dispatch(ChatActions.getConfigurationSchema({ modelId: model.id }));
+    if (configurationAppId && isNoMessages) {
+      if (!configurationLoadedRef.current) {
+        configurationLoadedRef.current = true;
+        dispatch(
+          ChatActions.getConfigurationSchema({ modelId: configurationAppId }),
+        );
+      }
     } else {
-      agentConfigurationLoadedRef.current = null;
       dispatch(ChatActions.resetConfigurationSchema());
     }
   }, [dispatch, isNoMessages, modelsMap, selectedConversations]);


### PR DESCRIPTION
**Description:**

revert send configuration model request based on modelId

Issues:

- Issue #4730

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
