### PR TITLE
fix(chat): fix application card not displayed upon accepting an invitation share link. (Issue #3904)

### DIFF
--- a/apps/chat/src/store/marketplace/marketplace.epics.ts
+++ b/apps/chat/src/store/marketplace/marketplace.epics.ts
@@ -64,21 +64,27 @@ const initEpic: AppEpic = (action$, state$) =>
       const previousRoute = UISelectors.selectPreviousRoute(state$.value);
       const firstRoutePart = previousRoute?.split('/')[1];
       const firstRoutePartWithoutParams = firstRoutePart?.split('?')[0];
-      const isPreviousRouteEditor =
-        !!firstRoutePartWithoutParams &&
-        ['apps-editor', 'toolset-editor'].includes(firstRoutePartWithoutParams);
+      const isShareLink = !!new URL(window.location.href).searchParams.get(
+        'share',
+      );
+      const shouldSaveFilters =
+        (!!firstRoutePartWithoutParams &&
+          ['apps-editor', 'toolset-editor'].includes(
+            firstRoutePartWithoutParams,
+          )) ||
+        isShareLink;
 
       return concat(
         of(
           MarketplaceActions.initSuccess({
-            saveFilters: isPreviousRouteEditor,
+            saveFilters: shouldSaveFilters,
             selectedTab: workSpaceTab
               ? MarketplaceTabs.MY_WORKSPACE
               : undefined,
           }),
         ),
         iif(
-          () => !isPreviousRouteEditor,
+          () => !shouldSaveFilters,
           of(
             MarketplaceActions.setSelectedTab(
               workSpaceTab


### PR DESCRIPTION
**Description:**

- Fixed resetting the AI DIAL CHAT state after accepting an application invitation share link.
- Resolved the problem causing the application card to not display upon accepting an invitation share link.

Issues:

- Issue #3904 

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
