### PR TITLE
fix(chat): add unknown schema property type (Issue #5239)

### DIFF
--- a/apps/chat/src/types/form-schema.ts
+++ b/apps/chat/src/types/form-schema.ts
@@ -1,4 +1,5 @@
 export enum FormSchemaPropertyType {
   Button = 'button',
   Checkbox = 'checkbox',
+  Unknown = 'unknown',
 }

--- a/apps/chat/src/utils/app/form-schema.ts
+++ b/apps/chat/src/utils/app/form-schema.ts
@@ -7,6 +7,7 @@ import {
   DialSchemaProperties,
   FormSchemaButtonOption,
   FormSchemaDefinition,
+  FormSchemaPropertyWidget,
   Message,
   MessageFormSchema,
   MessageFormValue,
@@ -158,18 +159,24 @@ export const getFormSchemaPropertyType = (
   property: string,
 ) => {
   if (
+    schema.properties[property]?.[DialSchemaProperties.DialWidget] ===
+    FormSchemaPropertyWidget.buttons
+  ) {
+    return FormSchemaPropertyType.Button;
+  } else if (
     schema.properties[property]?.uniqueItems &&
     schema.properties[property]?.items?.$ref
   ) {
     return FormSchemaPropertyType.Checkbox;
   }
-  return FormSchemaPropertyType.Button;
+  return FormSchemaPropertyType.Unknown;
 };
 
 export const getSortedFormSchemaProperties = (schema: MessageFormSchema) => {
   const priorityByType = {
     [FormSchemaPropertyType.Checkbox]: 0,
     [FormSchemaPropertyType.Button]: 1,
+    [FormSchemaPropertyType.Unknown]: 2,
   };
 
   return Object.entries(schema.properties).sort(


### PR DESCRIPTION
**Description:**

- some models like Dalle 3 have some custom schemas which cause unpredictable behaviour. Added unknown schema property type to avoid rendering unknown properties.

Issues:

- Issue #5239 

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
