### PR TITLE
fix: adjust file-manager height styles

### DIFF
--- a/apps/chat/src/components/FileManager/FileManager.tsx
+++ b/apps/chat/src/components/FileManager/FileManager.tsx
@@ -295,7 +295,7 @@ export const FileManager: React.FC = () => {
   };
 
   return (
-    <div className="relative size-full">
+    <div className="flex w-full grow overflow-auto">
       <DialFileManager
         path={currentPath}
         onPathChange={setCurrentPath}

--- a/apps/chat/src/pages/files-manager/index.tsx
+++ b/apps/chat/src/pages/files-manager/index.tsx
@@ -30,7 +30,7 @@ function FilesManagerPage() {
     dispatch(UIActions.setIsUserSettingsOpen(false));
   };
   return (
-    <div className="flex size-full flex-col overflow-hidden">
+    <div className="flex size-full flex-col">
       {enabledFeatures.has(Feature.Header) && (
         <BaseHeader
           RightItems={


### PR DESCRIPTION
**Description:**

adjust file-manager height styles

Issues:

- Issue #5160 

**UI changes**

<img width="971" height="1045" alt="image" src="https://github.com/user-attachments/assets/8fbd19aa-be72-4c99-b804-dc5513595ccb" />

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
