### PR TITLE
feat: display success and error toasts for file operations

### DIFF
--- a/apps/chat/src/components/Toasts/TitledToastMessage.tsx
+++ b/apps/chat/src/components/Toasts/TitledToastMessage.tsx
@@ -1,0 +1,16 @@
+interface TitledToastMessageProps {
+  title: string;
+  message: string;
+}
+
+export const TitledToastMessage = ({
+  title,
+  message,
+}: TitledToastMessageProps) => {
+  return (
+    <div className="flex flex-col gap-1 text-sm">
+      <div className="font-semibold">{title}</div>
+      <div>{message}</div>
+    </div>
+  );
+};

--- a/apps/chat/src/constants/file.ts
+++ b/apps/chat/src/constants/file.ts
@@ -4,3 +4,5 @@ export const MIME_FORMAT_REGEX =
 export const BYTES_IN_MB = 1_048_576;
 
 export const MAX_FILE_SIZE_IN_BYTES = BYTES_IN_MB * 512;
+
+export const MAX_VISIBLE_NOTIFICATION_ITEMS = 5;

--- a/apps/chat/src/store/files/files.epics.ts
+++ b/apps/chat/src/store/files/files.epics.ts
@@ -42,6 +42,8 @@ import {
 } from '@/src/store/actions';
 import { FilesSelectors, UISelectors } from '@/src/store/selectors';
 
+import { MAX_VISIBLE_NOTIFICATION_ITEMS } from '@/src/constants/file';
+
 import { UploadStatus } from '@epam/ai-dial-shared';
 import { DialFileNodeType } from '@epam/ai-dial-ui-kit';
 
@@ -703,6 +705,146 @@ const uploadArchiveEpic: AppEpic = (action$) =>
     }),
   );
 
