### PR TITLE
fix(chat): change share and publish error toast messages (Issue #6056)

### DIFF
--- a/apps/chat-e2e/src/testData/expectedConstants.ts
+++ b/apps/chat-e2e/src/testData/expectedConstants.ts
@@ -118,7 +118,7 @@ export const ExpectedConstants = {
   shareInviteAcceptanceFailureMessage:
     'Accepting sharing invite failed. Please open share link again to being able to see shared resource.',
   sharingWithAttachmentNotFromAllFilesErrorMessage:
-    'Sharing failed. You are only allowed to share conversations with attachments from "All files"',
+    'Sharing failed. You are only allowed to share conversations with attachments from "My files"',
   shareInviteDoesNotExist:
     'We are sorry, but the link you are trying to access has expired or does not exist.',
   copyUrlTooltip: 'Copy URL',
@@ -257,7 +257,7 @@ export const ExpectedConstants = {
   publishedAttachmentDownloadPath: (name: string) =>
     `${API.fileHost()}/public/${name}`,
   attachmentPublishErrorMessage:
-    'Publishing failed. You are only allowed to publish conversations with attachments from "All files"',
+    'Publishing failed. You are only allowed to publish conversations with attachments from "My files"',
   marketplacePath: '/marketplace',
   workspaceTab: 'tab=workspace',
   workspacePath: () =>

--- a/apps/chat/src/constants/errors.ts
+++ b/apps/chat/src/constants/errors.ts
@@ -38,7 +38,7 @@ export const errorsMessages = {
   exportFailed: 'Export failed',
   shareFailed: 'Sharing failed. Please try again later.',
   shareWithExternalFilesFailed:
-    'Sharing failed. You are only allowed to share conversations with attachments from "All files"',
+    'Sharing failed. You are only allowed to share conversations with attachments from "My files"',
   acceptShareFailed:
     'Accepting sharing invite failed. Please open share link again to being able to see shared resource.',
   acceptShareNotExists:
@@ -58,7 +58,7 @@ export const errorsMessages = {
   entityPathInvalidExternal: 'The parent folder name is invalid',
   publicationFailed: 'Creation of publication failed. Please try again later.',
   publicationWithExternalFilesFailed:
-    'Publishing failed. You are only allowed to publish conversations with attachments from "All files"',
+    'Publishing failed. You are only allowed to publish conversations with attachments from "My files"',
   publicationsUploadFailed: 'Publications uploading failed.',
   publicationUploadFailed: 'Publication uploading failed.',
   publishedItemsUploadFailed: 'Published items uploading failed.',


### PR DESCRIPTION
**Description:**

Need to rename toast messages when share or publish chat which contains files from Organization or shared with me

From All Files to My Files

Issues:

- Issue #6056

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
