### PR TITLE
fix(chat): fix playback buttons styles (Issue #6029)

### DIFF
--- a/apps/chat/src/components/Chat/ChatInput/ChatControls.tsx
+++ b/apps/chat/src/components/Chat/ChatInput/ChatControls.tsx
@@ -81,8 +81,8 @@ export const ChatControls: FC<Props> = ({
   return (
     <DialIconButton
       className={classNames(
-        'absolute p-0 size-[20px]',
-        isOverlay ? 'bottom-2 right-3' : 'top-3 right-4 md:bottom-3',
+        'absolute size-[20px] p-0',
+        isOverlay ? 'bottom-2 right-3' : 'right-4 top-3 md:bottom-3',
       )}
       onClick={handleReplayReStart}
       data-qa="proceed-reply"

--- a/apps/chat/src/components/Chat/ChatInput/ChatControls.tsx
+++ b/apps/chat/src/components/Chat/ChatInput/ChatControls.tsx
@@ -20,7 +20,7 @@ import { SendMessageButton } from '@/src/components/Chat/ChatInput/SendMessageBu
 import { Tooltip } from '@/src/components/Common/Tooltip';
 
 import RefreshCW from '@/public/images/icons/refresh-cw.svg';
-import { DialButton, DialIconButton } from '@epam/ai-dial-ui-kit';
+import { DialIconButton } from '@epam/ai-dial-ui-kit';
 
 interface Props {
   showReplayControls: boolean;

--- a/apps/chat/src/components/Chat/ChatInput/ChatControls.tsx
+++ b/apps/chat/src/components/Chat/ChatInput/ChatControls.tsx
@@ -20,7 +20,7 @@ import { SendMessageButton } from '@/src/components/Chat/ChatInput/SendMessageBu
 import { Tooltip } from '@/src/components/Common/Tooltip';
 
 import RefreshCW from '@/public/images/icons/refresh-cw.svg';
-import { DialButton } from '@epam/ai-dial-ui-kit';
+import { DialButton, DialIconButton } from '@epam/ai-dial-ui-kit';
 
 interface Props {
   showReplayControls: boolean;
@@ -79,15 +79,15 @@ export const ChatControls: FC<Props> = ({
   const Icon = isError ? RefreshCW : IconPlayerPlay;
 
   return (
-    <DialButton
+    <DialIconButton
       className={classNames(
-        'absolute',
-        isOverlay ? 'bottom-2 right-3' : 'bottom-2.5 right-4 md:bottom-3',
+        'absolute p-0 size-[20px]',
+        isOverlay ? 'bottom-2 right-3' : 'top-3 right-4 md:bottom-3',
       )}
       onClick={handleReplayReStart}
       data-qa="proceed-reply"
       data-replay-variables
-      iconBefore={
+      icon={
         <Tooltip
           tooltip={isError ? t('Try again') : t('Continue replay')}
           isTriggerClickable

--- a/apps/chat/src/components/Chat/Playback/PlaybackControls.tsx
+++ b/apps/chat/src/components/Chat/Playback/PlaybackControls.tsx
@@ -89,6 +89,8 @@ export const PlaybackControls = ({
   const controlsContainerRef = useRef<HTMLDivElement | null>(null);
   const [phase, setPhase] = useState<PlaybackPhases>(PlaybackPhases.EMPTY);
 
+  const iconClassName =
+    'absolute top-3 p-0 outline-none hover:text-accent-primary disabled:text-controls-disable size-[20px]';
   const isActiveIndex = typeof activeIndex === 'number';
 
   const isNextMessageInStack = useMemo(() => {
@@ -310,7 +312,7 @@ export const PlaybackControls = ({
               isDisabledPlaybackControls ||
               (activeIndex === 0 && phase !== PlaybackPhases.MESSAGE)
             }
-            className="absolute left-4 top-3 rounded p-0 outline-none hover:text-accent-primary disabled:text-controls-disable"
+            className={classNames(iconClassName, 'left-4')}
             icon={<IconPlayerPlay size={20} className="rotate-180" />}
           />
         </Tooltip>
@@ -355,7 +357,7 @@ export const PlaybackControls = ({
                     <DialIconButton
                       data-qa="playback-next"
                       onClick={handlePlayNextMessage}
-                      className="absolute right-4 top-3 rounded p-0 outline-none hover:text-accent-primary disabled:text-controls-disable"
+                      className={classNames(iconClassName, 'right-4')}
                       disabled={
                         isDisabledPlaybackControls ||
                         isMessageStreaming ||

--- a/apps/chat/src/components/Chat/Playback/PlaybackControls.tsx
+++ b/apps/chat/src/components/Chat/Playback/PlaybackControls.tsx
@@ -38,7 +38,7 @@ import {
   Feature,
   MessageFormValueType,
 } from '@epam/ai-dial-shared';
-import { DialButton } from '@epam/ai-dial-ui-kit';
+import { DialButton, DialIconButton } from '@epam/ai-dial-ui-kit';
 
 interface Props {
   showScrollDownButton: boolean;
@@ -303,14 +303,14 @@ export const PlaybackControls = ({
           asChild
           isTriggerClickable
         >
-          <DialButton
+          <DialIconButton
             data-qa="playback-prev"
             onClick={handlePrevMessage}
             disabled={
               isDisabledPlaybackControls ||
               (activeIndex === 0 && phase !== PlaybackPhases.MESSAGE)
             }
-            className="absolute bottom-3 left-4 rounded outline-none hover:text-accent-primary disabled:text-controls-disable"
+            className="absolute top-3 left-4 rounded outline-none hover:text-accent-primary disabled:text-controls-disable p-0"
             iconBefore={<IconPlayerPlay size={20} className="rotate-180" />}
           />
         </Tooltip>
@@ -352,16 +352,16 @@ export const PlaybackControls = ({
                     isTriggerClickable
                     asChild
                   >
-                    <DialButton
+                    <DialIconButton
                       data-qa="playback-next"
                       onClick={handlePlayNextMessage}
-                      className="absolute bottom-3 right-4 rounded outline-none hover:text-accent-primary disabled:text-controls-disable"
+                      className="absolute top-3 right-4 rounded outline-none hover:text-accent-primary disabled:text-controls-disable p-0"
                       disabled={
                         isDisabledPlaybackControls ||
                         isMessageStreaming ||
                         !isNextMessageInStack
                       }
-                      iconBefore={<IconPlayerPlay size={20} />}
+                      icon={<IconPlayerPlay size={20} />}
                     />
                   </Tooltip>
                 </>

--- a/apps/chat/src/components/Chat/Playback/PlaybackControls.tsx
+++ b/apps/chat/src/components/Chat/Playback/PlaybackControls.tsx
@@ -38,7 +38,7 @@ import {
   Feature,
   MessageFormValueType,
 } from '@epam/ai-dial-shared';
-import { DialButton, DialIconButton } from '@epam/ai-dial-ui-kit';
+import { DialIconButton } from '@epam/ai-dial-ui-kit';
 
 interface Props {
   showScrollDownButton: boolean;

--- a/apps/chat/src/components/Chat/Playback/PlaybackControls.tsx
+++ b/apps/chat/src/components/Chat/Playback/PlaybackControls.tsx
@@ -310,8 +310,8 @@ export const PlaybackControls = ({
               isDisabledPlaybackControls ||
               (activeIndex === 0 && phase !== PlaybackPhases.MESSAGE)
             }
-            className="absolute top-3 left-4 rounded outline-none hover:text-accent-primary disabled:text-controls-disable p-0"
-            iconBefore={<IconPlayerPlay size={20} className="rotate-180" />}
+            className="absolute left-4 top-3 rounded p-0 outline-none hover:text-accent-primary disabled:text-controls-disable"
+            icon={<IconPlayerPlay size={20} className="rotate-180" />}
           />
         </Tooltip>
         <div
@@ -355,7 +355,7 @@ export const PlaybackControls = ({
                     <DialIconButton
                       data-qa="playback-next"
                       onClick={handlePlayNextMessage}
-                      className="absolute top-3 right-4 rounded outline-none hover:text-accent-primary disabled:text-controls-disable p-0"
+                      className="absolute right-4 top-3 rounded p-0 outline-none hover:text-accent-primary disabled:text-controls-disable"
                       disabled={
                         isDisabledPlaybackControls ||
                         isMessageStreaming ||


### PR DESCRIPTION
**Description:**

fix playback buttons styles 

Issues:

- Issue #6029

**UI changes**
Playback
<img width="899" height="720" alt="image" src="https://github.com/user-attachments/assets/044e5ab9-0eab-4895-9dc1-54edd3e6a0fe" />

Replay 
<img width="886" height="126" alt="image" src="https://github.com/user-attachments/assets/ac7c8cdb-89f9-40b9-9b76-50a723e8190c" />


**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
