### PR TITLE
fix(chat): change `all files` to `my files` section name

### DIFF
--- a/apps/chat-e2e/src/testData/expectedConstants.ts
+++ b/apps/chat-e2e/src/testData/expectedConstants.ts
@@ -191,7 +191,7 @@ export const ExpectedConstants = {
     `The symbols ${ExpectedConstants.restrictedNameChars} are not allowed in file names. Please rename the file or remove it from your upload list: ${filename}`,
   endDotFilenameError: (filename: string) =>
     `Using a dot at the end of a name is not permitted. Please rename or delete them from uploading files list: ${filename}`,
-  allFilesRoot: 'All files',
+  allFilesRoot: 'My Files',
   copyTableTooltip: (copyType: CopyTableType) =>
     `Copy as ${copyType.toUpperCase()}`,
   charsToEscape: ['\\', '"'],

--- a/apps/chat-e2e/src/tests/uploadFromDevice.test.ts
+++ b/apps/chat-e2e/src/tests/uploadFromDevice.test.ts
@@ -146,7 +146,7 @@ dialTest(
     setTestIds('EPMRTC-3203', 'EPMRTC-3195', 'EPMRTC-3236');
     let deleteUploadedFileIcon: Locator;
     const attachments = [Attachment.longImageName, Attachment.cloudImageName];
-    const expectedExtensionClassAttribute = 'absolute right-2';
+    const expectedExtensionClassAttribute = 'text-secondary dial-small-text';
     let uploadedFileInput: BaseElement;
     let uploadedFileExtension: BaseElement;
 

--- a/apps/chat/src/components/Files/PreUploadModal.tsx
+++ b/apps/chat/src/components/Files/PreUploadModal.tsx
@@ -339,7 +339,7 @@ export const PreUploadDialog = ({
               <span className="truncate" data-qa="path">
                 {!bucket || isMyBucket(bucket)
                   ? constructPath(
-                      t(ChatI18nKeys.AllFiles),
+                      t(ChatI18nKeys.MyFiles),
                       folderPath ?? rootFolderName,
                     )
                   : constructPath(

--- a/apps/chat/src/constants/i18n.ts
+++ b/apps/chat/src/constants/i18n.ts
@@ -819,7 +819,6 @@ export enum ChatI18nKeys {
   MBUnit = 'MB',
   KBUnit = 'KB',
   UploadTo = 'Upload to',
-  AllFiles = 'All files',
   Files = 'Files',
   AddMoreFiles = 'Add more files...',
   Upload = 'Upload',

--- a/apps/chat/src/constants/sections.ts
+++ b/apps/chat/src/constants/sections.ts
@@ -19,7 +19,7 @@ export const SHARED_WITH_ME_SECTION_NAME = translate(
     ns: Translation.Chat,
   },
 );
-export const ROOT_SECTION_NAME = translate(ChatI18nKeys.AllFiles, {
+export const ROOT_SECTION_NAME = translate(ChatI18nKeys.MyFiles, {
   ns: Translation.Chat,
 });
 


### PR DESCRIPTION
**Description:**

fix(chat): change `all files` to `my files` section name

Issues:

- Issue #6053

**UI changes**

<img width="453" height="337" alt="image" src="https://github.com/user-attachments/assets/9d4ec6af-4c03-46a9-a0f9-b9e19f8871a6" />

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
