### PR TITLE
fix(chat): fix editing toolset editor after login (Issue #4901)

### DIFF
--- a/apps/chat/src/components/Marketplace/AddToolsButton.tsx
+++ b/apps/chat/src/components/Marketplace/AddToolsButton.tsx
@@ -40,6 +40,7 @@ export function AddToolsButton() {
               query: {
                 [ToolsetEditorQuery.ReturnUrl]:
                   window.location.pathname + window.location.search,
+                [ToolsetEditorQuery.IsCreate]: true,
               },
             });
           },

--- a/apps/chat/src/components/ToolsetEditor/ToolsetEditor.tsx
+++ b/apps/chat/src/components/ToolsetEditor/ToolsetEditor.tsx
@@ -30,9 +30,11 @@ export const ToolsetEditor = () => {
 
   const router = useRouter();
 
-  const { [ToolsetEditorQuery.Id]: idQuery } = router.query;
-  const isCreateRef = useRef(!idQuery);
-
+  const {
+    [ToolsetEditorQuery.Id]: idQuery,
+    [ToolsetEditorQuery.IsCreate]: isCreateQuery,
+  } = router.query;
+  const isCreateRef = useRef(!idQuery || !!isCreateQuery);
   const toolsetDetails = useAppSelector(ToolsetSelectors.selectToolsetDetails);
   const toolsets = useAppSelector(ToolsetSelectors.selectToolsets);
   const editorStep = useAppSelector(ToolsetSelectors.selectEditorStep);

--- a/apps/chat/src/constants/toolsets.ts
+++ b/apps/chat/src/constants/toolsets.ts
@@ -7,6 +7,7 @@ export enum ToolsetEditorQuery {
   PublicationUrl = 'publicationUrl',
   Step = 'step',
   ReturnUrl = 'returnUrl',
+  IsCreate = 'isCreate',
 }
 
 export const DRAFT_TOOLSET_ID = `${ApiKeys.Toolsets}/draft`;

--- a/apps/chat/src/store/toolset/toolset.epics.ts
+++ b/apps/chat/src/store/toolset/toolset.epics.ts
@@ -67,6 +67,24 @@ const isToolsetEditorStep = (step: string): step is ToolsetEditorSteps => {
   }
 };
 
+const getMyWorkspaceUrl = (
+  params?: Partial<Record<MarketplaceQueryParams, unknown>>,
+) => {
+  const route = new URL(Routes.Marketplace);
+  route.searchParams.append(
+    MarketplaceQueryParams.tab,
+    MarketplaceTabs.MY_WORKSPACE,
+  );
+
+  if (params) {
+    Object.entries(params).forEach(([key, value]) => {
+      route.searchParams.append(key, value as string);
+    });
+  }
+
+  return route;
+};
+
 const initEpic: AppEpic = (action$, state$) =>
   action$.pipe(
     ofType(ToolsetActions.init.type),
@@ -800,7 +818,7 @@ const initQueryParamsEpic: AppEpic = (action$) =>
     }),
   );
 
-const exitEditorEpic: AppEpic = (action$, state$, { router }) =>
+const exitEditorEpic: AppEpic = (action$, _state$, { router }) =>
   action$.pipe(
     ofType(ToolsetActions.exitEditor.type),
     switchMap(({ payload }) => {
@@ -820,17 +838,19 @@ const exitEditorEpic: AppEpic = (action$, state$, { router }) =>
         redirectUrl ??
         returnUrl ??
         (publicationUrl
-          ? {
-              pathname: Routes.Chat,
-            }
-          : {
-              pathname: Routes.Marketplace,
-              query: {
-                [MarketplaceQueryParams.tab]: MarketplaceTabs.MY_WORKSPACE,
-                [MarketplaceQueryParams.entitiesTab]:
-                  MarketplaceEntitiesTabs.TOOLSETS,
-              },
-            });
+          ? new URL(Routes.Chat)
+          : getMyWorkspaceUrl({
+              [MarketplaceQueryParams.entitiesTab]:
+                MarketplaceEntitiesTabs.TOOLSETS,
+            }));
+
+      if (
+        route.pathname === Routes.Marketplace &&
+        payload.shouldSelectToolset &&
+        reference
+      ) {
+        route.searchParams.append(MarketplaceQueryParams.toolset, reference);
+      }
 
       router.push(route).then(() => {
         if (route.pathname === Routes.Marketplace) {


### PR DESCRIPTION
**Description:**

- add isCreate query param for toolset editor (ref value is reset after login redirect)

Issues:

- Issue #4901 

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
