### PR TITLE
fix(chat): fix saving quick app 2 before login redirect, fix colors (Issues #5391, #5406, #5405)

### DIFF
--- a/apps/chat/src/components/AppsEditor/AppsEditorView.tsx
+++ b/apps/chat/src/components/AppsEditor/AppsEditorView.tsx
@@ -107,8 +107,8 @@ export const AppsEditorView = ({
   });
 
   const LeftContent = useMemo(
-    () => <EditorForm onNextClick={onNextClick} />,
-    [onNextClick],
+    () => <EditorForm onNextClick={onNextClick} onAutoSave={onAutoSave} />,
+    [onAutoSave, onNextClick],
   );
 
   const RightContent = useMemo(

--- a/apps/chat/src/components/AppsEditor/EditorForm/EditorForm.tsx
+++ b/apps/chat/src/components/AppsEditor/EditorForm/EditorForm.tsx
@@ -30,9 +30,10 @@ import { QuickAppForm } from '@/src/components/AppsEditor/EditorForm/QuickAppFor
 
 interface EditorFormProps {
   onNextClick: () => void;
+  onAutoSave: () => void;
 }
 
-export const EditorForm = ({ onNextClick }: EditorFormProps) => {
+export const EditorForm = ({ onNextClick, onAutoSave }: EditorFormProps) => {
   const router = useRouter();
   const editorStep = useAppSelector(ApplicationSelectors.selectEditorStep);
   const schema = useAppSelector(
@@ -47,7 +48,7 @@ export const EditorForm = ({ onNextClick }: EditorFormProps) => {
       return <QuickAppForm />;
     }
     if (isQuickApp2Editor(type.toString())) {
-      return <QuickApp2Form />;
+      return <QuickApp2Form onAutoSave={onAutoSave} />;
     }
     if (isExternalAppEditor(type.toString())) {
       return <ExternalAppForm />;
@@ -67,7 +68,7 @@ export const EditorForm = ({ onNextClick }: EditorFormProps) => {
         }
         return null;
     }
-  }, [schema, type]);
+  }, [onAutoSave, schema, type]);
 
   switch (editorStep) {
     case MarketplaceEditorSteps.Settings:

--- a/apps/chat/src/components/AppsEditor/EditorForm/QuickApp2Form.tsx
+++ b/apps/chat/src/components/AppsEditor/EditorForm/QuickApp2Form.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { FC, useCallback, useEffect, useMemo, useState } from 'react';
 import {
   Controller,
   useFormContext,
@@ -71,7 +71,11 @@ const ControlledField = withController(Field);
 
 const getItemLabel = (item: unknown): string => item as string;
 
-export const QuickApp2Form = () => {
+interface AppsEditorProps {
+  onAutoSave: () => void;
+}
+
+export const QuickApp2Form: FC<AppsEditorProps> = ({ onAutoSave }) => {
   const { t } = useTranslation(Translation.Marketplace);
 
   const appDetails = useAppSelector(
@@ -149,9 +153,13 @@ export const QuickApp2Form = () => {
     [selectedEntityId, allEntitiesMap],
   );
 
-  const handleOpenDetails = useCallback((entity: MarketplaceEntity) => {
-    setSelectedEntityId(entity.id);
-  }, []);
+  const handleOpenDetails = useCallback(
+    (entity: MarketplaceEntity) => {
+      setSelectedEntityId(entity.id);
+      onAutoSave();
+    },
+    [onAutoSave],
+  );
 
   const handleCloseDetails = useCallback(() => {
     setSelectedEntityId(null);

--- a/apps/chat/src/components/Chat/Publish/ApproveRequiredSection.tsx
+++ b/apps/chat/src/components/Chat/Publish/ApproveRequiredSection.tsx
@@ -247,7 +247,7 @@ export const ApproveRequiredSection = ({
       isHighlighted={isSectionHighlighted}
       additionalNode={
         !!publicationsToReviewCount && (
-          <span className="absolute right-4 flex h-[14px] min-w-[14px] select-none items-center justify-center rounded bg-accent-primary px-[2px] text-xxs font-semibold text-controls-disable">
+          <span className="absolute right-4 flex h-[14px] min-w-[14px] select-none items-center justify-center rounded bg-accent-secondary px-[2px] text-xxs font-semibold text-layer-3">
             {publicationsToReviewCount}
           </span>
         )

--- a/apps/chat/src/components/Common/AnnouncementBanner.tsx
+++ b/apps/chat/src/components/Common/AnnouncementBanner.tsx
@@ -42,7 +42,7 @@ export const AnnouncementsBanner = () => {
         <span dangerouslySetInnerHTML={{ __html: announcement }}></span>
       </div>
       <DialCloseButton
-        className="absolute right-2 top-[calc(50%_-_12px)] shrink-0"
+        className="absolute right-2 top-[calc(50%_-_12px)] shrink-0 text-primary"
         onClose={() => {
           dispatch(UIActions.closeAnnouncement({ announcement }));
         }}

--- a/apps/chat/tailwind.config.js
+++ b/apps/chat/tailwind.config.js
@@ -71,6 +71,7 @@ module.exports = {
       'accent-tertiary': 'var(--text-accent-tertiary, #A972FF)',
       'controls-permanent': 'var(--controls-text-permanent, #FCFCFC)',
       'controls-disable': 'var(--controls-text-disable, #5B6570)',
+      'layer-3': 'var(--bg-layer-3, #222932)',
     },
     gradientColorStops: commonBgColors,
     /////////


### PR DESCRIPTION
**Description:**

- save quick app 2 on opening toolset detailed view
- fix colors in approve required counter
- fix close button color in banner

Issues:

- Issue #5391 
- Issue #5406 
- Issue #5405 

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
