### PR TITLE
fix(chat): handle folder names in toast messages using root folder placeholder (Issue #5491)

### DIFF
--- a/apps/chat/src/store/files/files.epics.ts
+++ b/apps/chat/src/store/files/files.epics.ts
@@ -936,7 +936,6 @@ const deleteFilesResultToastEpic: AppEpic = (action$) =>
         const path = items[0].sourceUrl;
         const { parentPath, name, bucket } = splitEntityId(path);
 
-
         if (items.length === 1) {
           return UIActions.showToast({
             type: ToastType.Success,

--- a/apps/chat/src/store/files/files.epics.ts
+++ b/apps/chat/src/store/files/files.epics.ts
@@ -25,6 +25,7 @@ import { FileService } from '@/src/utils/app/data/file-service';
 import {
   constructPath,
   getDownloadPath,
+  getRootFolderPlaceholderName,
   triggerDownload,
 } from '@/src/utils/app/file';
 import {
@@ -848,7 +849,7 @@ const copyMoveFilesResultToastEpic: AppEpic = (action$) =>
       if (items.length > 0) {
         if (items.length === 1) {
           const destinationUrl = items[0].destinationUrl;
-          const { parentPath, name } = splitEntityId(destinationUrl);
+          const { parentPath, name, bucket } = splitEntityId(destinationUrl);
 
           return UIActions.showToast({
             type: ToastType.Success,
@@ -859,14 +860,14 @@ const copyMoveFilesResultToastEpic: AppEpic = (action$) =>
             message: translate('“{{fileName}}” {{verb}} to {{folder}}', {
               ns: Translation.Files,
               fileName: name,
-              folder: parentPath,
+              folder: parentPath ?? getRootFolderPlaceholderName(bucket),
               verb: verbPast,
             }),
           });
         }
 
         const destinationUrl = request.destinationFolder;
-        const { parentPath } = splitEntityId(destinationUrl);
+        const { parentPath, bucket } = splitEntityId(destinationUrl);
 
         return UIActions.showToast({
           type: ToastType.Success,
@@ -877,7 +878,7 @@ const copyMoveFilesResultToastEpic: AppEpic = (action$) =>
           message: translate('{{count}} items {{verb}} to {{folder}}', {
             ns: Translation.Files,
             count: items.length,
-            folder: parentPath,
+            folder: parentPath ?? getRootFolderPlaceholderName(bucket),
             verb: verbPast,
           }),
         });
@@ -933,7 +934,8 @@ const deleteFilesResultToastEpic: AppEpic = (action$) =>
 
       if (items.length > 0) {
         const path = items[0].sourceUrl;
-        const { parentPath, name } = splitEntityId(path);
+        const { parentPath, name, bucket } = splitEntityId(path);
+
 
         if (items.length === 1) {
           return UIActions.showToast({
@@ -945,7 +947,7 @@ const deleteFilesResultToastEpic: AppEpic = (action$) =>
             message: translate('“{{fileName}}” {{verb}} from {{folder}}', {
               ns: Translation.Files,
               fileName: name,
-              folder: parentPath,
+              folder: parentPath ?? getRootFolderPlaceholderName(bucket),
               verb: verbPast,
             }),
           });
@@ -960,7 +962,7 @@ const deleteFilesResultToastEpic: AppEpic = (action$) =>
           message: translate('{{count}} items {{verb}} from {{folder}}', {
             ns: Translation.Files,
             count: items.length,
-            folder: parentPath,
+            folder: getRootFolderPlaceholderName(bucket),
             verb: verbPast,
           }),
         });

--- a/apps/chat/src/utils/app/file.ts
+++ b/apps/chat/src/utils/app/file.ts
@@ -26,6 +26,7 @@ import { Attachment, UploadStatus } from '@epam/ai-dial-shared';
 import escapeRegExp from 'lodash-es/escapeRegExp';
 import uniq from 'lodash-es/uniq';
 import { extensions } from 'mime-types';
+import { PUBLIC_URL_PREFIX } from '@/src/constants/publication';
 
 export function triggerDownload(url: string, name: string): void {
   const link = document.createElement('a');
@@ -512,4 +513,16 @@ export const getMyBucketAttachments = (
   return attachments.filter((attachment) =>
     isMyEntity({ id: attachment.url ?? '' }),
   );
+};
+
+export const getRootFolderPlaceholderName = (bucket: string): string => {
+  const userBucket = BucketService.getBucket();
+  if (userBucket === bucket) {
+    return translate('My Files');
+  }
+  if (bucket === PUBLIC_URL_PREFIX) {
+    return translate('Organization');
+  }
+
+  return translate('Shared with Me');
 };

--- a/apps/chat/src/utils/app/file.ts
+++ b/apps/chat/src/utils/app/file.ts
@@ -18,6 +18,7 @@ import {
   FOLDER_ATTACHMENT_CONTENT_TYPE,
   METADATA_PREFIX,
 } from '@/src/constants/folders';
+import { PUBLIC_URL_PREFIX } from '@/src/constants/publication';
 
 import { doesHaveDotsInTheEnd, prepareEntityName } from './common';
 import { isFolderId } from './shared-utils';
@@ -26,7 +27,6 @@ import { Attachment, UploadStatus } from '@epam/ai-dial-shared';
 import escapeRegExp from 'lodash-es/escapeRegExp';
 import uniq from 'lodash-es/uniq';
 import { extensions } from 'mime-types';
-import { PUBLIC_URL_PREFIX } from '@/src/constants/publication';
 
 export function triggerDownload(url: string, name: string): void {
   const link = document.createElement('a');


### PR DESCRIPTION
…

**Description:**

<SHORT_DESCRIPTION>

Issues:

- Issue #5491 

**UI changes**

<img width="816" height="150" alt="image" src="https://github.com/user-attachments/assets/61c00786-9198-4260-9d67-4d1accc4f15d" />

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
