### PR TITLE
fix(chat): fix displaying markdown inline base64 images (Issue #5602)

### DIFF
--- a/apps/chat/src/components/Markdown/ChatMDComponent.tsx
+++ b/apps/chat/src/components/Markdown/ChatMDComponent.tsx
@@ -185,6 +185,9 @@ const rehypePlugins: Options['rehypePlugins'] = [
           ['className'],
         ],
       },
+      protocols: {
+        src: [...(defaultSchema.protocols?.src ?? []), 'data'],
+      },
     },
   ],
   [rehypeExternalLinks, { target: '_blank', rel: ['noopener', 'noreferrer'] }],


### PR DESCRIPTION
**Description:**

fix displaying markdown inline base64 images

Issues:

- Issue #5602

**UI changes**

<img width="805" height="250" alt="image" src="https://github.com/user-attachments/assets/99fa4341-91f2-4b6b-8b74-d5ee01ee84c6" />

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
