### PR TITLE
fix(chat): fix resolving user name with @ (Issue #5640)

### DIFF
--- a/apps/chat/src/utils/app/__tests__/common.test.ts
+++ b/apps/chat/src/utils/app/__tests__/common.test.ts
@@ -429,10 +429,12 @@ describe('utils/app/common.ts', () => {
   });
 
   describe('misc helpers', () => {
-    it('extractNameFromEmail: returns undefined for non-string; extracts part before @ for email-looking strings', () => {
+    it('extractNameFromEmail: extracts local part only for valid email-like strings', () => {
       expect(extractNameFromEmail(undefined)).toBeUndefined();
-      expect(extractNameFromEmail('john@doe.com')).toBe('john');
-      expect(extractNameFromEmail('not-an-email')).toBe('not-an-email');
+      expect(extractNameFromEmail('palina@epample.com')).toBe('palina');
+      expect(extractNameFromEmail('palina @@@')).toBe('palina @@@');
+      expect(extractNameFromEmail('palina @ test')).toBe('palina @ test');
+      expect(extractNameFromEmail('palina@')).toBe('palina@');
     });
 
     it('parseCommaSeparatedList: trims items; returns default when undefined', () => {

--- a/apps/chat/src/utils/app/common.ts
+++ b/apps/chat/src/utils/app/common.ts
@@ -329,9 +329,12 @@ export const fakeCallback = () => null;
 export const castToString = (value: unknown): string => value as string;
 
 export const extractNameFromEmail = (author: string | undefined) => {
-  if (typeof author !== 'string') return; // we expecting only string
-  const regEx = /^[^@]+@[^@]+.[^@]+$/; // regex to test is author in an email format
-  return regEx.test(author) ? author.split('@')[0] : author;
+  if (typeof author !== 'string') return;
+
+  // Extract name only from valid email-like strings (e.g. name@domain.tld).
+  const match = author.match(/^([^\s@]+)@([^\s@]+\.[^\s@]+)$/);
+
+  return match ? match[1] : author;
 };
 
 export const formatDate = (rawDate: number | string | Date): string => {


### PR DESCRIPTION
**Description:**

fix resolving user name with @

Issues:

- Issue #5640


**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
