### PR TITLE
fix(chat): fix document relative url tooltip placement (Issue #3659)

### DIFF
--- a/apps/chat/src/components/Common/FilesSelector/SelectedFile.tsx
+++ b/apps/chat/src/components/Common/FilesSelector/SelectedFile.tsx
@@ -1,6 +1,8 @@
 import { IconFile, IconTrashX } from '@tabler/icons-react';
 import { FC } from 'react';
 
+import classNames from 'classnames';
+
 import { Tooltip } from '@/src/components/Common/Tooltip';
 
 interface Props {
@@ -15,32 +17,36 @@ export const SelectedFile: FC<Props> = ({ document, readonly, onRemove }) => {
   const name = document.substring(last + 1, document.length);
 
   return (
-    <div className="flex cursor-pointer flex-row items-center justify-between rounded p-2 hover:bg-accent-primary-alpha">
-      <IconFile size={18} className="text-secondary" />
-      <div className="ml-2 flex min-w-0 flex-1 flex-col pr-2">
-        <Tooltip
-          tooltip={name}
-          triggerClassName="items-center flex"
-          contentClassName="text-primary"
-        >
-          <span className="mb-1.5 w-full truncate text-sm leading-4 text-primary">
+    <Tooltip
+      placement="top-start"
+      tooltip={name}
+      triggerClassName="items-center flex"
+      contentClassName="text-primary"
+    >
+      <div className="flex w-full cursor-pointer flex-row items-center justify-between rounded p-2 hover:bg-accent-primary-alpha">
+        <IconFile size={18} className="text-secondary" />
+        <div className="ml-2 flex min-w-0 flex-1 flex-col pr-2">
+          <span
+            className={classNames(
+              'w-full truncate text-sm leading-4 text-primary',
+              path && 'mb-1.5',
+            )}
+          >
             {name}
           </span>
-        </Tooltip>
 
-        <Tooltip tooltip={path} contentClassName="text-primary">
           <span className="w-full truncate text-xs leading-[15px] text-secondary">
             {path}
           </span>
-        </Tooltip>
+        </div>
+        {!readonly && onRemove && (
+          <IconTrashX
+            className="text-secondary hover:text-accent-primary"
+            onClick={() => onRemove(document)}
+            size={18}
+          />
+        )}
       </div>
-      {!readonly && onRemove && (
-        <IconTrashX
-          className="text-secondary hover:text-accent-primary"
-          onClick={() => onRemove(document)}
-          size={18}
-        />
-      )}
-    </div>
+    </Tooltip>
   );
 };


### PR DESCRIPTION
**Description:**

1) tooltip should point to the name of the file, not to the center of the line
2) align file name to center vertically when file does not have path

Issues:

- Issue #3659

**UI changes**

Before: 
<img width="823" height="365" alt="Снимок экрана 2025-11-04 в 20 13 44" src="https://github.com/user-attachments/assets/b97d398c-2984-4ff0-9703-fa4747c1673d" />
<img width="824" height="199" alt="Снимок экрана 2025-11-04 в 20 13 51" src="https://github.com/user-attachments/assets/fd21ffe4-27f8-45ad-b712-1369dcccbce2" />

After:
<img width="679" height="234" alt="Снимок экрана 2025-11-04 в 20 14 32" src="https://github.com/user-attachments/assets/209f7e0c-2b1e-4ba7-af69-8cc5730de321" />

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
