### PR TITLE
fix(chat): fix code block styles inside details (Issue #4879)

### DIFF
--- a/apps/chat/src/components/Markdown/ChatMDComponent.tsx
+++ b/apps/chat/src/components/Markdown/ChatMDComponent.tsx
@@ -138,9 +138,10 @@ const getMDComponents = (
 
       return (
         <details
+          open
           className={classnames(
-            'my-4 rounded bg-layer-3 [&_details]:bg-layer-1 [&_details_details]:bg-layer-3',
-            ' [&>summary]:border-tertiary [&[open]>summary>svg]:rotate-180 [&[open]>summary]:border-b [&_details>summary]:border-secondary [&_details_details>summary]:border-tertiary',
+            'rounded bg-layer-3 [&_details]:bg-layer-1 [&_details_details]:bg-layer-3',
+            ' [&>summary]:border-tertiary [&[open]>summary>svg]:rotate-180 [&[open]>summary]:border-b [&_.codeblock>*]:!bg-layer-1 [&_details>summary]:border-secondary [&_details]:border [&_details]:border-secondary [&_details_.codeblock>*]:!bg-layer-3 [&_details_.codeblock>div]:border-tertiary [&_details_.codeblock]:border-0 [&_details_details>summary]:border-tertiary [&_details_details]:border-0 [&_details_details_.codeblock>*]:!bg-layer-1 [&_details_details_.codeblock>div]:border-secondary [&_details_details_.codeblock]:border',
           )}
           {...props}
         >

--- a/apps/chat/src/components/Markdown/ChatMDComponent.tsx
+++ b/apps/chat/src/components/Markdown/ChatMDComponent.tsx
@@ -138,7 +138,6 @@ const getMDComponents = (
 
       return (
         <details
-          open
           className={classnames(
             'rounded bg-layer-3 [&_details]:bg-layer-1 [&_details_details]:bg-layer-3',
             ' [&>summary]:border-tertiary [&[open]>summary>svg]:rotate-180 [&[open]>summary]:border-b [&_.codeblock>*]:!bg-layer-1 [&_details>summary]:border-secondary [&_details]:border [&_details]:border-secondary [&_details_.codeblock>*]:!bg-layer-3 [&_details_.codeblock>div]:border-tertiary [&_details_.codeblock]:border-0 [&_details_details>summary]:border-tertiary [&_details_details]:border-0 [&_details_details_.codeblock>*]:!bg-layer-1 [&_details_details_.codeblock>div]:border-secondary [&_details_details_.codeblock]:border',


### PR DESCRIPTION
**Description:**

fix code block styles inside details

Issues:

- Issue #4879

**UI changes**

<img width="650" height="752" alt="image" src="https://github.com/user-attachments/assets/067c8547-5cbb-42e0-a4f8-1154fa37d497" />
<img width="638" height="742" alt="image" src="https://github.com/user-attachments/assets/dac6236c-14a2-4c81-b0e3-94179c2ab036" />


**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
