### PR TITLE
fix(chat): show tooltip for preview only on hovering (Issue #5362)

### DIFF
--- a/apps/chat/src/components/Marketplace/MarketplaceEditorView/PreviewModeButton.tsx
+++ b/apps/chat/src/components/Marketplace/MarketplaceEditorView/PreviewModeButton.tsx
@@ -61,7 +61,7 @@ export const PreviewModeButton = ({
       )}
       onClick={handlePreviewModeChange}
       iconBefore={
-        <Tooltip tooltip={t(previewModeTooltips[mode])}>
+        <Tooltip tooltip={t(previewModeTooltips[mode])} isTriggerClickable>
           <Icon size={size} />
         </Tooltip>
       }


### PR DESCRIPTION
**Description:**

show tooltip for preview only on hovering

Issues:

- Issue #5362

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
