### PR TITLE
fix(overlay): fix `Shared` and `Published` items listings not triggered when `Overlay` options are changed (Issue #6207)

### DIFF
--- a/apps/chat/src/store/overlay/overlay.epics.ts
+++ b/apps/chat/src/store/overlay/overlay.epics.ts
@@ -1235,6 +1235,9 @@ const setOverlayOptionsEpic: AppEpic = (action$, state$) =>
           );
 
           if (!shouldLogIn) {
+            // Trigger sharing and publication listings
+
+            // Conversations
             if (features.includes(Feature.ConversationsSharing)) {
               actions.push(
                 of(ShareActions.triggerGettingSharedConversationListings()),
@@ -1251,6 +1254,13 @@ const setOverlayOptionsEpic: AppEpic = (action$, state$) =>
               );
             }
 
+            // Prompts
+            if (features.includes(Feature.PromptsSharing)) {
+              actions.push(
+                of(ShareActions.triggerGettingSharedPromptListings()),
+              );
+            }
+
             if (features.includes(Feature.PromptsPublishing)) {
               actions.push(
                 of(
@@ -1261,6 +1271,14 @@ const setOverlayOptionsEpic: AppEpic = (action$, state$) =>
               );
             }
 
+            // Applications
+            if (features.includes(Feature.ApplicationsSharing)) {
+              actions.push(
+                of(ShareActions.triggerGettingSharedApplicationsListings()),
+              );
+            }
+
+            // Admin publications
             if (
               AuthSelectors.selectIsAdmin(state$.value) &&
               (features.includes(Feature.ConversationsPublishing) ||


### PR DESCRIPTION
**Description:**

- Fix `Shared` and `Published` items listings not triggered when `Overlay` options are changed.

Issues:

- Issue #6207 

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
