### PR TITLE
fix(chat): fix delete icon color (Issue #4742)

### DIFF
--- a/apps/chat/src/hooks/useAgentMenuItems.ts
+++ b/apps/chat/src/hooks/useAgentMenuItems.ts
@@ -186,7 +186,6 @@ export const useAgentMenuItems = ({
         display: isMyAppOrPreview && disabledActions.delete !== true,
         disabled: isModifyDisabled,
         Icon: IconTrashX,
-        iconClassName: 'stroke-error',
         onClick: handleDelete,
       },
     ],

--- a/apps/chat/src/hooks/useToolsetMenuItems.ts
+++ b/apps/chat/src/hooks/useToolsetMenuItems.ts
@@ -156,7 +156,6 @@ export const useToolsetMenuItems = ({
         dataQa: 'delete',
         display: isMyAppOrPreview && disabledActions.delete !== true,
         Icon: IconTrashX,
-        iconClassName: 'stroke-error',
         onClick: handleDelete,
       },
     ],


### PR DESCRIPTION
**Description:**

Need to change the color of the delete icon for agents and toolsets context menu

Issues:

- Issue #4742

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
