### PR TITLE
fix(chat): 'Max attachments number' always shows 'Invalid Input' error despite correct data (Issue #4887)

### DIFF
--- a/apps/chat/src/components/Common/Forms/ControlledFormField.tsx
+++ b/apps/chat/src/components/Common/Forms/ControlledFormField.tsx
@@ -12,6 +12,7 @@ import {
   ControllerRenderProps,
   FieldValues,
   Path,
+  PathValue,
   RegisterOptions,
   UseFormStateReturn,
 } from 'react-hook-form';
@@ -32,6 +33,7 @@ interface ControlledFormFieldProps<T extends FieldValues, K extends Path<T>> {
     RegisterOptions<T, K>,
     'disabled' | 'valueAsNumber' | 'valueAsDate'
   >;
+  defaultValue?: PathValue<T, K>;
 }
 
 export const ControlledFormField = <T extends FieldValues, K extends Path<T>>({
@@ -39,6 +41,7 @@ export const ControlledFormField = <T extends FieldValues, K extends Path<T>>({
   name,
   children,
   rules,
+  defaultValue = '' as PathValue<T, K>,
 }: ControlledFormFieldProps<T, K>) => {
   const newRules = useMemo(() => omit(rules ?? {}, 'setValueAs'), [rules]);
 
@@ -66,6 +69,7 @@ export const ControlledFormField = <T extends FieldValues, K extends Path<T>>({
       name={name}
       render={renderFn}
       rules={newRules}
+      defaultValue={defaultValue}
     />
   );
 };

--- a/apps/chat/src/constants/validation-helpers.ts
+++ b/apps/chat/src/constants/validation-helpers.ts
@@ -38,11 +38,13 @@ export const AttachmentTypesSchema = zodValidation
     'Please match the MIME format',
   );
 
-export const MaxInputAttachmentsSchema = zodValidation.number().refine((v) => {
-  if (!v) return true;
-  const reg = /^[0-9]+$/;
-  return reg.test(String(v));
-}, 'Max attachments must be a number');
+export const MaxInputAttachmentsSchema = zodValidation.coerce
+  .number<number>()
+  .refine((v) => {
+    if (!v) return true;
+    const reg = /^[0-9]+$/;
+    return reg.test(String(v));
+  }, 'Max attachments must be a number');
 
 export const DynamicFieldSchema = zodValidation.object({
   label: zodValidation


### PR DESCRIPTION
**Description:**

- Fix 'Max attachments number' always shows 'Invalid Input' error despite correct data;
- Add coercion in the zod validation `MaxInputAttachmentsSchema`.

Issues:

- Issue #4887 

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
