### PR TITLE
fix(chat): remove redundant loader in the settings section when exiting from Applications/Toolset Editor. Prevent full-screen loader hiding. (Issue #4910)

### DIFF
--- a/apps/chat/src/components/ToolsetEditor/ToolsetEditor.tsx
+++ b/apps/chat/src/components/ToolsetEditor/ToolsetEditor.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 
 import { useRouter } from 'next/router';
@@ -40,6 +40,8 @@ export const ToolsetEditor = () => {
   const changeEditorTabRef = useRef<ToolsetEditorSteps | null>(null);
   const saveAndExitRef = useRef(false);
   const redirectToChatRef = useRef(false);
+
+  const [isExiting, setIsExiting] = useState(false);
 
   const formMethods = useForm<ToolsetEditorForm>({
     defaultValues: getDefaultFormData(toolsetDetails, toolsets),
@@ -140,6 +142,7 @@ export const ToolsetEditor = () => {
 
   const handleSaveAndExit = useCallback(
     (saveDraft = false, redirectToChat = false) => {
+      setIsExiting(true);
       if ((!isDirty && toolsetDetails) || !toolsetDetails) {
         dispatch(
           ToolsetActions.exitEditor({
@@ -206,6 +209,7 @@ export const ToolsetEditor = () => {
           currentStep={editorStep}
           onNextClick={handleNextClick}
           currentToolset={toolsetDetails}
+          disableLoader={isExiting}
         />
       </div>
     </FormProvider>

--- a/apps/chat/src/store/application/application.epics.ts
+++ b/apps/chat/src/store/application/application.epics.ts
@@ -344,23 +344,18 @@ const updateApplicationEpic: AppEpic = (action$) =>
                   features: mergeFeatures(featuresRecord),
                 };
 
-                return concat(
-                  of(
-                    ApplicationActions.updateSuccess(updatedCustomApplication),
-                  ),
+                const actions: Observable<AppAction>[] = [];
+                actions.push(
                   of(
                     ModelsActions.updateModel({
                       model: modelData,
                       oldApplicationId: payload.oldApplication.id,
                     }),
                   ),
-                  iif(
-                    () => !!payload.tabToOpen,
-                    of(ApplicationActions.setEditorStep(payload.tabToOpen!)),
-                    EMPTY,
-                  ),
-                  iif(
-                    () => !!payload.isSaveAndExit,
+                );
+
+                if (payload.isSaveAndExit) {
+                  actions.push(
                     of(
                       ApplicationActions.exitEditor({
                         redirectUrl: payload.redirectUrl,
@@ -368,14 +363,24 @@ const updateApplicationEpic: AppEpic = (action$) =>
                           payload.shouldSelectApplication,
                       }),
                     ),
-                    EMPTY,
-                  ),
-                  iif(
-                    () => !!payload.tabToOpen,
-                    of(ApplicationActions.setEditorStep(payload.tabToOpen!)),
-                    EMPTY,
-                  ),
-                );
+                  );
+                } else {
+                  actions.push(
+                    of(
+                      ApplicationActions.updateSuccess(
+                        updatedCustomApplication,
+                      ),
+                    ),
+                  );
+
+                  if (payload.tabToOpen) {
+                    actions.push(
+                      of(ApplicationActions.setEditorStep(payload.tabToOpen!)),
+                    );
+                  }
+                }
+
+                return concat(...actions);
               }),
               catchError((err) => {
                 console.error('Failed to update application:', err);
@@ -805,60 +810,52 @@ const exitEditModeEpic: AppEpic = (action$, state$, { router }) =>
               },
             });
 
-      router.push(route).then(() => {
-        if (route.pathname === Routes.Marketplace) {
-          of(MarketplaceActions.initQueryParams());
-        }
-      });
+      const actions: Observable<AppAction>[] = [];
 
-      return concat(
-        iif(
-          () =>
-            !!payload.shouldSelectApplication &&
-            route.pathname === Routes.Marketplace &&
-            !!reference,
-          of(
-            MarketplaceActions.setDetailsEntity({
-              reference: reference as string,
-              type: MarketplaceEntitiesTabs.AGENTS,
-              isSuggested: false,
-            }),
-          ),
-          EMPTY,
-        ),
-        iif(
-          () =>
-            route.pathname === Routes.Chat &&
-            !publicationUrl &&
-            !returnConversationIds?.length,
-          of(
-            ConversationsActions.createNewConversations({
-              names: [DEFAULT_CONVERSATION_NAME],
-            }),
-          ),
-          EMPTY,
-        ),
-        iif(
-          () =>
-            route.pathname === Routes.Chat &&
-            !publicationUrl &&
-            !!returnConversationIds?.length,
-          of(
-            ConversationsActions.selectConversations({
-              conversationIds: returnConversationIds as string[],
-            }),
-          ),
-          EMPTY,
-        ),
-        iif(
-          () => route.pathname === Routes.Chat && !!publicationUrl,
-          of(
-            ConversationsActions.selectConversations({ conversationIds: [] }),
-            PublicationActions.setIsApplicationReview(true),
-          ),
-          EMPTY,
-        ),
-      );
+      if (route.pathname === Routes.Marketplace) {
+        if (payload.shouldSelectApplication && reference) {
+          actions.push(
+            of(
+              MarketplaceActions.setDetailsEntity({
+                reference: reference as string,
+                type: MarketplaceEntitiesTabs.AGENTS,
+                isSuggested: false,
+              }),
+            ),
+          );
+        }
+      }
+
+      if (route.pathname === Routes.Chat) {
+        if (publicationUrl) {
+          actions.push(
+            of(
+              ConversationsActions.selectConversations({
+                conversationIds: [],
+              }),
+              PublicationActions.setIsApplicationReview(true),
+            ),
+          );
+        } else if (returnConversationIds?.length) {
+          actions.push(
+            of(
+              ConversationsActions.selectConversations({
+                conversationIds: returnConversationIds as string[],
+              }),
+            ),
+          );
+        } else {
+          actions.push(
+            of(
+              ConversationsActions.createNewConversations({
+                names: [DEFAULT_CONVERSATION_NAME],
+              }),
+            ),
+          );
+        }
+      }
+
+      return from(router.push(route)).pipe(switchMap(() => concat(...actions)));
     }),
   );
 

--- a/apps/chat/src/store/toolset/toolset.epics.ts
+++ b/apps/chat/src/store/toolset/toolset.epics.ts
@@ -5,8 +5,10 @@ import {
   concat,
   filter,
   forkJoin,
+  from,
   iif,
   map,
+  mergeMap,
   of,
   switchMap,
 } from 'rxjs';
@@ -274,30 +276,34 @@ const updateToolsetEpic: AppEpic = (action$) =>
                     );
                   }
 
-                  return concat(
-                    iif(
-                      () => !!payload.exitAfterSave,
+                  const actions: Observable<AppAction>[] = [];
+
+                  if (payload.exitAfterSave) {
+                    actions.push(
                       of(
                         ToolsetActions.exitEditor({
                           redirectUrl: payload.redirectUrl,
                           shouldSelectToolset: payload.shouldSelectToolset,
                         }),
                       ),
-                      EMPTY,
-                    ),
-                    of(
-                      ToolsetActions.updateToolsetSuccess({
-                        oldToolset: payload.oldToolset,
-                        newToolset: savedUpdatedToolset,
-                      }),
-                    ),
-                    iif(
-                      () => !!payload.tabToOpen,
-                      of(ToolsetActions.setEditorStep(payload.tabToOpen!)),
-                      EMPTY,
-                    ),
-                    iif(
-                      () => !!payload.auth,
+                    );
+                  } else {
+                    actions.push(
+                      of(
+                        ToolsetActions.updateToolsetSuccess({
+                          oldToolset: payload.oldToolset,
+                          newToolset: savedUpdatedToolset,
+                        }),
+                      ),
+                    );
+                    if (payload.tabToOpen) {
+                      actions.push(
+                        of(ToolsetActions.setEditorStep(payload.tabToOpen!)),
+                      );
+                    }
+                  }
+                  if (payload.auth) {
+                    actions.push(
                       of(
                         ToolsetActions.startSignInProcess({
                           authLevel:
@@ -307,9 +313,10 @@ const updateToolsetEpic: AppEpic = (action$) =>
                           toolset: savedUpdatedToolset,
                         }),
                       ),
-                      EMPTY,
-                    ),
-                  );
+                    );
+                  }
+
+                  return concat(...actions);
                 }),
               ),
             ),
