### PR TITLE
fix: filter out old folder during renaming. handle renaming of opened folder.

### DIFF
--- a/apps/chat/src/components/FileManager/FileManager.tsx
+++ b/apps/chat/src/components/FileManager/FileManager.tsx
@@ -282,6 +282,8 @@ export const FileManager: React.FC = () => {
               destinationFolder,
             }),
           );
+
+          setCurrentPath(undefined);
         }}
         onDeleteFiles={(deletedItems, folderUrl) => {
           if (deletedItems.length === 0) return;

--- a/apps/chat/src/components/FileManager/FileManager.tsx
+++ b/apps/chat/src/components/FileManager/FileManager.tsx
@@ -25,6 +25,7 @@ import { SettingsSelectors } from '@/src/store/settings/settings.selectors';
 import { UploadStatus } from '@epam/ai-dial-shared';
 import {
   ButtonVariant,
+  DialCopiedItem,
   DialFileManager,
   DialLoader,
   FileManagerColumnKey,
@@ -219,6 +220,33 @@ export const FileManager: React.FC = () => {
     [t],
   );
 
+  const moveToFileHandler = useCallback(
+    (
+      movedItems: DialCopiedItem[],
+      sourceFolder: string,
+      destinationFolder: string,
+    ) => {
+      if (movedItems.length === 0) return;
+
+      dispatch(
+        FilesActions.moveFiles({
+          files: movedItems,
+          sourceFolder,
+          destinationFolder,
+        }),
+      );
+
+      const movedCurrent = movedItems.find(
+        (item) => item.sourceUrl === currentPath,
+      );
+
+      if (movedCurrent) {
+        setCurrentPath(undefined);
+      }
+    },
+    [dispatch, currentPath],
+  );
+
   return (
     <div className="relative size-full">
       <DialFileManager
@@ -273,18 +301,7 @@ export const FileManager: React.FC = () => {
             FilesActions.copyFiles({ files: copiedItems, destinationFolder }),
           );
         }}
-        onMoveToFiles={(movedItems, sourceFolder, destinationFolder) => {
-          if (movedItems.length === 0) return;
-          dispatch(
-            FilesActions.moveFiles({
-              files: movedItems,
-              sourceFolder,
-              destinationFolder,
-            }),
-          );
-
-          setCurrentPath(undefined);
-        }}
+        onMoveToFiles={moveToFileHandler}
         onDeleteFiles={(deletedItems, folderUrl) => {
           if (deletedItems.length === 0) return;
           dispatch(

--- a/apps/chat/src/store/files/files.epics.ts
+++ b/apps/chat/src/store/files/files.epics.ts
@@ -32,7 +32,7 @@ import { translate } from '@/src/utils/app/translation';
 import { ApiUtils } from '@/src/utils/server/api';
 
 import { FeatureType } from '@/src/types/common';
-import { AppEpic } from '@/src/types/store';
+import { AppAction, AppEpic } from '@/src/types/store';
 import { Translation } from '@/src/types/translation';
 
 import {
@@ -465,15 +465,23 @@ const moveFilesEpic: AppEpic = (action$) =>
     switchMap(({ payload }) => {
       return FileService.moveFiles(payload).pipe(
         switchMap((response) => {
-          return concat(
-            of(FilesActions.moveFilesSuccess({ files: response })),
-            of(
-              FilesActions.getFilesWithFolders({
-                id: payload.destinationFolder,
-              }),
-            ),
-            of(FilesActions.getFilesWithFolders({ id: payload.sourceFolder })),
+          const actions: AppAction[] = [
+            FilesActions.moveFilesSuccess({ files: response }),
+          ];
+
+          if (payload.destinationFolder !== payload.sourceFolder) {
+            actions.push(
+              FilesActions.getFilesWithFolders({ id: payload.sourceFolder }),
+            );
+          }
+
+          actions.push(
+            FilesActions.getFilesWithFolders({
+              id: payload.destinationFolder,
+            }),
           );
+
+          return from(actions);
         }),
         catchError(() => {
           return of(

--- a/apps/chat/src/store/files/files.reducers.ts
+++ b/apps/chat/src/store/files/files.reducers.ts
@@ -294,9 +294,15 @@ export const filesSlice = createSlice({
     ) => {
       state.loadingFolderId = undefined;
       state.foldersStatus = UploadStatus.LOADED;
+
+      const incomingIds = new Set(payload.folders.map((f) => f.id));
+      const filteredState = state.folders.filter(
+        (f) => f.folderId !== payload.folderId || incomingIds.has(f.id),
+      );
+
       state.folders = combineEntities(
         payload.folders,
-        state.folders.map((f) =>
+        filteredState.map((f) =>
           f.id === payload.folderId ? { ...f, status: UploadStatus.LOADED } : f,
         ),
       );


### PR DESCRIPTION
**Description:**

filter out old folder during renaming. handle renaming of opened folder.

Issues:

- Issue #5160 

**UI changes**

<Please, provide Screenshots or Figma links>

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
