### PR TITLE
fix(chat): change toolset detailed view default to true (Issue #4576)

### DIFF
--- a/apps/chat/src/components/ToolsetEditor/ToolsetPreview.tsx
+++ b/apps/chat/src/components/ToolsetEditor/ToolsetPreview.tsx
@@ -26,7 +26,7 @@ interface ToolsetPreviewProps {
 export const ToolsetPreview = ({ currentToolset }: ToolsetPreviewProps) => {
   const { t } = useTranslation(Translation.Marketplace);
   const { control } = useFormContext<ToolsetEditorForm>();
-  const [isDetailed, setIsDetailed] = useState(false);
+  const [isDetailed, setIsDetailed] = useState(true);
 
   const [
     name,


### PR DESCRIPTION
**Description:**

Need to set detailed view default true

Issues:

- Issue #4576

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
