### PR TITLE
fix(chat): fix marketplace button border color (Issue #5382)

### DIFF
--- a/apps/chat/src/components/Marketplace/ViewToggler.tsx
+++ b/apps/chat/src/components/Marketplace/ViewToggler.tsx
@@ -39,7 +39,7 @@ export const ViewToggler: React.FC = () => {
             'rounded border p-1.5',
             selectedViewType === view
               ? 'border-accent-primary text-accent-primary'
-              : 'stroke-primary text-secondary',
+              : 'border-primary text-secondary',
           )}
           onClick={() => handleToggleView(view)}
           iconBefore={<Icon />}

--- a/apps/chat/src/components/Marketplace/ViewToggler.tsx
+++ b/apps/chat/src/components/Marketplace/ViewToggler.tsx
@@ -39,7 +39,7 @@ export const ViewToggler: React.FC = () => {
             'rounded border p-1.5',
             selectedViewType === view
               ? 'border-accent-primary text-accent-primary'
-              : 'border-secondary text-secondary',
+              : 'stroke-primary text-secondary',
           )}
           onClick={() => handleToggleView(view)}
           iconBefore={<Icon />}


### PR DESCRIPTION
**Description:**

Expected the border of the button: stroke-primary

Issues:

- Issue #5382

**UI changes**

Before:
<img width="507" height="68" alt="Снимок экрана 2025-12-30 в 16 05 00" src="https://github.com/user-attachments/assets/48045c10-2759-4106-b65e-6a7b2c53fb95" />

After:
<img width="511" height="75" alt="Снимок экрана 2025-12-30 в 16 04 42" src="https://github.com/user-attachments/assets/8b5f878e-b7c4-483d-b147-bb0a52f2a8fb" />

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
