### PR TITLE
fix(share): enhance unshare functionality to show success and error toasts with item names

### DIFF
--- a/apps/chat/src/store/share/share.epics.ts
+++ b/apps/chat/src/store/share/share.epics.ts
@@ -56,6 +56,7 @@ import {
   ShareResource,
 } from '@/src/types/share';
 import { AppAction, AppEpic } from '@/src/types/store';
+import { Translation } from '@/src/types/translation';
 
 import {
   ApplicationActions,
@@ -90,7 +91,6 @@ import {
 import { Routes } from '@/src/constants/routes';
 
 import { ConversationInfo, Message, UploadStatus } from '@epam/ai-dial-shared';
-import { Translation } from '@/src/types/translation';
 
 const getInternalResourcesUrls = (
   messages: Message[] | undefined,

--- a/apps/chat/src/store/share/share.epics.ts
+++ b/apps/chat/src/store/share/share.epics.ts
@@ -90,6 +90,7 @@ import {
 import { Routes } from '@/src/constants/routes';
 
 import { ConversationInfo, Message, UploadStatus } from '@epam/ai-dial-shared';
+import { Translation } from '@/src/types/translation';
 
 const getInternalResourcesUrls = (
   messages: Message[] | undefined,
@@ -1185,8 +1186,12 @@ const discardSharedWithMeEpic: AppEpic = (action$) =>
 
       return ShareService.shareDiscard(resourceUrls).pipe(
         mergeMap(() => {
-          const actions: Observable<AppAction>[] = payload.resourceIds.map(
-            (resourceId) =>
+          const actions: Observable<AppAction>[] = [];
+
+          payload.resourceIds.forEach((resourceId) => {
+            const { name } = splitEntityId(resourceId);
+
+            actions.push(
               of(
                 ShareActions.discardSharedWithMeSuccess({
                   resourceId,
@@ -1194,10 +1199,48 @@ const discardSharedWithMeEpic: AppEpic = (action$) =>
                   isFolder: payload.isFolder,
                 }),
               ),
-          );
+              of(
+                UIActions.showSuccessToast(
+                  translate(
+                    payload.isFolder
+                      ? 'Folder "{{itemName}}" has been unshared successfully'
+                      : '"{{itemName}}" has been unshared successfully',
+                    {
+                      ns: Translation.Common,
+                      itemName: name,
+                    },
+                  ),
+                ),
+              ),
+            );
+          });
+
           return concat(...actions);
         }),
-        catchError(() => of(ShareActions.discardSharedWithMeFail())),
+        catchError(() => {
+          const errorActions: Observable<AppAction>[] = payload.resourceIds.map(
+            (resourceId) => {
+              const { name } = splitEntityId(resourceId);
+              return of(
+                UIActions.showErrorToast(
+                  translate(
+                    payload.isFolder
+                      ? 'Failed to unshare folder "{{itemName}}". Please try again later'
+                      : 'Failed to unshare "{{itemName}}". Please try again later',
+                    {
+                      ns: Translation.Common,
+                      itemName: name,
+                    },
+                  ),
+                ),
+              );
+            },
+          );
+          return concat(
+            ...errorActions,
+            of(ShareActions.discardSharedWithMeFail()),
+          );
+        }),
       );
     }),
   );


### PR DESCRIPTION

**Description:**
enhance unshare functionality to show success and error toasts with item names

Issues:

- Issue #5494 

**UI changes**

<img width="1334" height="674" alt="image" src="https://github.com/user-attachments/assets/d78ef70c-7649-4b35-8cea-01dee2eba43f" />

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
