### PR TITLE
feat(chat): implement opportunity to hide "Custom app" from "Add app" (Issue #5864)

### DIFF
--- a/apps/chat/src/components/Marketplace/AddAppButton.tsx
+++ b/apps/chat/src/components/Marketplace/AddAppButton.tsx
@@ -43,6 +43,9 @@ export function AddAppButton() {
   );
 
   const isCodeAppsEnabled = enabledFeatures.has(Feature.CodeApps);
+  const hideCustomAppCreation = enabledFeatures.has(
+    Feature.HideCustomAppCreation,
+  );
 
   const openEditor = useCallback(
     (type: string) => {
@@ -62,7 +65,7 @@ export function AddAppButton() {
           name: t(MarketplaceI18nKeys.CustomApp),
           type: ApplicationType.CUSTOM_APP,
           dataQa: 'add-custom-app',
-          display: true,
+          display: !hideCustomAppCreation,
           onClick: (e: React.MouseEvent) => {
             e.stopPropagation();
             dispatch(
@@ -100,7 +103,14 @@ export function AddAppButton() {
           },
         })) ?? []),
       ].sort((a, b) => (a.name.toLowerCase() < b.name.toLowerCase() ? -1 : 1)),
-    [t, isCodeAppsEnabled, applicationTypeSchemas, openEditor, dispatch],
+    [
+      t,
+      hideCustomAppCreation,
+      isCodeAppsEnabled,
+      applicationTypeSchemas,
+      dispatch,
+      openEditor,
+    ],
   );
 
   return (

--- a/libs/shared/src/types/features.ts
+++ b/libs/shared/src/types/features.ts
@@ -78,6 +78,7 @@ export enum Feature {
 
   // Applications
   CustomApplications = 'custom-applications', // Enable creating of applications ('Add app' button/menu)
+  HideCustomAppCreation = 'hide-custom-app-creation', // Hide "Custom app" option in 'Add app' button/menu
   CodeApps = 'code-apps', // Enable creating of Code apps (into the 'Add app' menu)
   CodeInterpreter = 'code-interpreter', // Enable Code Interpreter feature
 


### PR DESCRIPTION
**Description:**

implement opportunity to hide "Custom app" from "Add app"

Issues:

- Issue #5864

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
