### PR TITLE
feat(chat): update toolsets logic to include hidden entities only in `Quick Apps 2.0` (Issue #6254).

### DIFF
--- a/apps/chat/src/components/AppsEditor/EditorForm/QuickApp2Form/AgentsAndToolsetsField.tsx
+++ b/apps/chat/src/components/AppsEditor/EditorForm/QuickApp2Form/AgentsAndToolsetsField.tsx
@@ -80,7 +80,9 @@ export const AgentsAndToolsetsField: FC<AgentsAndToolsetsFieldProps> = ({
   const modelsMap = useAppSelector(ModelsSelectors.selectModelsMap);
   const toolsetsMap = useAppSelector(ToolsetSelectors.selectToolsetsMap);
   const allModels = useAppSelector(ModelsSelectors.selectModels);
-  const allToolsets = useAppSelector(ToolsetSelectors.selectToolsets);
+  const allToolsets = useAppSelector((state) =>
+    ToolsetSelectors.selectToolsets(state, true),
+  );
   const editorError = useAppSelector(ApplicationSelectors.selectEditorError);
   const isLoading = useAppSelector(
     ApplicationSelectors.selectIsApplicationLoading,

--- a/apps/chat/src/components/Chat/Publish/PublicationHandler/ReviewRowItems/PublicationToolsetRow.tsx
+++ b/apps/chat/src/components/Chat/Publish/PublicationHandler/ReviewRowItems/PublicationToolsetRow.tsx
@@ -18,7 +18,10 @@ export const PublicationToolsetRow: React.FC<PublicationItemProps> = ({
   level,
   publicationUrl,
 }) => {
-  const toolsets = useAppSelector(ToolsetSelectors.selectToolsets);
+  // Select all toolsets including with `hiddenEntityTag` ones to show all versions in the dropdown
+  const toolsets = useAppSelector((state) =>
+    ToolsetSelectors.selectToolsets(state, true),
+  );
   const publishRequestToolsets = useAppSelector(
     ToolsetSelectors.selectPublishRequestToolsets,
   );

--- a/apps/chat/src/components/Common/AgentAndToolsetSelector/AgentAndToolsetModal.tsx
+++ b/apps/chat/src/components/Common/AgentAndToolsetSelector/AgentAndToolsetModal.tsx
@@ -168,7 +168,9 @@ const AgentAndToolsetModalView = ({
   const isMyWorkspace = scopeTab === MarketplaceTabs.MY_WORKSPACE;
 
   const allAgents = useAppSelector(ModelsSelectors.selectModels);
-  const allToolsets = useAppSelector(ToolsetSelectors.selectToolsets);
+  const allToolsets = useAppSelector((state) =>
+    ToolsetSelectors.selectToolsets(state, true),
+  );
   const widgetsSchemaIds = useAppSelector(
     WidgetsSelectors.selectWidgetsSchemaIds,
   );

--- a/apps/chat/src/components/Marketplace/ToolsetLoginDialog.tsx
+++ b/apps/chat/src/components/Marketplace/ToolsetLoginDialog.tsx
@@ -67,7 +67,10 @@ const ToolsetLoginDialogView: FC<ToolsetLoginDialogProps> = ({ toolset }) => {
 
   const loginEntity = useAppSelector(MarketplaceSelectors.selectLoginEntity);
   const isAdmin = useAppSelector(AuthSelectors.selectIsAdmin);
-  const allToolsets = useAppSelector(ToolsetSelectors.selectToolsets);
+  // Select all toolsets including with `hiddenEntityTag` ones to show all versions in the dropdown
+  const allToolsets = useAppSelector((state) =>
+    ToolsetSelectors.selectToolsets(state, true),
+  );
   const isToolsetLoading = useAppSelector(
     ToolsetSelectors.selectIsToolsetDetailsLoading,
   );

--- a/apps/chat/src/store/toolset/toolset.selectors.ts
+++ b/apps/chat/src/store/toolset/toolset.selectors.ts
@@ -5,10 +5,16 @@ import {
   getGroupMarketplaceEntityKey,
   groupMarketplaceEntityAndSaveOrder,
 } from '@/src/utils/app/marketplace';
+import {
+  filterHiddenEntities,
+  shouldShowHiddenEntities,
+} from '@/src/utils/app/models';
 import { getIdWithoutVersionFromApiKey } from '@/src/utils/server/api';
 
 import { RootState } from '@/src/types/store';
-import { ToolsetModel } from '@/src/types/toolsets';
+import { ToolsetModel, ToolsetsMap } from '@/src/types/toolsets';
+
+import { SettingsSelectors } from '@/src/store/settings/settings.selectors';
 
 import { UploadStatus } from '@epam/ai-dial-shared';
 import sortBy from 'lodash-es/sortBy';
@@ -20,22 +26,35 @@ const selectInitialized = (state: RootState) => rootSelector(state).initialized;
 
 const selectToolsetsMap = (state: RootState) => rootSelector(state).toolsetsMap;
 
-const selectToolsets = createSelector([selectToolsetsMap], (toolsetsMap) => {
-  const toolsets = uniq(Object.values(toolsetsMap)) as ToolsetModel[];
-  const sortedToolsets = sortBy(toolsets, (toolset) =>
-    toolset.name.toLowerCase(),
-  );
+const _toolsetsFromMap = (toolsetsMap: ToolsetsMap) =>
+  uniq(Object.values(toolsetsMap).filter((t): t is ToolsetModel => t != null));
 
-  return groupMarketplaceEntityAndSaveOrder(sortedToolsets).flatMap(
-    ({ entities }) => {
-      if (entities.length > 0 && entities[0].id !== entities[0].reference) {
-        sortItemsVersions(entities);
-      }
+const selectToolsets = createSelector(
+  [
+    selectToolsetsMap,
+    SettingsSelectors.selectHiddenEntityTag,
+    (_state, showHidden?: boolean) => showHidden,
+  ],
+  (toolsetsMap, hiddenEntityTag, showHidden) => {
+    const toolsets = _toolsetsFromMap(toolsetsMap);
+    const filteredHidden = shouldShowHiddenEntities(hiddenEntityTag, showHidden)
+      ? toolsets
+      : filterHiddenEntities(toolsets, hiddenEntityTag);
+    const sortedToolsets = sortBy(filteredHidden, (toolset) =>
+      toolset.name.toLowerCase(),
+    );
 
-      return entities;
-    },
-  );
-});
+    return groupMarketplaceEntityAndSaveOrder(sortedToolsets).flatMap(
+      ({ entities }) => {
+        if (entities.length > 0 && entities[0].id !== entities[0].reference) {
+          sortItemsVersions(entities);
+        }
+
+        return entities;
+      },
+    );
+  },
+);
 
 const selectToolsetVersionGroupByGroupId = createSelector(
   [
@@ -103,12 +122,23 @@ const selectAllGroupToolsetsKeySet = (
   );
 };
 
-const selectToolsetsTopics = createSelector([selectToolsets], (toolsets) => {
-  return sortBy(
-    uniq(toolsets?.flatMap((toolset) => toolset.topics ?? []) ?? []),
-    (topic) => topic.toLowerCase(),
-  );
-});
+const selectToolsetsTopics = createSelector(
+  [
+    selectToolsetsMap,
+    SettingsSelectors.selectHiddenEntityTag,
+    (_state, showHidden?: boolean) => showHidden,
+  ],
+  (toolsetsMap, hiddenEntityTag, showHidden) => {
+    const toolsets = _toolsetsFromMap(toolsetsMap);
+    const filteredHidden = shouldShowHiddenEntities(hiddenEntityTag, showHidden)
+      ? toolsets
+      : filterHiddenEntities(toolsets, hiddenEntityTag);
+    return sortBy(
+      uniq(filteredHidden?.flatMap((toolset) => toolset.topics ?? []) ?? []),
+      (topic) => topic.toLowerCase(),
+    );
+  },
+);
 
 const selectIsInstalledToolsetsInitialized = (state: RootState) =>
   rootSelector(state).isInstalledToolsetsInitialized;


### PR DESCRIPTION


**Description:**

- Update toolset selector to include hidden entities only in `Quick Apps 2.0`

Issues:

- Issue #6254


**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
