### PR TITLE
fix(chat): fix issues with selecting files and folders in chat message (Issues #5876, #5986)

### DIFF
--- a/apps/chat/src/components/Chat/ChatInput/ChatInputMessage.tsx
+++ b/apps/chat/src/components/Chat/ChatInput/ChatInputMessage.tsx
@@ -14,6 +14,7 @@ import { usePromptSelection } from '@/src/hooks/usePromptSelection';
 import { useTokenizer } from '@/src/hooks/useTokenizer';
 import { useTranslation } from '@/src/hooks/useTranslation';
 
+import { addTrailingSlashIfAbsent } from '@/src/utils/app/common';
 import { getUserCustomContent } from '@/src/utils/app/file';
 import {
   getConversationSchema,
@@ -227,6 +228,14 @@ export const ChatInputMessage = Inversify.register(
 
       return isFormValueValid(schema, chatFormValue);
     }, [selectedConversations, configurationSchema, chatFormValue]);
+
+    const selectedAttachmentsIds = useMemo(
+      () =>
+        selectedFiles
+          .map((f) => f.id)
+          .concat(selectedFolders.map((f) => addTrailingSlashIfAbsent(f.id))),
+      [selectedFolders, selectedFiles],
+    );
 
     const isInputEmpty = useMemo(() => {
       return (
@@ -571,9 +580,7 @@ export const ChatInputMessage = Inversify.register(
                 )}
               >
                 <AttachButton
-                  selectedFilesIds={selectedFiles
-                    .map((f) => f.id)
-                    .concat(selectedFolders.map((f) => `${f.id}/`))}
+                  selectedFilesIds={selectedAttachmentsIds}
                   onSelectAlreadyUploaded={handleSelectAlreadyUploaded}
                   onUploadFromDevice={handleUploadFromDevice}
                   onAddLinkToMessage={handleAddLinkToMessage}

--- a/apps/chat/src/components/Files/FileManagerModal.tsx
+++ b/apps/chat/src/components/Files/FileManagerModal.tsx
@@ -72,6 +72,9 @@ export const FileManagerModal = memo(
     const dispatch = useAppDispatch();
     const { t } = useTranslation(Translation.Chat);
 
+    const initialSelectionPerformedRef = useRef(false);
+    const prevSelectionRef = useRef<Set<string>>(new Set());
+
     const headingId = useId();
     const descriptionId = useId();
 
@@ -95,7 +98,15 @@ export const FileManagerModal = memo(
       [folders],
     );
 
-    const prevSelectionRef = useRef<Set<string>>(new Set());
+    const handleClose = useCallback(
+      (value: boolean | string[]) => {
+        initialSelectionPerformedRef.current = false;
+        prevSelectionRef.current.clear();
+        onClose(value);
+        dispatch(FilesActions.resetChosenFiles());
+      },
+      [onClose, initialSelectionPerformedRef, prevSelectionRef],
+    );
 
     const pathSelectionHandler = useCallback(
       (paths: Set<string>) => {
@@ -153,16 +164,23 @@ export const FileManagerModal = memo(
     }, [allowedTypesArray, allowedTypesLabel, t]);
 
     useEffect(() => {
-      if (isOpen) {
+      if (isOpen && !initialSelectionPerformedRef.current) {
         dispatch(FilesActions.resetAllFoldersStatus());
         dispatch(FilesActions.getFilesWithFolders({}));
         dispatch(FilesActions.resetNewFolderId());
+        dispatch(
+          FilesActions.setChosenFilesAndFolders({
+            ids: previousSelectedFilesIds ?? [],
+          }),
+        );
+        initialSelectionPerformedRef.current = true;
       }
-
-      return () => {
-        dispatch(FilesActions.resetChosenFiles());
-      };
-    }, [dispatch, isOpen]);
+    }, [
+      dispatch,
+      isOpen,
+      previousSelectedFilesIds,
+      initialSelectionPerformedRef.current,
+    ]);
 
     const handleAttachFiles = useCallback(() => {
       const accumulatedIds = new Set<string>(previousSelectedFilesIds);
@@ -227,7 +245,7 @@ export const FileManagerModal = memo(
         return;
       }
 
-      onClose(Array.from(accumulatedIds));
+      handleClose(Array.from(accumulatedIds));
     }, [
       allowedTypesArray,
       canAttachFolders,
@@ -235,7 +253,7 @@ export const FileManagerModal = memo(
       files,
       previousSelectedFilesIds,
       maximumAttachmentsAmount,
-      onClose,
+      handleClose,
       selectedFilesIds,
       selectedFolderIds,
       t,
@@ -312,11 +330,21 @@ export const FileManagerModal = memo(
       availableTabs,
     });
 
+    const defaultSelectedPaths = useMemo(
+      () =>
+        new Set(
+          previousSelectedFilesIds.map((id) =>
+            id.endsWith('/') ? id.slice(0, -1) : id,
+          ) ?? [],
+        ),
+      [previousSelectedFilesIds],
+    );
+
     return (
       <Modal
         portalId="theme-main"
         state={isOpen ? ModalState.OPENED : ModalState.CLOSED}
-        onClose={() => onClose(false)}
+        onClose={() => handleClose(false)}
         dataQa="file-manager-modal"
         containerClassName="flex flex-col gap-4 w-full sm:w-[1200px] h-[min(800px,100vh)] !bg-layer-2"
         dismissProps={OUTSIDE_PRESS_AND_MOUSE_EVENT}
@@ -393,6 +421,7 @@ export const FileManagerModal = memo(
               onCreateFolderValidate={handleRenameValidation}
               sharedWithMeIds={sharedWithMeIds}
               uploadEnabled={uploadEnabled}
+              defaultSelectedPaths={defaultSelectedPaths}
             />
             {isAnyOperationInProgress && (
               <div className="absolute inset-0 z-50 flex items-center justify-center bg-overlay">

--- a/apps/chat/src/components/Files/FileManagerModal.tsx
+++ b/apps/chat/src/components/Files/FileManagerModal.tsx
@@ -5,10 +5,16 @@ import { useFileManager } from '@/src/components/FileManager/hooks/useFileManage
 import { useTranslation } from '@/src/hooks/useTranslation';
 
 import {
+  addTrailingSlashIfAbsent,
+  removeTrailingSlash,
+} from '@/src/utils/app/common';
+import {
   formatFileSize,
   getDialFilesWithInvalidFileType,
   getShortExtensionsListFromMimeType,
 } from '@/src/utils/app/file';
+import { isParentFolderSelected } from '@/src/utils/app/folders';
+import { isHiddenEntity } from '@/src/utils/app/search';
 
 import { FileSourceType } from '@/src/types/files';
 import { ModalState } from '@/src/types/modal';
@@ -108,35 +114,6 @@ export const FileManagerModal = memo(
       [onClose, initialSelectionPerformedRef, prevSelectionRef],
     );
 
-    const pathSelectionHandler = useCallback(
-      (paths: Set<string>) => {
-        const prev = prevSelectionRef.current;
-        const next = new Set(paths);
-
-        const added = [...next].filter((id) => !prev.has(id));
-        const removed = [...prev].filter((id) => !next.has(id));
-
-        prevSelectionRef.current = next;
-
-        for (const id of added) {
-          if (folderPaths.has(id)) {
-            dispatch(FilesActions.setChosenFolder({ folderId: id }));
-          } else {
-            dispatch(FilesActions.setChosenFiles({ ids: [id] }));
-          }
-        }
-
-        for (const id of removed) {
-          if (folderPaths.has(id)) {
-            dispatch(FilesActions.setChosenFolder({ folderId: id }));
-          } else {
-            dispatch(FilesActions.setChosenFiles({ ids: [id] }));
-          }
-        }
-      },
-      [dispatch, folderPaths],
-    );
-
     const allowedTypesArray = useMemo(
       () => (!canAttachFiles && canAttachFolders ? ['*/*'] : allowedTypes),
       [allowedTypes, canAttachFiles, canAttachFolders],
@@ -183,7 +160,7 @@ export const FileManagerModal = memo(
     ]);
 
     const handleAttachFiles = useCallback(() => {
-      const accumulatedIds = new Set<string>(previousSelectedFilesIds);
+      const accumulatedIds = new Set<string>([]);
 
       const selectedFiles = files.filter((file) =>
         selectedFilesIds.includes(file.id),
@@ -193,6 +170,9 @@ export const FileManagerModal = memo(
         getDialFilesWithInvalidFileType(selectedFiles, allowedTypesArray).map(
           (file) => file.id,
         ),
+      );
+      const hiddenFilesIds = new Set(
+        selectedFiles.filter(isHiddenEntity).map(({ id }) => id),
       );
 
       if (invalidFileIds.size > 0) {
@@ -209,12 +189,21 @@ export const FileManagerModal = memo(
 
       if (canAttachFolders) {
         selectedFolderIds.forEach((folderId) => {
-          accumulatedIds.add(folderId);
+          if (
+            !isParentFolderSelected({
+              currentFolderId: folderId,
+              selectedFolderIds: selectedFolderIds.filter(
+                (id) => id !== folderId,
+              ),
+            })
+          ) {
+            accumulatedIds.add(folderId);
+          }
         });
       }
 
       selectedFilesIds.forEach((fileId) => {
-        if (invalidFileIds.has(fileId)) {
+        if (invalidFileIds.has(fileId) || hiddenFilesIds.has(fileId)) {
           return;
         }
 
@@ -251,7 +240,6 @@ export const FileManagerModal = memo(
       canAttachFolders,
       dispatch,
       files,
-      previousSelectedFilesIds,
       maximumAttachmentsAmount,
       handleClose,
       selectedFilesIds,
@@ -330,14 +318,27 @@ export const FileManagerModal = memo(
       availableTabs,
     });
 
-    const defaultSelectedPaths = useMemo(
+    const selectedPaths = useMemo(
       () =>
         new Set(
-          previousSelectedFilesIds.map((id) =>
-            id.endsWith('/') ? id.slice(0, -1) : id,
-          ) ?? [],
+          selectedFilesIds
+            .concat(selectedFolderIds.map(removeTrailingSlash))
+            .filter(
+              (id) => id.split('/').slice(0, -1).join('/') === currentPath,
+            ),
         ),
-      [previousSelectedFilesIds],
+      [selectedFilesIds, selectedFolderIds],
+    );
+
+    const pathSelectionHandler = useCallback(
+      (paths: Set<string>) => {
+        const normalizedIds = [...paths].map((id) =>
+          folderPaths.has(id) ? addTrailingSlashIfAbsent(id) : id,
+        );
+
+        dispatch(FilesActions.setChosenFilesAndFolders({ ids: normalizedIds }));
+      },
+      [dispatch, folderPaths, currentPath],
     );
 
     return (
@@ -421,7 +422,7 @@ export const FileManagerModal = memo(
               onCreateFolderValidate={handleRenameValidation}
               sharedWithMeIds={sharedWithMeIds}
               uploadEnabled={uploadEnabled}
-              defaultSelectedPaths={defaultSelectedPaths}
+              selectedPaths={selectedPaths}
             />
             {isAnyOperationInProgress && (
               <div className="absolute inset-0 z-50 flex items-center justify-center bg-overlay">

--- a/apps/chat/src/store/files/files.epics.ts
+++ b/apps/chat/src/store/files/files.epics.ts
@@ -247,6 +247,7 @@ const getFilesEpic: AppEpic = (action$) =>
               FilesActions.getFilesSuccess({
                 files,
                 foldersSet: new Set([payload.id ?? getFileRootId()]),
+                selectedEmptyFoldersIds: payload.selectedEmptyFoldersIds,
               }),
             ),
             catchError(() => of(FilesActions.getFilesFail())),
@@ -314,6 +315,7 @@ const getFileFoldersEpic: AppEpic = (action$) =>
           FilesActions.getFoldersSuccess({
             folderId: payload.id,
             folders,
+            selectedEmptyFoldersIds: payload.selectedEmptyFoldersIds,
           }),
         ),
         catchError(() =>
@@ -323,13 +325,17 @@ const getFileFoldersEpic: AppEpic = (action$) =>
     ),
   );
 
-const getFilesWithFoldersEpic: AppEpic = (action$) =>
+const getFilesWithFoldersEpic: AppEpic = (action$, state$) =>
   action$.pipe(
     ofType(FilesActions.getFilesWithFolders.type),
     switchMap(({ payload }) => {
+      const selectedEmptyFoldersIds = FilesSelectors.selectChosenEmptyFolderIds(
+        state$.value,
+      );
+
       return concat(
-        of(FilesActions.getFolders(payload)),
-        of(FilesActions.getFiles(payload)),
+        of(FilesActions.getFolders({ ...payload, selectedEmptyFoldersIds })),
+        of(FilesActions.getFiles({ ...payload, selectedEmptyFoldersIds })),
       );
     }),
   );

--- a/apps/chat/src/store/files/files.reducers.ts
+++ b/apps/chat/src/store/files/files.reducers.ts
@@ -208,6 +208,7 @@ export const filesSlice = createSlice({
       state,
       _action: PayloadAction<{
         id?: string;
+        selectedEmptyFoldersIds?: string[];
       }>,
     ) => {
       state.filesStatus = UploadStatus.LOADING;
@@ -219,6 +220,7 @@ export const filesSlice = createSlice({
       }: PayloadAction<{
         files: DialFile[];
         foldersSet: Set<string>;
+        selectedEmptyFoldersIds?: string[];
       }>,
     ) => {
       const parentFolderId = Array.from(payload.foldersSet)[0];
@@ -264,7 +266,10 @@ export const filesSlice = createSlice({
         );
       }
 
-      const idsToReselect = state.chosenEmptyFoldersIds.reduce<{
+      const selectedEmptyFolderIds =
+        payload.selectedEmptyFoldersIds ?? state.chosenEmptyFoldersIds;
+
+      const idsToReselect = selectedEmptyFolderIds.reduce<{
         folderIds: string[];
         fileIds: string[];
       }>(
@@ -391,6 +396,7 @@ export const filesSlice = createSlice({
         payload,
       }: PayloadAction<{
         id?: string;
+        selectedEmptyFoldersIds?: string[];
       }>,
     ) => {
       state.foldersStatus = UploadStatus.LOADING;
@@ -409,6 +415,7 @@ export const filesSlice = createSlice({
       }: PayloadAction<{
         folders: FileFolderInterface[];
         folderId?: string;
+        selectedEmptyFoldersIds?: string[];
       }>,
     ) => {
       state.loadingFolderId = undefined;
@@ -429,10 +436,11 @@ export const filesSlice = createSlice({
         ),
       );
 
+      const selectedEmptyFolderIds =
+        payload.selectedEmptyFoldersIds ?? state.chosenEmptyFoldersIds;
+
       const folderIdsToSelect = payload.folders
-        .filter((f) =>
-          state.chosenEmptyFoldersIds.some((id) => f.id.startsWith(id)),
-        )
+        .filter((f) => selectedEmptyFolderIds.some((id) => f.id.startsWith(id)))
         .map(({ id }) => addTrailingSlashIfAbsent(id));
 
       state.chosenEmptyFoldersIds = xor(
@@ -692,10 +700,18 @@ export const filesSlice = createSlice({
     ) => {
       const folderIds = payload.ids.filter(isFolderId);
       const fileIds = payload.ids.filter((id) => !isFolderId(id));
+      const emptyFolderIds = state.folders
+        .filter((f) => !state.files.some(({ id }) => id.startsWith(f.id)))
+        .map(({ id }) => id);
 
-      const emptyFolderIds = folderIds.filter(
-        (id) => !state.files.some((f) => f.id.startsWith(id)),
-      );
+      const selectedEmptyFolderIds = folderIds
+        .filter((id) => !state.files.some((f) => f.id.startsWith(id)))
+        .concat(
+          emptyFolderIds.filter((id) =>
+            folderIds.some((folderId) => id.startsWith(folderId)),
+          ),
+        );
+
       const fileIdsToSelect = [
         ...fileIds,
         ...state.files
@@ -706,13 +722,13 @@ export const filesSlice = createSlice({
       ];
 
       if (
-        isEqual(emptyFolderIds, state.chosenEmptyFoldersIds) &&
+        isEqual(selectedEmptyFolderIds, state.chosenEmptyFoldersIds) &&
         isEqual(state.chosenFileIds, fileIdsToSelect)
       ) {
         return;
       }
 
-      state.chosenEmptyFoldersIds = emptyFolderIds;
+      state.chosenEmptyFoldersIds = selectedEmptyFolderIds;
       state.chosenFileIds = fileIdsToSelect;
     },
     setChosenFolder: (

--- a/apps/chat/src/utils/app/common.ts
+++ b/apps/chat/src/utils/app/common.ts
@@ -397,8 +397,11 @@ export const replaceStringRange = (
 
 export const getLastPathSegment = (path: string) => path.split('/').pop() ?? '';
 
-export const addTrailingSlashIfAbsent = (id: string) =>
-  id.endsWith('/') ? id : `${id}/`;
+export const addTrailingSlashIfAbsent = (str: string) =>
+  str.endsWith('/') ? str : `${str}/`;
+
+export const removeTrailingSlash = (str: string) =>
+  str.endsWith('/') ? str.slice(0, -1) : str;
 
 export const getEntityBaseId = (id: string): string => {
   const lastColonIndex = id.lastIndexOf(':');

--- a/apps/chat/src/utils/app/folders.ts
+++ b/apps/chat/src/utils/app/folders.ts
@@ -689,6 +689,10 @@ export const getPartialAndFullyChosenFolders = (
   emptyFolderIds: string[] = [],
   selectedEmptyFolderIds: string[] = [],
 ) => {
+  const selectedEmptyFolderIdsSet = new Set(
+    selectedEmptyFolderIds.map(addTrailingSlashIfAbsent),
+  );
+
   const fullyChosenFolderIds = folders
     .map((folder) => addTrailingSlashIfAbsent(folder.id))
     .filter(
@@ -704,7 +708,7 @@ export const getPartialAndFullyChosenFolders = (
         emptyFolderIds
           .filter((id) => id.startsWith(folderId))
           .every((id) =>
-            selectedEmptyFolderIds.includes(addTrailingSlashIfAbsent(id)),
+            selectedEmptyFolderIdsSet.has(addTrailingSlashIfAbsent(id)),
           ),
     );
 


### PR DESCRIPTION
**Description:**

- fix selecting hidden files when selecting folder
- fix selecting nested folder on parent folder select
- fix rendering initially selected attachments on file manager modal open
- optimize overall process by reducing actions needed to recalculate selection to 1

Issues:

- Issue #5876 
- Issue #5986 

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
