### PR TITLE
fix(chat): fix intro text shown only after conversation started (Issue #6077)

### DIFF
--- a/apps/chat/src/components/Chat/Chat.tsx
+++ b/apps/chat/src/components/Chat/Chat.tsx
@@ -617,6 +617,12 @@ const ChatView = memo(({ customViewer }: ChatViewProps) => {
       !(isSomeConversationWithSchema && selectedConversations.length > 1)) ||
     (isValidApproveRequiredConversation && isApproveRequiredInput);
 
+  const shouldShowIntroText =
+    selectedConversations.length === 1 &&
+    !selectedConversations[0].messages.find(
+      (userMessage) => userMessage.role === Role.User,
+    );
+
   useEffect(() => {
     if (!enabledFeatures.has(Feature.SkipFocusChatInputOnLoad)) {
       textareaRef.current?.focus();
@@ -909,7 +915,7 @@ const ChatView = memo(({ customViewer }: ChatViewProps) => {
                       />
                     ) : (
                       <>
-                        {selectedConversations.length === 1 && (
+                        {shouldShowIntroText && (
                           <IntroText
                             isWideLayout={isWideLayout}
                             modelId={selectedConversations[0].model.id}


### PR DESCRIPTION
**Description:**

fix intro text shown only after conversation started

Issues:

- Issue #6077

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
