### PR TITLE
fix(chat): add info tooltip to author in edit mode (Issue #4815)

### DIFF
--- a/apps/chat/src/components/Chat/Publish/PublicationHandler/PublicationHandler.tsx
+++ b/apps/chat/src/components/Chat/Publish/PublicationHandler/PublicationHandler.tsx
@@ -73,6 +73,9 @@ import { ReviewToolsetDialog } from './ReviewToolsetDialog/ReviewToolsetDialog';
 import { PublishActions } from '@epam/ai-dial-shared';
 import isEqual from 'lodash-es/isEqual';
 
+const AUTHOR_PUBLIC_NAME_TOOLTIP =
+  "This name will be displayed instead of the author's name for this publication.";
+
 interface Props {
   publication: Publication;
   onSubmit: (
@@ -476,6 +479,7 @@ export function PublicationHandler({ publication, onSubmit }: Props) {
                     {showPublicDisplayAuthor &&
                       (isEditMode || !isReview ? (
                         <Field
+                          info={t(AUTHOR_PUBLIC_NAME_TOOLTIP)}
                           label={t("Author's public name")}
                           {...formMethods.register(
                             PublishRequestFieldsNames.PUBLICATION_AUTHOR,
@@ -494,9 +498,7 @@ export function PublicationHandler({ publication, onSubmit }: Props) {
                           label={t("Author's public name")}
                           valueDataQa="publication-display-author"
                           valueToDisplay={publication.displayAuthor ?? ''}
-                          infoTooltip={t(
-                            "This name will be displayed instead of the author's name for this publication.",
-                          )}
+                          infoTooltip={t(AUTHOR_PUBLIC_NAME_TOOLTIP)}
                         />
                       ))}
 


### PR DESCRIPTION
**Description:**

add info tooltip to author in edit mode

Issues:

- Issue #4815

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
