### PR TITLE
fix(chat): fix infinite loader on editor exit, add initial editor form validation on edit (Issues #6007, #5960)

### DIFF
--- a/apps/chat/src/components/AppsEditor/AppsEditor.tsx
+++ b/apps/chat/src/components/AppsEditor/AppsEditor.tsx
@@ -110,6 +110,7 @@ export const AppsEditor = () => {
   const saveAndExitRef = useRef(false);
   const redirectToChatRef = useRef(false);
   const isSimpleViewSwitchRef = useRef(false);
+  const firstValidationPerformedRef = useRef(false);
 
   const isAppPublic = !!appDetails && isEntityIdPublic(appDetails);
 
@@ -390,6 +391,13 @@ export const AppsEditor = () => {
       dispatch(ApplicationActions.setShouldTriggerEditorAutoUpdate(false));
     }
   }, [shouldTriggerEditorAutoUpdate, isAppPublic, handleSubmit, dispatch]);
+
+  useEffect(() => {
+    if (idQuery && !firstValidationPerformedRef.current) {
+      void formMethods.trigger();
+    }
+    firstValidationPerformedRef.current = true;
+  }, [idQuery, formMethods.trigger]);
 
   return (
     <FormProvider {...formMethods}>

--- a/apps/chat/src/components/AppsEditor/AppsEditor.tsx
+++ b/apps/chat/src/components/AppsEditor/AppsEditor.tsx
@@ -393,11 +393,11 @@ export const AppsEditor = () => {
   }, [shouldTriggerEditorAutoUpdate, isAppPublic, handleSubmit, dispatch]);
 
   useEffect(() => {
-    if (idQuery && !firstValidationPerformedRef.current) {
+    if (idQuery && !firstValidationPerformedRef.current && !isAppPublic) {
       void formMethods.trigger();
     }
     firstValidationPerformedRef.current = true;
-  }, [idQuery, formMethods.trigger]);
+  }, [idQuery, formMethods.trigger, isAppPublic]);
 
   return (
     <FormProvider {...formMethods}>

--- a/apps/chat/src/components/AppsEditor/form.ts
+++ b/apps/chat/src/components/AppsEditor/form.ts
@@ -322,7 +322,7 @@ const getCustomAppFormData = (app?: CustomApplicationModel): CustomAppForm => ({
   type: AppsEditorSchemaTypes.CustomApp,
   inputAttachmentTypes: app?.inputAttachmentTypes ?? [],
   maxInputAttachments: app?.maxInputAttachments ?? undefined,
-  completionUrl: app?.completionUrl || MANDATORY_FIELD_PLACEHOLDER,
+  completionUrl: app ? (app.completionUrl ?? '') : MANDATORY_FIELD_PLACEHOLDER,
   features: safeStringifyApplicationFeatures(app?.features),
 });
 
@@ -485,9 +485,9 @@ const getExternalAppFormData = (
   app?: CustomApplicationModel,
 ): ExternalAppForm => ({
   type: AppsEditorSchemaTypes.ExternalApp,
-  externalUrl:
-    (app?.applicationProperties as ExternalAppConfig)?.external_url ||
-    MANDATORY_FIELD_PLACEHOLDER,
+  externalUrl: app
+    ? ((app?.applicationProperties as ExternalAppConfig)?.external_url ?? '')
+    : MANDATORY_FIELD_PLACEHOLDER,
 });
 
 const getSettingsFormData = ({

--- a/apps/chat/src/components/ToolsetEditor/ToolsetEditor.tsx
+++ b/apps/chat/src/components/ToolsetEditor/ToolsetEditor.tsx
@@ -235,11 +235,11 @@ export const ToolsetEditor = () => {
   }, [formMethods, toolsetDetails]);
 
   useEffect(() => {
-    if (idQuery && !firstValidationPerformedRef.current) {
+    if (idQuery && !firstValidationPerformedRef.current && !isToolsetPublic) {
       void formMethods.trigger();
     }
     firstValidationPerformedRef.current = true;
-  }, [idQuery, formMethods.trigger]);
+  }, [idQuery, formMethods.trigger, isToolsetPublic]);
 
   return (
     <FormProvider {...formMethods}>

--- a/apps/chat/src/components/ToolsetEditor/ToolsetEditor.tsx
+++ b/apps/chat/src/components/ToolsetEditor/ToolsetEditor.tsx
@@ -20,6 +20,7 @@ import { ToolsetEditorQuery } from '@/src/constants/toolsets';
 import { ToolsetEditorHeader } from '@/src/components/ToolsetEditor/ToolsetEditorHeader';
 import { ToolsetEditorView } from '@/src/components/ToolsetEditor/ToolsetEditorView';
 import {
+  ENDPOINT_PLACEHOLDER,
   ToolsetEditorForm,
   ToolsetEditorFormSchema,
   getDefaultFormData,
@@ -45,6 +46,7 @@ export const ToolsetEditor = () => {
   const changeEditorTabRef = useRef<ToolsetEditorSteps | null>(null);
   const saveAndExitRef = useRef(false);
   const redirectToChatRef = useRef(false);
+  const firstValidationPerformedRef = useRef(false);
 
   const [isExiting, setIsExiting] = useState(false);
 
@@ -66,7 +68,8 @@ export const ToolsetEditor = () => {
       const payloadToolset = getToolsetPayload(
         {
           name: data.name,
-          endpoint: data.endpoint.trim(),
+          endpoint:
+            data.endpoint === ENDPOINT_PLACEHOLDER ? '' : data.endpoint.trim(),
           iconUrl: data.iconUrl,
           transport: data.protocol,
           description: data.description,
@@ -230,6 +233,13 @@ export const ToolsetEditor = () => {
       });
     }
   }, [formMethods, toolsetDetails]);
+
+  useEffect(() => {
+    if (idQuery && !firstValidationPerformedRef.current) {
+      void formMethods.trigger();
+    }
+    firstValidationPerformedRef.current = true;
+  }, [idQuery, formMethods.trigger]);
 
   return (
     <FormProvider {...formMethods}>

--- a/apps/chat/src/components/ToolsetEditor/form.ts
+++ b/apps/chat/src/components/ToolsetEditor/form.ts
@@ -160,7 +160,7 @@ export const getDefaultFormData = (
     name:
       toolset?.name ??
       getNextDefaultName(DEFAULT_TOOLSET_NAME, toolsets ?? [], 0, true),
-    endpoint: toolset?.endpoint ?? ENDPOINT_PLACEHOLDER,
+    endpoint: toolset ? (toolset.endpoint ?? '') : ENDPOINT_PLACEHOLDER,
     protocol: toolset?.transport ?? ToolsetTransportType.HTTP,
     description: toolset?.description ?? '',
     allowedTools: toolset?.allowedTools ?? [],

--- a/apps/chat/src/store/application/application.epics.ts
+++ b/apps/chat/src/store/application/application.epics.ts
@@ -294,13 +294,17 @@ const updateApplicationEpic: AppEpic = (action$) =>
             .pipe(
               map(() => ({ success: true as const })),
               catchError((err) => {
+                const failActions = [
+                  ApplicationActions.updateFail({
+                    oldApplication: payload.oldApplication,
+                  }),
+                  UIActions.setEditorLoader(false),
+                ];
                 if (err.status === 412) {
                   return of({
                     success: false as const,
                     actions: [
-                      ApplicationActions.updateFail({
-                        oldApplication: payload.oldApplication,
-                      }),
+                      ...failActions,
                       UIActions.showErrorToast(
                         translate(
                           'An application with this name and this version already exists.',
@@ -313,9 +317,7 @@ const updateApplicationEpic: AppEpic = (action$) =>
                 return of({
                   success: false as const,
                   actions: [
-                    ApplicationActions.updateFail({
-                      oldApplication: payload.oldApplication,
-                    }),
+                    ...failActions,
                     UIActions.showErrorToast(
                       translate('Failed to move application'),
                     ),
@@ -406,6 +408,7 @@ const updateApplicationEpic: AppEpic = (action$) =>
                     ),
                     EMPTY,
                   ),
+                  of(UIActions.setEditorLoader(false)),
                 );
               }),
               endWith(ApplicationActions.updateComplete()),

--- a/apps/chat/src/store/toolset/toolset.epics.ts
+++ b/apps/chat/src/store/toolset/toolset.epics.ts
@@ -290,13 +290,17 @@ const updateToolsetEpic: AppEpic = (action$) =>
             .pipe(
               map(() => ({ success: true as const })),
               catchError((err) => {
+                const failActions = [
+                  ToolsetActions.updateToolsetFailed({
+                    oldToolset: payload.oldToolset,
+                  }),
+                  UIActions.setEditorLoader(false),
+                ];
                 if (err.status === 412) {
                   return of({
                     success: false as const,
                     actions: [
-                      ToolsetActions.updateToolsetFailed({
-                        oldToolset: payload.oldToolset,
-                      }),
+                      ...failActions,
                       UIActions.showErrorToast(
                         translate(errorsMessages.toolsetAlreadyExists),
                       ),
@@ -307,9 +311,7 @@ const updateToolsetEpic: AppEpic = (action$) =>
                 return of({
                   success: false as const,
                   actions: [
-                    ToolsetActions.updateToolsetFailed({
-                      oldToolset: payload.oldToolset,
-                    }),
+                    ...failActions,
                     UIActions.showErrorToast(
                       translate(errorsMessages.toolsetMoveFailed),
                     ),
@@ -409,10 +411,13 @@ const updateToolsetEpic: AppEpic = (action$) =>
                       },
                     }),
                   ),
-                  of(
-                    ToolsetActions.updateToolsetFailed({
-                      oldToolset: payload.oldToolset,
-                    }),
+                  concat(
+                    of(
+                      ToolsetActions.updateToolsetFailed({
+                        oldToolset: payload.oldToolset,
+                      }),
+                    ),
+                    of(UIActions.setEditorLoader(false)),
                   ),
                 ),
               );


### PR DESCRIPTION
**Description:**

- turn off editor loader on toolset or application failed save attempt
- validate editor form once when user opens it in edit mode

Issues:

- Issue #6007 
- Issue #5960 

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
