### PR TITLE
fix(chat): fix divider color set by `show-layout-dividers` feature flag (Issue #6143)

### DIFF
--- a/apps/chat/src/components/Navigation/NavigationWrapper.tsx
+++ b/apps/chat/src/components/Navigation/NavigationWrapper.tsx
@@ -46,7 +46,7 @@ export const NavigationWrapper = ({ children }: NavigationWrapperProps) => {
         className={classNames(
           'flex size-full flex-col md:flex-row',
           enabledFeatures.has(Feature.ShowLayoutDividers) &&
-            'sidebar-overlay:divide-x-[15px] sidebar-overlay:divide-accent-tertiary',
+            'sidebar-overlay:divide-x-[15px] sidebar-overlay:divide-tertiary',
         )}
       >
         {shouldShowNavigation && <Navigation />}


### PR DESCRIPTION
**Description:**

- Fix divider color set by `show-layout-dividers` feature flag.

Issues:

- Issue #6143 


**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
