### PR TITLE
fix: set bg for attachments file-manager (Issue #5550)

### DIFF
--- a/apps/chat/src/components/Files/FileManagerModal.tsx
+++ b/apps/chat/src/components/Files/FileManagerModal.tsx
@@ -362,7 +362,7 @@ export const FileManagerModal = memo(
             data-qa="file-manager"
           >
             <DialFileManager
-              className="px-0 pb-5"
+              className="bg-layer-2 px-0 pb-5"
               path={currentPath}
               onPathChange={setCurrentPath}
               onSelectedPathsChange={pathSelectionHandler}


### PR DESCRIPTION
**Description:**

set bg for attachments file-manager

Issues:

- Issue #5550

**UI changes**

<img width="1236" height="832" alt="image" src="https://github.com/user-attachments/assets/b7acdbfd-480a-423f-aa21-af07b195ff43" />

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
