### PR TITLE
fix(chat): remove shared access when document relative URL changes (#6034)

### DIFF
--- a/apps/chat/src/components/AppsEditor/AppsEditor.tsx
+++ b/apps/chat/src/components/AppsEditor/AppsEditor.tsx
@@ -6,6 +6,7 @@ import { useRouter } from 'next/router';
 import { useTranslation } from '@/src/hooks/useTranslation';
 
 import {
+  getQuick2AppDocumentUrl,
   getQuickAppDocumentUrl,
   isApplicationDeployed,
   isApplicationType,
@@ -69,8 +70,19 @@ const checkShouldRevokeAccess = ({
       getQuickAppDocumentUrl(newApp),
       getQuickAppDocumentUrl(oldApp),
     );
+  const differentQuickApp2DocumentUrl =
+    !!oldApp &&
+    !arraysHaveSameElements(
+      getQuick2AppDocumentUrl(newApp),
+      getQuick2AppDocumentUrl(oldApp),
+    );
 
-  return isShared && (differentSourceFolders || differentDocumentUrl);
+  return (
+    isShared &&
+    (differentSourceFolders ||
+      differentDocumentUrl ||
+      differentQuickApp2DocumentUrl)
+  );
 };
 
 export const AppsEditor = () => {


### PR DESCRIPTION
**Description:**

When in shared app author updates Document relative url, then sharing should be stoped

Issues:

- Issue #6034

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
