### PR TITLE
feat(chat): move dialogs from ConversationContextMenu to ConversationDialogs (Issue #5178)

### DIFF
--- a/apps/chat/src/components/Chat/ConversationContextMenu.tsx
+++ b/apps/chat/src/components/Chat/ConversationContextMenu.tsx
@@ -1,14 +1,7 @@
 import { useDismiss, useFloating, useInteractions } from '@floating-ui/react';
-import {
-  MouseEventHandler,
-  useCallback,
-  useEffect,
-  useMemo,
-  useState,
-} from 'react';
+import { MouseEventHandler, useCallback, useEffect, useMemo } from 'react';
 
 import { useScreenState } from '@/src/hooks/useScreenState';
-import { useTranslation } from '@/src/hooks/useTranslation';
 
 import {
   isPlaybackConversation,
@@ -18,7 +11,6 @@ import {
 import { Conversation } from '@/src/types/chat';
 import { FeatureType, ScreenState, isNotLoaded } from '@/src/types/common';
 import { ContextMenuProps } from '@/src/types/menu';
-import { Translation } from '@/src/types/translation';
 
 import {
   ChatActions,
@@ -35,8 +27,6 @@ import {
   PublicationSelectors,
 } from '@/src/store/selectors';
 
-import { ExportModal } from '@/src/components/Chatbar/ExportModal';
-import { ConfirmDialog } from '@/src/components/Common/ConfirmDialog';
 import { ItemContextMenu } from '@/src/components/Common/ItemContextMenu';
 
 import {
@@ -66,8 +56,6 @@ export const ConversationContextMenu = ({
   isHeaderMenu,
   disabledState,
 }: ConversationContextMenuProps) => {
-  const { t } = useTranslation(Translation.Chat);
-
   const dispatch = useAppDispatch();
 
   const modelsMap = useAppSelector(ModelsSelectors.selectModelsMap);
@@ -80,10 +68,6 @@ export const ConversationContextMenu = ({
       conversation.id,
     ),
   );
-
-  const [isDeleting, setIsDeleting] = useState(false);
-  const [isUnshared, setIsUnshared] = useState(false);
-  const [isShowExportModal, setIsShowExportModal] = useState(false);
 
   const screenState = useScreenState();
   const isMobileOrTablet =
@@ -117,19 +101,24 @@ export const ConversationContextMenu = ({
   const { getFloatingProps } = useInteractions([dismiss]);
 
   const handleOpenExportModal = useCallback(() => {
-    setIsShowExportModal(true);
-  }, []);
+    dispatch(ConversationsActions.setExportingConversationId(conversation.id));
+  }, [conversation.id, dispatch]);
 
   const handleCloseExportModal = useCallback(() => {
-    setIsShowExportModal(false);
-  }, []);
+    dispatch(ConversationsActions.setExportingConversationId());
+  }, [dispatch]);
 
   const handleOpenDeleteModal: MouseEventHandler<HTMLButtonElement> =
-    useCallback((e) => {
-      e.stopPropagation();
+    useCallback(
+      (e) => {
+        e.stopPropagation();
 
-      setIsDeleting(true);
-    }, []);
+        dispatch(
+          ConversationsActions.setDeletingConversationId(conversation.id),
+        );
+      },
+      [conversation.id, dispatch],
+    );
 
   const handleOpenPublishing = useCallback(() => {
     dispatch(
@@ -214,22 +203,13 @@ export const ConversationContextMenu = ({
     }, [conversation, dispatch, setIsOpen]);
 
   const handleOpenUnshareModal: MouseEventHandler<HTMLButtonElement> =
-    useCallback((e) => {
-      e.stopPropagation();
-      setIsUnshared(true);
-    }, []);
-
-  const handleUnsharing = useCallback(() => {
-    if (conversation.sharedWithMe) {
-      dispatch(
-        ShareActions.discardSharedWithMe({
-          resourceIds: [conversation.id],
-          featureType: FeatureType.Chat,
-        }),
-      );
-    }
-    setIsUnshared(false);
-  }, [conversation.id, conversation.sharedWithMe, dispatch]);
+    useCallback(
+      (e) => {
+        e.stopPropagation();
+        dispatch(ShareActions.setUnshareEntity(conversation));
+      },
+      [conversation, dispatch],
+    );
 
   const handleSelect: MouseEventHandler<HTMLButtonElement> = useCallback(
     (e) => {
@@ -243,15 +223,6 @@ export const ConversationContextMenu = ({
     },
     [conversation.id, dispatch, setIsOpen],
   );
-
-  const handleDelete = useCallback(() => {
-    dispatch(
-      ConversationsActions.deleteConversations({
-        conversationIds: [conversation.id],
-      }),
-    );
-    setIsDeleting(false);
-  }, [conversation.id, dispatch]);
 
   const handleOpenMoveToModal = useCallback(() => {
     dispatch(ConversationsActions.setMoveToConversationId(conversation.id));
@@ -302,90 +273,50 @@ export const ConversationContextMenu = ({
   }, [conversation, dispatch]);
 
   return (
-    <>
-      <button
-        ref={refs.setFloating}
-        {...getFloatingProps()}
-        data-qa="dots-menu"
-        disabled={disabledState}
-        className="group"
-      >
-        <ItemContextMenu
-          TriggerIcon={TriggerIcon}
-          className={className}
-          entity={conversation}
-          isEmptyConversation={!isReplay && !isPlayback && isEmptyConversation}
-          featureType={FeatureType.Chat}
-          onOpenMoveToModal={handleOpenMoveToModal}
-          onDelete={handleOpenDeleteModal}
-          onRename={handleOpenRenameModal}
-          onExport={handleExport}
-          onOpenExportModal={handleOpenExportModal}
-          onCompare={
-            !isReplay && !isPlayback && !isCustomViewerApplication
-              ? handleCompare
-              : undefined
-          }
-          onDuplicate={handleDuplicate}
-          onReplay={
-            !isReplay && !isPlayback && !isCustomViewerApplication
-              ? handleStartReplay
-              : undefined
-          }
-          onPlayback={
-            isPlaybackActionAvailable ? handleCreatePlayback : undefined
-          }
-          onShare={!isReplay ? handleOpenSharing : undefined}
-          onUnshare={!isReplay ? handleOpenUnshareModal : undefined}
-          onPublish={!isReplay ? handleOpenPublishing : undefined}
-          onUnpublish={isUnpublishVisible ? handleOpenUnpublishing : undefined}
-          onOpenChange={setIsOpen}
-          isOpen={isOpen}
-          isLoading={conversation.status !== UploadStatus.LOADED}
-          onSelect={isHeaderMenu ? undefined : handleSelect}
-          useStandardColor={isHeaderMenu}
-          onShowInfo={handleOpenInfoModal}
-          hideTriggerIcon={!isHeaderMenu && isMobileOrTablet}
-        />
-      </button>
-
-      {isShowExportModal && (
-        <ExportModal onExport={handleExport} onClose={handleCloseExportModal} />
-      )}
-
-      {isDeleting && (
-        <ConfirmDialog
-          isOpen
-          heading={t('Confirm deleting conversation')}
-          description={`${t('Are you sure that you want to delete a conversation?')}${t(
-            conversation.isShared
-              ? '\nDeleting will stop sharing and other users will no longer see this conversation.'
-              : '',
-          )}`}
-          confirmLabel={t('Delete')}
-          cancelLabel={t('Cancel')}
-          onClose={(result) => {
-            setIsDeleting(false);
-            if (result) handleDelete();
-          }}
-        />
-      )}
-
-      {isUnshared && (
-        <ConfirmDialog
-          isOpen
-          heading={t('Confirm unshare conversation')}
-          description={t(
-            'Are you sure that you want to unshare a conversation?',
-          )}
-          confirmLabel={t('Unshare')}
-          cancelLabel={t('Cancel')}
-          onClose={(result) => {
-            setIsUnshared(false);
-            if (result) handleUnsharing();
-          }}
-        />
-      )}
-    </>
+    <button
+      ref={refs.setFloating}
+      {...getFloatingProps()}
+      data-qa="dots-menu"
+      disabled={disabledState}
+      className="group"
+    >
+      <ItemContextMenu
+        TriggerIcon={TriggerIcon}
+        className={className}
+        entity={conversation}
+        isEmptyConversation={!isReplay && !isPlayback && isEmptyConversation}
+        featureType={FeatureType.Chat}
+        onOpenMoveToModal={handleOpenMoveToModal}
+        onDelete={handleOpenDeleteModal}
+        onRename={handleOpenRenameModal}
+        onExport={handleExport}
+        onOpenExportModal={handleOpenExportModal}
+        onCompare={
+          !isReplay && !isPlayback && !isCustomViewerApplication
+            ? handleCompare
+            : undefined
+        }
+        onDuplicate={handleDuplicate}
+        onReplay={
+          !isReplay && !isPlayback && !isCustomViewerApplication
+            ? handleStartReplay
+            : undefined
+        }
+        onPlayback={
+          isPlaybackActionAvailable ? handleCreatePlayback : undefined
+        }
+        onShare={!isReplay ? handleOpenSharing : undefined}
+        onUnshare={!isReplay ? handleOpenUnshareModal : undefined}
+        onPublish={!isReplay ? handleOpenPublishing : undefined}
+        onUnpublish={isUnpublishVisible ? handleOpenUnpublishing : undefined}
+        onOpenChange={setIsOpen}
+        isOpen={isOpen}
+        isLoading={conversation.status !== UploadStatus.LOADED}
+        onSelect={isHeaderMenu ? undefined : handleSelect}
+        useStandardColor={isHeaderMenu}
+        onShowInfo={handleOpenInfoModal}
+        hideTriggerIcon={!isHeaderMenu && isMobileOrTablet}
+      />
+    </button>
   );
 };

--- a/apps/chat/src/components/Chatbar/ConversationDialogs/DeleteConversationDialog.tsx
+++ b/apps/chat/src/components/Chatbar/ConversationDialogs/DeleteConversationDialog.tsx
@@ -1,0 +1,63 @@
+import { FC, useCallback } from 'react';
+
+import { useTranslation } from '@/src/hooks/useTranslation';
+
+import { Translation } from '@/src/types/translation';
+
+import { ConversationsActions } from '@/src/store/actions';
+import { useAppDispatch, useAppSelector } from '@/src/store/hooks';
+import { ConversationsSelectors } from '@/src/store/selectors';
+
+import { ConfirmDialog } from '@/src/components/Common/ConfirmDialog';
+import { withRenderWhenEntities } from '@/src/components/Common/RenderWhen';
+
+interface DeleteConversationDialogProps {
+  conversationId: string;
+}
+
+const DeleteConversationDialogView: FC<DeleteConversationDialogProps> = ({
+  conversationId,
+}) => {
+  const { t } = useTranslation(Translation.Chat);
+  const dispatch = useAppDispatch();
+
+  const conversation = useAppSelector((state) =>
+    ConversationsSelectors.selectConversationById(state, conversationId),
+  );
+
+  const handleClose = useCallback(
+    (result: boolean) => {
+      if (!result) {
+        dispatch(ConversationsActions.setDeletingConversationId());
+        return;
+      }
+      dispatch(
+        ConversationsActions.deleteConversations({
+          conversationIds: [conversationId],
+        }),
+      );
+      dispatch(ConversationsActions.setDeletingConversationId());
+    },
+    [conversationId, dispatch],
+  );
+
+  return (
+    <ConfirmDialog
+      isOpen
+      heading={t('Confirm deleting conversation')}
+      description={`${t('Are you sure that you want to delete a conversation?')}${t(
+        conversation?.isShared
+          ? '\nDeleting will stop sharing and other users will no longer see this conversation.'
+          : '',
+      )}`}
+      confirmLabel={t('Delete')}
+      cancelLabel={t('Cancel')}
+      onClose={handleClose}
+    />
+  );
+};
+
+export const DeleteConversationDialog =
+  withRenderWhenEntities<DeleteConversationDialogProps>({
+    conversationId: ConversationsSelectors.selectDeletingConversationId,
+  })(DeleteConversationDialogView);

--- a/apps/chat/src/components/Chatbar/ConversationDialogs/ExportConversationDialog.tsx
+++ b/apps/chat/src/components/Chatbar/ConversationDialogs/ExportConversationDialog.tsx
@@ -1,0 +1,46 @@
+import { FC, useCallback } from 'react';
+
+import { ConversationsActions, ImportExportActions } from '@/src/store/actions';
+import { useAppDispatch } from '@/src/store/hooks';
+import { ConversationsSelectors } from '@/src/store/selectors';
+
+import { ExportModal } from '@/src/components/Chatbar/ExportModal';
+import { withRenderWhenEntities } from '@/src/components/Common/RenderWhen';
+
+interface ExportConversationDialogProps {
+  conversationId: string;
+}
+
+const ExportConversationDialogView: FC<ExportConversationDialogProps> = ({
+  conversationId,
+}) => {
+  const dispatch = useAppDispatch();
+
+  const handleCloseExportModal = useCallback(() => {
+    dispatch(ConversationsActions.setExportingConversationId());
+  }, [dispatch]);
+
+  const handleExport = useCallback(
+    (args?: unknown) => {
+      const typedArgs = args as { withAttachments?: boolean };
+
+      dispatch(
+        ImportExportActions.exportConversation({
+          conversationId: conversationId,
+          withAttachments: typedArgs?.withAttachments ?? false,
+        }),
+      );
+      handleCloseExportModal();
+    },
+    [dispatch, handleCloseExportModal, conversationId],
+  );
+
+  return (
+    <ExportModal onExport={handleExport} onClose={handleCloseExportModal} />
+  );
+};
+
+export const ExportConversationDialog =
+  withRenderWhenEntities<ExportConversationDialogProps>({
+    conversationId: ConversationsSelectors.selectExportingConversationId,
+  })(ExportConversationDialogView);

--- a/apps/chat/src/components/Chatbar/ConversationDialogs/index.tsx
+++ b/apps/chat/src/components/Chatbar/ConversationDialogs/index.tsx
@@ -1,9 +1,15 @@
-import { ConversationMoveToDialog } from './ConversationMoveToDialog';
+import { FC } from 'react';
 
-export const ConversationDialogs: React.FC = () => {
+import { ConversationMoveToDialog } from './ConversationMoveToDialog';
+import { DeleteConversationDialog } from './DeleteConversationDialog';
+import { ExportConversationDialog } from './ExportConversationDialog';
+
+export const ConversationDialogs: FC = () => {
   return (
     <>
       <ConversationMoveToDialog />
+      <DeleteConversationDialog />
+      <ExportConversationDialog />
     </>
   );
 };

--- a/apps/chat/src/components/Common/UnshareDialog.tsx
+++ b/apps/chat/src/components/Common/UnshareDialog.tsx
@@ -2,7 +2,9 @@ import { useCallback } from 'react';
 
 import { useTranslation } from '@/src/hooks/useTranslation';
 
-import { FeatureType } from '@/src/types/common';
+import { EnumMapper } from '@/src/utils/app/mappers';
+import { splitEntityId } from '@/src/utils/app/shared-utils';
+
 import { Translation } from '@/src/types/translation';
 
 import { ShareActions } from '@/src/store/actions';
@@ -82,7 +84,9 @@ function UnshareDialogView() {
         dispatch(
           ShareActions.discardSharedWithMe({
             resourceIds: [unshareEntity.id],
-            featureType: FeatureType.Application,
+            featureType: EnumMapper.getFeatureTypeByApiKey(
+              splitEntityId(unshareEntity.id).apiKey,
+            ),
           }),
         );
         dispatch(ShareActions.setUnshareEntity(undefined));

--- a/apps/chat/src/pages/files-manager/index.tsx
+++ b/apps/chat/src/pages/files-manager/index.tsx
@@ -25,6 +25,7 @@ function FilesManagerPage() {
   const isUserSettingsOpen = useAppSelector(
     UISelectors.selectIsUserSettingsOpen,
   );
+  const isUserMenuHidden = enabledFeatures.has(Feature.HideUserMenu);
 
   const onClose = () => {
     dispatch(UIActions.setIsUserSettingsOpen(false));
@@ -34,12 +35,15 @@ function FilesManagerPage() {
       {enabledFeatures.has(Feature.Header) && (
         <BaseHeader
           RightItems={
-            <>
-              <div className="flex w-[48px] items-center justify-center md:w-auto">
-                <User />
-              </div>
-              <SettingDialog open={isUserSettingsOpen} onClose={onClose} />
-            </>
+            !isUserMenuHidden && (
+              <>
+                <div className="w-[48px] overflow-hidden md:w-auto">
+                  <User />
+                </div>
+
+                <SettingDialog open={isUserSettingsOpen} onClose={onClose} />
+              </>
+            )
           }
         />
       )}

--- a/apps/chat/src/store/conversations/conversations.reducers.ts
+++ b/apps/chat/src/store/conversations/conversations.reducers.ts
@@ -859,6 +859,18 @@ export const conversationsSlice = createSlice({
     ) => {
       state.moveToConversationId = payload;
     },
+    setDeletingConversationId: (
+      state,
+      { payload }: PayloadAction<string | undefined>,
+    ) => {
+      state.deletingConversationId = payload;
+    },
+    setExportingConversationId: (
+      state,
+      { payload }: PayloadAction<string | undefined>,
+    ) => {
+      state.exportingConversationId = payload;
+    },
   },
 });
 

--- a/apps/chat/src/store/conversations/conversations.selectors.ts
+++ b/apps/chat/src/store/conversations/conversations.selectors.ts
@@ -807,6 +807,12 @@ const selectAction = (state: RootState) =>
 const selectMoveToConversationId = (state: RootState) =>
   rootSelector(state).moveToConversationId;
 
+const selectDeletingConversationId = (state: RootState) =>
+  rootSelector(state).deletingConversationId;
+
+const selectExportingConversationId = (state: RootState) =>
+  rootSelector(state).exportingConversationId;
+
 export const ConversationsSelectors = {
   selectConversations,
   selectConversationsByFolderId,
@@ -885,4 +891,6 @@ export const ConversationsSelectors = {
   selectIsNotAllowed,
   selectNotAllowedItemsForDisplay,
   selectMoveToConversationId,
+  selectDeletingConversationId,
+  selectExportingConversationId,
 };

--- a/apps/chat/src/store/conversations/conversations.types.ts
+++ b/apps/chat/src/store/conversations/conversations.types.ts
@@ -47,6 +47,9 @@ export interface ConversationsState {
   preselectedAction?: string | null;
 
   moveToConversationId: string | undefined;
+
+  deletingConversationId?: string | undefined;
+  exportingConversationId?: string | undefined;
 }
 
 export interface BaseSendMessagePayload {

--- a/apps/chat/src/utils/app/__tests__/common.test.ts
+++ b/apps/chat/src/utils/app/__tests__/common.test.ts
@@ -367,7 +367,10 @@ describe('utils/app/common.ts', () => {
       const expectedNewEntityId = `${ApiKeys.Prompts}/public/parent/path/${newName}`;
 
       const publicVersionGroups: PublicVersionGroups = {
-        [expectedNewEntityId]: { allVersions: [{ version: '3.3.3' }] } as any,
+        [expectedNewEntityId]: {
+          allVersions: [{ version: '3.3.3', id: entityId }],
+          selectedVersion: { version: '3.3.3', id: entityId },
+        },
       };
 
       expect(


### PR DESCRIPTION
**Description:**

- fix files manager header
- move dialogs from context menu component to ConversationDialogs
- resolve ***any*** in tests for common utils

Issues:

- Issue #5178 

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
