### PR TITLE
fix(chat): fix extra line is shown in user-prompt if user uses populate buttons (Issue #5891)

### DIFF
--- a/apps/chat/src/components/Chat/ChatMessage/MessageSchema/UserSchema.tsx
+++ b/apps/chat/src/components/Chat/ChatMessage/MessageSchema/UserSchema.tsx
@@ -98,7 +98,7 @@ const UserSchemaView = memo(function UserSchemaView({
       />
     );
 
-  return schemaPropertiesWithUserResponse ? (
+  return schemaPropertiesWithUserResponse.length ? (
     <div className="flex flex-col gap-6">
       {schemaPropertiesWithUserResponse.map((row) => (
         <div key={row.property}>


### PR DESCRIPTION
**Description:**

- Prevent rendering of the empty element if there is empty `schemaPropertiesWithUserResponse` array.

Issues:

- Issue #5891 

**UI changes**

**Before fix:**
<img width="989" height="155" alt="image" src="https://github.com/user-attachments/assets/37478555-3c6d-4201-8aa0-746147fd10d8" />

**After fix:**
<img width="970" height="132" alt="image" src="https://github.com/user-attachments/assets/133a1d11-fc3a-400e-b366-0421fbf38503" />


**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
