### PR TITLE
fix(chat): add requestTimeout property for custom renderers config (Issue #5839)

### DIFF
--- a/apps/chat/src/components/VisualalizerRenderer/VisualizerRenderer.tsx
+++ b/apps/chat/src/components/VisualalizerRenderer/VisualizerRenderer.tsx
@@ -116,8 +116,10 @@ export const VisualizerRenderer = ({
       height:
         isFullScreen && containerHeight
           ? containerHeight
-          : (customAttachmentData?.layout.height ??
-            DEFAULT_CUSTOM_ATTACHMENT_HEIGHT),
+          : Number(
+              customAttachmentData?.layout.height ??
+                DEFAULT_CUSTOM_ATTACHMENT_HEIGHT,
+            ),
       themeId,
     };
   }, [

--- a/apps/chat/src/components/VisualalizerRenderer/VisualizerRenderer.tsx
+++ b/apps/chat/src/components/VisualalizerRenderer/VisualizerRenderer.tsx
@@ -64,7 +64,7 @@ export const VisualizerRenderer = ({
   const { t } = useTranslation(Translation.Chat);
 
   const [ready, setReady] = useState<boolean>();
-  const { url: rendererUrl, title: visualizerTitle } = renderer;
+  const { url: rendererUrl, title: visualizerTitle, requestTimeout } = renderer;
 
   const dispatch = useAppDispatch();
 
@@ -157,6 +157,7 @@ export const VisualizerRenderer = ({
         hostDomain: window.location.origin,
         visualizerName: visualizerTitle,
         loaderStyles: { display: 'none' },
+        requestTimeout,
       });
 
       return () => {
@@ -164,7 +165,7 @@ export const VisualizerRenderer = ({
         visualizer.current = null;
       };
     }
-  }, [rendererUrl, visualizerTitle]);
+  }, [requestTimeout, rendererUrl, visualizerTitle]);
 
   useEffect(() => {
     if (

--- a/apps/chat/src/types/custom-visualizers.ts
+++ b/apps/chat/src/types/custom-visualizers.ts
@@ -4,6 +4,7 @@ export interface CustomVisualizer {
   icon: string;
   contentType: string;
   url: string;
+  requestTimeout?: number;
 }
 
 export type MappedVisualizers = Record<string, CustomVisualizer[]>;

--- a/libs/overlay/src/lib/ChatOverlay.ts
+++ b/libs/overlay/src/lib/ChatOverlay.ts
@@ -239,7 +239,6 @@ export class ChatOverlay {
    * @param event {MessageEvent} post message event
    */
   protected process = (event: MessageEvent<OverlayRequest>): void => {
-
     // Only process messages from this specific iframe instance
     if (event.source !== this.iframe.contentWindow) {
       return;

--- a/libs/overlay/src/lib/ChatOverlay.ts
+++ b/libs/overlay/src/lib/ChatOverlay.ts
@@ -239,6 +239,12 @@ export class ChatOverlay {
    * @param event {MessageEvent} post message event
    */
   protected process = (event: MessageEvent<OverlayRequest>): void => {
+
+    // Only process messages from this specific iframe instance
+    if (event.source !== this.iframe.contentWindow) {
+      return;
+    }
+
     if (event.data.type === `${overlayAppName}/${OverlayEvents.initReady}`) {
       this.showLoader();
 

--- a/libs/visualizer-connector/src/lib/VisualizerConnector.ts
+++ b/libs/visualizer-connector/src/lib/VisualizerConnector.ts
@@ -196,6 +196,12 @@ export class VisualizerConnector {
   protected process = (
     event: MessageEvent<VisualizerConnectorRequest>,
   ): void => {
+
+    // Only process messages from this specific iframe instance
+    if (event.source !== this.iframe.contentWindow) {
+      return;
+    }
+
     if (
       event.data.type ===
       `${this.options.visualizerName}/${VisualizerConnectorEvents.ready}`

--- a/libs/visualizer-connector/src/lib/VisualizerConnector.ts
+++ b/libs/visualizer-connector/src/lib/VisualizerConnector.ts
@@ -196,7 +196,6 @@ export class VisualizerConnector {
   protected process = (
     event: MessageEvent<VisualizerConnectorRequest>,
   ): void => {
-
     // Only process messages from this specific iframe instance
     if (event.source !== this.iframe.contentWindow) {
       return;


### PR DESCRIPTION
**Description:**

- add requestTimout for CUSTOM_VISUALIZERS config
- force convert custom visualiser attachment height to number
- restrict message processing to specific iframe instance

Issues:

- Issue #5839 

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
