### PR TITLE
fix(chat): show correct entity type in the warning text on the publication request creation form (Issue #4724)

### DIFF
--- a/apps/chat/src/components/Chat/Publish/PublicationHandler/PublicationHandler.tsx
+++ b/apps/chat/src/components/Chat/Publish/PublicationHandler/PublicationHandler.tsx
@@ -15,8 +15,10 @@ import { getFolderIdFromEntityId } from '@/src/utils/app/folders';
 import { getStringValidationErrors } from '@/src/utils/app/forms';
 import {
   getIdWithoutFeatureType,
+  isApplicationId,
   isConversationId,
   isFileId,
+  isToolsetId,
 } from '@/src/utils/app/id';
 import { EnumMapper } from '@/src/utils/app/mappers';
 import {
@@ -526,6 +528,18 @@ export function PublicationHandler({ publication }: Props) {
     }, 0);
   }, [publication.resources, publication.targetFolder]);
 
+  const errorMessageEntityType = useMemo(() => {
+    if (!publicationModel) return '';
+    if (isApplicationId(publicationModel.entity.id)) {
+      return FeatureType.Application;
+    }
+
+    if (isToolsetId(publicationModel.entity.id)) {
+      return FeatureType.Toolset;
+    }
+    return '';
+  }, [publicationModel]);
+
   const isSomeResourceIsUnpublish = publication.resources.some(
     (resource) => resource.action === PublishActions.DELETE,
   );
@@ -787,7 +801,7 @@ export function PublicationHandler({ publication }: Props) {
                                 <ErrorMessage
                                   type="warning"
                                   error={t(
-                                    `The icon used for this ${featureType} is in the "${isEntityIdPublic({ id: firstNotMyFileEntity.reviewUrl }) ? 'Organization' : 'Shared with me'}" section and cannot be published. Please replace the icon, otherwise the ${featureType} will be published with the default one.`,
+                                    `The icon used for this ${errorMessageEntityType} is in the "${isEntityIdPublic({ id: firstNotMyFileEntity.reviewUrl }) ? 'Organization' : 'Shared with me'}" section and cannot be published. Please replace the icon, otherwise the ${errorMessageEntityType} will be published with the default one.`,
                                   )}
                                 />
                               )}


### PR DESCRIPTION
**Description:**

- Fix the warning text on the publication request creation form to show `application` or `toolset` instead of `file`.

Issues:

- Issue #4724 

**UI changes**

<img width="470" height="310" alt="image" src="https://github.com/user-attachments/assets/944f299f-2d1f-4c55-9b37-562637ab7f5c" />

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
