### PR TITLE
chore(chat): bump NextJS from 15.5.9 to 15.5.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
         "mime-types": "^2.1.35",
         "monaco-editor": "0.54.0",
         "nanoid": "^5.1.5",
-        "next": "15.5.9",
+        "next": "15.5.11",
         "next-auth": "4.24.12",
         "next-i18next": "^13.2.2",
         "node-fetch": "^3.3.2",
@@ -5292,9 +5292,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "15.5.9",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.9.tgz",
-      "integrity": "sha512-4GlTZ+EJM7WaW2HEZcyU317tIQDjkQIyENDLxYJfSWlfqguN+dHkZgyQTV/7ykvobU7yEH5gKvreNrH4B6QgIg==",
+      "version": "15.5.11",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.11.tgz",
+      "integrity": "sha512-g9s5SS9gC7GJCEOR3OV3zqs7C5VddqxP9X+/6BpMbdXRkqsWfFf2CJPBZNvNEtAkKTNuRgRXAgNxSAXzfLdaTg==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
@@ -25026,12 +25026,12 @@
       "license": "MIT"
     },
     "node_modules/next": {
-      "version": "15.5.9",
-      "resolved": "https://registry.npmjs.org/next/-/next-15.5.9.tgz",
-      "integrity": "sha512-agNLK89seZEtC5zUHwtut0+tNrc0Xw4FT/Dg+B/VLEo9pAcS9rtTKpek3V6kVcVwsB2YlqMaHdfZL4eLEVYuCg==",
+      "version": "15.5.11",
+      "resolved": "https://registry.npmjs.org/next/-/next-15.5.11.tgz",
+      "integrity": "sha512-L2KPiKmqTDpRdeVDdPjhf43g2/VPe0NCNndq7OKDCgOLWtxe1kbr/zXGIZtYY7kZEAjRf7Bj/mwUFSr+tYC2Yg==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "15.5.9",
+        "@next/env": "15.5.11",
         "@swc/helpers": "0.5.15",
         "caniuse-lite": "^1.0.30001579",
         "postcss": "8.4.31",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "mime-types": "^2.1.35",
     "monaco-editor": "0.54.0",
     "nanoid": "^5.1.5",
-    "next": "15.5.9",
+    "next": "15.5.11",
     "next-auth": "4.24.12",
     "next-i18next": "^13.2.2",
     "node-fetch": "^3.3.2",


### PR DESCRIPTION
**Description:**

bump NextJS from 15.5.9 to 15.5.11

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
