### PR TITLE
fix(chat): fix public version selector color (Issue #5866)

### DIFF
--- a/apps/chat/src/components/Chat/ChatHeader/Header.tsx
+++ b/apps/chat/src/components/Chat/ChatHeader/Header.tsx
@@ -219,6 +219,7 @@ export const ChatHeader = Inversify.register(
                       publicVersionGroupId={publicVersionGroupId}
                       onChangeSelectedVersion={handleChangeSelectedVersion}
                       selectedEntityId={conversation.id}
+                      btnClassNames="!text-primary"
                     />
                   ) : (
                     <p

--- a/apps/chat/src/components/Chat/ConversationCompareItem.tsx
+++ b/apps/chat/src/components/Chat/ConversationCompareItem.tsx
@@ -65,7 +65,7 @@ export function ConversationCompareItem({
 
       {conv.publicationInfo?.version && (
         <PublicVersionSelector
-          btnClassNames="cursor-pointer h-[34px] flex items-center"
+          btnClassNames="cursor-pointer h-[34px] !text-primary flex items-center"
           publicVersionGroupId={getPublicItemIdWithoutVersion(
             conv.publicationInfo.version,
             conv.id,

--- a/apps/chat/src/components/Chat/Publish/PublicVersionSelector.tsx
+++ b/apps/chat/src/components/Chat/Publish/PublicVersionSelector.tsx
@@ -171,13 +171,14 @@ export function PublicVersionSelector({
       trigger={
         <DialLinkButton
           onClick={stopBubbling}
-          disabled={mappedAllVersions.length <= 1 && readonly}
+          disabled={mappedAllVersions.length <= 1}
           className={classNames(
-            'flex px-0 text-primary enabled:hover:text-primary',
-            mappedAllVersions.length <= 1 &&
-              '!cursor-default text-controls-permanent',
+            'flex px-0',
+            mappedAllVersions.length <= 1 && 'cursor-default',
             btnClassNames,
-            readonly && 'text-xs text-secondary',
+            readonly
+              ? 'text-xs text-secondary'
+              : 'text-primary hover:text-primary',
           )}
           data-qa="version"
           textClassName={classNames(

--- a/apps/chat/src/components/Promptbar/components/ViewPrompt.tsx
+++ b/apps/chat/src/components/Promptbar/components/ViewPrompt.tsx
@@ -155,6 +155,7 @@ export const ViewPrompt = ({ prompt, onEditMode }: Props) => {
                 <PublicVersionSelector
                   publicVersionGroupId={publicVersionGroupId}
                   onChangeSelectedVersion={handleChangeSelectedVersion}
+                  btnClassNames="!text-primary"
                 />
               )}
               <DialPrimaryButton


### PR DESCRIPTION
**Description:**

fix public version selector color

Issues:

- Issue #5866

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
