### PR TITLE
fix(chat): fix Regular attachments

### DIFF
--- a/apps/chat/src/components/Chat/MessageAttachments.tsx
+++ b/apps/chat/src/components/Chat/MessageAttachments.tsx
@@ -58,7 +58,6 @@ export const MessageAttachments = ({
     }
 
     if (applicationVisualizerConfig) {
-      const visualizerContentType = applicationVisualizerConfig.contentType;
       const visualizerAttachments = attachments.filter((a) => a.url);
       const groupedVisualizerItems = visualizerAttachments.map((a) => ({
         url: getMappedAttachmentUrl(a.url)!,
@@ -71,9 +70,7 @@ export const MessageAttachments = ({
             config: applicationVisualizerConfig,
             attachments: groupedVisualizerItems,
           },
-          regularAttachments: attachments.filter(
-            (a) => a.type !== visualizerContentType,
-          ),
+          regularAttachments: [],
         };
       }
     }


### PR DESCRIPTION
**Description:**

When a message contains attachments and applicationVisualizerConfig is present, all attachments with a URL are expected to be passed exclusively to the GroupedVisualizerRenderer. However, due to incorrect filtering logic in MessageAttachments.tsx, regularAttachments was being populated with attachments whose type did not match visualizerContentType — even when the grouped visualizer was already active.

This caused those attachments to be rendered a second time via renderRegularAttachments(), resulting in duplicate or unintended attachment cards appearing below the grouped visualizer.

Root cause:
```
// Before fix — regularAttachments was still populated when grouped visualizer was active
regularAttachments: attachments.filter((a) => a.type !== visualizerContentType),
```

Fix applied:
```
// After fix — regularAttachments is cleared when grouped visualizer takes ownership
regularAttachments: [],
```
Issues:

- Issue #6071

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
