### PR TITLE
fix(chat): add additional decoding while validating entity names in publication modal (Issue #5854)

### DIFF
--- a/apps/chat/src/utils/app/common.ts
+++ b/apps/chat/src/utils/app/common.ts
@@ -116,6 +116,22 @@ export const isEntityNameValid = (
   );
 };
 
+export const isEntityNameValidWithDecode = (
+  name: string,
+  options?: {
+    checkDotsInTheEnd?: boolean;
+    minLength?: number;
+    maxLength?: number;
+  },
+) => {
+  const decoded = decodeURIComponent(name);
+
+  return isEntityNameValid(
+    decoded.length !== name.length ? decoded : name,
+    options,
+  );
+};
+
 export const hasInvalidNameInPath = (path: string) =>
   path.split('/').some((part) => isEntityNameInvalid(part));
 

--- a/apps/chat/src/utils/app/publications.ts
+++ b/apps/chat/src/utils/app/publications.ts
@@ -34,7 +34,7 @@ import {
 } from '@/src/constants/publication';
 
 import {
-  isEntityNameValid,
+  isEntityNameValidWithDecode,
   prepareEntityName,
   sortItemsVersions,
 } from './common';
@@ -473,7 +473,7 @@ export const allEditedFoldersAreValid = (obj: unknown) => {
         }
         const folderName = (value[EDITED_FOLDER_NAME_KEY] as string).trim();
 
-        if (!isEntityNameValid(folderName)) {
+        if (!isEntityNameValidWithDecode(folderName)) {
           return false;
         }
       }

--- a/apps/chat/src/utils/app/publications.ts
+++ b/apps/chat/src/utils/app/publications.ts
@@ -473,6 +473,7 @@ export const allEditedFoldersAreValid = (obj: unknown) => {
         }
         const folderName = (value[EDITED_FOLDER_NAME_KEY] as string).trim();
 
+        // TODO: remove when double encoding in appdata is fixed on core
         if (!isEntityNameValidWithDecode(folderName)) {
           return false;
         }


### PR DESCRIPTION
**Description:**

When quick app creates attachments they are stored with double encoding, added additional decoding for such cases to prevent blocking of publication with such attachments.

Issues:

- Issue #5854

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
