### PR TITLE
fix(chat): fix `DIAL Chat` crashes with TypeError when processing folders with `name: null` (Issue #5798)

### DIFF
--- a/apps/chat/src/types/common.ts
+++ b/apps/chat/src/types/common.ts
@@ -58,7 +58,16 @@ export interface BackendFolder<ItemType>
   items: ItemType[];
 }
 
+export interface BackendFolderWithDefName<ItemType>
+  extends BackendFolder<ItemType> {
+  name: string;
+}
+
 export type BackendChatFolder = BackendFolder<
+  BackendChatEntity | BackendChatFolder
+>;
+
+export type BackendChatFolderWithDefName = BackendFolderWithDefName<
   BackendChatEntity | BackendChatFolder
 >;
 

--- a/apps/chat/src/types/common.ts
+++ b/apps/chat/src/types/common.ts
@@ -51,7 +51,9 @@ export interface BackendChatEntity extends BackendEntity {
   author?: string;
 }
 
-export interface BackendFolder<ItemType> extends BackendDataEntity {
+export interface BackendFolder<ItemType>
+  extends Omit<BackendDataEntity, 'name'> {
+  name: string | null;
   nodeType: BackendDataNodeType.FOLDER;
   items: ItemType[];
 }

--- a/apps/chat/src/types/files.ts
+++ b/apps/chat/src/types/files.ts
@@ -1,6 +1,7 @@
 import {
   BackendEntity,
   BackendFolder,
+  BackendFolderWithDefName,
   BaseDialEntity,
 } from '@/src/types/common';
 
@@ -16,6 +17,9 @@ export interface BackendFile extends BackendEntity {
 }
 
 export type BackendFileFolder = BackendFolder<BackendFile | BackendFileFolder>;
+export type BackendFileFolderWithDefName = BackendFolderWithDefName<
+  BackendFile | BackendFileFolder
+>;
 
 export type DialFile = Omit<
   BackendFile,

--- a/apps/chat/src/utils/app/data/file-service.ts
+++ b/apps/chat/src/utils/app/data/file-service.ts
@@ -173,7 +173,9 @@ export class FileService {
       map((folders: BackendFileFolder[]) => {
         return folders
           .filter(
-            (folder) => !!folder.parentPath || folder.name !== CLIENTDATA_PATH,
+            (folder) =>
+              !!folder.parentPath ||
+              (!!folder.name && folder.name !== CLIENTDATA_PATH),
           )
           .map((folder): FileFolderInterface => {
             const relativePath = folder.parentPath
@@ -187,7 +189,7 @@ export class FileService {
                 relativePath,
                 folder.name,
               ),
-              name: folder.name,
+              name: folder.name!,
               type: FeatureType.File,
               absolutePath: constructPath(
                 ApiKeys.Files,

--- a/apps/chat/src/utils/app/data/file-service.ts
+++ b/apps/chat/src/utils/app/data/file-service.ts
@@ -13,6 +13,7 @@ import {
 import {
   BackendFile,
   BackendFileFolder,
+  BackendFileFolderWithDefName,
   DialFile,
   FileFolderInterface,
   FileOperationsResult,
@@ -171,40 +172,37 @@ export class FileService {
       this.getListingUrl({ path: parentPath, resultQuery }),
     ).pipe(
       map((folders: BackendFileFolder[]) => {
-        return folders
-          .filter(
+        return (
+          folders.filter(
             (folder) =>
               !!folder.parentPath ||
               (!!folder.name && folder.name !== CLIENTDATA_PATH),
-          )
-          .map((folder): FileFolderInterface => {
-            const relativePath = folder.parentPath
-              ? ApiUtils.decodeApiUrl(folder.parentPath)
-              : undefined;
+          ) as BackendFileFolderWithDefName[]
+        ).map((folder): FileFolderInterface => {
+          const relativePath = folder.parentPath
+            ? ApiUtils.decodeApiUrl(folder.parentPath)
+            : undefined;
 
-            return {
-              id: constructPath(
-                ApiKeys.Files,
-                folder.bucket,
-                relativePath,
-                folder.name,
-              ),
-              name: folder.name!,
-              type: FeatureType.File,
-              absolutePath: constructPath(
-                ApiKeys.Files,
-                folder.bucket,
-                relativePath,
-              ),
-              relativePath: relativePath,
-              folderId: constructPath(
-                getFileRootId(folder.bucket),
-                relativePath,
-              ),
-              serverSynced: true,
-              permissions: folder.permissions,
-            };
-          });
+          return {
+            id: constructPath(
+              ApiKeys.Files,
+              folder.bucket,
+              relativePath,
+              folder.name,
+            ),
+            name: folder.name,
+            type: FeatureType.File,
+            absolutePath: constructPath(
+              ApiKeys.Files,
+              folder.bucket,
+              relativePath,
+            ),
+            relativePath: relativePath,
+            folderId: constructPath(getFileRootId(folder.bucket), relativePath),
+            serverSynced: true,
+            permissions: folder.permissions,
+          };
+        });
       }),
     );
   }

--- a/apps/chat/src/utils/app/data/share-service.ts
+++ b/apps/chat/src/utils/app/data/share-service.ts
@@ -109,7 +109,10 @@ export class ShareService {
       body: JSON.stringify(sharedListingData),
     }).pipe(
       map((resp: { resources: BackendDataEntity[] }) => {
-        const folders: FolderInterface[] = [];
+        const folders: (Omit<FolderInterface, 'name'> & {
+          name: string | null;
+        })[] = [];
+
         const entities: (
           | ConversationInfo
           | PromptInfo
@@ -241,7 +244,9 @@ export class ShareService {
         });
 
         return {
-          folders,
+          folders: folders.filter(
+            (folder) => !!folder.name,
+          ) as FolderInterface[],
           entities,
         };
       }),

--- a/apps/chat/src/utils/app/data/storages/api/api-entity-storage.ts
+++ b/apps/chat/src/utils/app/data/storages/api/api-entity-storage.ts
@@ -11,6 +11,7 @@ import {
   ApiKeys,
   BackendChatEntity,
   BackendChatFolder,
+  BackendChatFolderWithDefName,
   BackendDataNodeType,
 } from '@/src/types/common';
 import { FolderInterface, FoldersAndEntities } from '@/src/types/folder';
@@ -26,9 +27,7 @@ export abstract class ApiEntityStorage<
   APIModel = APIResponse,
 > implements EntityStorage<TEntityInfo, TEntity>
 {
-  private mapFolder(
-    folder: BackendChatFolder & { name: string },
-  ): FolderInterface {
+  private mapFolder(folder: BackendChatFolderWithDefName): FolderInterface {
     const id = ApiUtils.decodeApiUrl(
       folder.url.slice(0, folder.url.length - 1),
     );
@@ -88,7 +87,7 @@ export abstract class ApiEntityStorage<
       map((items: (BackendChatFolder | BackendChatEntity)[]) => {
         const folders = items.filter(
           (item) => item.nodeType === BackendDataNodeType.FOLDER && !!item.name,
-        ) as (BackendChatFolder & { name: string })[];
+        ) as BackendChatFolderWithDefName[];
         const entities = items.filter(
           (item) => item.nodeType === BackendDataNodeType.ITEM,
         ) as BackendChatEntity[];
@@ -113,7 +112,7 @@ export abstract class ApiEntityStorage<
       map((folders: BackendChatFolder[]) => {
         const filteredFolders = folders.filter(
           (folder) => !!folder.name,
-        ) as (BackendChatFolder & { name: string })[];
+        ) as BackendChatFolderWithDefName[];
         return filteredFolders.map((folder) => this.mapFolder(folder));
       }),
     );

--- a/apps/chat/src/utils/app/data/storages/api/api-entity-storage.ts
+++ b/apps/chat/src/utils/app/data/storages/api/api-entity-storage.ts
@@ -26,7 +26,9 @@ export abstract class ApiEntityStorage<
   APIModel = APIResponse,
 > implements EntityStorage<TEntityInfo, TEntity>
 {
-  private mapFolder(folder: BackendChatFolder): FolderInterface {
+  private mapFolder(
+    folder: BackendChatFolder & { name: string },
+  ): FolderInterface {
     const id = ApiUtils.decodeApiUrl(
       folder.url.slice(0, folder.url.length - 1),
     );
@@ -85,8 +87,8 @@ export abstract class ApiEntityStorage<
     return ApiUtils.request(this.getListingUrl({ path })).pipe(
       map((items: (BackendChatFolder | BackendChatEntity)[]) => {
         const folders = items.filter(
-          (item) => item.nodeType === BackendDataNodeType.FOLDER,
-        ) as BackendChatFolder[];
+          (item) => item.nodeType === BackendDataNodeType.FOLDER && !!item.name,
+        ) as (BackendChatFolder & { name: string })[];
         const entities = items.filter(
           (item) => item.nodeType === BackendDataNodeType.ITEM,
         ) as BackendChatEntity[];
@@ -109,7 +111,10 @@ export abstract class ApiEntityStorage<
 
     return ApiUtils.request(this.getListingUrl({ path, resultQuery })).pipe(
       map((folders: BackendChatFolder[]) => {
-        return folders.map((folder) => this.mapFolder(folder));
+        const filteredFolders = folders.filter(
+          (folder) => !!folder.name,
+        ) as (BackendChatFolder & { name: string })[];
+        return filteredFolders.map((folder) => this.mapFolder(folder));
       }),
     );
   }


### PR DESCRIPTION
**Description:**

- Fix `DIAL Chat` crashes with TypeError when processing folders with `name : null`

Issues:

- Issue #5798 

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
