### PR TITLE
fix(chat): fix clearing created subfolder in change path dialog (Issue #5515)

### DIFF
--- a/apps/chat/src/components/Common/CodeEditor.tsx
+++ b/apps/chat/src/components/Common/CodeEditor.tsx
@@ -30,6 +30,7 @@ import {
   getNextDefaultName,
 } from '@/src/utils/app/folders';
 import { getIdWithoutRootPathSegments } from '@/src/utils/app/id';
+import { isHiddenEntity } from '@/src/utils/app/search';
 import { splitEntityId } from '@/src/utils/app/shared-utils';
 
 import { FeatureType } from '@/src/types/common';
@@ -334,7 +335,7 @@ export const CodeEditor = ({ sourcesFolderId, readOnly }: Props) => {
   const loadingFolderIds = useAppSelector(
     FilesSelectors.selectLoadingFolderIds,
   );
-  const files = useAppSelector(FilesSelectors.selectFiles);
+  const allFiles = useAppSelector(FilesSelectors.selectFiles);
   const folders = useAppSelector(FilesSelectors.selectFolders);
   const selectedFileId = useAppSelector(CodeEditorSelectors.selectSelectedFile);
   const modifiedFileIds = useAppSelector(
@@ -349,6 +350,11 @@ export const CodeEditor = ({ sourcesFolderId, readOnly }: Props) => {
   const [deletingFileId, setDeletingFileId] = useState<string>();
   const [isFullScreen, setIsFullScreen] = useState(false);
   const [isSidebarOpen, setIsSidebarOpen] = useState(true);
+
+  const files = useMemo(
+    () => allFiles.filter((file) => !isHiddenEntity(file)),
+    [allFiles],
+  );
 
   const { rootFiles, rootFolders } = useMemo(() => {
     if (sourcesFolderId) {

--- a/apps/chat/src/store/files/files.reducers.ts
+++ b/apps/chat/src/store/files/files.reducers.ts
@@ -399,7 +399,10 @@ export const filesSlice = createSlice({
 
       const incomingIds = new Set(payload.folders.map((f) => f.id));
       const filteredState = state.folders.filter(
-        (f) => f.folderId !== payload.folderId || incomingIds.has(f.id),
+        (f) =>
+          f.folderId !== payload.folderId ||
+          incomingIds.has(f.id) ||
+          f.temporary,
       );
 
       state.folders = combineEntities(
@@ -467,6 +470,7 @@ export const filesSlice = createSlice({
           type: FeatureType.File,
           folderId: payload.parentId || getFileRootId(),
           status: UploadStatus.LOADED,
+          temporary: true,
         }),
       );
       state.newAddedFolderId = newAddedFolderId;


### PR DESCRIPTION
**Description:**

- fix clearing temporary subfolder after getFoldersSuccess action
- hide dot prefixed files in code editor

Issues:

- Issue #5515

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
