### PR TITLE
fix(chat): fix infinity loader when 2 apps with configuration selected (Issue #4986)

### DIFF
--- a/apps/chat/src/store/chat/chat.epics.ts
+++ b/apps/chat/src/store/chat/chat.epics.ts
@@ -135,7 +135,7 @@ const getConfigurationSchemaEpic: AppEpic = (action$, state$) =>
 const startConfigurationSchemaUploadingEpic: AppEpic = (action$) =>
   action$.pipe(
     ofType(ChatActions.startConfigurationSchemaUploading.type),
-    switchMap(({ payload }) => {
+    mergeMap(({ payload }) => {
       return ApplicationService.getConfigurationSchema(payload.modelId).pipe(
         switchMap((schema) => {
           return of(


### PR DESCRIPTION
**Description:**

fix infinity loader when 2 apps with configuration selected

Issues:

- Issue #4986
- 
**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
