### PR TITLE
fix(chat): remove attachments wrapper if it contains borderless attachment (Issue #5772)

### DIFF
--- a/apps/chat/src/components/Chat/MessageAttachment.tsx
+++ b/apps/chat/src/components/Chat/MessageAttachment.tsx
@@ -51,6 +51,7 @@ interface AttachmentDataRendererProps {
   isFullScreen?: boolean;
   onFullScreenClick?: () => void;
   isInner?: boolean;
+  forceDefaultView?: boolean;
 }
 
 const getSourceDataUrl = (attachment: Attachment): string | undefined => {
@@ -199,6 +200,7 @@ const ChartAttachmentUrlRenderer = ({
 interface Props {
   attachment: Attachment;
   isInner?: boolean;
+  forceDefaultView?: boolean;
 }
 
 const AttachmentRendererComponent = withErrorBoundary(
@@ -207,6 +209,7 @@ const AttachmentRendererComponent = withErrorBoundary(
     isInner,
     isFullScreen,
     onFullScreenClick,
+    forceDefaultView,
   }: AttachmentDataRendererProps) => {
     const attachmentType: MIMEType = attachment.type;
     const mappedAttachmentUrl = useMemo(
@@ -232,6 +235,7 @@ const AttachmentRendererComponent = withErrorBoundary(
           mimeType={attachmentType}
           isFullScreen={isFullScreen}
           onFullScreenClick={onFullScreenClick}
+          forceDefaultView={forceDefaultView}
         />
       );
     }
@@ -259,7 +263,11 @@ const AttachmentRendererComponent = withErrorBoundary(
   },
 );
 
-export const MessageAttachment = ({ attachment, isInner }: Props) => {
+export const MessageAttachment = ({
+  attachment,
+  isInner,
+  forceDefaultView,
+}: Props) => {
   const { t } = useTranslation(Translation.Chat);
 
   const anchorRef = useRef<HTMLDivElement>(null);
@@ -276,9 +284,11 @@ export const MessageAttachment = ({ attachment, isInner }: Props) => {
     SettingsSelectors.selectAttachmentsSettings,
   );
 
-  const isBorderless = borderlessTypes.includes(attachment.type);
+  const isBorderless =
+    borderlessTypes.includes(attachment.type) && !forceDefaultView;
   const isExpandedByDefault =
-    isBorderless || expandedTypes.includes(attachment.type);
+    (isBorderless || expandedTypes.includes(attachment.type)) &&
+    !forceDefaultView;
 
   const [isOpened, setIsOpened] = useState(isExpandedByDefault);
   const [wasOpened, setWasOpened] = useState(isExpandedByDefault);
@@ -531,6 +541,7 @@ export const MessageAttachment = ({ attachment, isInner }: Props) => {
             isInner={isInner}
             isFullScreen={isFullScreen}
             onFullScreenClick={handleToggleFullScreen}
+            forceDefaultView={forceDefaultView}
           />
           {mappedAttachmentReferenceUrl && (
             <a

--- a/apps/chat/src/components/Chat/MessageAttachments.tsx
+++ b/apps/chat/src/components/Chat/MessageAttachments.tsx
@@ -92,6 +92,7 @@ export const MessageAttachments = ({ attachments, isInner }: Props) => {
           key={attachment.url || attachment.title}
           attachment={attachment}
           isInner={isInner}
+          forceDefaultView={isInner}
         />
       ))}
     </div>

--- a/apps/chat/src/components/Chat/MessageAttachments.tsx
+++ b/apps/chat/src/components/Chat/MessageAttachments.tsx
@@ -6,6 +6,9 @@ import { useTranslation } from '@/src/hooks/useTranslation';
 
 import { Translation } from '@/src/types/translation';
 
+import { useAppSelector } from '@/src/store/hooks';
+import { SettingsSelectors } from '@/src/store/selectors';
+
 import { MessageAttachment } from './MessageAttachment';
 
 import ChevronDown from '@/public/images/icons/chevron-down.svg';
@@ -19,11 +22,30 @@ interface Props {
 
 export const MessageAttachments = ({ attachments, isInner }: Props) => {
   const { t } = useTranslation(Translation.Chat);
-  const isUnderSection = useMemo(() => {
-    return !!attachments && attachments.length > 3;
-  }, [attachments]);
 
-  const [isSectionOpened, setIsSectionOpened] = useState(false);
+  const { expandedTypes, borderlessTypes } = useAppSelector(
+    SettingsSelectors.selectAttachmentsSettings,
+  );
+
+  const { hasBorderlessAttachments, hasExpandedAttachments } = useMemo(
+    () => ({
+      hasBorderlessAttachments: !!attachments?.some((a) =>
+        borderlessTypes.includes(a.type),
+      ),
+      hasExpandedAttachments: !!attachments?.some((a) =>
+        expandedTypes.includes(a.type),
+      ),
+    }),
+    [attachments, borderlessTypes, expandedTypes],
+  );
+
+  const isUnderSection = useMemo(() => {
+    return !!attachments && attachments.length > 3 && !hasBorderlessAttachments;
+  }, [attachments, hasBorderlessAttachments]);
+
+  const [isSectionOpened, setIsSectionOpened] = useState(
+    hasExpandedAttachments,
+  );
 
   if (!attachments?.length) {
     return null;

--- a/apps/chat/src/components/VisualalizerRenderer/VisualizerRenderer.tsx
+++ b/apps/chat/src/components/VisualalizerRenderer/VisualizerRenderer.tsx
@@ -47,6 +47,7 @@ interface Props {
   renderer: CustomVisualizer;
   mimeType: string;
   isFullScreen?: boolean;
+  forceDefaultView?: boolean;
   onFullScreenClick?: () => void;
 }
 
@@ -55,6 +56,7 @@ export const VisualizerRenderer = ({
   renderer,
   mimeType,
   isFullScreen,
+  forceDefaultView,
   onFullScreenClick,
 }: Props) => {
   const iframeContainerRef = useRef<HTMLDivElement>(null);
@@ -88,8 +90,8 @@ export const VisualizerRenderer = ({
     SettingsSelectors.selectAttachmentsSettings,
   );
 
-  const hideTitle = withoutTitleTypes.includes(mimeType);
-  const isBorderless = borderlessTypes.includes(mimeType);
+  const hideTitle = withoutTitleTypes.includes(mimeType) && !forceDefaultView;
+  const isBorderless = borderlessTypes.includes(mimeType) && !forceDefaultView;
 
   const scrollWidth = iframeContainerRef.current?.scrollWidth ?? null;
   const containerHeight = iframeContainerRef.current?.clientHeight ?? null;


### PR DESCRIPTION
**Description:**

- remove attachments wrapper if it contains borderless attachment
- expand by default attachments wrapper if it contains expanded by default attachment
- disable attachment view settings in stages

Issues:

- Issue #5772 

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
