### PR TITLE
fix(chat): implement search by folder name, fix path in shared with me, fix search inside folders (Issues #5690, #5793, #5795)

### DIFF
--- a/apps/chat/src/components/FileManager/hooks/useFileManager.tsx
+++ b/apps/chat/src/components/FileManager/hooks/useFileManager.tsx
@@ -68,7 +68,7 @@ import groupBy from 'lodash-es/groupBy';
 
 const formatSharedPath = (path: string | undefined | null) => {
   if (!path) return path;
-  return path.replace(/^files\/[^/]+/, 'Shared with me');
+  return path.replace(/^files\/[^/]+/, SHARED_WITH_ME_FILES_SECTION);
 };
 
 function extractHiddenSharedPathPart(

--- a/apps/chat/src/components/FileManager/hooks/useFileManager.tsx
+++ b/apps/chat/src/components/FileManager/hooks/useFileManager.tsx
@@ -10,6 +10,7 @@ import { constructPath, prepareFileName } from '@/src/utils/app/file';
 import {
   buildFileTree,
   convertToUIKitFile,
+  convertToUIKitFolder,
   filterFilesByFilters,
   filterFoldersByFilters,
 } from '@/src/utils/app/file-manager-adapter';
@@ -64,6 +65,33 @@ import {
 } from '@epam/ai-dial-ui-kit';
 import cloneDeep from 'lodash-es/cloneDeep';
 import groupBy from 'lodash-es/groupBy';
+
+const formatSharedPath = (path: string | undefined | null) => {
+  if (!path) return path;
+  return path.replace(/^files\/[^/]+/, 'Shared with me');
+};
+
+function extractHiddenSharedPathPart(
+  rootFolderPath: string,
+  rootItemPath: string,
+  rootItemName: string,
+): string | null {
+  if (!rootItemPath.startsWith(rootFolderPath)) {
+    return null;
+  }
+
+  const afterRoot = rootItemPath
+    .slice(rootFolderPath.length)
+    .replace(/^\/+/, '');
+
+  if (!afterRoot.endsWith(rootItemName)) {
+    return null;
+  }
+
+  const hidden = afterRoot.slice(0, afterRoot.length - rootItemName.length);
+
+  return hidden.replace(/\/$/, '') || null;
+}
 
 const newActions = {
   uploadFiles: {
@@ -123,6 +151,10 @@ export const useFileManager = ({
   const files = useAppSelector(FilesSelectors.selectFiles);
   const folders = useAppSelector(FilesSelectors.selectFolders);
 
+  const sharedWithMeIds = useAppSelector(
+    FilesSelectors.selectSharedWithMeFilesAndFoldersIds,
+  );
+
   const isUploadingFiles = useAppSelector(
     FilesSelectors.selectIsUploadingFiles,
   );
@@ -179,21 +211,6 @@ export const useFileManager = ({
 
   const canWriteCurrentFolder = hasWritePermission(currentFolder?.permissions);
 
-  const searchSelector = useCallback(
-    (state: RootState) =>
-      currentPath && isSearching && !isLoadingSearchListing
-        ? FilesSelectors.selectSearchResultsForFolder(state, currentPath)
-        : [],
-    [currentPath, isSearching, isLoadingSearchListing],
-  );
-
-  const searchResults = useAppSelector(searchSelector);
-
-  const searchResultsUIKit = useMemo(
-    () => searchResults.map(convertToUIKitFile),
-    [searchResults],
-  );
-
   const [treeCollapsedState, setTreeCollapsedState] = useState<
     boolean | undefined
   >(false);
@@ -205,6 +222,44 @@ export const useFileManager = ({
     review: REVIEW_FILES_SECTION,
   });
   const previousActiveTabRef = useRef<DialFileManagerTabs | null>(null);
+
+  const searchSelector = useCallback(
+    (state: RootState) =>
+      currentPath && isSearching && !isLoadingSearchListing
+        ? FilesSelectors.selectSearchResultsForFolder(
+            state,
+            activeTab === DialFileManagerTabs.Shared && isRootId(currentPath)
+              ? undefined
+              : currentPath,
+            activeTab === DialFileManagerTabs.Shared,
+          )
+        : { files: [], folders: [] },
+    [currentPath, isSearching, isLoadingSearchListing, activeTab],
+  );
+
+  const searchResults = useAppSelector(searchSelector);
+
+  const searchResultsUIKit = useMemo(
+    () => [
+      ...searchResults.folders.map((f) => {
+        const uiFolder = convertToUIKitFolder(f, []);
+        if (activeTab === DialFileManagerTabs.Shared) {
+          uiFolder.parentPath = formatSharedPath(uiFolder.parentPath);
+          uiFolder.folderId = formatSharedPath(uiFolder.folderId) as string;
+        }
+        return uiFolder;
+      }),
+      ...searchResults.files.map((f) => {
+        const uiFile = convertToUIKitFile(f);
+        if (activeTab === DialFileManagerTabs.Shared) {
+          uiFile.parentPath = formatSharedPath(uiFile.parentPath);
+          uiFile.folderId = formatSharedPath(uiFile.folderId) as string;
+        }
+        return uiFile;
+      }),
+    ],
+    [searchResults, activeTab],
+  );
 
   const filteredTabs = useMemo(() => {
     if (!availableTabs || !availableTabs.size) {
@@ -462,9 +517,20 @@ export const useFileManager = ({
       if (folder !== currentPath) {
         setCurrentPath(folder);
       }
-      dispatch(FilesActions.getFullListing({ folderPath: folder }));
+
+      if (activeTab === DialFileManagerTabs.Shared && isRootId(folder)) {
+        const sharedSet = new Set(sharedWithMeIds);
+        dispatch(
+          FilesActions.getFullListing({
+            folderPath: folder,
+            paths: folders.filter((f) => sharedSet.has(f.id)).map((f) => f.id),
+          }),
+        );
+      } else {
+        dispatch(FilesActions.getFullListing({ folderPath: folder }));
+      }
     },
-    [dispatch, currentPath],
+    [dispatch, currentPath, activeTab, folders, sharedWithMeIds],
   );
 
   const handleClearSearch = useCallback(() => {
@@ -552,32 +618,7 @@ export const useFileManager = ({
     };
   }, [t, isFileMetadataLoading, fileMetadata, currentPathRootAlias]);
 
-  function extractHiddenSharedPathPart(
-    rootFolderPath: string,
-    rootItemPath: string,
-    rootItemName: string,
-  ): string | null {
-    if (!rootItemPath.startsWith(rootFolderPath)) {
-      return null;
-    }
-
-    const afterRoot = rootItemPath
-      .slice(rootFolderPath.length)
-      .replace(/^\/+/, '');
-
-    if (!afterRoot.endsWith(rootItemName)) {
-      return null;
-    }
-
-    const hidden = afterRoot.slice(0, afterRoot.length - rootItemName.length);
-
-    return hidden.replace(/\/$/, '') || null;
-  }
-
-  const { navigationPanelOptions, isLocalSearch } = useMemo(() => {
-    const localSearch =
-      activeTab === DialFileManagerTabs.Shared &&
-      currentPath === rootFolder.path;
+  const navigationPanelOptions = useMemo<NavigationPanelOptions>(() => {
     const options: NavigationPanelOptions = {
       searchable: true,
     };
@@ -605,7 +646,7 @@ export const useFileManager = ({
       }
     }
 
-    return { navigationPanelOptions: options, isLocalSearch: localSearch };
+    return options;
   }, [currentPath, rootFolder, activeTab]);
 
   const gridOptions: GridOptions = useMemo(
@@ -903,10 +944,6 @@ export const useFileManager = ({
     [t],
   );
 
-  const sharedWithMeIds = useAppSelector(
-    FilesSelectors.selectSharedWithMeFilesAndFoldersIds,
-  );
-
   const emptyStateTitle = useMemo(() => {
     switch (activeTab) {
       case DialFileManagerTabs.Shared:
@@ -954,7 +991,7 @@ export const useFileManager = ({
     destinationFolderPopupOptions,
     deleteConfirmationOptions,
 
-    handleSearchFiles: isLocalSearch ? undefined : handleSearchFiles,
+    handleSearchFiles,
     handleClearSearch,
     handleCopyFiles,
     handleGetInfo,

--- a/apps/chat/src/store/files/files.epics.ts
+++ b/apps/chat/src/store/files/files.epics.ts
@@ -279,6 +279,28 @@ const getFullListingEpic: AppEpic = (action$, state$) =>
     ofType(FilesActions.getFullListing.type),
     switchMap(({ payload }) => {
       const folderPath = payload.folderPath || '';
+      const paths = payload.paths;
+
+      if (paths) {
+        if (paths.length === 0) {
+          return of(
+            FilesActions.getFullListingSuccess({
+              folderPath,
+              files: [],
+            }),
+          );
+        }
+
+        return FileService.getMultipleFoldersFiles(paths, true).pipe(
+          map((files) =>
+            FilesActions.getFullListingSuccess({
+              folderPath,
+              files,
+            }),
+          ),
+          catchError(() => of(FilesActions.getFullListingFail())),
+        );
+      }
 
       const metadata = state$.value.files.searchListingMetadata[folderPath];
       const cacheAge = metadata ? Date.now() - metadata.loadedAt : Infinity;

--- a/apps/chat/src/store/files/files.reducers.ts
+++ b/apps/chat/src/store/files/files.reducers.ts
@@ -327,6 +327,7 @@ export const filesSlice = createSlice({
       state,
       _action: PayloadAction<{
         folderPath?: string;
+        paths?: string[];
       }>,
     ) => {
       state.isLoadingSearchListing = true;

--- a/apps/chat/src/store/files/files.selectors.ts
+++ b/apps/chat/src/store/files/files.selectors.ts
@@ -266,30 +266,31 @@ const selectIsSearchListingLoaded = createSelector(
 const selectSearchResultsForFolder = createSelector(
   [
     selectFiles,
+    selectFolders,
     (_state: RootState, folderPath?: string) => folderPath,
-    (_state: RootState, _folder, searchTerm?: string) => searchTerm,
+    (_state: RootState, _folder, isSharedFilter?: boolean) => isSharedFilter,
   ],
-  (files, folderPath, searchTerm) => {
+  (files, folders, folderPath, isSharedFilter) => {
     let filteredFiles = files;
+    let filteredFolders = folders;
 
-    if (folderPath) {
+    if (isSharedFilter && !folderPath) {
+      filteredFiles = filteredFiles.filter((file) => file.sharedWithMe);
+      filteredFolders = filteredFolders.filter((folder) => folder.sharedWithMe);
+    } else if (folderPath) {
       filteredFiles = filteredFiles.filter(
         (file) =>
           file.folderId === folderPath ||
           file.folderId?.startsWith(`${folderPath}/`),
       );
-    }
-
-    if (searchTerm) {
-      const term = searchTerm.toLowerCase();
-      filteredFiles = filteredFiles.filter(
-        (file) =>
-          file.name.toLowerCase().includes(term) ||
-          file.relativePath?.toLowerCase().includes(term),
+      filteredFolders = filteredFolders.filter(
+        (folder) =>
+          folder.folderId === folderPath ||
+          folder.folderId?.startsWith(`${folderPath}/`),
       );
     }
 
-    return filteredFiles;
+    return { files: filteredFiles, folders: filteredFolders };
   },
 );
 


### PR DESCRIPTION
**Description:**

Need to implement search for both folder's and file's name for all tabs: My Files, Shared with me Organization
Path should start from Shared with me/
Files from folders should be displayed in search results like on My Files and Organization tabs

Issues:

- Issue #5690
- Issue #5793 
- Issue #5795

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
