### PR TITLE
feat(chat): add support for collapsible sections in markdown (Issue #4875)

### DIFF
--- a/apps/chat/src/components/Markdown/ChatMDComponent.tsx
+++ b/apps/chat/src/components/Markdown/ChatMDComponent.tsx
@@ -1,4 +1,4 @@
-import { memo } from 'react';
+import { Children, ReactNode, memo } from 'react';
 import { Components } from 'react-markdown';
 import { PluggableList } from 'react-markdown/lib/react-markdown';
 
@@ -25,8 +25,12 @@ import { Table } from '@/src/components/Markdown/Table';
 import { CodeBlock } from './CodeBlock';
 import { MemoizedReactMarkdown } from './MemoizedReactMarkdown';
 
+import ChevronDown from '@/public/images/icons/chevron-down.svg';
 import 'katex/dist/katex.min.css';
+import { isObject, partition } from 'lodash-es';
 import rehypeKatex from 'rehype-katex';
+import rehypeRaw from 'rehype-raw';
+import rehypeSanitize, { defaultSchema } from 'rehype-sanitize';
 import remarkGfm from 'remark-gfm';
 import remarkMath from 'remark-math';
 
@@ -111,6 +115,47 @@ const getMDComponents = (
         </p>
       );
     },
+    details({ children, ...props }) {
+      // In order to style the contents paddings correctly, we need to wrap them into container
+      // Contents of <details> element follow the summary element unwrapped by default,
+      // so styling them otherwise would be hacky.
+      const [summary, content] = partition(
+        Children.toArray(children),
+        (child: ReactNode) =>
+          isObject(child) &&
+          'type' in child &&
+          isObject(child.type) &&
+          'name' in child.type &&
+          child.type.name === 'summary',
+      );
+
+      return (
+        <details
+          className={classnames(
+            'my-4 rounded bg-layer-3',
+            ' [&[open]>summary>svg]:rotate-180 [&[open]>summary]:border-b',
+          )}
+          {...props}
+        >
+          {summary}
+          <div className="p-3">{content}</div>
+        </details>
+      );
+    },
+    summary({ children, ...props }) {
+      return (
+        <summary
+          className={classnames(
+            'flex items-center justify-between gap-3 border-tertiary p-3 text-sm',
+            'cursor-pointer [&::marker]:hidden',
+          )}
+          {...props}
+        >
+          <span className="truncate">{children}</span>
+          <ChevronDown height={18} width={18} className="shrink-0 transition" />
+        </summary>
+      );
+    },
   };
 };
 
