### PR TITLE
fix(chat): add check for decodeApiUrl if path is empty ( Issue #6263)

### DIFF
--- a/apps/chat/src/utils/server/api.ts
+++ b/apps/chat/src/utils/server/api.ts
@@ -168,8 +168,10 @@ export class ApiUtils {
       ...path.split('/').map((part) => this.safeEncodeURIComponent(part)),
     );
 
-  static decodeApiUrl = (path: string): string =>
-    constructPath(...path.split('/').map((part) => decodeURIComponent(part)));
+  static decodeApiUrl = (path?: string): string =>
+    constructPath(
+      ...(path?.split('/').map((part) => decodeURIComponent(part)) || []),
+    );
 
   static request(url: string, options?: RequestInit) {
     return fromFetch(url, {


### PR DESCRIPTION
**Description:**

add check for decodeApiUrl if path is empty

Issues:

- Issue #6263


**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
