### PR TITLE
feat(chat): add feature flag to enable Code Interpreter into Quick App 2.0 (Issue #5110)

### DIFF
--- a/apps/chat/.env.development
+++ b/apps/chat/.env.development
@@ -104,7 +104,7 @@ FEDERATED_LOGOUT_PROVIDERS="auth0,keycloak,azure-ad-b2c"
 # ALLOW_OPEN_SIGNIN_PAGE_IN_IFRAME="false"
 
 # Application UI settings
-ENABLED_FEATURES="conversations-section,prompts-section,top-settings,top-clear-conversation,top-chat-info,top-chat-model-settings,empty-chat-settings,header,footer,request-api-key,report-an-issue,likes,conversations-sharing,prompts-sharing,input-files,attachments-manager,conversations-publishing,prompts-publishing,custom-logo,input-links,custom-applications,message-templates,marketplace,code-apps,applications-sharing,marketplace-table-view,edit-last-assistant-message,edit-all-assistant-message,toolsets"
+ENABLED_FEATURES="conversations-section,prompts-section,top-settings,top-clear-conversation,top-chat-info,top-chat-model-settings,empty-chat-settings,header,footer,request-api-key,report-an-issue,likes,conversations-sharing,prompts-sharing,input-files,attachments-manager,conversations-publishing,prompts-publishing,custom-logo,input-links,custom-applications,message-templates,marketplace,code-apps,applications-sharing,marketplace-table-view,edit-last-assistant-message,edit-all-assistant-message,toolsets,code-interpreter"
 
 ## JSON Object Format:
 # ENABLED_FEATURES_ROLES: {"code-apps":["code-app-developer", "admin"],"custom-applications":["custom-app-developer"],"message-templates":["admin"]}

--- a/apps/chat/src/components/AppsEditor/EditorForm/QuickApp2Form.tsx
+++ b/apps/chat/src/components/AppsEditor/EditorForm/QuickApp2Form.tsx
@@ -12,6 +12,7 @@ import { useAppSelector } from '@/src/store/hooks';
 import {
   ApplicationSelectors,
   ModelsSelectors,
+  SettingsSelectors,
   ToolsetSelectors,
 } from '@/src/store/selectors';
 
@@ -28,6 +29,7 @@ import { withLabel } from '@/src/components/Common/Forms/Label';
 import { ModelsSelector } from '@/src/components/Common/ModelsSelector';
 import { ToggleSwitch } from '@/src/components/Common/ToggleSwitch/ToggleSwitch';
 
+import { Feature } from '@epam/ai-dial-shared';
 import uniq from 'lodash-es/uniq';
 
 const FilesSelectorField = withErrorMessage(withLabel(FilesSelector));
@@ -46,6 +48,10 @@ export const QuickApp2Form = () => {
   );
   const modelsMap = useAppSelector(ModelsSelectors.selectModelsMap);
   const toolsetsMap = useAppSelector(ToolsetSelectors.selectToolsetsMap);
+
+  const isCodeInterpreterEnabled = useAppSelector((state) =>
+    SettingsSelectors.isFeatureEnabled(state, Feature.CodeInterpreter),
+  );
 
   const allEntitiesMap = useMemo(
     () => ({
@@ -135,22 +141,24 @@ export const QuickApp2Form = () => {
         tooltip={isAppPublic ? PUBLIC_APP_TOOLTIP : ''}
       />
 
-      <Controller
-        name="codeInterpreter"
-        control={control}
-        render={({ field }) => (
-          <ToggleSwitchField
-            label={t('Code Interpreter')}
-            isOn={field.value}
-            handleSwitch={field.onChange}
-            switchOnText={t('ON')}
-            switchOFFText={t('OFF')}
-            className="flex w-fit"
-            disabled={isAppPublic}
-            tooltip={isAppPublic ? PUBLIC_APP_TOOLTIP : ''}
-          />
-        )}
-      />
+      {isCodeInterpreterEnabled && (
+        <Controller
+          name="codeInterpreter"
+          control={control}
+          render={({ field }) => (
+            <ToggleSwitchField
+              label={t('Code Interpreter')}
+              isOn={field.value}
+              handleSwitch={field.onChange}
+              switchOnText={t('ON')}
+              switchOFFText={t('OFF')}
+              className="flex w-fit"
+              disabled={isAppPublic}
+              tooltip={isAppPublic ? PUBLIC_APP_TOOLTIP : ''}
+            />
+          )}
+        />
+      )}
 
       <Controller
         name="temperature"

--- a/apps/chat/src/components/Chat/Publish/PublicationHandler/ReviewApplicationDialog/ReviewQuickApp2Section.tsx
+++ b/apps/chat/src/components/Chat/Publish/PublicationHandler/ReviewApplicationDialog/ReviewQuickApp2Section.tsx
@@ -22,10 +22,12 @@ import {
 import { Translation } from '@/src/types/translation';
 
 import { useAppSelector } from '@/src/store/hooks';
-import { ModelsSelectors } from '@/src/store/selectors';
+import { ModelsSelectors, SettingsSelectors } from '@/src/store/selectors';
 
 import { AgentAndToolsetChip } from '@/src/components/Common/AgentAndToolsetSelector/AgentAndToolsetChip';
 import { Tooltip } from '@/src/components/Common/Tooltip';
+
+import { Feature } from '@epam/ai-dial-shared';
 
 interface DocumentFieldProps {
   url?: string;
@@ -79,6 +81,9 @@ const ReviewQuickApp2SectionView = ({
   const { t } = useTranslation(Translation.Chat);
 
   const modelsMap = useAppSelector(ModelsSelectors.selectModelsMap);
+  const isCodeInterpreterEnabled = useAppSelector((state) =>
+    SettingsSelectors.isFeatureEnabled(state, Feature.CodeInterpreter),
+  );
 
   const { agents, toolsets, isCodeInterpreter } = useMemo(
     () =>
@@ -128,7 +133,7 @@ const ReviewQuickApp2SectionView = ({
 
   return (
     <>
-      {isCodeInterpreter && (
+      {isCodeInterpreterEnabled && isCodeInterpreter && (
         <div className="flex gap-4">
           <span className="w-[122px] text-secondary">
             {t('Code Interpreter: ')}

--- a/libs/shared/src/types/features.ts
+++ b/libs/shared/src/types/features.ts
@@ -70,6 +70,7 @@ export enum Feature {
   // Applications
   CustomApplications = 'custom-applications', // Enable creating of applications ('Add app' button/menu)
   CodeApps = 'code-apps', // Enable creating of Code apps (into the 'Add app' menu)
+  CodeInterpreter = 'code-interpreter', // Enable Code Interpreter feature
 
   // Marketplace
   Marketplace = 'marketplace', // Enable Marketplace


### PR DESCRIPTION
**Description:**

add feature flag to enable Code Interpreter into Quick App 2.0

Copy of #5115

Issues:

- Issue #5110

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