@@ -119,7 +164,22 @@ const remarkPlugins: PluggableList = [
   [remarkMath, { singleDollarTextMath: true }],
 ];
 const rehypePlugins = [
+  rehypeRaw,
   [rehypeKatex, { output: 'mathml', strict: false }],
+  [
+    rehypeSanitize,
+    {
+      ...defaultSchema,
+      attributes: {
+        ...defaultSchema.attributes,
+        code: [
+          ...(defaultSchema.attributes?.code || []),
+          // Preserve className for syntax highlighting
+          ['className'],
+        ],
+      },
+    },
+  ],
 ] as PluggableList;
 
 export const ChatMDComponent = memo(

--- a/apps/chat/src/components/Markdown/__tests__/ChatMDComponent.test.tsx
+++ b/apps/chat/src/components/Markdown/__tests__/ChatMDComponent.test.tsx
@@ -1,0 +1,281 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { render, screen } from '@testing-library/react';
+
+import { Provider } from 'react-redux';
+
+import { configureStore } from '@reduxjs/toolkit';
+
+import { ChatMDComponent } from '../ChatMDComponent';
+
+// Mock the SVG import
+vi.mock('@/public/images/icons/chevron-down.svg', () => ({
+  default: (props: React.SVGProps<SVGSVGElement>) => (
+    <svg data-testid="chevron-down-icon" {...props}>
+      <path d="M6 9L12 15L18 9" />
+    </svg>
+  ),
+}));
+
+global.ResizeObserver = class ResizeObserver {
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  observe() {}
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  unobserve() {}
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  disconnect() {}
+};
+
+// Mock store setup
+const mockStore = configureStore({
+  reducer: {
+    ui: () => ({
+      isChatFullWidth: false,
+    }),
+    settings: () => ({
+      isOverlay: false,
+    }),
+  },
+});
+
+const renderWithStore = (component: React.ReactElement) => {
+  return render(<Provider store={mockStore}>{component}</Provider>);
+};
+
+// Helper to trim indentation from template literals
+const trimIndent = (str: string): string => {
+  const lines = str.split('\n');
+  // Remove first and last line if empty
+  if (lines[0].trim() === '') lines.shift();
+  if (lines[lines.length - 1].trim() === '') lines.pop();
+
+  // Find minimum indentation
+  const minIndent = lines
+    .filter((line) => line.trim().length > 0)
+    .reduce((min, line) => {
+      const indent = line.match(/^\s*/)?.[0].length || 0;
+      return Math.min(min, indent);
+    }, Infinity);
+
+  // Remove minimum indentation from all lines
+  return lines.map((line) => line.slice(minIndent)).join('\n');
+};
+
+describe('ChatMDComponent', () => {
+  describe('basic rendering', () => {
+    it('renders plain text content', () => {
+      renderWithStore(
+        <ChatMDComponent
+          isShowResponseLoader={false}
+          content="Hello, World!"
+        />,
+      );
+
+      expect(screen.getByText('Hello, World!')).toBeInTheDocument();
+    });
+
+    it('renders markdown formatted text', () => {
+      renderWithStore(
+        <ChatMDComponent
+          isShowResponseLoader={false}
+          content="**bold text** and *italic text*"
+        />,
+      );
+
+      const boldElement = screen.getByText('bold text');
+      const italicElement = screen.getByText('italic text');
+
+      expect(boldElement).toBeInTheDocument();
+      expect(boldElement.tagName).toBe('STRONG');
+      expect(italicElement).toBeInTheDocument();
+      expect(italicElement.tagName).toBe('EM');
+    });
+  });
+
+  describe('collapsible sections', () => {
+    it('renders details element with summary', () => {
+      const content = trimIndent(`
+        <details>
+          <summary>Click to expand</summary>
+
+          Content here
+
+        </details>
+      `);
+
+      renderWithStore(
+        <ChatMDComponent isShowResponseLoader={false} content={content} />,
+      );
+
+      // details element has role 'group'
+      const detailsElement = screen.getByRole('group');
+      expect(detailsElement).toBeInTheDocument();
+      expect(screen.getByText('Click to expand')).toBeInTheDocument();
+      expect(screen.getByText('Content here')).toBeInTheDocument();
+    });
+
+    it('renders details with styling', () => {
+      const content = trimIndent(`
+        <details>
+          <summary>Test Summary</summary>
+
+          Test Content
+
+        </details>
+      `);
+
+      renderWithStore(
+        <ChatMDComponent isShowResponseLoader={false} content={content} />,
+      );
+
+      const detailsElement = screen.getByRole('group');
+      expect(detailsElement).toBeInTheDocument();
+      expect(detailsElement).toHaveAttribute('class');
+    });
+
+    it('renders summary with styling', () => {
+      const content = trimIndent(`
+        <details>
+          <summary>Test Summary</summary>
+
+          Test Content
+
+        </details>
+      `);
+
+      renderWithStore(
+        <ChatMDComponent isShowResponseLoader={false} content={content} />,
+      );
+
+      const summaryElement = screen.getByText('Test Summary');
+      expect(summaryElement).toBeInTheDocument();
+      expect(summaryElement).toHaveAttribute('class');
+    });
+
+    it('renders markdown content inside details', () => {
+      const content = trimIndent(`
+        <details>
+          <summary>Markdown Example</summary>
+
+          **Bold text** inside details
+
+          - List item 1
+          - List item 2
+
+        </details>
+      `);
+
+      renderWithStore(
+        <ChatMDComponent isShowResponseLoader={false} content={content} />,
+      );
+
+      expect(screen.getByText('Markdown Example')).toBeInTheDocument();
+      expect(screen.getByText('Bold text')).toBeInTheDocument();
+      expect(screen.getByText('List item 1')).toBeInTheDocument();
+      expect(screen.getByText('List item 2')).toBeInTheDocument();
+    });
+
+    it('renders multiple collapsible sections', () => {
+      const content = trimIndent(`
+        <details>
+          <summary>Section 1</summary>
+
+          Content 1
+
+        </details>
+
+        <details>
+          <summary>Section 2</summary>
+
+          Content 2
+
+        </details>
+      `);
+
+      renderWithStore(
+        <ChatMDComponent isShowResponseLoader={false} content={content} />,
+      );
+
+      expect(screen.getByText('Section 1')).toBeInTheDocument();
+      expect(screen.getByText('Section 2')).toBeInTheDocument();
+      expect(screen.getByText('Content 1')).toBeInTheDocument();
+      expect(screen.getByText('Content 2')).toBeInTheDocument();
+    });
+
+    it('renders nested markdown elements in details', () => {
+      const content = trimIndent(`
+        <details>
+          <summary>Markdown Example</summary>
+
+          **Bold text** in details
+
+        </details>
+      `);
+
+      renderWithStore(
+        <ChatMDComponent isShowResponseLoader={false} content={content} />,
+      );
+
+      expect(screen.getByText('Markdown Example')).toBeInTheDocument();
+      const boldElement = screen.getByText('Bold text');
+      expect(boldElement).toBeInTheDocument();
+      expect(boldElement.tagName).toBe('STRONG');
+    });
+
+    it('handles details with open attribute', () => {
+      const content = trimIndent(`
+        <details open>
+          <summary>Default Open</summary>
+
+          This is visible by default
+
+        </details>
+      `);
+
+      renderWithStore(
+        <ChatMDComponent isShowResponseLoader={false} content={content} />,
+      );
+
+      const detailsElement = screen.getByRole('group');
+      expect(detailsElement).toHaveAttribute('open');
+      expect(screen.getByText('Default Open')).toBeInTheDocument();
+      expect(
+        screen.getByText('This is visible by default'),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('security', () => {
+    it('sanitizes dangerous HTML while keeping details/summary', () => {
+      const content = trimIndent(`
+        <details>
+          <summary>Safe Content</summary>
+
+          <script id="unsafe-script">alert('xss')</script>
+          **Safe markdown**
+
+        </details>
+      `);
+
+      renderWithStore(
+        <ChatMDComponent isShowResponseLoader={false} content={content} />,
+      );
+
+      expect(screen.getByText('Safe Content')).toBeInTheDocument();
+      expect(screen.getByText('Safe markdown')).toBeInTheDocument();
+      // Script tag should be sanitized out
+      expect(screen.queryByText(/alert/)).not.toBeInTheDocument();
+      expect(screen.queryByRole('script')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('response loader', () => {
+    it('shows response loader cursor when isShowResponseLoader is true', () => {
+      renderWithStore(
+        <ChatMDComponent isShowResponseLoader content="Loading..." />,
+      );
+
+      expect(screen.getByText('Loading...')).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
**Description:**

Copy of #4830

Adds support for `<details>` and `<summary>` tags in markdown rendering to enable collapsible content sections.

It is a feature of GitHub flavored markdown which is missing from remark-gfm.

https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/organizing-information-with-collapsed-sections

Issues:

I just really really need this for an agent for our epam customer.

- Issue #4875

**UI changes**
<img width="736" height="936" alt="image" src="https://github.com/user-attachments/assets/83d38870-8cee-4db9-913f-07971abe9ac8" />




**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs