### PR TITLE
fix(chat): don't save agents and toolsets json automatically (Issue #5764)

### DIFF
--- a/apps/chat/src/components/AppsEditor/AppsEditor.tsx
+++ b/apps/chat/src/components/AppsEditor/AppsEditor.tsx
@@ -42,6 +42,7 @@ import { AppsEditorHeader } from '@/src/components/AppsEditor/AppsEditorHeader';
 import { AppsEditorView } from '@/src/components/AppsEditor/AppsEditorView';
 import {
   AppsEditorFormType,
+  QuickApp2Form,
   getApplicationPayload,
   getDefaultFormData,
   getValidationSchema,
@@ -137,6 +138,12 @@ export const AppsEditor = () => {
     }),
   );
   const isDirty = formMethods.formState.isDirty;
+  const isQuickAppJsonDirty = (
+    formMethods.formState.dirtyFields as Record<keyof QuickApp2Form, boolean>
+  )['agentsAndToolsetsJson'];
+  const onlyQuickAppJsonChanged =
+    Object.keys(formMethods.formState.dirtyFields).length === 1 &&
+    isQuickAppJsonDirty;
 
   const marketplaceEntities = useMemo(
     () =>
@@ -156,6 +163,7 @@ export const AppsEditor = () => {
         data,
         allEntitiesMap: marketplaceEntities,
         currentApp: appDetails,
+        keepCurrentToolsets: isSimpleViewSwitchRef.current,
       });
 
       if (!appDetails) {
@@ -214,21 +222,42 @@ export const AppsEditor = () => {
         );
       }
 
-      isSimpleViewSwitchRef.current = false;
-      changeEditorTabRef.current = null;
-      saveAndExitRef.current = false;
-      redirectToChatRef.current = false;
-      formMethods.reset(formMethods.getValues(), {
-        keepIsValid: true,
-        keepErrors: true,
-      });
+      formMethods.reset(
+        {
+          ...formMethods.getValues(),
+          ...(!isSimpleViewSwitchRef.current &&
+            isQuickAppJsonDirty && {
+              agentsAndToolsetsJson: (
+                lastSubmittedValuesRef.current as QuickApp2Form
+              ).agentsAndToolsetsJson,
+            }),
+        },
+        {
+          keepIsValid: true,
+          keepErrors: true,
+        },
+      );
+      // Make agentsAndToolsetsJson dirty if it was not saved manually
+      if (!isSimpleViewSwitchRef.current && isQuickAppJsonDirty) {
+        formMethods.setValue(
+          'agentsAndToolsetsJson',
+          (data as QuickApp2Form).agentsAndToolsetsJson as string,
+          { shouldDirty: true, shouldTouch: true, shouldValidate: true },
+        );
+      }
+
       lastSubmittedValuesRef.current = getDefaultFormData({
         app: payload,
         type,
         runtime: pythonVersions[0],
       });
+      isSimpleViewSwitchRef.current = false;
+      changeEditorTabRef.current = null;
+      saveAndExitRef.current = false;
+      redirectToChatRef.current = false;
     },
     [
+      isQuickAppJsonDirty,
       appDetails,
       dispatch,
       formMethods,
@@ -345,10 +374,12 @@ export const AppsEditor = () => {
       if (editorStep === MarketplaceEditorSteps.General || isAppPublic) return;
       if (isSimpleViewSwitch) {
         isSimpleViewSwitchRef.current = true;
+      } else if (onlyQuickAppJsonChanged) {
+        return;
       }
       void handleSubmit(undefined, true, true);
     },
-    [editorStep, handleSubmit, isAppPublic],
+    [editorStep, handleSubmit, isAppPublic, onlyQuickAppJsonChanged],
   );
 
   useEffect(() => {

--- a/apps/chat/src/components/AppsEditor/AppsEditorView.tsx
+++ b/apps/chat/src/components/AppsEditor/AppsEditorView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useFormContext, useWatch } from 'react-hook-form';
 
 import { useRouter } from 'next/router';
@@ -116,6 +116,8 @@ export const AppsEditorView = ({
     [onAutoSave],
   );
 
+  const handlePureAutoSave = useCallback(() => onAutoSave(), [onAutoSave]);
+
   useEffect(() => {
     if (
       editorStep === MarketplaceEditorSteps.Settings &&
@@ -135,7 +137,7 @@ export const AppsEditorView = ({
       closedPreviewLabel={`${t('Preview')}: ${name} v. ${version}`}
       leftTabLabel={t(mobileTabLabels[editorStep])}
       rightQa="entity-preview-settings"
-      onLeftMouseLeave={onAutoSave}
+      onLeftMouseLeave={handlePureAutoSave}
     />
   );
 };

--- a/apps/chat/src/components/AppsEditor/form.ts
+++ b/apps/chat/src/components/AppsEditor/form.ts
@@ -715,10 +715,12 @@ export const getApplicationPayload = ({
   data,
   currentApp,
   allEntitiesMap,
+  keepCurrentToolsets,
 }: {
   data: AppsEditorFormType;
   allEntitiesMap: Record<string, MarketplaceEntity>;
   currentApp?: CustomApplicationModel;
+  keepCurrentToolsets?: boolean;
 }): CustomApplicationModel => {
   const generalData = {
     id: '',
@@ -825,9 +827,10 @@ export const getApplicationPayload = ({
               url,
               type: 'file',
             })) ?? [],
-          tool_sets: data.isJsonView
-            ? (JSON.parse(data.agentsAndToolsetsJson) as AnyToolset[])
-            : getQuickApp2Toolsets({ data, allEntitiesMap }),
+          tool_sets:
+            data.isJsonView && !keepCurrentToolsets
+              ? (JSON.parse(data.agentsAndToolsetsJson) as AnyToolset[])
+              : getQuickApp2Toolsets({ data, allEntitiesMap }),
         },
       };
     }

--- a/apps/chat/src/components/Marketplace/MarketplaceEditorView/MarketplaceEditorView.tsx
+++ b/apps/chat/src/components/Marketplace/MarketplaceEditorView/MarketplaceEditorView.tsx
@@ -1,4 +1,10 @@
-import React, { ReactNode, useCallback, useEffect, useMemo } from 'react';
+import React, {
+  MouseEvent,
+  ReactNode,
+  useCallback,
+  useEffect,
+  useMemo,
+} from 'react';
 
 import classNames from 'classnames';
 
@@ -21,7 +27,7 @@ interface MarketplaceEditorViewProps {
   onPreviewModeChange: (mode: PreviewMode) => void;
 
   defaultPreviewMode?: PreviewMode;
-  onLeftMouseLeave?: () => void;
+  onLeftMouseLeave?: (e?: MouseEvent<HTMLDivElement>) => void;
   rightQa?: string;
   closedPreviewLabel?: string;
   leftTabLabel?: string;


### PR DESCRIPTION
**Description:**

- skip auto save if only json was changed
- save old json value on auto-save if other form values was changed (make json field dirty in form state after save)

Issues:

- Issue #5764 

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
