### PR TITLE
fix(chat): include ui-kit sources in tailwind content (Issue #5160)

### DIFF
--- a/apps/chat/tailwind.config.js
+++ b/apps/chat/tailwind.config.js
@@ -40,7 +40,10 @@ const commonBorderColors = {
 // Do not use palette directly, only through semantic colors
 /** @type {import('tailwindcss').Config} */
 module.exports = {
-  content: ['./src/**/*.{js,ts,jsx,tsx}'],
+  content: [
+    './src/**/*.{js,ts,jsx,tsx}',
+    './../../node_modules/@epam/ai-dial-ui-kit/**/*.{js,ts,jsx,tsx}',
+  ],
   darkMode: 'class',
   theme: {
     backgroundColor: {


### PR DESCRIPTION
**Description:**

Tailwind wasn’t generating some utility classes used inside the UI-kit (like hidden sm:inline) because the UI-kit source files weren’t included in the content scan. Added the UI-kit path to tailwind.config so all required utilities are generated and component styles work correctly.

Issues:

- Issue #5160 

**UI changes**

<img width="1280" height="337" alt="image" src="https://github.com/user-attachments/assets/f005d61a-0f98-46ef-8a2a-ca88675706c2" />
<img width="525" height="352" alt="image" src="https://github.com/user-attachments/assets/3c371868-3a5b-488f-a074-ca12e92d5302" />


**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
