### PR TITLE
fix(chat): fix MindMap validation (Issue #6055)

### DIFF
--- a/apps/chat/src/components/AppsEditor/form.ts
+++ b/apps/chat/src/components/AppsEditor/form.ts
@@ -324,8 +324,8 @@ const getCustomAppFormData = (app?: CustomApplicationModel): CustomAppForm => ({
   maxInputAttachments: app?.maxInputAttachments ?? undefined,
   completionUrl:
     app && !app.applicationTypeSchemaId
-      ? (app.completionUrl ?? '')
-      : app?.completionUrl || MANDATORY_FIELD_PLACEHOLDER,
+      ? (app.completionUrl ?? '') // for custom apps
+      : app?.completionUrl || MANDATORY_FIELD_PLACEHOLDER, // fallback for schema-applications
   features: safeStringifyApplicationFeatures(app?.features),
 });
 

--- a/apps/chat/src/components/AppsEditor/form.ts
+++ b/apps/chat/src/components/AppsEditor/form.ts
@@ -325,7 +325,7 @@ const getCustomAppFormData = (app?: CustomApplicationModel): CustomAppForm => ({
   completionUrl:
     app && !app.applicationTypeSchemaId
       ? (app.completionUrl ?? '')
-      : MANDATORY_FIELD_PLACEHOLDER,
+      : app?.completionUrl || MANDATORY_FIELD_PLACEHOLDER,
   features: safeStringifyApplicationFeatures(app?.features),
 });
 

--- a/apps/chat/src/components/AppsEditor/form.ts
+++ b/apps/chat/src/components/AppsEditor/form.ts
@@ -322,7 +322,10 @@ const getCustomAppFormData = (app?: CustomApplicationModel): CustomAppForm => ({
   type: AppsEditorSchemaTypes.CustomApp,
   inputAttachmentTypes: app?.inputAttachmentTypes ?? [],
   maxInputAttachments: app?.maxInputAttachments ?? undefined,
-  completionUrl: app ? (app.completionUrl ?? '') : MANDATORY_FIELD_PLACEHOLDER,
+  completionUrl:
+    app && !app.applicationTypeSchemaId
+      ? (app.completionUrl ?? '')
+      : MANDATORY_FIELD_PLACEHOLDER,
   features: safeStringifyApplicationFeatures(app?.features),
 });
 


### PR DESCRIPTION
**Description:**

fix MindMap validation

Issues:

- Issue #6055

**UI changes**

<img width="272" height="144" alt="image" src="https://github.com/user-attachments/assets/540b4b9a-5690-4a16-9abe-c8e588829e19" />
->
<img width="186" height="93" alt="image" src="https://github.com/user-attachments/assets/7de0f15e-4d04-4ce3-9ac9-cf66ccd4ca42" />

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
