### PR TITLE
fix(chat): long folder name in publications (Issue ##1969)

### DIFF
--- a/apps/chat/src/components/Chat/Publish/RuleListItem.tsx
+++ b/apps/chat/src/components/Chat/Publish/RuleListItem.tsx
@@ -10,9 +10,9 @@ import { getFilterLabel } from '@/src/utils/app/rules';
 import { PublicationRule } from '@/src/types/publication';
 import { Translation } from '@/src/types/translation';
 
+import { DialEllipsisTooltip } from '@epam/ai-dial-ui-kit';
 import startCase from 'lodash-es/startCase';
 import toLower from 'lodash-es/toLower';
-import { DialEllipsisTooltip } from '@epam/ai-dial-ui-kit';
 
 interface Props {
   path: string;

--- a/apps/chat/src/components/Chat/Publish/RuleListItem.tsx
+++ b/apps/chat/src/components/Chat/Publish/RuleListItem.tsx
@@ -12,6 +12,7 @@ import { Translation } from '@/src/types/translation';
 
 import startCase from 'lodash-es/startCase';
 import toLower from 'lodash-es/toLower';
+import { DialEllipsisTooltip } from '@epam/ai-dial-ui-kit';
 
 interface Props {
   path: string;
@@ -31,7 +32,7 @@ export function RuleListItem({
   return (
     <>
       <div className="mb-1 text-xs text-secondary" data-qa="published-path">
-        {getLastPathSegment(path)}
+        <DialEllipsisTooltip text={getLastPathSegment(path)} />
       </div>
       <div className="mb-3 flex flex-wrap gap-1 text-xs" data-qa="rules-list">
         {rules.map((rule, idx) => (


### PR DESCRIPTION
**Description:**

long folder name in publications

Issues:

- Issue ##1969

**UI changes**
<img width="477" height="539" alt="image" src="https://github.com/user-attachments/assets/7c31a9f5-4b84-4063-9536-ea46598ad27d" />

**Checklist:**

- [ ] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [ ] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
