### PR TITLE
fix(chat): fix adding agent to to installed models on background when marketplace feature is turned off (Issue #2850)

### DIFF
--- a/apps/chat/src/store/conversations/conversations.epics.ts
+++ b/apps/chat/src/store/conversations/conversations.epics.ts
@@ -1343,6 +1343,7 @@ const sendMessageEpic: AppEpic = (action$, state$) =>
     map(({ payload }) => ({
       payload,
       modelsMap: ModelsSelectors.selectModelsMap(state$.value),
+      installedModelIds: ModelsSelectors.selectInstalledModelIds(state$.value),
       conversations: ConversationsSelectors.selectConversations(state$.value),
       selectedConversationIds:
         ConversationsSelectors.selectSelectedConversationsIds(state$.value),
@@ -1354,6 +1355,8 @@ const sendMessageEpic: AppEpic = (action$, state$) =>
     switchMap(
       ({
         payload,
+        modelsMap,
+        installedModelIds,
         conversations,
         selectedConversationIds,
         overlaySystemPrompt,
@@ -1460,11 +1463,31 @@ const sendMessageEpic: AppEpic = (action$, state$) =>
           isMessageStreaming: true,
         });
 
+        const isMarketplaceEnabled = SettingsSelectors.isFeatureEnabled(
+          state$.value,
+          Feature.Marketplace,
+        );
+        const model = modelsMap[updatedConversation.model.id];
+
         if (!payload.skipRecentModelsUpdate) {
           actions.push(
             of(
               ModelsActions.updateRecentModels({
                 modelId: updatedConversation.model.id,
+              }),
+            ),
+          );
+        }
+
+        if (
+          !isMarketplaceEnabled &&
+          model &&
+          !installedModelIds.has(model.reference)
+        ) {
+          actions.push(
+            of(
+              ModelsActions.addInstalledModels({
+                references: [model.reference],
               }),
             ),
           );


### PR DESCRIPTION
**Description:**

- if marketplace feature is off, add agent to installed when sending a message

Issues:

- Issue #2850

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
