### PR TITLE
fix(chat): fix agent and toolset sorting, tab switch autoscroll (Issues #5276, #5300)

### DIFF
--- a/apps/chat/src/components/AppsEditor/EditorForm/QuickApp2Form.tsx
+++ b/apps/chat/src/components/AppsEditor/EditorForm/QuickApp2Form.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   Controller,
   useFormContext,
@@ -11,6 +11,7 @@ import classNames from 'classnames';
 import { useTranslation } from '@/src/hooks/useTranslation';
 
 import {
+  getEntityDisplayName,
   getSharedTooltip,
   isDialAiEntityModel,
 } from '@/src/utils/app/application';
@@ -54,6 +55,7 @@ import { SimpleToolsetDetailsFooter } from '@/src/components/Marketplace/Toolset
 import { ToolsetDetails } from '@/src/components/Marketplace/ToolsetsDetails/ToolsetDetails';
 
 import { Feature } from '@epam/ai-dial-shared';
+import { isEqual } from 'lodash-es';
 import uniq from 'lodash-es/uniq';
 
 const FilesSelectorField = withErrorMessage(withLabel(FilesSelector));
@@ -106,6 +108,30 @@ export const QuickApp2Form = () => {
     control,
     name: 'model',
   });
+
+  const agentsAndToolsets = useWatch({
+    control,
+    name: 'agentsAndToolsets',
+  });
+
+  const sortedAgentsAndToolsets = useMemo(() => {
+    if (!agentsAndToolsets || Object.keys(allEntitiesMap).length === 0) {
+      return agentsAndToolsets || [];
+    }
+    return [...agentsAndToolsets].sort((a, b) =>
+      getEntityDisplayName(a, allEntitiesMap).localeCompare(
+        getEntityDisplayName(b, allEntitiesMap),
+      ),
+    );
+  }, [agentsAndToolsets, allEntitiesMap]);
+
+  useEffect(() => {
+    if (!isEqual(sortedAgentsAndToolsets, agentsAndToolsets)) {
+      setValue('agentsAndToolsets', sortedAgentsAndToolsets, {
+        shouldDirty: false,
+      });
+    }
+  }, [sortedAgentsAndToolsets, agentsAndToolsets, setValue]);
 
   const showTemperatureSlider = useMemo(() => {
     const selectedModel = modelsMap[modelId];

--- a/apps/chat/src/components/AppsEditor/form.ts
+++ b/apps/chat/src/components/AppsEditor/form.ts
@@ -12,7 +12,8 @@ import { BucketService } from '@/src/utils/app/data/bucket-service';
 import { DefaultsService } from '@/src/utils/app/data/defaults-service';
 import { getNextDefaultName } from '@/src/utils/app/folders';
 import { isApplicationId, isToolsetId } from '@/src/utils/app/id';
-import { ApiUtils } from '@/src/utils/server/api';
+import { splitEntityId } from '@/src/utils/app/shared-utils';
+import { ApiUtils, parseEntityApiKey } from '@/src/utils/server/api';
 
 import {
   ApplicationType,
@@ -316,13 +317,52 @@ const getQuickAppFormData = (app?: CustomApplicationModel): QuickAppForm => {
   };
 };
 
+const getQuickAppItemNameFromConfig = (
+  item: MCPToolset | DialDeploymentSimpleTool,
+): string => {
+  if ('dial_id' in item) {
+    return (
+      item.name ||
+      ApiUtils.decodeApiUrl(
+        parseEntityApiKey(splitEntityId(item.dial_id).name, {
+          parseVersion: true,
+        }).name,
+      )
+    );
+  }
+
+  if (isApplicationId(item.deployment_id)) {
+    return ApiUtils.decodeApiUrl(
+      parseEntityApiKey(splitEntityId(item.deployment_id).name, {
+        parseVersion: true,
+      }).name,
+    );
+  }
+
+  return item.deployment_id;
+};
+
 const getQuickApp2FormData = (app?: CustomApplicationModel): QuickApp2Form => {
   const appProperties = app?.applicationProperties as QuickApp2Config;
+
   const agentToolsets =
     appProperties?.tool_sets
       ?.filter(isDialDeploymentToolset)
       ?.flatMap((toolset) => toolset.tools) ?? [];
   const mcpToolsets = appProperties?.tool_sets?.filter(isMcpToolset) ?? [];
+
+  const allItems = [...agentToolsets, ...mcpToolsets];
+
+  const sortedItems = allItems.sort((a, b) =>
+    getQuickAppItemNameFromConfig(a).localeCompare(
+      getQuickAppItemNameFromConfig(b),
+    ),
+  );
+
+  const sortedIds = sortedItems.map((item) => {
+    const id = 'dial_id' in item ? item.dial_id : item.deployment_id;
+    return ApiUtils.decodeApiUrl(id);
+  });
 
   return {
     type: AppsEditorSchemaTypes.QuickApp2,
@@ -334,14 +374,7 @@ const getQuickApp2FormData = (app?: CustomApplicationModel): QuickApp2Form => {
     temperature:
       appProperties?.orchestrator?.deployment?.parameters?.temperature ??
       DEFAULT_TEMPERATURE,
-    agentsAndToolsets: [
-      ...agentToolsets.map((agentToolset) =>
-        ApiUtils.decodeApiUrl(agentToolset.deployment_id),
-      ),
-      ...mcpToolsets.map((mcpToolset) =>
-        ApiUtils.decodeApiUrl(mcpToolset.dial_id),
-      ),
-    ],
+    agentsAndToolsets: sortedIds,
     codeInterpreter:
       appProperties?.tool_sets?.some(
         (toolset) => toolset.type === ToolsetTypes.CodeInterpreter,

--- a/apps/chat/src/components/Common/AgentAndToolsetSelector/AgentAndToolsetModal.tsx
+++ b/apps/chat/src/components/Common/AgentAndToolsetSelector/AgentAndToolsetModal.tsx
@@ -262,6 +262,7 @@ const AgentAndToolsetModalView = ({
     (tab: MarketplaceTabs = MarketplaceTabs.HOME) => {
       setScopeTab(tab);
       setShouldResetSliderState(true);
+      setActiveSlide(0);
     },
     [],
   );

--- a/apps/chat/src/utils/app/application.ts
+++ b/apps/chat/src/utils/app/application.ts
@@ -1,6 +1,10 @@
 import { DefaultsService } from '@/src/utils/app/data/defaults-service';
 import { getTopicColors } from '@/src/utils/app/style-helpers';
-import { ApiUtils, getMarketplaceEntityApiKey } from '@/src/utils/server/api';
+import {
+  ApiUtils,
+  getMarketplaceEntityApiKey,
+  parseEntityApiKey,
+} from '@/src/utils/server/api';
 
 import { ApiDetailedApplicationTypeSchema } from '@/src/types/application-type-schema';
 import {
@@ -35,6 +39,7 @@ import { constructPath } from './file';
 import { getFolderIdFromEntityId } from './folders';
 import { getApplicationRootId, getEntityBucket } from './id';
 import { isEntityIdPublic } from './publications';
+import { splitEntityId } from './shared-utils';
 import { translate } from './translation';
 
 import isObject from 'lodash-es/isObject';
@@ -421,3 +426,19 @@ export const isDialAiEntityModel = (
   entity: MarketplaceEntity,
 ): entity is DialAIEntityModel =>
   entity?.type === EntityType.Application || entity?.type === EntityType.Model;
+
+export const getEntityDisplayName = (
+  id: string,
+  allEntitiesMap: Record<string, MarketplaceEntity | undefined>,
+): string => {
+  const entity = allEntitiesMap[id];
+  if (entity?.name) {
+    return entity.name;
+  }
+
+  return ApiUtils.decodeApiUrl(
+    parseEntityApiKey(splitEntityId(id).name, {
+      parseVersion: true,
+    }).name,
+  );
+};


### PR DESCRIPTION
**Description:**

When user switches between My workspace and Marketplace tabs, the first page should be opened
The order of selected items in 'Agents & Toolsets' field should be sorted alphabetically; 'Select agents and toolsets' modal should stay the same as user selected in current session; after refresh - alphabetical is fine

Issues:

- Issue #5276 
- Issue #5300

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
