### PR TITLE
fix(chat): fix logging into predefined toolsets (Issue #5674)

### DIFF
--- a/apps/chat/src/components/Marketplace/CredentialsStatusIndicator.tsx
+++ b/apps/chat/src/components/Marketplace/CredentialsStatusIndicator.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from '@/src/hooks/useTranslation';
 
+import { isPredefinedEntity } from '@/src/utils/app/id';
 import { isEntityIdPublic } from '@/src/utils/app/publications';
 import { isToolsetSignedIn, isToolsetWithAuth } from '@/src/utils/app/toolsets';
 
@@ -7,7 +8,6 @@ import { ToolsetCredentialsLevel, ToolsetModel } from '@/src/types/toolsets';
 import { Translation } from '@/src/types/translation';
 
 import { Badge } from '@/src/components/Badge';
-import { isPredefinedEntity } from '@/src/utils/app/id';
 
 interface CredentialsStatusIndicatorProps {
   entity: ToolsetModel;

--- a/apps/chat/src/components/Marketplace/CredentialsStatusIndicator.tsx
+++ b/apps/chat/src/components/Marketplace/CredentialsStatusIndicator.tsx
@@ -7,6 +7,7 @@ import { ToolsetCredentialsLevel, ToolsetModel } from '@/src/types/toolsets';
 import { Translation } from '@/src/types/translation';
 
 import { Badge } from '@/src/components/Badge';
+import { isPredefinedEntity } from '@/src/utils/app/id';
 
 interface CredentialsStatusIndicatorProps {
   entity: ToolsetModel;
@@ -24,7 +25,7 @@ export const CredentialsStatusIndicator = ({
     entity,
     ToolsetCredentialsLevel.USER,
   );
-  const isPublic = isEntityIdPublic(entity);
+  const isPublic = isEntityIdPublic(entity) || isPredefinedEntity(entity);
   const isSignedIn = isSignedInUser || isSignedInGlobal;
 
   const loginLabel = isSignedInUser || !isPublic ? 'MY CREDS' : 'ORG CREDS';

--- a/apps/chat/src/components/Marketplace/MarketplaceEntitiesList/MarketplaceEntitiesTiles/MarketplaceEntityCard.tsx
+++ b/apps/chat/src/components/Marketplace/MarketplaceEntitiesList/MarketplaceEntitiesTiles/MarketplaceEntityCard.tsx
@@ -142,24 +142,26 @@ export const MarketplaceEntityCard = memo(
               </ShareIcon>
             </div>
             <div className="flex grow flex-col justify-center gap-2 overflow-hidden">
-              {entity.version && (
-                <div
-                  className={classNames(
-                    'mr-6 flex items-center gap-1 text-xs leading-[14px] text-secondary',
-                    !isMyEntity && '!mr-12',
-                  )}
-                >
-                  {t('Version: ')}
-                  <span
-                    className="mr-1 max-w-full overflow-hidden truncate whitespace-nowrap"
-                    data-qa="version"
-                  >
-                    {entity.version}
-                  </span>
+              <div
+                className={classNames(
+                  'mr-6 flex items-center gap-1 text-xs leading-[14px] text-secondary',
+                  !isMyEntity && '!mr-12',
+                )}
+              >
+                {entity.version && (
+                  <>
+                    {t('Version: ')}
+                    <span
+                      className="mr-1 max-w-full overflow-hidden truncate whitespace-nowrap"
+                      data-qa="version"
+                    >
+                      {entity.version}
+                    </span>
+                  </>
+                )}
 
-                  <MarketplaceEntityIndicator entity={entity} />
-                </div>
-              )}
+                <MarketplaceEntityIndicator entity={entity} />
+              </div>
               <div className="flex whitespace-nowrap">
                 <div
                   className={classNames(

--- a/apps/chat/src/components/Marketplace/ToolsetLoginDialog.tsx
+++ b/apps/chat/src/components/Marketplace/ToolsetLoginDialog.tsx
@@ -39,6 +39,7 @@ import {
 
 import { ToolsetAuthTypes } from '@epam/ai-dial-shared';
 import { zodResolver } from '@hookform/resolvers/zod';
+import { isPredefinedEntity } from '@/src/utils/app/id';
 
 const credsTabs = [
   {
@@ -67,7 +68,7 @@ export const ToolsetLoginDialogView: FC<ToolsetLoginDialogProps> = ({
   const isAdmin = useAppSelector(AuthSelectors.selectIsAdmin);
   const allToolsets = useAppSelector(ToolsetSelectors.selectToolsets);
   const authType = entity.authSettings.authenticationType;
-  const isPublic = isEntityIdPublic(entity);
+  const isPublic = isEntityIdPublic(entity) || isPredefinedEntity(entity);
 
   const [authLevel, setAuthLevel] = useState<
     ToolsetCredentialsLevel | undefined
@@ -90,7 +91,7 @@ export const ToolsetLoginDialogView: FC<ToolsetLoginDialogProps> = ({
   });
 
   const isOrganizationView = isAdmin && isPublic;
-  const isSignedIn = isToolsetSignedIn(entity, ToolsetCredentialsLevel.GLOBAL);
+  const isSignedIn = isToolsetSignedIn(entity, isPublic ? ToolsetCredentialsLevel.USER : ToolsetCredentialsLevel.GLOBAL);
 
   const fieldsInfo = useMemo(
     () => ({
@@ -145,26 +146,27 @@ export const ToolsetLoginDialogView: FC<ToolsetLoginDialogProps> = ({
     (data: ToolsetLoginFormType) => {
       dispatch(
         ToolsetActions.startSignInProcess({
-          authLevel: authLevel ?? ToolsetCredentialsLevel.GLOBAL,
+          authLevel: authLevel ?? (isPublic ? ToolsetCredentialsLevel.USER : ToolsetCredentialsLevel.GLOBAL),
           apiKey: data.apiKey,
           toolset: entity,
         }),
       );
       handleClose();
     },
-    [dispatch, entity, handleClose, authLevel],
+    [dispatch, authLevel, isPublic, entity, handleClose],
   );
 
   const handleLogout = useCallback(() => {
     dispatch(
       ToolsetActions.logOutToolset({
-        authLevel: authLevel ?? ToolsetCredentialsLevel.GLOBAL,
+        authLevel: authLevel ?? (isPublic ? ToolsetCredentialsLevel.USER : ToolsetCredentialsLevel.GLOBAL),
         authType: entity.authSettings.authenticationType,
         toolsetId: entity.id,
       }),
     );
     handleClose();
   }, [
+    isPublic,
     dispatch,
     entity.authSettings.authenticationType,
     entity.id,
@@ -244,13 +246,15 @@ export const ToolsetLoginDialogView: FC<ToolsetLoginDialogProps> = ({
           <div className="flex items-center gap-1">
             <span className="text-xs text-primary">{t('Version: ')}</span>
 
-            <ModelVersionSelect
-              entities={isAppsEditor ? [entity] : allVersions}
-              currentEntity={entity}
-              onSelect={handleVersionChange}
-              className="truncate"
-              triggerClassName="!text-xs bg-layer-4 rounded p-1"
-            />
+            {entity.version ? (
+              <ModelVersionSelect
+                entities={isAppsEditor ? [entity] : allVersions}
+                currentEntity={entity}
+                onSelect={handleVersionChange}
+                className="truncate"
+                triggerClassName="!text-xs bg-layer-4 rounded p-1"
+              />
+            ) : <span className="text-xs text-secondary">N/A</span>}
           </div>
         </div>
       </div>
@@ -289,7 +293,7 @@ export const ToolsetLoginDialogView: FC<ToolsetLoginDialogProps> = ({
             ))
           ) : (
             <ToolsetLoginForm
-              credentialsLevel={ToolsetCredentialsLevel.GLOBAL}
+              credentialsLevel={isPublic ? ToolsetCredentialsLevel.USER : ToolsetCredentialsLevel.GLOBAL}
               type={entity.authSettings.authenticationType}
               toolset={entity}
               buttonClassName="ml-auto"

--- a/apps/chat/src/components/Marketplace/ToolsetLoginDialog.tsx
+++ b/apps/chat/src/components/Marketplace/ToolsetLoginDialog.tsx
@@ -5,6 +5,7 @@ import { FormProvider, useForm } from 'react-hook-form';
 import { useTranslation } from 'next-i18next';
 import { useRouter } from 'next/router';
 
+import { isPredefinedEntity } from '@/src/utils/app/id';
 import { getGroupMarketplaceEntityKey } from '@/src/utils/app/marketplace';
 import { isEntityIdPublic } from '@/src/utils/app/publications';
 import { isToolsetSignedIn } from '@/src/utils/app/toolsets';
@@ -39,7 +40,6 @@ import {
 
 import { ToolsetAuthTypes } from '@epam/ai-dial-shared';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { isPredefinedEntity } from '@/src/utils/app/id';
 
 const credsTabs = [
   {
@@ -91,7 +91,10 @@ export const ToolsetLoginDialogView: FC<ToolsetLoginDialogProps> = ({
   });
 
   const isOrganizationView = isAdmin && isPublic;
-  const isSignedIn = isToolsetSignedIn(entity, isPublic ? ToolsetCredentialsLevel.USER : ToolsetCredentialsLevel.GLOBAL);
+  const isSignedIn = isToolsetSignedIn(
+    entity,
+    isPublic ? ToolsetCredentialsLevel.USER : ToolsetCredentialsLevel.GLOBAL,
+  );
 
   const fieldsInfo = useMemo(
     () => ({
@@ -146,7 +149,11 @@ export const ToolsetLoginDialogView: FC<ToolsetLoginDialogProps> = ({
     (data: ToolsetLoginFormType) => {
       dispatch(
         ToolsetActions.startSignInProcess({
-          authLevel: authLevel ?? (isPublic ? ToolsetCredentialsLevel.USER : ToolsetCredentialsLevel.GLOBAL),
+          authLevel:
+            authLevel ??
+            (isPublic
+              ? ToolsetCredentialsLevel.USER
+              : ToolsetCredentialsLevel.GLOBAL),
           apiKey: data.apiKey,
           toolset: entity,
         }),
@@ -159,7 +166,11 @@ export const ToolsetLoginDialogView: FC<ToolsetLoginDialogProps> = ({
   const handleLogout = useCallback(() => {
     dispatch(
       ToolsetActions.logOutToolset({
-        authLevel: authLevel ?? (isPublic ? ToolsetCredentialsLevel.USER : ToolsetCredentialsLevel.GLOBAL),
+        authLevel:
+          authLevel ??
+          (isPublic
+            ? ToolsetCredentialsLevel.USER
+            : ToolsetCredentialsLevel.GLOBAL),
         authType: entity.authSettings.authenticationType,
         toolsetId: entity.id,
       }),
@@ -254,7 +265,9 @@ export const ToolsetLoginDialogView: FC<ToolsetLoginDialogProps> = ({
                 className="truncate"
                 triggerClassName="!text-xs bg-layer-4 rounded p-1"
               />
-            ) : <span className="text-xs text-secondary">N/A</span>}
+            ) : (
+              <span className="text-xs text-secondary">N/A</span>
+            )}
           </div>
         </div>
       </div>
@@ -293,7 +306,11 @@ export const ToolsetLoginDialogView: FC<ToolsetLoginDialogProps> = ({
             ))
           ) : (
             <ToolsetLoginForm
-              credentialsLevel={isPublic ? ToolsetCredentialsLevel.USER : ToolsetCredentialsLevel.GLOBAL}
+              credentialsLevel={
+                isPublic
+                  ? ToolsetCredentialsLevel.USER
+                  : ToolsetCredentialsLevel.GLOBAL
+              }
               type={entity.authSettings.authenticationType}
               toolset={entity}
               buttonClassName="ml-auto"

--- a/apps/chat/src/components/Marketplace/ToolsetsDetails/LoginButton.tsx
+++ b/apps/chat/src/components/Marketplace/ToolsetsDetails/LoginButton.tsx
@@ -21,6 +21,7 @@ import { useAppSelector } from '@/src/store/hooks';
 import { ToolsetAuthAction } from '@/src/constants/toolsets';
 
 import { DialNeutralButton, DialPrimaryButton } from '@epam/ai-dial-ui-kit';
+import { isPredefinedEntity } from '@/src/utils/app/id';
 
 interface LoginButtonProps {
   entity: ToolsetModel;
@@ -32,7 +33,7 @@ export const LoginButton: FC<LoginButtonProps> = ({ entity }) => {
 
   const isAdmin = useAppSelector(AuthSelectors.selectIsAdmin);
 
-  const isPublic = isEntityIdPublic(entity);
+  const isPublic = isEntityIdPublic(entity) || isPredefinedEntity(entity);
   const withAuth = isToolsetWithAuth(entity);
   const { handleLogin } = useToolsetMenuActions(entity);
   const authAction = getToolsetAuthAction(entity, isAdmin);

--- a/apps/chat/src/components/Marketplace/ToolsetsDetails/LoginButton.tsx
+++ b/apps/chat/src/components/Marketplace/ToolsetsDetails/LoginButton.tsx
@@ -5,6 +5,7 @@ import { useScreenState } from '@/src/hooks/useScreenState';
 import { useToolsetMenuActions } from '@/src/hooks/useToolsetActions';
 import { useTranslation } from '@/src/hooks/useTranslation';
 
+import { isPredefinedEntity } from '@/src/utils/app/id';
 import { isEntityIdPublic } from '@/src/utils/app/publications';
 import {
   getToolsetAuthAction,
@@ -21,7 +22,6 @@ import { useAppSelector } from '@/src/store/hooks';
 import { ToolsetAuthAction } from '@/src/constants/toolsets';
 
 import { DialNeutralButton, DialPrimaryButton } from '@epam/ai-dial-ui-kit';
-import { isPredefinedEntity } from '@/src/utils/app/id';
 
 interface LoginButtonProps {
   entity: ToolsetModel;

--- a/apps/chat/src/hooks/useToolsetMenuItems.ts
+++ b/apps/chat/src/hooks/useToolsetMenuItems.ts
@@ -100,7 +100,10 @@ export const useToolsetMenuItems = ({
         name: t('Manage creds'),
         dataQa: 'toolset-login',
         display:
-          disabledActions.login !== true && isWithAuth && isPublicApp && isAdmin,
+          disabledActions.login !== true &&
+          isWithAuth &&
+          isPublicApp &&
+          isAdmin,
         Icon: IconKey,
         onClick: handleLogin,
       },
@@ -108,7 +111,9 @@ export const useToolsetMenuItems = ({
         name: t(getToolsetAuthActionLabel(authAction, screenState)),
         dataQa: 'toolset-login',
         display:
-          disabledActions.login !== true && isWithAuth && !(isPublicApp && isAdmin),
+          disabledActions.login !== true &&
+          isWithAuth &&
+          !(isPublicApp && isAdmin),
         Icon: authAction === ToolsetAuthAction.LogOut ? IconLogout : IconLogin,
         iconClassName:
           authAction === ToolsetAuthAction.LogOut
@@ -158,7 +163,29 @@ export const useToolsetMenuItems = ({
         onClick: handleDelete,
       },
     ],
-    [t, isPublicApp, disabledActions.copyLink, disabledActions.edit, disabledActions.login, disabledActions.publish, disabledActions.unpublish, disabledActions.delete, handleCopy, isAppIdPublic, canEditOrView, handleEdit, isWithAuth, isAdmin, handleLogin, authAction, screenState, isMyAppOrPreview, handlePublish, handleUnpublish, handleDelete],
+    [
+      t,
+      isPublicApp,
+      disabledActions.copyLink,
+      disabledActions.edit,
+      disabledActions.login,
+      disabledActions.publish,
+      disabledActions.unpublish,
+      disabledActions.delete,
+      handleCopy,
+      isAppIdPublic,
+      canEditOrView,
+      handleEdit,
+      isWithAuth,
+      isAdmin,
+      handleLogin,
+      authAction,
+      screenState,
+      isMyAppOrPreview,
+      handlePublish,
+      handleUnpublish,
+      handleDelete,
+    ],
   );
 
   return menuItems;

--- a/apps/chat/src/hooks/useToolsetMenuItems.ts
+++ b/apps/chat/src/hooks/useToolsetMenuItems.ts
@@ -75,11 +75,10 @@ export const useToolsetMenuItems = ({
   const isAppIdPublic = isEntityIdPublic(entity);
   const canWrite = canWriteSharedWithMe(entity);
   const isMyAppOrPreview = isMyApp || isPreview;
-  const isPublicAndAdmin = isAppIdPublic && isAdmin;
   const isWithAuth = isToolsetWithAuth(entity);
   const authAction = getToolsetAuthAction(entity, isAdmin);
 
-  const canEditOrView = isMyApp || canWrite || isPublicAndAdmin;
+  const canEditOrView = isMyApp || canWrite || (isAppIdPublic && isAdmin);
 
   const menuItems: DisplayMenuItemProps[] = useMemo(
     () => [
@@ -101,7 +100,7 @@ export const useToolsetMenuItems = ({
         name: t('Manage creds'),
         dataQa: 'toolset-login',
         display:
-          disabledActions.login !== true && isWithAuth && isPublicAndAdmin,
+          disabledActions.login !== true && isWithAuth && isPublicApp && isAdmin,
         Icon: IconKey,
         onClick: handleLogin,
       },
@@ -109,7 +108,7 @@ export const useToolsetMenuItems = ({
         name: t(getToolsetAuthActionLabel(authAction, screenState)),
         dataQa: 'toolset-login',
         display:
-          disabledActions.login !== true && isWithAuth && !isPublicAndAdmin,
+          disabledActions.login !== true && isWithAuth && !(isPublicApp && isAdmin),
         Icon: authAction === ToolsetAuthAction.LogOut ? IconLogout : IconLogin,
         iconClassName:
           authAction === ToolsetAuthAction.LogOut
@@ -159,29 +158,7 @@ export const useToolsetMenuItems = ({
         onClick: handleDelete,
       },
     ],
-    [
-      t,
-      isPublicApp,
-      disabledActions.copyLink,
-      disabledActions.edit,
-      disabledActions.login,
-      disabledActions.publish,
-      disabledActions.unpublish,
-      disabledActions.delete,
-      handleCopy,
-      isAppIdPublic,
-      canEditOrView,
-      handleEdit,
-      isWithAuth,
-      isPublicAndAdmin,
-      handleLogin,
-      authAction,
-      screenState,
-      isMyAppOrPreview,
-      handlePublish,
-      handleUnpublish,
-      handleDelete,
-    ],
+    [t, isPublicApp, disabledActions.copyLink, disabledActions.edit, disabledActions.login, disabledActions.publish, disabledActions.unpublish, disabledActions.delete, handleCopy, isAppIdPublic, canEditOrView, handleEdit, isWithAuth, isAdmin, handleLogin, authAction, screenState, isMyAppOrPreview, handlePublish, handleUnpublish, handleDelete],
   );
 
   return menuItems;

--- a/apps/chat/src/store/toolset/toolset.epics.ts
+++ b/apps/chat/src/store/toolset/toolset.epics.ts
@@ -22,7 +22,11 @@ import { ClientDataService } from '@/src/utils/app/data/client-data-service';
 import { DataService } from '@/src/utils/app/data/data-service';
 import { ToolsetService } from '@/src/utils/app/data/toolset-service';
 import { refreshToolset$ } from '@/src/utils/app/epics-helpers/toolset.epic-helpers';
-import { getEntityNameFromId, isMyEntity, isPredefinedEntity } from '@/src/utils/app/id';
+import {
+  getEntityNameFromId,
+  isMyEntity,
+  isPredefinedEntity,
+} from '@/src/utils/app/id';
 import { getGroupMarketplaceEntityKey } from '@/src/utils/app/marketplace';
 import { isEntityIdPublic } from '@/src/utils/app/publications';
 import {
@@ -764,7 +768,9 @@ const logInToolsetEpic: AppEpic = (action$, state$, { router }) =>
       return ToolsetService.signIn(data).pipe(
         switchMap(() => {
           const isAdmin = AuthSelectors.selectIsAdmin(state$.value);
-          const isPublic = isEntityIdPublic({ id: payload.toolsetId }) || isPredefinedEntity({ id: payload.toolsetId });
+          const isPublic =
+            isEntityIdPublic({ id: payload.toolsetId }) ||
+            isPredefinedEntity({ id: payload.toolsetId });
           const name = getEntityNameFromId(payload.toolsetId, {
             removeVersion: true,
           });
@@ -822,7 +828,9 @@ const logOutToolsetEpic: AppEpic = (action$, state$) =>
       }).pipe(
         switchMap(() => {
           const isAdmin = AuthSelectors.selectIsAdmin(state$.value);
-          const isPublic = isEntityIdPublic({ id: payload.toolsetId }) || isPredefinedEntity({ id: payload.toolsetId });
+          const isPublic =
+            isEntityIdPublic({ id: payload.toolsetId }) ||
+            isPredefinedEntity({ id: payload.toolsetId });
           const name = getEntityNameFromId(payload.toolsetId, {
             removeVersion: true,
           });

--- a/apps/chat/src/store/toolset/toolset.epics.ts
+++ b/apps/chat/src/store/toolset/toolset.epics.ts
@@ -22,7 +22,7 @@ import { ClientDataService } from '@/src/utils/app/data/client-data-service';
 import { DataService } from '@/src/utils/app/data/data-service';
 import { ToolsetService } from '@/src/utils/app/data/toolset-service';
 import { refreshToolset$ } from '@/src/utils/app/epics-helpers/toolset.epic-helpers';
-import { getEntityNameFromId, isMyEntity } from '@/src/utils/app/id';
+import { getEntityNameFromId, isMyEntity, isPredefinedEntity } from '@/src/utils/app/id';
 import { getGroupMarketplaceEntityKey } from '@/src/utils/app/marketplace';
 import { isEntityIdPublic } from '@/src/utils/app/publications';
 import {
@@ -764,7 +764,7 @@ const logInToolsetEpic: AppEpic = (action$, state$, { router }) =>
       return ToolsetService.signIn(data).pipe(
         switchMap(() => {
           const isAdmin = AuthSelectors.selectIsAdmin(state$.value);
-          const isPublic = isEntityIdPublic({ id: payload.toolsetId });
+          const isPublic = isEntityIdPublic({ id: payload.toolsetId }) || isPredefinedEntity({ id: payload.toolsetId });
           const name = getEntityNameFromId(payload.toolsetId, {
             removeVersion: true,
           });
@@ -822,7 +822,7 @@ const logOutToolsetEpic: AppEpic = (action$, state$) =>
       }).pipe(
         switchMap(() => {
           const isAdmin = AuthSelectors.selectIsAdmin(state$.value);
-          const isPublic = isEntityIdPublic({ id: payload.toolsetId });
+          const isPublic = isEntityIdPublic({ id: payload.toolsetId }) || isPredefinedEntity({ id: payload.toolsetId });
           const name = getEntityNameFromId(payload.toolsetId, {
             removeVersion: true,
           });

--- a/apps/chat/src/utils/app/data/toolset-service.ts
+++ b/apps/chat/src/utils/app/data/toolset-service.ts
@@ -37,7 +37,7 @@ export class ToolsetService {
   }
 
   public static getToolsetById(id: string): Observable<ToolsetModel | null> {
-    if (!isPredefinedEntity({ id })) {
+    if (isPredefinedEntity({ id })) {
       return ToolsetService.getToolsetByName(id);
     }
 

--- a/apps/chat/src/utils/app/data/toolset-service.ts
+++ b/apps/chat/src/utils/app/data/toolset-service.ts
@@ -1,5 +1,6 @@
 import { Observable, catchError, map, of } from 'rxjs';
 
+import { isPredefinedEntity, isToolsetId } from '@/src/utils/app/id';
 import { convertToolsetFromApi } from '@/src/utils/app/toolsets';
 import { ApiUtils, getOpsApiUrl } from '@/src/utils/server/api';
 
@@ -24,7 +25,22 @@ export class ToolsetService {
     );
   }
 
+  public static getToolsetByName(
+    name: string,
+  ): Observable<ToolsetModel | null> {
+    return ApiUtils.request(`/api/toolsets-listing/${name}`, {
+      method: HTTPMethod.GET,
+    }).pipe(
+      map(convertToolsetFromApi),
+      catchError(() => of(null)),
+    );
+  }
+
   public static getToolsetById(id: string): Observable<ToolsetModel | null> {
+    if (!isPredefinedEntity({ id })) {
+      return ToolsetService.getToolsetByName(id);
+    }
+
     return DataService.getDataStorage().getToolsetById(id);
   }
 

--- a/apps/chat/src/utils/app/data/toolset-service.ts
+++ b/apps/chat/src/utils/app/data/toolset-service.ts
@@ -1,6 +1,6 @@
 import { Observable, catchError, map, of } from 'rxjs';
 
-import { isPredefinedEntity, isToolsetId } from '@/src/utils/app/id';
+import { isPredefinedEntity } from '@/src/utils/app/id';
 import { convertToolsetFromApi } from '@/src/utils/app/toolsets';
 import { ApiUtils, getOpsApiUrl } from '@/src/utils/server/api';
 

--- a/apps/chat/src/utils/app/id.ts
+++ b/apps/chat/src/utils/app/id.ts
@@ -115,12 +115,18 @@ export const filterIdsByFeatureType = (
   return [];
 };
 
-export const isPredefinedEntity = (entity: { id: string; reference?: string}) => {
+export const isPredefinedEntity = (entity: {
+  id: string;
+  reference?: string;
+}) => {
   if (entity.id === entity.reference) return true;
   const idParts = entity.id.split('/');
 
-  return !Object.values(ApiKeys).includes(idParts[0] as ApiKeys) && idParts.length >= 3;
-}
+  return (
+    !Object.values(ApiKeys).includes(idParts[0] as ApiKeys) &&
+    idParts.length >= 3
+  );
+};
 
 export const isRootEntity = (id: string) => {
   return id.split('/').length === 3;

--- a/apps/chat/src/utils/app/id.ts
+++ b/apps/chat/src/utils/app/id.ts
@@ -120,12 +120,9 @@ export const isPredefinedEntity = (entity: {
   reference?: string;
 }) => {
   if (entity.id === entity.reference) return true;
-  const idParts = entity.id.split('/');
+  const [key, bucket] = entity.id.split('/');
 
-  return (
-    !Object.values(ApiKeys).includes(idParts[0] as ApiKeys) &&
-    idParts.length >= 3
-  );
+  return !Object.values(ApiKeys).includes(key as ApiKeys) || !bucket;
 };
 
 export const isRootEntity = (id: string) => {

--- a/apps/chat/src/utils/app/id.ts
+++ b/apps/chat/src/utils/app/id.ts
@@ -115,6 +115,13 @@ export const filterIdsByFeatureType = (
   return [];
 };
 
+export const isPredefinedEntity = (entity: { id: string; reference?: string}) => {
+  if (entity.id === entity.reference) return true;
+  const idParts = entity.id.split('/');
+
+  return !Object.values(ApiKeys).includes(idParts[0] as ApiKeys) && idParts.length >= 3;
+}
+
 export const isRootEntity = (id: string) => {
   return id.split('/').length === 3;
 };


### PR DESCRIPTION
**Description:**

- add isPredefinedEntity method
- treat predefined toolsets as public in login flow
- fetch predefined toolsets by name instead of by id

Issues:

- Issue #5674 

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
