### PR TITLE
fix(chat): fix displaying application which was created manually without versions in paths (Issue #5869)

### DIFF
--- a/apps/chat/src/components/Chat/ModelVersionSelect.tsx
+++ b/apps/chat/src/components/Chat/ModelVersionSelect.tsx
@@ -4,6 +4,9 @@ import classNames from 'classnames';
 
 import { useTranslation } from '@/src/hooks/useTranslation';
 
+import { isEntityIdPublic } from '@/src/utils/app/publications';
+import { getVersionFromId } from '@/src/utils/server/api';
+
 import { MarketplaceEntity } from '@/src/types/marketplace';
 import { Translation } from '@/src/types/translation';
 
@@ -15,6 +18,7 @@ import { Menu, MenuItem } from '@/src/components/Common/DropdownMenu';
 import { Tooltip } from '@/src/components/Common/Tooltip';
 
 import ChevronDownIcon from '@/public/images/icons/chevron-down.svg';
+import { en } from 'zod/v4/locales';
 
 const VersionPrefix = () => {
   const { t } = useTranslation(Translation.Chat);
@@ -27,9 +31,15 @@ const VersionPrefix = () => {
   );
 };
 
-const getDisplayValue = <T extends MarketplaceEntity>(entity: T) =>
-  entity.version || entity.id;
-
+const getDisplayValue = <T extends MarketplaceEntity>(entity: T) => {
+  if (entity.version) {
+    return entity.version;
+  }
+  if (isEntityIdPublic(entity) || entity.id !== entity.reference) {
+    return getVersionFromId(entity.id);
+  }
+  return entity.id;
+};
 interface EntityVersionSelectProps<T extends MarketplaceEntity> {
   entities: T[];
   currentEntity: T;

--- a/apps/chat/src/components/Chat/ModelVersionSelect.tsx
+++ b/apps/chat/src/components/Chat/ModelVersionSelect.tsx
@@ -18,7 +18,6 @@ import { Menu, MenuItem } from '@/src/components/Common/DropdownMenu';
 import { Tooltip } from '@/src/components/Common/Tooltip';
 
 import ChevronDownIcon from '@/public/images/icons/chevron-down.svg';
-import { en } from 'zod/v4/locales';
 
 const VersionPrefix = () => {
   const { t } = useTranslation(Translation.Chat);

--- a/apps/chat/src/utils/server/__tests__/api.test.ts
+++ b/apps/chat/src/utils/server/__tests__/api.test.ts
@@ -1,6 +1,12 @@
 import { ServerSlugs } from '@/src/types/slugs-types';
 
-import { decodeModelId, encodeModelId, getOpsApiUrl } from '../api';
+import {
+  decodeModelId,
+  encodeModelId,
+  getModelIdWithoutVersion,
+  getOpsApiUrl,
+  getVersionFromId,
+} from '../api';
 
 describe('decodeModelId and encodeModelId', () => {
   it.each([
@@ -43,5 +49,31 @@ describe('getOpsApiUrl', () => {
     expect(
       getOpsApiUrl(ServerSlugs.PUBLICATION_REJECT, 'test app', 'v1.0.0'),
     ).toBe('/api/ops/publication/reject/test app/v1.0.0');
+  });
+});
+
+describe('getModelIdWithoutVersion', () => {
+  it.each([
+    ['gpt_4', 'gpt_4'],
+    ['gpt_4__0.1.1', 'gpt_4'],
+    ['gpt_4__1', 'gpt_4__1'],
+    ['gpt_4___1', 'gpt_4___1'],
+    ['gpt_4____1', 'gpt_4____1'],
+    ['gpt_4__100.1000.11', 'gpt_4'],
+    ['gpt_4___0.0.1', 'gpt_4_'],
+    ['gpt_4____0.0.1', 'gpt_4__'],
+  ])('getModelIdWithoutVersion(%s) = %s', (id: string, expected: string) => {
+    expect(getModelIdWithoutVersion(id)).toBe(expected);
+  });
+});
+
+describe('getVersionFromId', () => {
+  it.each([
+    ['gpt_4', 'N/A'],
+    ['gpt_4__0.1.1', '0.1.1'],
+    ['gpt_4__100.1000.11', '100.1000.11'],
+    ['gpt_4__1', 'N/A'],
+  ])('getVersionFromId(%s) = %s', (id: string, expected: string) => {
+    expect(getVersionFromId(id)).toBe(expected);
   });
 });

--- a/apps/chat/src/utils/server/__tests__/api.test.ts
+++ b/apps/chat/src/utils/server/__tests__/api.test.ts
@@ -73,6 +73,8 @@ describe('getVersionFromId', () => {
     ['gpt_4__0.1.1', '0.1.1'],
     ['gpt_4__100.1000.11', '100.1000.11'],
     ['gpt_4__1', 'N/A'],
+    ['conversations/bucket/echo__4', 'N/A'],
+    ['conversations/bucket/echo__4__0.1.1', '0.1.1'],
   ])('getVersionFromId(%s) = %s', (id: string, expected: string) => {
     expect(getVersionFromId(id)).toBe(expected);
   });

--- a/apps/chat/src/utils/server/api.ts
+++ b/apps/chat/src/utils/server/api.ts
@@ -150,6 +150,9 @@ export const parseEntityApiKey = <T extends ParseEntityApiKeyOptions>(
 export const getMarketplaceEntityApiKey = (
   entity: Omit<ApplicationInfo | ToolsetInfo, 'folderId' | 'id'>,
 ): string => {
+  if (!entity.version || entity.version === NA_VERSION) {
+    return entity.name;
+  }
   return [entity.name, entity.version].join(pathKeySeparator);
 };
 
@@ -284,7 +287,14 @@ export class ApiUtils {
 
 export const getModelIdWithoutVersion = (id: string) => {
   const parts = id.split(pathKeySeparator);
+  if (parts.length < 2) {
+    return id;
+  }
   const name = parts.slice(0, -1).join(pathKeySeparator);
+  const version = parts.at(-1)?.replace(/^_/, '');
+  if (!version || !validVersionRegEx.test(version)) {
+    return id;
+  }
   if (parts.at(-1)?.startsWith('_')) {
     return `${name}_`;
   }
@@ -317,6 +327,9 @@ export const getIdWithoutVersionFromApiKey = (id: string) => {
 
 export const getVersionFromId = (id: string) => {
   const parts = id.split(pathKeySeparator);
+  if (parts.length < 2) {
+    return NA_VERSION;
+  }
   const version = parts.at(-1)?.replace(/^_/, '');
 
   // conversations also have model (example: conversations/public/gpt-3.5-turbo__name__0.0.1)

--- a/apps/chat/src/utils/server/api.ts
+++ b/apps/chat/src/utils/server/api.ts
@@ -330,12 +330,13 @@ export const getVersionFromId = (id: string) => {
   if (parts.length < 2) {
     return NA_VERSION;
   }
-  const version = parts.at(-1)?.replace(/^_/, '');
 
   // conversations also have model (example: conversations/public/gpt-3.5-turbo__name__0.0.1)
-  if (id.startsWith(`${ApiKeys.Conversations}/`) && parts.length <= 2) {
+  if (isConversationId(id) && parts.length < 3) {
     return NA_VERSION;
   }
+
+  const version = parts.at(-1)?.replace(/^_/, '');
 
   return version && validVersionRegEx.test(version) ? version : NA_VERSION;
 };


### PR DESCRIPTION
**Description:**

fix displaying application which was created manually without versions in paths

We had 2problems here:

- public paths without versions are split incorrectly (e.g. if public path `applications/public/app_5869` instead of `applications/public/app_5869__0.0.1`)
- version selector for applications with public paths without versions displays id 
<img width="366" height="127" alt="Image" src="https://github.com/user-attachments/assets/05c0fa79-64ec-4a2b-ae6c-d64b75067305" />

Issues:

- Issue #5869

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
