### PR TITLE
fix(chat): fix revoke access for multiple files and folders (Issue #6281).

### DIFF
--- a/apps/chat/src/store/share/share.epics.ts
+++ b/apps/chat/src/store/share/share.epics.ts
@@ -1125,7 +1125,7 @@ const getSharedListingSuccessEpic: AppEpic = (action$, state$) =>
 const revokeAccessEpic: AppEpic = (action$) =>
   action$.pipe(
     ofType(ShareActions.revokeAccess.type),
-    switchMap(({ payload }) => {
+    mergeMap(({ payload }) => {
       const resourceUrls = payload.isFolder
         ? payload.resourceIds.map((id) =>
             addTrailingSlashIfAbsent(ApiUtils.encodeApiUrl(id)),


### PR DESCRIPTION
**Description:**

- Fix `revokeAccessEpic` to support multiple files and folders revoke requests.

Issues:

- Issue #6281 


**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
