### PR TITLE
fix(chat): fix under counter x style (Issue #5297)

### DIFF
--- a/apps/chat/src/components/Common/AgentAndToolsetSelector/OverflowListItem.tsx
+++ b/apps/chat/src/components/Common/AgentAndToolsetSelector/OverflowListItem.tsx
@@ -56,7 +56,10 @@ const ListItemContent: React.FC<ListItemContentProps> = ({
         <ChipTitle name={name} version={version} isError={isError} />
       </div>
       <DialCloseButton
-        className={classNames('text-secondary', isError && 'hover:text-error')}
+        className={classNames(
+          'text-secondary',
+          isError && 'hover:enabled:text-error',
+        )}
         onClose={handleRemove}
         size={18}
       />


### PR DESCRIPTION
**Description:**

It should be blue on hover for regular agents/toolsets
It should be red on hover for not available agents/toolsets

Issues:

- Issue #5297

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
