### PR TITLE
fix(chat): toolset's reference is not removed from the query on close it's card in the 'Marketplace' (Issues #4899, #4842)

### DIFF
--- a/apps/chat/src/store/marketplace/marketplace.epics.ts
+++ b/apps/chat/src/store/marketplace/marketplace.epics.ts
@@ -107,6 +107,7 @@ const setQueryParamsEpic: AppEpic = (action$, state$) =>
       const pathname = window.location.pathname;
       // workspace tab
       const selectedTab = MarketplaceSelectors.selectSelectedTab(state);
+
       addToQuery(
         query,
         MarketplaceQueryParams.tab,
@@ -117,6 +118,7 @@ const setQueryParamsEpic: AppEpic = (action$, state$) =>
       // entities tab
       const selectedEntitiesTab =
         MarketplaceSelectors.selectSelectedEntitiesTab(state);
+
       addToQuery(
         query,
         MarketplaceQueryParams.entitiesTab,
@@ -127,7 +129,8 @@ const setQueryParamsEpic: AppEpic = (action$, state$) =>
       // application link
       const detailsEntity = MarketplaceSelectors.selectDetailsEntity(state);
       const referenceQuery =
-        detailsEntity?.type === MarketplaceEntitiesTabs.TOOLSETS
+        detailsEntity?.type === MarketplaceEntitiesTabs.TOOLSETS ||
+        selectedEntitiesTab === MarketplaceEntitiesTabs.TOOLSETS
           ? MarketplaceQueryParams.toolset
           : MarketplaceQueryParams.model;
       addToQuery(query, referenceQuery, detailsEntity?.reference);


### PR DESCRIPTION
**Description:**

- Fix toolset's reference is not removed from the query on close it's card in the Marketplace and an error toast is displayed with text "Toolset by this link not found".

Issues:

- Issue #4899 
- Isuue #4842 


**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
