### PR TITLE
feat(chat): add extra borders for chat input/header (Issue #6180)

### DIFF
--- a/apps/chat/src/components/Chat/ChatHeader/Header.tsx
+++ b/apps/chat/src/components/Chat/ChatHeader/Header.tsx
@@ -126,6 +126,9 @@ export const ChatHeader = Inversify.register(
       Feature.DisallowChangeAgent,
     );
     const isChatbarEnabled = enabledFeatures.has(Feature.ConversationsSection);
+    const isChatHeaderBorderEnabled = enabledFeatures.has(
+      Feature.ChatHeaderBorder,
+    );
 
     const [model, setModel] = useState<DialAIEntityModel | undefined>(() => {
       return modelsMap[conversation.model.id];
@@ -185,6 +188,7 @@ export const ChatHeader = Inversify.register(
         <div
           className={classNames(
             'sticky top-0 z-10 flex w-full min-w-0 items-center justify-center gap-2 bg-layer-2 px-3 py-2 text-sm md:flex-wrap md:px-0 lg:flex-row',
+            isChatHeaderBorderEnabled && 'border-b border-secondary',
             isChatFullWidth && 'px-3 md:px-5 lg:flex-nowrap',
           )}
           data-qa="chat-header"

--- a/apps/chat/src/components/Chat/ChatInput/ChatInputMessage.tsx
+++ b/apps/chat/src/components/Chat/ChatInput/ChatInputMessage.tsx
@@ -166,6 +166,9 @@ export const ChatInputMessage = Inversify.register(
     const disabledInputFeatureData = useAppSelector((state) =>
       SettingsSelectors.selectFeatureData(state, Feature.DisabledSend),
     );
+    const isChatInputBorderEnabled = useAppSelector((state) =>
+      SettingsSelectors.isFeatureEnabled(state, Feature.ChatInputBorder),
+    );
 
     const shouldRegenerate =
       isLastMessageError ||
@@ -557,7 +560,10 @@ export const ChatInputMessage = Inversify.register(
         )}
       >
         <div
-          className="relative m-0 flex max-h-[400px] min-h-[38px] w-full grow flex-col rounded bg-layer-3 focus-within:border-accent-primary"
+          className={classNames(
+            'relative m-0 flex max-h-[400px] min-h-[38px] w-full grow flex-col rounded bg-layer-3 focus-within:border-accent-primary',
+            isChatInputBorderEnabled && 'border border-primary',
+          )}
           data-qa="message"
         >
           <AdjustedTextarea

--- a/libs/shared/src/types/features.ts
+++ b/libs/shared/src/types/features.ts
@@ -10,6 +10,9 @@ export enum Feature {
   AttachmentsManager = 'attachments-manager', // Display attachments manager in conversation
   ChatFullWidthByDefault = 'chat-full-width-by-default', // Enforce chat full-width
 
+  // Chat Header
+  ChatHeaderBorder = 'chat-header-border', // Display a separator line below the chat header
+
   // Conversation Header
   HideNewConversation = 'hide-new-conversation', // hide "New conversation" button
   TopSettings = 'top-settings', // Display conversation top header
@@ -41,6 +44,7 @@ export enum Feature {
 
   // Chat input
   SkipFocusChatInputOnLoad = 'skip-focus-chat-input-onload', // Skip default focusing chat input when on screen onload or after navigation
+  ChatInputBorder = 'chat-input-border', // Display border around chat input area
 
   // Send button
   DisabledSend = 'disabled-send', // Disable input


### PR DESCRIPTION
**Description:**

Add extra borders for chat input/header

Issues:

- Issue #6180

**UI changes**
<img width="2209" height="1066" alt="image" src="https://github.com/user-attachments/assets/4fa5f8f8-564b-4758-bbc2-7eaefe0b2304" />

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