@@ -832,45 +839,42 @@ const exitEditorEpic: AppEpic = (action$, state$, { router }) =>
               },
             });
 
-      router.push(route).then(() => {
-        if (route.pathname === Routes.Marketplace) {
-          of(MarketplaceActions.initQueryParams());
-        }
-      });
+      const actions: Observable<AppAction>[] = [];
 
-      return concat(
-        iif(
-          () =>
-            !!payload.shouldSelectToolset &&
-            route.pathname === Routes.Marketplace &&
-            !!reference,
-          of(
-            MarketplaceActions.setDetailsEntity({
-              reference: reference as string,
-              type: MarketplaceEntitiesTabs.TOOLSETS,
-              isSuggested: false,
-            }),
-          ),
-          EMPTY,
-        ),
-        iif(
-          () => route.pathname === Routes.Chat && !publicationUrl,
-          of(
-            ConversationsActions.createNewConversations({
-              names: [DEFAULT_CONVERSATION_NAME],
-            }),
-          ),
-          EMPTY,
-        ),
-        iif(
-          () => route.pathname === Routes.Chat && !!publicationUrl,
-          of(
-            ConversationsActions.selectConversations({ conversationIds: [] }),
-            PublicationActions.setIsToolsetReview(true),
-          ),
-          EMPTY,
-        ),
-      );
+      if (route.pathname === Routes.Marketplace) {
+        if (payload.shouldSelectToolset && reference) {
+          actions.push(
+            of(
+              MarketplaceActions.setDetailsEntity({
+                reference: reference as string,
+                type: MarketplaceEntitiesTabs.TOOLSETS,
+                isSuggested: false,
+              }),
+            ),
+          );
+        }
+      }
+
+      if (route.pathname === Routes.Chat) {
+        if (!publicationUrl) {
+          actions.push(
+            of(
+              ConversationsActions.createNewConversations({
+                names: [DEFAULT_CONVERSATION_NAME],
+              }),
+            ),
+          );
+        } else {
+          actions.push(
+            of(
+              ConversationsActions.selectConversations({ conversationIds: [] }),
+            ),
+            of(PublicationActions.setIsToolsetReview(true)),
+          );
+        }
+      }
+
+      return from(router.push(route)).pipe(mergeMap(() => concat(...actions)));
     }),
   );
 

