### PR TITLE
fix: merge newly downloaded files to get rid of duplicates and keep meaningful state props (Issue #5160)

### DIFF
--- a/apps/chat/src/store/files/files.reducers.ts
+++ b/apps/chat/src/store/files/files.reducers.ts
@@ -191,15 +191,27 @@ export const filesSlice = createSlice({
           : { ...file },
       );
 
-      state.files = mappedFiles.concat(
-        state.files.filter(
-          (stateFile) =>
-            //remove all files from loaded folder to have latest folder update
-            !payload.foldersSet.has(stateFile.folderId) ||
-            stateFile.publishedWithMe ||
-            stateFile.sharedWithMe,
-        ),
+      const prevById: Record<string, DialFile> = Object.fromEntries(
+        state.files.map((f) => [f.id, f]),
       );
+
+      const mergedMappedFiles: DialFile[] = mappedFiles.map((newFile) => {
+        const oldFile = prevById[newFile.id];
+        if (!oldFile) return newFile;
+
+        const merged: DialFile = {
+          ...oldFile,
+          ...newFile,
+        };
+
+        return merged;
+      });
+
+      const otherFiles = state.files.filter(
+        (f) => !payload.foldersSet.has(f.folderId),
+      );
+
+      state.files = [...mergedMappedFiles, ...otherFiles];
       state.filesStatus = UploadStatus.LOADED;
 
       if (!isRootId(parentFolderId)) {


### PR DESCRIPTION
**Description:**

merge newly downloaded files to get rid of duplicates and keep meaningful state props

Issues:

- Issue #5160 

**UI changes**

<img width="1390" height="567" alt="image" src="https://github.com/user-attachments/assets/2a2af19e-b70d-4771-a712-6014415d44f5" />

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
