### PR TITLE
fix(chat): fix default preview mode for mindmaps editor (Issue #5144)

### DIFF
--- a/apps/chat/src/components/AppsEditor/AppsEditorView.tsx
+++ b/apps/chat/src/components/AppsEditor/AppsEditorView.tsx
@@ -1,15 +1,22 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useFormContext, useWatch } from 'react-hook-form';
 
 import { useScreenState } from '@/src/hooks/useScreenState';
 import { useTranslation } from '@/src/hooks/useTranslation';
 
+import {
+  ApiDetailedApplicationTypeSchema,
+  ApplicationTypeSchemaProperties,
+} from '@/src/types/application-type-schema';
 import { ScreenState } from '@/src/types/common';
 import { MarketplaceEditorSteps, PreviewMode } from '@/src/types/marketplace';
 import { Translation } from '@/src/types/translation';
 
 import { useAppSelector } from '@/src/store/hooks';
-import { ApplicationSelectors } from '@/src/store/selectors';
+import {
+  ApplicationSelectors,
+  ApplicationTypesSchemasSelectors,
+} from '@/src/store/selectors';
 
 import { AppEditorPreview } from '@/src/components/AppsEditor/AppEditorPreview/AppEditorPreview';
 import { EditorForm } from '@/src/components/AppsEditor/EditorForm/EditorForm';
@@ -21,6 +28,17 @@ const mobileTabLabels = {
   [MarketplaceEditorSteps.Settings]: 'Settings',
 };
 
