### PR TITLE
chore(chat): bump `@modern-js/utils` from 2.68.2 to 2.69.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4551,9 +4551,9 @@
       }
     },
     "node_modules/@modern-js/utils": {
-      "version": "2.68.2",
-      "resolved": "https://registry.npmjs.org/@modern-js/utils/-/utils-2.68.2.tgz",
-      "integrity": "sha512-revom/i/EhKfI0STNLo/AUbv7gY0JY0Ni2gO6P/Z4cTyZZRgd5j90678YB2DGn+LtmSrEWtUphyDH5Jn1RKjgg==",
+      "version": "2.69.4",
+      "resolved": "https://registry.npmjs.org/@modern-js/utils/-/utils-2.69.4.tgz",
+      "integrity": "sha512-GSmon6lGv3RioYkwzb+dgDEnlCLYY/vMHclW7dsXYf9dMYYyXSZT6pJhbWO4C3J39CMYrK84ssYWB2+hksRrXA==",
       "license": "MIT",
       "dependencies": {
         "@swc/helpers": "^0.5.17",

--- a/package.json
+++ b/package.json
@@ -190,7 +190,8 @@
     "nodemailer": "7.0.10",
     "dompurify": "3.3.0",
     "js-yaml": "4.1.1",
-    "glob": "11.1.0"
+    "glob": "11.1.0",
+    "@modern-js/utils": "2.69.4"
   },
   "engines": {
     "node": ">=24.11.1",


### PR DESCRIPTION
**Description:**

bump `@modern-js/utils` from 2.68.2 to 2.69.4

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
