### PR TITLE
chore(ci): enable GitHub runner cleanup before container-related jobs

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -14,3 +14,4 @@ jobs:
     secrets: inherit
     with:
       node-version: 22
+      maximize-build-space: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,3 +14,4 @@ jobs:
     secrets: inherit
     with:
       node-version: 22
+      maximize-build-space: true


### PR DESCRIPTION
**Description:**

The latest release workflows fail on building a container image due to no space left. Let's enable cleanup.