--- a/apps/chat/src/utils/app/application.ts
+++ b/apps/chat/src/utils/app/application.ts
@@ -1,7 +1,3 @@
-import { NextRouter } from 'next/router';
-
-import { Observable, concatMap, from } from 'rxjs';
-
 import { DefaultsService } from '@/src/utils/app/data/defaults-service';
 import { getTopicColors } from '@/src/utils/app/style-helpers';
 import { ApiUtils, getMarketplaceEntityApiKey } from '@/src/utils/server/api';
@@ -22,7 +18,6 @@ import { EntityType, PartialBy } from '@/src/types/common';
 import { MarketplaceEntity } from '@/src/types/marketplace';
 import { DialAIEntityFeatures, DialAIEntityModel } from '@/src/types/models';
 import { QuickApp2Config, QuickAppConfig } from '@/src/types/quick-apps';
-import { AppAction } from '@/src/types/store';
 import { ToolsetModel } from '@/src/types/toolsets';
 import { Translation } from '@/src/types/translation';
 
@@ -426,15 +421,3 @@ export const isDialAiEntityModel = (
   entity: MarketplaceEntity,
 ): entity is DialAIEntityModel =>
   entity?.type === EntityType.Application || entity?.type === EntityType.Model;
-
-export const navigateAndThen = (
-  router: NextRouter,
-  to: Parameters<NextRouter['push']>[0],
-  after$: Observable<AppAction>,
-) => {
-  return from(
-    router.push(to, undefined, {
-      shallow: true,
-    }),
-  ).pipe(concatMap(() => after$));
-};


### PR DESCRIPTION
**Description:**

- Remove redundant loader when exiting Applications/Toolset or the Editor in the settings section. 
- Prevent full-screen loader hiding. 

Issues:

- Issue #4910 


**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
