### PR TITLE
fix(chat): fix rules displaying after change path (Issues #5667, #2594)

### DIFF
--- a/apps/chat/src/components/Chat/Publish/PublicationHandler/PublicationHandler.tsx
+++ b/apps/chat/src/components/Chat/Publish/PublicationHandler/PublicationHandler.tsx
@@ -226,12 +226,20 @@ export function PublicationHandler({ publication, onSubmit }: Props) {
     PublishRequestFieldsNames.PUBLISH_TO_URL,
   );
 
+  const rulesPath = !isReview ? editedPublishToUrl : publication.targetFolder;
+
   const rules = useAppSelector((state) =>
-    PublicationSelectors.selectRulesByPath(
-      state,
-      !isReview ? editedPublishToUrl : publication.targetFolder,
-    ),
+    PublicationSelectors.selectRulesByPath(state, rulesPath),
   );
+
+  useEffect(() => {
+    if (rules && !isReview) {
+      formMethods.setValue(
+        PublishRequestFieldsNames.RULES,
+        rules[rulesPath] ?? [],
+      );
+    }
+  }, [formMethods, rulesPath, rules]);
 
   useEffect(() => {
     if (!isEditMode) {

--- a/apps/chat/src/store/publication/publication.selectors.ts
+++ b/apps/chat/src/store/publication/publication.selectors.ts
@@ -112,7 +112,7 @@ const selectRulesByPath = createSelector(
   (rules, path) => {
     return Object.fromEntries(
       Object.entries(rules).filter(
-        ([key]) => path.startsWith(key) && key.split('/').length !== 1,
+        ([key]) => path === key || path.startsWith(`${key}/`),
       ),
     );
   },


### PR DESCRIPTION
**Description:**

fix rules displaying after change path

Issues:

- Issue #5667
- Issue #2594

**UI changes**

<img width="492" height="289" alt="image" src="https://github.com/user-attachments/assets/330cbfe7-7178-4e51-8758-0125a9ade4d8" />

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
