### PR TITLE
fix(chat): fix display of the preview buttons and handler for the fullscreen view in the `Application Editor`(Issues #5205, #4895)

### DIFF
--- a/apps/chat/src/components/AppsEditor/AppEditorPreview/SettingsPreview.tsx
+++ b/apps/chat/src/components/AppsEditor/AppEditorPreview/SettingsPreview.tsx
@@ -298,7 +298,7 @@ export const SettingsPreview = ({ onSave }: SettingsPreviewProps) => {
           )}
           <PreviewModeButton
             mode={PreviewMode.closed}
-            className="max-xl:hidden"
+            className="max-md:hidden"
           />
         </div>
       </div>

--- a/apps/chat/src/components/Marketplace/MarketplaceEditorView/PreviewModeButton.tsx
+++ b/apps/chat/src/components/Marketplace/MarketplaceEditorView/PreviewModeButton.tsx
@@ -43,9 +43,13 @@ export const PreviewModeButton = ({
 
   const Icon = useMemo(() => previewModeIcons[mode], [mode]);
 
-  const handlePreviewModeChange = useCallback(() => {
-    changePreviewMode(mode);
-  }, [mode, changePreviewMode]);
+  const handlePreviewModeChange = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      changePreviewMode(mode);
+    },
+    [mode, changePreviewMode],
+  );
 
   return (
     <button


### PR DESCRIPTION
**Description:**
Fix `Application Editor` issues:
- Fix `Hide preview`, `Expand preview`, `Split preview` are not available on `App settings` step on the tablet size screen.
- Fix regression  `Expand preview` button opens preview on half of the screen insead of fullscreen.

Issues:

- Issue #5205 
- Issue #4895 

**UI changes**

<img width="1045" height="910" alt="image" src="https://github.com/user-attachments/assets/6b926b94-41bc-4c35-a055-b132ddfa6297" />

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
