### PR TITLE
fix(chat): fix agents and toolsets autoscroll (Issue #5300)

### DIFF
--- a/apps/chat/src/components/Common/AgentAndToolsetSelector/AgentAndToolsetModal.tsx
+++ b/apps/chat/src/components/Common/AgentAndToolsetSelector/AgentAndToolsetModal.tsx
@@ -263,8 +263,9 @@ const AgentAndToolsetModalView = ({
       setScopeTab(tab);
       setShouldResetSliderState(true);
       setActiveSlide(0);
+      setScrollToItemId(null);
     },
-    [],
+    [setScrollToItemId],
   );
 
   const handleSetSearchTerm = (searchTerm: string) => {
@@ -424,6 +425,12 @@ const AgentAndToolsetModalView = ({
     () => (shouldResetSliderState ? [isMyWorkspace, searchTerm] : undefined),
     [isMyWorkspace, searchTerm, shouldResetSliderState],
   );
+
+  useEffect(() => {
+    if (shouldResetSliderState) {
+      setShouldResetSliderState(false);
+    }
+  }, [shouldResetSliderState]);
 
   const handleConfirm = useCallback(() => {
     onConfirm(selectedIds);


### PR DESCRIPTION
**Description:**

Need to fix the problem where when we change the tab after clicking on an element with multiple versions, the page doesn't reset to the first one.

Issues:

- Issue #5300

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
