### PR TITLE
feat: create hook for building file-manager action labels for different views tabs

### DIFF
--- a/apps/chat/src/components/FileManager/FileManager.tsx
+++ b/apps/chat/src/components/FileManager/FileManager.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
+import { useFileManagerActionLabels } from '@/src/hooks/useFileManagerActionLabels';
 import { useTranslation } from '@/src/hooks/useTranslation';
 
 import {
@@ -175,6 +176,9 @@ export const FileManager: React.FC = () => {
     [t],
   );
 
+  const { bulkActionLabels, treeActionLabels, gridActionLabels } =
+    useFileManagerActionLabels(activeTab, t);
+
   return (
     <DialFileManager
       path={currentPath || bucketRootId}
@@ -183,13 +187,7 @@ export const FileManager: React.FC = () => {
       rootItem={rootFolder}
       filesLoading={areFilesLoading || areFoldersLoading}
       bulkActionsToolbarOptions={{
-        actionLabels: {
-          duplicate: t('Duplicate'),
-          copy: t('Copy to'),
-          move: t('Move to'),
-          delete: t('Delete'),
-          download: t('Download'),
-        },
+        actionLabels: bulkActionLabels,
         getSelectionLabel(selectedCount) {
           return selectedCount === 1
             ? t('{{count}} item selected', { count: selectedCount })
@@ -201,14 +199,7 @@ export const FileManager: React.FC = () => {
         collapsed: treeCollapsedState,
         onCollapseChange: setTreeCollapsedState,
         loadedPaths: loadedFoldersPaths,
-        actionLabels: {
-          duplicate: t('Duplicate'),
-          copy: t('Copy to'),
-          move: t('Move to'),
-          delete: t('Delete'),
-          download: t('Download'),
-          rename: t('Rename'),
-        },
+        actionLabels: treeActionLabels,
       }}
       navigationPanelOptions={{
         searchable: true,
@@ -221,13 +212,7 @@ export const FileManager: React.FC = () => {
           month: 'short',
           day: '2-digit',
         },
-        actionLabels: {
-          duplicate: t('Duplicate'),
-          copy: t('Copy to'),
-          move: t('Move to'),
-          delete: t('Delete'),
-          download: t('Download'),
-        },
+        actionLabels: gridActionLabels,
       }}
       toolbarOptions={{
         tabs: tabs,

--- a/apps/chat/src/hooks/useFileManagerActionLabels.ts
+++ b/apps/chat/src/hooks/useFileManagerActionLabels.ts
@@ -1,0 +1,63 @@
+import { useMemo } from 'react';
+
+import { TranslationOptions } from '@/src/types/translation';
+
+import { DialFileManagerTabs } from '@epam/ai-dial-ui-kit';
+
+type TranslationFn = (key: string, options?: TranslationOptions) => string;
+
+const ACTION_LABELS = {
+  duplicate: (t: TranslationFn) => t('Duplicate'),
+  copy: (t: TranslationFn) => t('Copy to'),
+  move: (t: TranslationFn) => t('Move to'),
+  delete: (t: TranslationFn) => t('Delete'),
+  download: (t: TranslationFn) => t('Download'),
+  rename: (t: TranslationFn) => t('Rename'),
+  unshare: (t: TranslationFn) => t('Unshare'),
+} as const;
+
+type FileAction = keyof typeof ACTION_LABELS;
+
+const TAB_ACTIONS: Record<DialFileManagerTabs, FileAction[]> = {
+  my_files: ['duplicate', 'copy', 'move', 'delete', 'download'],
+  shared: ['download'],
+  organization: ['download'],
+};
+
+const buildLabelMap = (actions: FileAction[], t: TranslationFn) =>
+  Object.fromEntries(actions.map((a) => [a, ACTION_LABELS[a](t)]));
+
+/**
+ * Returns translated action label maps for bulk, grid, and tree views.
+ */
+export function useFileManagerActionLabels(
+  activeTab: DialFileManagerTabs,
+  t: TranslationFn,
+) {
+  const baseActions = useMemo<FileAction[]>(
+    () => TAB_ACTIONS[activeTab],
+    [activeTab],
+  );
+
+  const bulkActionLabels = useMemo(
+    () => buildLabelMap(baseActions, t),
+    [baseActions, t],
+  );
+
+  const gridActionLabels = bulkActionLabels;
+
+  const treeActions = useMemo<FileAction[]>(
+    () =>
+      activeTab === DialFileManagerTabs.MyFiles
+        ? [...baseActions, 'rename']
+        : baseActions,
+    [activeTab, baseActions],
+  );
+
+  const treeActionLabels = useMemo(
+    () => buildLabelMap(treeActions, t),
+    [treeActions, t],
+  );
+
+  return { bulkActionLabels, gridActionLabels, treeActionLabels };
+}


### PR DESCRIPTION
**Description:**

create hook for building file-manager action labels for different views tabs

Issues:

- Issue #5160 

**UI changes**

<img width="1220" height="269" alt="image" src="https://github.com/user-attachments/assets/720dfba7-4482-4f46-8222-d400af944f91" />

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
