### PR TITLE
fix(chat): fix subscribe on app editor, use personal creds by default in chat-user interactions (Issue #6205)

### DIFF
--- a/apps/chat/src/components/Chat/ChatEventsModal/ToolsetLoginEvents/ToolsetLoginEvents.tsx
+++ b/apps/chat/src/components/Chat/ChatEventsModal/ToolsetLoginEvents/ToolsetLoginEvents.tsx
@@ -23,11 +23,7 @@ import {
   ToolsetActions,
 } from '@/src/store/actions';
 import { useAppDispatch, useAppSelector } from '@/src/store/hooks';
-import {
-  AuthSelectors,
-  ChatEventsSelectors,
-  ToolsetSelectors,
-} from '@/src/store/selectors';
+import { ChatEventsSelectors, ToolsetSelectors } from '@/src/store/selectors';
 
 import { ModelIcon } from '@/src/components/Chatbar/ModelIcon';
 import { Spinner } from '@/src/components/Common/Spinner';
@@ -57,7 +53,6 @@ export const ToolsetLoginEvents: FC<ToolsetLoginEventsProps> = ({ events }) => {
   const toolsets = useAppSelector(ToolsetSelectors.selectToolsetsMap);
   const areToolsetsLoading = useAppSelector(ToolsetSelectors.selectIsLoading);
   const isReporting = useAppSelector(ChatEventsSelectors.selectIsReporting);
-  const isAdmin = useAppSelector(AuthSelectors.selectIsAdmin);
 
   const loginToolsets = useMemo(
     () =>
@@ -76,11 +71,13 @@ export const ToolsetLoginEvents: FC<ToolsetLoginEventsProps> = ({ events }) => {
     (t: ToolsetModel) => {
       const isPublic = isEntityIdPublic(t) || isPredefinedEntity(t);
 
-      if (
-        (isPublic && isAdmin) ||
-        t.authSettings?.authenticationType !== ToolsetAuthTypes.OAUTH
-      ) {
-        dispatch(MarketplaceActions.setLoginEntity(t));
+      if (t.authSettings?.authenticationType !== ToolsetAuthTypes.OAUTH) {
+        dispatch(
+          MarketplaceActions.setLoginEntity({
+            toolset: t,
+            disableAdminView: true,
+          }),
+        );
       } else {
         dispatch(
           ToolsetActions.startSignInProcess({
@@ -92,7 +89,7 @@ export const ToolsetLoginEvents: FC<ToolsetLoginEventsProps> = ({ events }) => {
         );
       }
     },
-    [dispatch, isAdmin],
+    [dispatch],
   );
 
   const handleDeclineAllClick = useCallback(() => {

--- a/apps/chat/src/components/Marketplace/ToolsetLoginDialog.tsx
+++ b/apps/chat/src/components/Marketplace/ToolsetLoginDialog.tsx
@@ -56,21 +56,25 @@ const credsTabs = [
 ];
 
 interface ToolsetLoginDialogProps {
-  entity: ToolsetModel;
+  entity: { toolset: ToolsetModel; disableAdminView?: boolean };
 }
 
-const ToolsetLoginDialogView: FC<ToolsetLoginDialogProps> = ({ entity }) => {
+const ToolsetLoginDialogView: FC<ToolsetLoginDialogProps> = ({
+  entity: loginParams,
+}) => {
   const { t } = useTranslation(Translation.Marketplace);
   const dispatch = useAppDispatch();
   const { route } = useRouter();
+
+  const { toolset, disableAdminView } = loginParams;
 
   const isAdmin = useAppSelector(AuthSelectors.selectIsAdmin);
   const allToolsets = useAppSelector(ToolsetSelectors.selectToolsets);
   const isToolsetLoading = useAppSelector(
     ToolsetSelectors.selectIsToolsetDetailsLoading,
   );
-  const authType = entity.authSettings.authenticationType;
-  const isPublic = isEntityIdPublic(entity) || isPredefinedEntity(entity);
+  const authType = toolset.authSettings.authenticationType;
+  const isPublic = isEntityIdPublic(toolset) || isPredefinedEntity(toolset);
 
   const [authLevel, setAuthLevel] = useState<
     ToolsetCredentialsLevel | undefined
@@ -81,7 +85,7 @@ const ToolsetLoginDialogView: FC<ToolsetLoginDialogProps> = ({ entity }) => {
   const formMethods = useForm<ToolsetLoginFormType>({
     defaultValues: getDefaultLoginFormData(
       authType,
-      entity,
+      toolset,
       {
         withLogin: WithLogin.WithLogin,
       },
@@ -92,29 +96,29 @@ const ToolsetLoginDialogView: FC<ToolsetLoginDialogProps> = ({ entity }) => {
     resolver: zodResolver(ToolsetLoginFormSchema),
   });
 
-  const isOrganizationView = isAdmin && isPublic;
+  const isOrganizationView = isAdmin && isPublic && !disableAdminView;
   const isSignedIn = isToolsetSignedIn(
-    entity,
+    toolset,
     isPublic ? ToolsetCredentialsLevel.USER : ToolsetCredentialsLevel.GLOBAL,
   );
 
   const fieldsInfo = useMemo(
     () => ({
       apiKey: t('Enter your API key value for "{{header}}" header', {
-        header: entity.authSettings.apiKeyHeader,
+        header: toolset.authSettings.apiKeyHeader,
       }),
     }),
-    [entity.authSettings.apiKeyHeader, t],
+    [toolset.authSettings.apiKeyHeader, t],
   );
 
   const organizationFormTitle = useMemo(() => {
     switch (authLevel) {
       case ToolsetCredentialsLevel.USER:
-        return isToolsetSignedIn(entity, authLevel)
+        return isToolsetSignedIn(toolset, authLevel)
           ? t('Log out of the toolset using personal credentials.')
           : t('Log in with personal credentials.');
       case ToolsetCredentialsLevel.GLOBAL:
-        return isToolsetSignedIn(entity, authLevel) ? (
+        return isToolsetSignedIn(toolset, authLevel) ? (
           <>
             {t('Log out of the toolset ')}
             <strong>{t('for all users in the organization ')}</strong>
@@ -131,16 +135,16 @@ const ToolsetLoginDialogView: FC<ToolsetLoginDialogProps> = ({ entity }) => {
       default:
         return '';
     }
-  }, [authLevel, entity, t]);
+  }, [authLevel, toolset, t]);
 
   const allVersions = useMemo(
     () =>
       allToolsets.filter(
         (t) =>
           getGroupMarketplaceEntityKey(t) ===
-          getGroupMarketplaceEntityKey(entity),
+          getGroupMarketplaceEntityKey(toolset),
       ),
-    [allToolsets, entity],
+    [allToolsets, toolset],
   );
 
   const handleClose = useCallback(() => {
@@ -157,12 +161,12 @@ const ToolsetLoginDialogView: FC<ToolsetLoginDialogProps> = ({ entity }) => {
               ? ToolsetCredentialsLevel.USER
               : ToolsetCredentialsLevel.GLOBAL),
           apiKey: data.apiKey,
-          toolset: entity,
+          toolset,
         }),
       );
       handleClose();
     },
-    [dispatch, authLevel, isPublic, entity, handleClose],
+    [dispatch, authLevel, isPublic, toolset, handleClose],
   );
 
   const handleLogout = useCallback(() => {
@@ -173,23 +177,23 @@ const ToolsetLoginDialogView: FC<ToolsetLoginDialogProps> = ({ entity }) => {
           (isPublic
             ? ToolsetCredentialsLevel.USER
             : ToolsetCredentialsLevel.GLOBAL),
-        authType: entity.authSettings.authenticationType,
-        toolsetId: entity.id,
+        authType: toolset.authSettings.authenticationType,
+        toolsetId: toolset.id,
       }),
     );
     handleClose();
   }, [
     isPublic,
     dispatch,
-    entity.authSettings.authenticationType,
-    entity.id,
+    toolset.authSettings.authenticationType,
+    toolset.id,
     handleClose,
     authLevel,
   ]);
 
   const handleVersionChange = useCallback(
     (toolset: ToolsetModel) => {
-      dispatch(MarketplaceActions.setLoginEntity(toolset));
+      dispatch(MarketplaceActions.setLoginEntity({ toolset }));
     },
     [dispatch],
   );
@@ -200,7 +204,7 @@ const ToolsetLoginDialogView: FC<ToolsetLoginDialogProps> = ({ entity }) => {
       formMethods.reset(
         getDefaultLoginFormData(
           authType,
-          entity,
+          toolset,
           {
             withLogin: WithLogin.WithLogin,
           },
@@ -208,7 +212,7 @@ const ToolsetLoginDialogView: FC<ToolsetLoginDialogProps> = ({ entity }) => {
         ),
       );
     },
-    [authType, entity, formMethods],
+    [authType, toolset, formMethods],
   );
 
   const handleCloseLogoutModal = useCallback(
@@ -253,16 +257,16 @@ const ToolsetLoginDialogView: FC<ToolsetLoginDialogProps> = ({ entity }) => {
       </div>
 
       <div className="flex gap-2 px-6 py-4">
-        <ModelIcon size={40} entityId={entity.id} entity={entity} />
+        <ModelIcon size={40} entityId={toolset.id} entity={toolset} />
         <div className="flex flex-col justify-between">
-          <h3 className="text-sm font-semibold text-primary">{entity.name}</h3>
+          <h3 className="text-sm font-semibold text-primary">{toolset.name}</h3>
           <div className="flex items-center gap-1">
             <span className="text-xs text-primary">{t('Version: ')}</span>
 
-            {entity.version ? (
+            {toolset.version ? (
               <ModelVersionSelect
-                entities={isAppsEditor ? [entity] : allVersions}
-                currentEntity={entity}
+                entities={isAppsEditor ? [toolset] : allVersions}
+                currentEntity={toolset}
                 onSelect={handleVersionChange}
                 className="truncate"
                 triggerClassName="!text-xs bg-layer-4 rounded p-1"
@@ -287,17 +291,19 @@ const ToolsetLoginDialogView: FC<ToolsetLoginDialogProps> = ({ entity }) => {
                 onClick={() => handleCredsTabClick(key)}
                 statusBadge={{
                   label: t(
-                    isToolsetSignedIn(entity, key) ? 'LOGGED IN' : 'LOGGED OUT',
+                    isToolsetSignedIn(toolset, key)
+                      ? 'LOGGED IN'
+                      : 'LOGGED OUT',
                   ),
-                  type: isToolsetSignedIn(entity, key) ? 'success' : 'error',
+                  type: isToolsetSignedIn(toolset, key) ? 'success' : 'error',
                 }}
               >
                 <p className="text-sm text-primary">{organizationFormTitle}</p>
 
                 <ToolsetLoginForm
                   credentialsLevel={authLevel}
-                  type={entity.authSettings.authenticationType}
-                  toolset={entity}
+                  type={toolset.authSettings.authenticationType}
+                  toolset={toolset}
                   buttonClassName="ml-auto"
                   onLogin={handleLogin}
                   onLogout={handleLogout}
@@ -313,8 +319,8 @@ const ToolsetLoginDialogView: FC<ToolsetLoginDialogProps> = ({ entity }) => {
                   ? ToolsetCredentialsLevel.USER
                   : ToolsetCredentialsLevel.GLOBAL
               }
-              type={entity.authSettings.authenticationType}
-              toolset={entity}
+              type={toolset.authSettings.authenticationType}
+              toolset={toolset}
               buttonClassName="ml-auto"
               onLogin={handleLogin}
               onLogout={handleLogout}

--- a/apps/chat/src/components/Marketplace/ToolsetLoginDialog.tsx
+++ b/apps/chat/src/components/Marketplace/ToolsetLoginDialog.tsx
@@ -56,18 +56,15 @@ const credsTabs = [
 ];
 
 interface ToolsetLoginDialogProps {
-  entity: { toolset: ToolsetModel; disableAdminView?: boolean };
+  toolset: ToolsetModel;
 }
 
-const ToolsetLoginDialogView: FC<ToolsetLoginDialogProps> = ({
-  entity: loginParams,
-}) => {
+const ToolsetLoginDialogView: FC<ToolsetLoginDialogProps> = ({ toolset }) => {
   const { t } = useTranslation(Translation.Marketplace);
   const dispatch = useAppDispatch();
   const { route } = useRouter();
 
-  const { toolset, disableAdminView } = loginParams;
-
+  const loginEntity = useAppSelector(MarketplaceSelectors.selectLoginEntity);
   const isAdmin = useAppSelector(AuthSelectors.selectIsAdmin);
   const allToolsets = useAppSelector(ToolsetSelectors.selectToolsets);
   const isToolsetLoading = useAppSelector(
@@ -96,7 +93,8 @@ const ToolsetLoginDialogView: FC<ToolsetLoginDialogProps> = ({
     resolver: zodResolver(ToolsetLoginFormSchema),
   });
 
-  const isOrganizationView = isAdmin && isPublic && !disableAdminView;
+  const isOrganizationView =
+    isAdmin && isPublic && !loginEntity?.disableAdminView;
   const isSignedIn = isToolsetSignedIn(
     toolset,
     isPublic ? ToolsetCredentialsLevel.USER : ToolsetCredentialsLevel.GLOBAL,
@@ -112,13 +110,14 @@ const ToolsetLoginDialogView: FC<ToolsetLoginDialogProps> = ({
   );
 
   const organizationFormTitle = useMemo(() => {
+    const isSignedIn = isToolsetSignedIn(toolset, authLevel);
     switch (authLevel) {
       case ToolsetCredentialsLevel.USER:
-        return isToolsetSignedIn(toolset, authLevel)
+        return isSignedIn
           ? t('Log out of the toolset using personal credentials.')
           : t('Log in with personal credentials.');
       case ToolsetCredentialsLevel.GLOBAL:
-        return isToolsetSignedIn(toolset, authLevel) ? (
+        return isSignedIn ? (
           <>
             {t('Log out of the toolset ')}
             <strong>{t('for all users in the organization ')}</strong>
@@ -337,5 +336,5 @@ const ToolsetLoginDialogView: FC<ToolsetLoginDialogProps> = ({
 
 export const ToolsetLoginDialog =
   withRenderWhenEntities<ToolsetLoginDialogProps>({
-    entity: MarketplaceSelectors.selectLoginEntity,
+    toolset: (state) => MarketplaceSelectors.selectLoginEntity(state)?.toolset,
   })(ToolsetLoginDialogView);

--- a/apps/chat/src/hooks/useToolsetActions.ts
+++ b/apps/chat/src/hooks/useToolsetActions.ts
@@ -124,7 +124,7 @@ export const useToolsetMenuActions = (toolset: ToolsetModel) => {
     (e: React.MouseEvent) => {
       e.preventDefault();
       e.stopPropagation();
-      dispatch(MarketplaceActions.setLoginEntity(toolset));
+      dispatch(MarketplaceActions.setLoginEntity({ toolset }));
     },
     [dispatch, toolset],
   );

--- a/apps/chat/src/store/marketplace/marketplace.reducers.ts
+++ b/apps/chat/src/store/marketplace/marketplace.reducers.ts
@@ -168,7 +168,11 @@ export const marketplaceSlice = createSlice({
     },
     setLoginEntity: (
       state,
-      { payload }: PayloadAction<ToolsetModel | undefined>,
+      {
+        payload,
+      }: PayloadAction<
+        { toolset: ToolsetModel; disableAdminView?: boolean } | undefined
+      >,
     ) => {
       state.loginEntity = payload;
     },

--- a/apps/chat/src/store/marketplace/marketplace.types.ts
+++ b/apps/chat/src/store/marketplace/marketplace.types.ts
@@ -35,6 +35,8 @@ export interface MarketplaceState {
 
   detailsEntity: DetailsEntity | undefined;
   deleteEntity: { entity: MarketplaceEntity; action: DeleteType } | undefined;
-  loginEntity: ToolsetModel | undefined;
+  loginEntity:
+    | { toolset: ToolsetModel; disableAdminView?: boolean }
+    | undefined;
   showLoader?: boolean;
 }

--- a/apps/chat/src/store/settings/settings.epics.ts
+++ b/apps/chat/src/store/settings/settings.epics.ts
@@ -91,6 +91,7 @@ const getInitActions = (page?: PageType): Observable<AppAction>[] => {
         of(ConversationsActions.init()),
         of(ApplicationTypesSchemasActions.init()),
         of(ToolsetActions.init()),
+        of(ChatEventsActions.subscribe()),
       ];
     default:
       return [


### PR DESCRIPTION
**Description:**

- subscribe to channel on apps editor page
- use personal level creds for admin if logging into toolset on chat completion

Issues:

- Issue #6205 

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
