### PR TITLE
feat(chat): Display `+ Add toolset` button in mobile view (Issue #4625)

### DIFF
--- a/apps/chat/src/components/Marketplace/AddMarketplaceEntityButton.tsx
+++ b/apps/chat/src/components/Marketplace/AddMarketplaceEntityButton.tsx
@@ -13,6 +13,7 @@ import { Translation } from '@/src/types/translation';
 import { ContextMenu } from '@/src/components/Common/ContextMenu';
 
 import { FeatureType } from '@epam/ai-dial-shared';
+import { ButtonVariant, DialButton } from '@epam/ai-dial-ui-kit';
 
 interface AddMarketplaceEntityButtonProps {
   menuItems: DisplayMenuItemProps[];
@@ -40,14 +41,13 @@ export function AddMarketplaceEntityButton({
 
   if (visibleActions.length === 1)
     return (
-      <button
+      <DialButton
         onClick={visibleActions[0].onClick}
-        className="button button-primary hidden items-center gap-2 py-2 xl:flex"
+        label={t(`Add ${label}`)}
+        variant={ButtonVariant.Primary}
+        iconBefore={<IconPlus size={18} />}
         data-qa={dataQa}
-      >
-        <IconPlus size={18} />
-        <span>{t(`Add ${label}`)}</span>
-      </button>
+      />
     );
 
   return (


### PR DESCRIPTION
**Description:**

- Display `+ Add toolset` button in mobile view.

Issues:

- Issue #4625 

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
