### PR TITLE
fix(chat): update text when user does not have any item in Shared with me or Organization tab (Issue #5730)

### DIFF
--- a/apps/chat/src/components/FileManager/FileManager.tsx
+++ b/apps/chat/src/components/FileManager/FileManager.tsx
@@ -66,6 +66,9 @@ export const FileManager: React.FC = () => {
     sharedWithMeIds,
 
     uploadEnabled,
+
+    emptyStateDescription,
+    emptyStateTitle,
   } = useFileManager();
 
   useEffect(() => {
@@ -112,6 +115,8 @@ export const FileManager: React.FC = () => {
           sharedWithMeIds={sharedWithMeIds}
           uploadEnabled={uploadEnabled}
           clearSearchResults={handleClearSearch}
+          emptyStateTitle={emptyStateTitle}
+          emptyStateDescription={emptyStateDescription}
         />
       )}
       {isAnyOperationInProgress && (

--- a/apps/chat/src/components/FileManager/hooks/useFileManager.tsx
+++ b/apps/chat/src/components/FileManager/hooks/useFileManager.tsx
@@ -851,6 +851,28 @@ export const useFileManager = ({
     FilesSelectors.selectSharedWithMeFilesAndFoldersIds,
   );
 
+  const emptyStateTitle = useMemo(() => {
+    switch (activeTab) {
+      case DialFileManagerTabs.Shared:
+        return t('No shared files');
+      case DialFileManagerTabs.Organization:
+        return t('No organization files');
+      default:
+        return t('You don’t have any files');
+    }
+  }, [activeTab, t]);
+
+  const emptyStateDescription = useMemo(() => {
+    switch (activeTab) {
+      case DialFileManagerTabs.Shared:
+        return t('Files shared with you will appear here.');
+      case DialFileManagerTabs.Organization:
+        return t('Public files will appear here.');
+      default:
+        return t('Upload or drag and drop files');
+    }
+  }, [activeTab, t]);
+
   return {
     currentPath,
     setCurrentPath,
@@ -892,5 +914,8 @@ export const useFileManager = ({
     sharedWithMeIds,
 
     uploadEnabled,
+
+    emptyStateDescription,
+    emptyStateTitle,
   };
 };


### PR DESCRIPTION
<img width="1853" height="981" alt="image" src="https://github.com/user-attachments/assets/9d3dcdeb-5989-4c5c-8fc3-18e9e7902457" />
<img width="1525" height="872" alt="image" src="https://github.com/user-attachments/assets/f68f8c0e-4745-4ffb-b108-8fb90b3a3838" />

Issues:

- Issue #5730

**UI changes**

<Please, provide Screenshots or Figma links>

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
