### PR TITLE
fix(chat): fix letter bottom cutting (Issue #5581)

### DIFF
--- a/apps/chat/src/components/Marketplace/EntityDetailsHeader.tsx
+++ b/apps/chat/src/components/Marketplace/EntityDetailsHeader.tsx
@@ -104,7 +104,7 @@ export function EntityHeader<T extends MarketplaceEntity>({
               )}
               <div className="flex max-w-full items-center gap-[2px] whitespace-nowrap">
                 <div
-                  className="shrink truncate text-lg font-semibold leading-[18px] md:text-xl md:leading-6"
+                  className="shrink truncate text-lg font-semibold leading-5 md:text-xl md:leading-6"
                   data-qa="entity-name"
                 >
                   {entity.name}

--- a/apps/chat/src/components/Marketplace/EntityDetailsHeader.tsx
+++ b/apps/chat/src/components/Marketplace/EntityDetailsHeader.tsx
@@ -104,7 +104,7 @@ export function EntityHeader<T extends MarketplaceEntity>({
               )}
               <div className="flex max-w-full items-center gap-[2px] whitespace-nowrap">
                 <div
-                  className="shrink truncate text-lg font-semibold leading-5 md:text-xl md:leading-6"
+                  className="shrink truncate text-lg font-semibold leading-6 md:text-xl"
                   data-qa="entity-name"
                 >
                   {entity.name}


### PR DESCRIPTION
**Description:**

fix letter bottom cutting (for mobiles, < 768px)

Issues:

- Issue #5581

**UI changes**
<img width="135" height="60" alt="image" src="https://github.com/user-attachments/assets/1a2a656d-cd68-48e6-a4f0-080bb04778aa" />
->
<img width="161" height="71" alt="image" src="https://github.com/user-attachments/assets/3723ac30-3177-4121-95f7-007dd5fd6d75" />


**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
