### PR TITLE
fix(chat): remove attachments button (Issue #5160)

### DIFF
--- a/apps/chat-e2e/src/tests/conversationWithAttachmentInResponse.test.ts
+++ b/apps/chat-e2e/src/tests/conversationWithAttachmentInResponse.test.ts
@@ -1,23 +1,22 @@
 import { Conversation } from '@/chat/types/chat';
 import dialTest from '@/src/core/dialFixtures';
 import { API, Attachment } from '@/src/testData';
-import { Button } from '@/src/ui/webElements';
 import { GeneratorUtil, ModelsUtil } from '@/src/utils';
 
 dialTest(
   'Generated in response picture appears in Manage attachments',
   async ({
     dialHomePage,
+    filesManagerPage,
     setTestIds,
-    chatBar,
+    navigationPanel,
     conversationData,
     localStorageManager,
     dataInjector,
     fileApiHelper,
-    filesManagerModalFoldersTree,
-    filesManagerModalGrid,
-    filesManagerModalGridAssertion,
-    filesManagerModal,
+    filesManagerFoldersTree,
+    filesManagerGrid,
+    filesManagerGridAssertion,
     chatHeader,
     chat,
     talkToAgentDialog,
@@ -34,7 +33,6 @@ dialTest(
     const secondImagePath = API.modelFilePath(updatedModel.id);
     const secondImagePathSegments = secondImagePath.split('/');
     const requestContent = 'request';
-    let closeButton: Button;
 
     await dialTest.step(
       'Create conversation with attachment in the response',
@@ -57,46 +55,44 @@ dialTest(
     );
 
     await dialTest.step(
-      'Open "Manage attachments" modal and verify image is placed inside nested folders',
+      'Open "Files manager" page and verify image is placed inside nested folders',
       async () => {
-        await dialHomePage.openHomePage();
-        await dialHomePage.waitForPageLoaded();
-        await conversations.selectEntity(responseImageConversation.name);
-        await chatBar.openManageAttachmentsModal();
-        await filesManagerModalFoldersTree.expandFolders(...imagePathSegments);
-        await filesManagerModalGridAssertion.assertElementState(
-          filesManagerModalGrid.gridRowByNameCell(Attachment.sunImageName),
+        await filesManagerPage.openFilesManagerPage();
+        await filesManagerPage.waitForPageLoaded();
+        await filesManagerFoldersTree.expandFolders(...imagePathSegments);
+        await filesManagerGridAssertion.assertGridRowByNameState(
+          Attachment.sunImageName,
           'visible',
         );
-        closeButton = filesManagerModal.getCloseButton();
-        await closeButton.click();
       },
     );
 
     await dialTest.step(
-      'Generate one more picture for the same conversation and verify it is visible on "Manage attachments" modal',
+      'Generate one more picture for the same conversation and verify it is visible on "Files manager"',
       async () => {
+        await navigationPanel.backToChat();
         await dialHomePage.mockChatImageResponse(
           defaultModel.id,
           Attachment.cloudImageName,
         );
+        await conversations.selectEntity(responseImageConversation.name);
         await chat.sendRequestWithButton(requestContent);
         await fileApiHelper.putFile(Attachment.cloudImageName, {
           parentPath: imagePath,
         });
 
-        await chatBar.openManageAttachmentsModal();
-        await filesManagerModalFoldersTree.expandFolders(...imagePathSegments);
-        await filesManagerModalGridAssertion.assertElementState(
-          filesManagerModalGrid.gridRowByNameCell(Attachment.cloudImageName),
+        await navigationPanel.goToFilesManager();
+        await filesManagerFoldersTree.expandFolders(...imagePathSegments);
+        await filesManagerGridAssertion.assertElementState(
+          filesManagerGrid.gridRowByNameCell(Attachment.cloudImageName),
           'visible',
         );
-        await closeButton.click();
+        await navigationPanel.backToChat();
       },
     );
 
     await dialTest.step(
-      'Change conversation model, generate one more picture and verify it is visible on "Manage attachments" modal under new model folder',
+      'Change conversation model, generate one more picture and verify it is visible on "Files manager" under new model folder',
       async () => {
         await chatHeader.chatAgent.click();
         await talkToAgentDialog.selectAgent(updatedModel);
@@ -110,12 +106,10 @@ dialTest(
           parentPath: secondImagePath,
         });
 
-        await chatBar.openManageAttachmentsModal();
-        await filesManagerModalFoldersTree.expandFolders(
-          ...secondImagePathSegments,
-        );
-        await filesManagerModalGridAssertion.assertElementState(
-          filesManagerModalGrid.gridRowByNameCell(Attachment.flowerImageName),
+        await navigationPanel.goToFilesManager();
+        await filesManagerFoldersTree.expandFolders(...secondImagePathSegments);
+        await filesManagerGridAssertion.assertElementState(
+          filesManagerGrid.gridRowByNameCell(Attachment.flowerImageName),
           'visible',
         );
       },

--- a/apps/chat-e2e/src/tests/errorUploadFromDevice.test.ts
+++ b/apps/chat-e2e/src/tests/errorUploadFromDevice.test.ts
@@ -3,6 +3,7 @@ import {
   Attachment,
   ExpectedConstants,
   ExpectedMessages,
+  UploadMenuOptions,
 } from '@/src/testData';
 import { ThemeColorAttributes } from '@/src/ui/domData';
 import { GeneratorUtil } from '@/src/utils';
@@ -13,15 +14,13 @@ dialTest(
   '[Upload from device] Error appears if to load the file with the same name and extension if it already exists in a folder.\n' +
     'Long file name in errors does not break UI on "Upload from device"',
   async ({
-    dialHomePage,
+    filesManagerPage,
     setTestIds,
-    filesManagerModal,
-    filesManagerModalGrid,
+    filesManagerToolbar,
+    filesManagerGridAssertion,
     fileConflictConfirmationPopup,
     fileConflictConfirmationPopupAssertion,
     fileApiHelper,
-    chatBar,
-    baseAssertion,
     localStorageManager,
   }) => {
     setTestIds('EPMRTC-1777', 'EPMRTC-1778');
@@ -32,18 +31,21 @@ dialTest(
     });
 
     await dialTest.step(
-      'Upload the same file again through chat bar dots menu',
+      'Upload the same file again through Files manager',
       async () => {
-        await dialHomePage.openHomePage();
-        await dialHomePage.waitForPageLoaded();
-        await chatBar.openManageAttachmentsModal();
-        await baseAssertion.assertElementState(
-          filesManagerModalGrid.gridRowByNameCell(Attachment.longImageName),
+        await filesManagerPage.openFilesManagerPage();
+        await filesManagerPage.waitForPageLoaded();
+        await filesManagerGridAssertion.assertGridRowByNameState(
+          Attachment.longImageName,
           'visible',
         );
-        await dialHomePage.uploadData(
+        await filesManagerToolbar.getNewButton().click();
+        await filesManagerPage.uploadData(
           { path: Attachment.longImageName, dataType: 'upload' },
-          () => filesManagerModal.openUploadFromDevice(),
+          () =>
+            filesManagerToolbar
+              .getNewButtonDropdownMenu()
+              .selectItem(UploadMenuOptions.uploadFiles),
         );
         await fileConflictConfirmationPopupAssertion.assertConfirmationPopupHeader(
           ExpectedConstants.replaceAttachmentConfirmationTitle,
@@ -54,8 +56,8 @@ dialTest(
           ),
         );
         await fileConflictConfirmationPopup.getCancelButton().click();
-        await baseAssertion.assertElementState(
-          filesManagerModalGrid.gridRowByNameCell(Attachment.longImageName),
+        await filesManagerGridAssertion.assertGridRowByNameState(
+          Attachment.longImageName,
           'visible',
         );
       },

--- a/apps/chat-e2e/src/tests/overlay/headerFeature.test.ts
+++ b/apps/chat-e2e/src/tests/overlay/headerFeature.test.ts
@@ -142,7 +142,6 @@ dialOverlayTest(
     overlayProfilePanel,
     overlayRequestApiKeyModal,
     overlayReportAnIssueModal,
-    overlayAttachFilesModal,
     overlayChatMessages,
     overlayBaseAssertion,
     overlayConversationAssertion,
@@ -227,18 +226,12 @@ dialOverlayTest(
     );
 
     await dialTest.step(
-      'Verify "Manage attachments" modal is opened on click "Clip" in the bottom menu',
+      'Verify "Clip" icon is not visible at the bottom menu',
       async () => {
         await overlayBaseAssertion.assertElementState(
           overlayChatBar.attachments,
-          'visible',
+          'hidden',
         );
-        await overlayChatBar.openManageAttachmentsModal();
-        await overlayBaseAssertion.assertElementState(
-          overlayAttachFilesModal,
-          'visible',
-        );
-        await overlayAttachFilesModal.closeButton.click();
       },
     );
 

--- a/apps/chat-e2e/src/tests/sidePanels.test.ts
+++ b/apps/chat-e2e/src/tests/sidePanels.test.ts
@@ -1,7 +1,7 @@
 import { CENTRAL_CHAT_MIN_WIDTH } from '@/chat/constants/chat';
 import { SIDEBAR_MIN_WIDTH } from '@/chat/constants/default-ui-settings';
 import dialTest from '@/src/core/dialFixtures';
-import { ExpectedConstants, ExpectedMessages } from '@/src/testData';
+import { ExpectedMessages } from '@/src/testData';
 import { Colors, Styles } from '@/src/ui/domData';
 import { expect } from '@playwright/test';
 
@@ -52,9 +52,9 @@ dialTest(
     setTestIds,
     appContainer,
     chatBar,
+    chatBarAssertion,
     promptBar,
     header,
-    tooltip,
     conversationData,
     dataInjector,
     localStorageManager,
@@ -105,28 +105,16 @@ dialTest(
     );
 
     await dialTest.step(
-      'Verify Attachment icon is visible at the panel bottom menu',
+      'Verify Attachment icon is not visible at the panel bottom menu',
       async () => {
-        await chatBar.attachments.waitForState();
-        await expect
-          .soft(
-            chatBar.bottomDotsMenuIcon.getElementLocator(),
-            ExpectedMessages.dotsMenuIsHidden,
-          )
-          .toBeHidden();
-
-        await chatBar.attachments.hoverOver();
-        const iconTooltip = await tooltip.getContent();
-        expect
-          .soft(iconTooltip, ExpectedMessages.tooltipContentIsValid)
-          .toBe(ExpectedConstants.attachments);
-
-        const iconColor = await chatBar.attachments.getComputedStyleProperty(
-          Styles.color,
+        await chatBarAssertion.assertElementState(
+          chatBar.attachments,
+          'hidden',
         );
-        expect
-          .soft(iconColor[0], ExpectedMessages.iconColorIsValid)
-          .toBe(Colors.textAccentSecondary);
+        await chatBarAssertion.assertElementState(
+          chatBar.bottomDotsMenuIcon,
+          'hidden',
+        );
       },
     );
 

--- a/apps/chat/src/components/Chatbar/ChatbarSettings.tsx
+++ b/apps/chat/src/components/Chatbar/ChatbarSettings.tsx
@@ -22,10 +22,7 @@ import {
   UIActions,
 } from '@/src/store/actions';
 import { useAppDispatch, useAppSelector } from '@/src/store/hooks';
-import {
-  ConversationsSelectors,
-  UISelectors,
-} from '@/src/store/selectors';
+import { ConversationsSelectors, UISelectors } from '@/src/store/selectors';
 
 import { DEFAULT_CONVERSATION_NAME } from '@/src/constants/default-ui-settings';
 import { PINNED_CONVERSATIONS_SECTION_NAME } from '@/src/constants/sections';

--- a/apps/chat/src/components/Chatbar/ChatbarSettings.tsx
+++ b/apps/chat/src/components/Chatbar/ChatbarSettings.tsx
@@ -1,7 +1,6 @@
 import {
   IconFileArrowLeft,
   IconFileArrowRight,
-  IconPaperclip,
   IconScale,
   IconSquareCheck,
   IconSquareOff,
@@ -25,7 +24,6 @@ import {
 import { useAppDispatch, useAppSelector } from '@/src/store/hooks';
 import {
   ConversationsSelectors,
-  SettingsSelectors,
   UISelectors,
 } from '@/src/store/selectors';
 
@@ -38,7 +36,7 @@ import { FileManagerModal } from '@/src/components/Files/FileManagerModal';
 import { Import } from '@/src/components/Settings/Import';
 
 import FolderPlus from '@/public/images/icons/folder-plus.svg';
-import { Feature, SupportedExportFormats } from '@epam/ai-dial-shared';
+import { SupportedExportFormats } from '@epam/ai-dial-shared';
 
 export const ChatbarSettings = () => {
   const { t } = useTranslation(Translation.SideBar);
@@ -49,9 +47,6 @@ export const ChatbarSettings = () => {
 
   const isStreaming = useAppSelector(
     ConversationsSelectors.selectIsConversationsStreaming,
-  );
-  const enabledFeatures = useAppSelector(
-    SettingsSelectors.selectEnabledFeatures,
   );
   const [isSelectFilesDialogOpened, setIsSelectFilesDialogOpened] =
     useState(false);
@@ -190,17 +185,6 @@ export const ChatbarSettings = () => {
         },
         display: !isSelectMode,
       },
-      {
-        name: t('Attachments'),
-        display:
-          enabledFeatures.has(Feature.AttachmentsManager) && !isSelectMode,
-        dataQa: 'attachments',
-        Icon: IconPaperclip,
-        disabled: isStreaming,
-        onClick: () => {
-          setIsSelectFilesDialogOpened(true);
-        },
-      },
     ],
     [
       t,
@@ -208,7 +192,6 @@ export const ChatbarSettings = () => {
       isStreaming,
       isSelectMode,
       deleteTerm,
-      enabledFeatures,
       dispatch,
       collapsedSections,
       jsonImportHandler,


### PR DESCRIPTION
**Description:**

remove attachments button

Issues:

- Issue #5160

**UI changes**

<img width="598" height="1086" alt="image" src="https://github.com/user-attachments/assets/1d058bf7-9af0-40ce-b3ba-e2273468aa59" />

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
