### PR TITLE
fix(chat): fix agents and toolset looged out highlight, x button design (Issues #5273, #5297, #5299)

### DIFF
--- a/apps/chat/src/components/Common/AgentAndToolsetSelector/AgentAndToolsetChip.tsx
+++ b/apps/chat/src/components/Common/AgentAndToolsetSelector/AgentAndToolsetChip.tsx
@@ -50,7 +50,7 @@ const ChipRemoveButton: React.FC<ChipRemoveButtonProps> = ({
     onClick={() => onRemove?.(id)}
     aria-label="Remove item"
   >
-    <IconX size={14} />
+    <IconX size={18} />
   </button>
 );
 

--- a/apps/chat/src/components/Common/AgentAndToolsetSelector/OverflowListItem.tsx
+++ b/apps/chat/src/components/Common/AgentAndToolsetSelector/OverflowListItem.tsx
@@ -55,7 +55,10 @@ const ListItemContent: React.FC<ListItemContentProps> = ({
         <ChipTitle name={name} version={version} isError={isError} />
       </div>
       <button
-        className="shrink-0 text-secondary hover:text-primary"
+        className={classNames(
+          'shrink-0 text-secondary',
+          isError ? 'hover:text-error' : 'hover:text-accent-primary',
+        )}
         onClick={handleRemove}
       >
         <IconX size={18} />

--- a/apps/chat/src/components/Common/OverflowContainer.tsx
+++ b/apps/chat/src/components/Common/OverflowContainer.tsx
@@ -79,17 +79,9 @@ export function OverflowContainer<T>({
       }
     });
 
-    setVisibleItems((currentVisible) => {
-      const newKeys = newVisibleItems.map(getKey).join(',');
-      const currentKeys = currentVisible.map(getKey).join(',');
-      return newKeys === currentKeys ? currentVisible : newVisibleItems;
-    });
-    setHiddenItems((currentHidden) => {
-      const newKeys = newHiddenItems.map(getKey).join(',');
-      const currentKeys = currentHidden.map(getKey).join(',');
-      return newKeys === currentKeys ? currentHidden : newHiddenItems;
-    });
-  }, [items, overflowIndicatorWidth, getKey]);
+    setVisibleItems(newVisibleItems);
+    setHiddenItems(newHiddenItems);
+  }, [items, overflowIndicatorWidth]);
 
   useResizeObserver(containerRef.current, recalculateItems);
   useLayoutEffect(() => {


### PR DESCRIPTION
**Description:**

The counter should be red-highlighted when there is a toolset in logged out status immediately.
'X' should be blue on hover for regular agents/toolsets and red on hover for not available agents/toolsets.
'X' size should be equal in the selected and in counter. Th size of the 'x' is netter in counter.

Issues:

- Issue #5273
- Issue #5297 
- Issue #5299

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
