### PR TITLE
fix(chat): fix disappearing code app files on admin review (Issues #5463, #5103)

### DIFF
--- a/apps/chat/src/components/ToolsetEditor/ToolsetEditorHeader.tsx
+++ b/apps/chat/src/components/ToolsetEditor/ToolsetEditorHeader.tsx
@@ -5,6 +5,8 @@ import { useRouter } from 'next/router';
 
 import { useTranslation } from '@/src/hooks/useTranslation';
 
+import { isEntityIdPublic } from '@/src/utils/app/publications';
+
 import { ToolsetEditorSteps } from '@/src/types/toolsets';
 import { Translation } from '@/src/types/translation';
 
@@ -148,6 +150,12 @@ export const ToolsetEditorHeader = ({
     [dispatch, errorSteps, onSave, redirectToChat],
   );
 
+  const saveLabel =
+    isExistingToolset &&
+    (currentToolset ? !isEntityIdPublic(currentToolset) : false)
+      ? 'Save and exit'
+      : 'Exit';
+
   return (
     <>
       <EditorHeader
@@ -157,7 +165,7 @@ export const ToolsetEditorHeader = ({
         isEditing={isExistingToolset}
         onTabClick={handleTabClick}
         title={t(isCreatingToolset ? 'Add toolset' : 'Edit toolset')}
-        saveLabel={isExistingToolset ? 'Save and exit' : 'Exit'}
+        saveLabel={saveLabel}
         onSave={handleSaveClick}
         onLogoClick={handleLogoClick}
         dataQa="entity-editor-header"

--- a/apps/chat/src/store/files/files.reducers.ts
+++ b/apps/chat/src/store/files/files.reducers.ts
@@ -629,10 +629,14 @@ export const filesSlice = createSlice({
     },
     addSharedFiles: (
       state,
-      { payload }: PayloadAction<{ files: DialFile[] }>,
+      { payload }: PayloadAction<{ files: DialFile[]; reviewFolder?: string }>,
     ) => {
-      //remove sharedWithMe files from state to have latest state from API
-      const filteredFiles = state.files.filter((file) => !file.sharedWithMe);
+      //remove sharedWithMe files from state except those on review to have the latest state from API
+      const filteredFiles = state.files.filter(
+        (file) =>
+          !file.sharedWithMe ||
+          (payload.reviewFolder && file.id.startsWith(payload.reviewFolder)),
+      );
       state.files = combineEntities(payload.files, filteredFiles);
     },
     resetAllFoldersStatus: (state) => {

--- a/apps/chat/src/store/share/share.epics.ts
+++ b/apps/chat/src/store/share/share.epics.ts
@@ -19,6 +19,7 @@ import {
   getApplicationType,
   getQuickAppDocumentUrl,
 } from '@/src/utils/app/application';
+import { BucketService } from '@/src/utils/app/data/bucket-service';
 import { ConversationService } from '@/src/utils/app/data/conversation-service';
 import { ShareService } from '@/src/utils/app/data/share-service';
 import {
@@ -26,7 +27,9 @@ import {
   isAttachmentLink,
   isConversationHasExternalAttachments,
 } from '@/src/utils/app/file';
+import { getParentFolderIdsFromEntityId } from '@/src/utils/app/folders';
 import {
+  getEntityBucket,
   isApplicationId,
   isConversationId,
   isEntityIdExternal,
@@ -69,6 +72,7 @@ import { ModelUpdatedValues } from '@/src/store/models/models.types';
 import {
   ApplicationSelectors,
   ApplicationTypesSchemasSelectors,
+  CodeEditorSelectors,
   ConversationsSelectors,
   FilesSelectors,
   ModelsSelectors,
@@ -99,6 +103,14 @@ const getInternalResourcesUrls = (
     )
     .filter(Boolean)
     .flat() || []) as string[];
+};
+
+const getSharedParentFolder = (id?: string) => {
+  if (!id || getEntityBucket({ id }) === BucketService.getBucket())
+    return undefined;
+  if (id.split('/').length < 3) return id;
+
+  return getParentFolderIdsFromEntityId(id)[0];
 };
 
 const shareEpic: AppEpic = (action$) =>
@@ -915,6 +927,11 @@ const getSharedListingSuccessEpic: AppEpic = (action$, state$) =>
           const selectedFilesIds = FilesSelectors.selectSelectedFilesIds(
             state$.value,
           );
+          const selectedCodeEditorFileId =
+            CodeEditorSelectors.selectSelectedFile(state$.value);
+          const codeEditorFolderOnReview = getSharedParentFolder(
+            selectedCodeEditorFileId?.split('/')?.slice(0, -1)?.join('/'),
+          );
 
           actions.push(
             FilesActions.addSharedFiles({
@@ -925,6 +942,7 @@ const getSharedListingSuccessEpic: AppEpic = (action$, state$) =>
                   ...res,
                   sharedWithMe: true,
                 })) as DialFile[],
+              reviewFolder: codeEditorFolderOnReview,
             }),
           );
 


### PR DESCRIPTION
**Description:**

- do not clear shared code editor files if admin is reviewing on updating shared listing
- fix exit button label for admin reviewing toolset

Issues:

- Issue #5463
- Issue #5103 

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