+const getDefaultPreviewMode = (
+  screenState: ScreenState,
+  editorStep: MarketplaceEditorSteps,
+  schema?: ApiDetailedApplicationTypeSchema | null,
+) =>
+  screenState <= ScreenState.MD ||
+  (schema?.[ApplicationTypeSchemaProperties.applicationTypeViewerUrl] &&
+    editorStep === MarketplaceEditorSteps.Settings)
+    ? PreviewMode.closed
+    : PreviewMode.half;
+
 interface AppsEditorViewProps {
   onNextClick: () => void;
   onAutoSave: () => void;
@@ -31,11 +49,19 @@ export const AppsEditorView = ({
   onAutoSave,
 }: AppsEditorViewProps) => {
   const { t } = useTranslation(Translation.Marketplace);
+  const settingsVisitedRef = useRef(false);
 
   const editorStep = useAppSelector(ApplicationSelectors.selectEditorStep);
+  const schema = useAppSelector(
+    ApplicationTypesSchemasSelectors.selectDetailedApplicationTypeSchema,
+  );
 
   const screenState = useScreenState();
   const { control } = useFormContext<AppsEditorFormType>();
+
+  const [previewMode, setPreviewMode] = useState<PreviewMode>(
+    getDefaultPreviewMode(screenState, editorStep, schema),
+  );
 
   const [name, version] = useWatch({
     control,
@@ -52,13 +78,22 @@ export const AppsEditorView = ({
     [onAutoSave],
   );
 
+  useEffect(() => {
+    if (
+      editorStep === MarketplaceEditorSteps.Settings &&
+      !settingsVisitedRef.current
+    ) {
+      setPreviewMode(getDefaultPreviewMode(screenState, editorStep, schema));
+      settingsVisitedRef.current = true;
+    }
+  }, [editorStep, schema, screenState]);
+
   return (
     <MarketplaceEditorView
       leftContent={LeftContent}
       rightContent={RightContent}
-      defaultPreviewMode={
-        screenState <= ScreenState.MD ? PreviewMode.closed : PreviewMode.half
-      }
+      previewMode={previewMode}
+      onPreviewModeChange={setPreviewMode}
       closedPreviewLabel={`${t('Preview')}: ${name} v. ${version}`}
       leftTabLabel={t(mobileTabLabels[editorStep])}
       rightQa="entity-preview-settings"

--- a/apps/chat/src/components/Marketplace/MarketplaceEditorView/MarketplaceEditorView.tsx
+++ b/apps/chat/src/components/Marketplace/MarketplaceEditorView/MarketplaceEditorView.tsx
@@ -1,10 +1,4 @@
-import React, {
-  ReactNode,
-  useCallback,
-  useEffect,
-  useMemo,
-  useState,
-} from 'react';
+import React, { ReactNode, useCallback, useEffect, useMemo } from 'react';
 
 import classNames from 'classnames';
 
@@ -23,6 +17,8 @@ import { MarketplaceEditorViewContext } from './marketplaceEditorViewContext';
 interface MarketplaceEditorViewProps {
   leftContent: ReactNode;
   rightContent: ReactNode;
+  previewMode: PreviewMode;
+  onPreviewModeChange: (mode: PreviewMode) => void;
 
   defaultPreviewMode?: PreviewMode;
   onLeftMouseLeave?: () => void;
@@ -34,7 +30,8 @@ interface MarketplaceEditorViewProps {
 export const MarketplaceEditorView = ({
   leftContent,
   rightContent,
-  defaultPreviewMode = PreviewMode.closed,
+  previewMode,
+  onPreviewModeChange,
   onLeftMouseLeave,
   rightQa,
   closedPreviewLabel,
@@ -43,38 +40,31 @@ export const MarketplaceEditorView = ({
   const { t } = useTranslation(Translation.Marketplace);
   const screenState = useScreenState();
 
-  const [previewMode, setPreviewMode] =
-    useState<PreviewMode>(defaultPreviewMode);
-
   const isPreviewClosed = previewMode === PreviewMode.closed;
   const isPreviewHalf = previewMode === PreviewMode.half;
   const isPreviewFull = previewMode === PreviewMode.full;
 
-  const handlePreviewModeChange = useCallback((mode: PreviewMode) => {
-    setPreviewMode(mode);
-  }, []);
-
   const handleOpenPreview = useCallback(() => {
     if (screenState > ScreenState.MD) {
-      handlePreviewModeChange(PreviewMode.half);
+      onPreviewModeChange(PreviewMode.half);
     } else {
-      handlePreviewModeChange(PreviewMode.full);
+      onPreviewModeChange(PreviewMode.full);
     }
-  }, [handlePreviewModeChange, screenState]);
+  }, [onPreviewModeChange, screenState]);
 
   const providerValue = useMemo(
     () => ({
       previewMode,
-      changePreviewMode: handlePreviewModeChange,
+      changePreviewMode: onPreviewModeChange,
     }),
-    [handlePreviewModeChange, previewMode],
+    [onPreviewModeChange, previewMode],
   );
 
   useEffect(() => {
     if (screenState <= ScreenState.MD && isPreviewHalf) {
-      handlePreviewModeChange(PreviewMode.closed);
+      onPreviewModeChange(PreviewMode.closed);
     }
-  }, [handlePreviewModeChange, isPreviewHalf, previewMode, screenState]);
+  }, [onPreviewModeChange, isPreviewHalf, previewMode, screenState]);
 
   return (
     <MarketplaceEditorViewContext.Provider value={providerValue}>
@@ -83,7 +73,7 @@ export const MarketplaceEditorView = ({
           <TabButton
             tabKey={PreviewMode.closed}
             selected={!isPreviewFull}
-            onClick={handlePreviewModeChange}
+            onClick={onPreviewModeChange}
             className="w-full"
           >
             {leftTabLabel}
@@ -91,7 +81,7 @@ export const MarketplaceEditorView = ({
           <TabButton
             tabKey={PreviewMode.full}
             selected={isPreviewFull}
-            onClick={handlePreviewModeChange}
+            onClick={onPreviewModeChange}
             className="w-full"
           >
             {t('Preview')}

--- a/apps/chat/src/components/ToolsetEditor/ToolsetEditorView.tsx
+++ b/apps/chat/src/components/ToolsetEditor/ToolsetEditorView.tsx
@@ -39,6 +39,10 @@ export const ToolsetEditorView = ({
     ToolsetSelectors.selectIsToolsetDetailsLoading,
   );
 
+  const [previewMode, setPreviewMode] = React.useState<PreviewMode>(
+    screenState <= ScreenState.MD ? PreviewMode.closed : PreviewMode.half,
+  );
+
   const { control } = useFormContext<ToolsetEditorForm>();
 
   const [name, version] = useWatch({
@@ -71,9 +75,8 @@ export const ToolsetEditorView = ({
     <MarketplaceEditorView
       leftContent={LeftContent}
       rightContent={RightContent}
-      defaultPreviewMode={
-        screenState <= ScreenState.MD ? PreviewMode.closed : PreviewMode.half
-      }
+      previewMode={previewMode}
+      onPreviewModeChange={setPreviewMode}
       closedPreviewLabel={`${t('Preview')}: ${name} v. ${version}`}
       leftTabLabel={t('Info')}
       rightQa="entity-preview-settings"


### PR DESCRIPTION
**Description:**

- move preview and handler outside of the wrapper component for more flexibility

Issues:

- Issue #5144 

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
