### PR TITLE
fix(chat): fix publishing credentials (Issue #4856)

### DIFF
--- a/apps/chat/src/store/publication/publication.reducers.ts
+++ b/apps/chat/src/store/publication/publication.reducers.ts
@@ -235,6 +235,20 @@ export const publicationSlice = createSlice({
       }>,
     ) => {
       state.selectedPublicationItems[payload.publicationUrl] = payload.ids;
+
+      const publishCredentialsResources = state.publications
+        .find((publication) => publication.url === payload.publicationUrl)
+        ?.resources?.filter(
+          ({ publishCredentials, reviewUrl }) =>
+            publishCredentials && payload.ids.includes(reviewUrl),
+        );
+
+      if (!payload.publicationUrl) {
+        state.selectedCredentialsItems[payload.publicationUrl] = [];
+      } else if (publishCredentialsResources) {
+        state.selectedCredentialsItems[payload.publicationUrl] =
+          publishCredentialsResources.map(({ reviewUrl }) => reviewUrl);
+      }
     },
     selectPublicationItems: (
       state,


### PR DESCRIPTION
**Description:**

- set publish creds checkbox off by default when creating publication request
- fix issue with checkbox set off when admin reviewing request

Issues:

- Issue #4856 

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