+const copyMoveFilesResultToastEpic: AppEpic = (action$) =>
+  action$.pipe(
+    ofType(
+      FilesActions.copyFilesSuccess.type,
+      FilesActions.moveFilesSuccess.type,
+    ),
+    map((action) => {
+      const { result } = action.payload;
+      const { results, errors } = result;
+
+      const isCopy = FilesActions.copyFilesSuccess.match(action);
+      const verbPast = isCopy ? 'copied' : 'moved';
+
+      if (results.length > 0) {
+        if (results.length === 1) {
+          const destinationUrl = results[0].data.destinationUrl;
+          const { parentPath, name } = splitEntityId(destinationUrl);
+
+          return UIActions.showSuccessToast(
+            translate('“{{fileName}}” {{verb}} to {{folder}}', {
+              ns: Translation.Files,
+              fileName: name,
+              folder: parentPath,
+              verb: verbPast,
+            }),
+          );
+        }
+
+        const destinationUrl = results[0].data.destinationUrl;
+        const { parentPath } = splitEntityId(destinationUrl);
+
+        return UIActions.showSuccessToast(
+          translate('{{count}} items {{verb}} to {{folder}}', {
+            ns: Translation.Files,
+            count: results.length,
+            folder: parentPath,
+            verb: verbPast,
+          }),
+        );
+      }
+
+      if (errors && errors.length > 0) {
+        const visibleErrors = errors.slice(0, MAX_VISIBLE_NOTIFICATION_ITEMS);
+        const hiddenCount = errors.length - visibleErrors.length;
+
+        const fileNames = visibleErrors
+          .map((e) => splitEntityId(e.data.destinationUrl).name)
+          .join(', ');
+
+        const restText =
+          hiddenCount > 0
+            ? translate(' and {{count}} other items', {
+                ns: Translation.Files,
+                count: hiddenCount,
+              })
+            : '';
+
+        return UIActions.showErrorToast(
+          translate('{{files}}{{rest}} were not {{verb}}. Please try again.', {
+            ns: Translation.Files,
+            files: fileNames,
+            rest: restText,
+            verb: verbPast,
+          }),
+        );
+      }
+
+      return null;
+    }),
+    filter(Boolean),
+  );
+
+const deleteFilesResultToastEpic: AppEpic = (action$) =>
+  action$.pipe(
+    ofType(FilesActions.deleteFilesSuccess.type),
+    map(({ payload }) => {
+      const { result } = payload;
+      const { results, errors } = result;
+
+      const verbPast = 'deleted';
+
+      if (results.length > 0) {
+        if (results.length === 1) {
+          const path = results[0].data;
+          const { parentPath, name } = splitEntityId(path);
+
+          return UIActions.showSuccessToast(
+            translate('“{{fileName}}” {{verb}} from {{folder}}', {
+              ns: Translation.Files,
+              fileName: name,
+              folder: parentPath,
+              verb: verbPast,
+            }),
+          );
+        }
+
+        const path = results[0].data;
+        const { parentPath } = splitEntityId(path);
+
+        return UIActions.showSuccessToast(
+          translate('{{count}} items {{verb}} from {{folder}}', {
+            ns: Translation.Files,
+            count: results.length,
+            folder: parentPath,
+            verb: verbPast,
+          }),
+        );
+      }
+
+      if (errors && errors.length > 0) {
+        const visibleErrors = errors.slice(0, MAX_VISIBLE_NOTIFICATION_ITEMS);
+        const hiddenCount = errors.length - visibleErrors.length;
+
+        const fileNames = visibleErrors
+          .map((e) => splitEntityId(e.data).name)
+          .join(', ');
+
+        const restText =
+          hiddenCount > 0
+            ? translate(' and {{count}} other items', {
+                ns: Translation.Files,
+                count: hiddenCount,
+              })
+            : '';
+
+        return UIActions.showErrorToast(
+          translate('{{files}}{{rest}} were not {{verb}}. Please try again.', {
+            ns: Translation.Files,
+            files: fileNames,
+            rest: restText,
+            verb: verbPast,
+          }),
+        );
+      }
+
+      return null;
+    }),
+    filter(Boolean),
+  );
+
 export const FilesEpics = combineEpics(
   initEpic,
 
@@ -730,4 +872,6 @@ export const FilesEpics = combineEpics(
   downloadFilesAsArchiveEpic,
   uploadFilesEpic,
   uploadArchiveEpic,
+  copyMoveFilesResultToastEpic,
+  deleteFilesResultToastEpic,
 );

--- a/apps/chat/src/store/files/files.epics.ts
+++ b/apps/chat/src/store/files/files.epics.ts
@@ -832,6 +832,7 @@ const deleteFilesResultToastEpic: AppEpic = (action$) =>
           type: ToastType.Success,
           title: translate('Items {{verb}} successfully', {
             ns: Translation.Common,
+            verb: verbPast,
           }),
           message: translate('{{count}} items {{verb}} from {{folder}}', {
             ns: Translation.Files,
@@ -860,7 +861,7 @@ const deleteFilesResultToastEpic: AppEpic = (action$) =>
 
         return UIActions.showToast({
           type: ToastType.Error,
-          title: translate('Items deletion successfully', {
+          title: translate('Items deleting failed', {
             ns: Translation.Common,
           }),
           message: translate(

--- a/apps/chat/src/store/files/files.epics.ts
+++ b/apps/chat/src/store/files/files.epics.ts
@@ -33,6 +33,7 @@ import { ApiUtils } from '@/src/utils/server/api';
 
 import { FeatureType } from '@/src/types/common';
 import { AppAction, AppEpic } from '@/src/types/store';
+import { ToastType } from '@/src/types/toasts';
 import { Translation } from '@/src/types/translation';
 
 import {
@@ -723,27 +724,37 @@ const copyMoveFilesResultToastEpic: AppEpic = (action$) =>
           const destinationUrl = results[0].data.destinationUrl;
           const { parentPath, name } = splitEntityId(destinationUrl);
 
-          return UIActions.showSuccessToast(
-            translate('“{{fileName}}” {{verb}} to {{folder}}', {
+          return UIActions.showToast({
+            type: ToastType.Success,
+            title: translate('Items {{verb}} successfully', {
+              ns: Translation.Common,
+              verb: verbPast,
+            }),
+            message: translate('“{{fileName}}” {{verb}} to {{folder}}', {
               ns: Translation.Files,
               fileName: name,
               folder: parentPath,
               verb: verbPast,
             }),
-          );
+          });
         }
 
         const destinationUrl = results[0].data.destinationUrl;
         const { parentPath } = splitEntityId(destinationUrl);
 
-        return UIActions.showSuccessToast(
-          translate('{{count}} items {{verb}} to {{folder}}', {
+        return UIActions.showToast({
+          type: ToastType.Success,
+          title: translate('Items {{verb}} successfully', {
+            ns: Translation.Common,
+            verb: verbPast,
+          }),
+          message: translate('{{count}} items {{verb}} to {{folder}}', {
             ns: Translation.Files,
             count: results.length,
             folder: parentPath,
             verb: verbPast,
           }),
-        );
+        });
       }
 
       if (errors && errors.length > 0) {
@@ -762,14 +773,22 @@ const copyMoveFilesResultToastEpic: AppEpic = (action$) =>
               })
             : '';
 
-        return UIActions.showErrorToast(
-          translate('{{files}}{{rest}} were not {{verb}}. Please try again.', {
-            ns: Translation.Files,
-            files: fileNames,
-            rest: restText,
-            verb: verbPast,
+        return UIActions.showToast({
+          type: ToastType.Error,
+          title: translate('Items {{verb}} failed', {
+            ns: Translation.Common,
+            verb: isCopy ? 'copying' : 'moving',
           }),
-        );
+          message: translate(
+            '{{files}}{{rest}} were not {{verb}}. Please try again.',
+            {
+              ns: Translation.Files,
+              files: fileNames,
+              rest: restText,
+              verb: verbPast,
+            },
+          ),
+        });
       }
 
       return null;
@@ -791,27 +810,36 @@ const deleteFilesResultToastEpic: AppEpic = (action$) =>
           const path = results[0].data;
           const { parentPath, name } = splitEntityId(path);
 
-          return UIActions.showSuccessToast(
-            translate('“{{fileName}}” {{verb}} from {{folder}}', {
+          return UIActions.showToast({
+            type: ToastType.Success,
+            title: translate('Items {{verb}} successfully', {
+              ns: Translation.Common,
+              verb: verbPast,
+            }),
+            message: translate('“{{fileName}}” {{verb}} from {{folder}}', {
               ns: Translation.Files,
               fileName: name,
               folder: parentPath,
               verb: verbPast,
             }),
-          );
+          });
         }
 
         const path = results[0].data;
         const { parentPath } = splitEntityId(path);
 
-        return UIActions.showSuccessToast(
-          translate('{{count}} items {{verb}} from {{folder}}', {
+        return UIActions.showToast({
+          type: ToastType.Success,
+          title: translate('Items {{verb}} successfully', {
+            ns: Translation.Common,
+          }),
+          message: translate('{{count}} items {{verb}} from {{folder}}', {
             ns: Translation.Files,
             count: results.length,
             folder: parentPath,
             verb: verbPast,
           }),
-        );
+        });
       }
 
       if (errors && errors.length > 0) {
@@ -830,14 +858,21 @@ const deleteFilesResultToastEpic: AppEpic = (action$) =>
               })
             : '';
 
-        return UIActions.showErrorToast(
-          translate('{{files}}{{rest}} were not {{verb}}. Please try again.', {
-            ns: Translation.Files,
-            files: fileNames,
-            rest: restText,
-            verb: verbPast,
+        return UIActions.showToast({
+          type: ToastType.Error,
+          title: translate('Items deletion successfully', {
+            ns: Translation.Common,
           }),
-        );
+          message: translate(
+            '{{files}}{{rest}} were not {{verb}}. Please try again.',
+            {
+              ns: Translation.Files,
+              files: fileNames,
+              rest: restText,
+              verb: verbPast,
+            },
+          ),
+        });
       }
 
       return null;

--- a/apps/chat/src/store/ui/ui.epics.tsx
+++ b/apps/chat/src/store/ui/ui.epics.tsx
@@ -1,4 +1,4 @@
-import { ToastOptions, toast } from 'react-hot-toast';
+import { Renderable, ToastOptions, toast } from 'react-hot-toast';
 
 import {
   EMPTY,
@@ -31,6 +31,7 @@ import { SettingsSelectors, UISelectors } from '@/src/store/selectors';
 import { errorsMessages } from '@/src/constants/errors';
 import { FALLBACK_THEME_CONFIG } from '@/src/constants/themes';
 
+import { TitledToastMessage } from '../../components/Toasts/TitledToastMessage';
 import { Spinner } from '@/src/components/Common/Spinner';
 
 import { Feature } from '@epam/ai-dial-shared';
@@ -275,21 +276,28 @@ const showToastEpic: AppEpic = (action$) =>
         icon: payload.icon,
       };
 
+      let content: Renderable = message;
+      if (payload.title) {
+        content = (
+          <TitledToastMessage title={payload.title} message={message} />
+        );
+      }
+
       switch (payload.type) {
         case ToastType.Error:
-          toast.error(message, { ...toastConfig, id: ToastType.Error });
+          toast.error(content, { ...toastConfig, id: ToastType.Error });
           break;
         case ToastType.Success:
-          toast.success(message, { ...toastConfig, id: ToastType.Success });
+          toast.success(content, { ...toastConfig, id: ToastType.Success });
           break;
         case ToastType.Warning:
-          toast.loading(message, { ...toastConfig, id: ToastType.Warning });
+          toast.loading(content, { ...toastConfig, id: ToastType.Warning });
           break;
         case ToastType.Loading:
-          toast.loading(message, { ...toastConfig, id: ToastType.Loading });
+          toast.loading(content, { ...toastConfig, id: ToastType.Loading });
           break;
         default:
-          toast.loading(message, { ...toastConfig, id: ToastType.Info });
+          toast.loading(content, { ...toastConfig, id: ToastType.Info });
           break;
       }
     }),

--- a/apps/chat/src/store/ui/ui.reducers.ts
+++ b/apps/chat/src/store/ui/ui.reducers.ts
@@ -125,6 +125,7 @@ export const uiSlice = createSlice({
       state,
       _action: PayloadAction<{
         message?: string | null;
+        title?: string;
         type?: ToastType;
         response?: Response;
         icon?: JSX.Element;


### PR DESCRIPTION
**Description:**

display success and error toasts for file operations

Issues:

- Issue #5160 

**UI changes**

<Please, provide Screenshots or Figma links>

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
