### PR TITLE
fix(chat): fix auto-selection for uploaded files (Issue #5673)

### DIFF
--- a/apps/chat/src/store/files/files.epics.ts
+++ b/apps/chat/src/store/files/files.epics.ts
@@ -34,6 +34,7 @@ import {
 import {
   getFolderFromId,
   getGeneratedFolderId,
+  getPartialAndFullyChosenFolders,
   updateMovedEntityId,
 } from '@/src/utils/app/folders';
 import {
@@ -543,17 +544,27 @@ const autoSelectNestedFoldersEpic: AppEpic = (action$, state$) =>
       const chosenEmptyFolderIds =
         FilesSelectors.selectChosenEmptyFolderIds(state);
       const allFolders = FilesSelectors.selectFolders(state);
+      const allFiles = FilesSelectors.selectFiles(state);
+      const emptyFolderIds = FilesSelectors.selectEmptyFolderIds(state);
 
       const normalizedParentId = addTrailingSlashIfAbsent(parentFolderId);
 
-      // The parent is considered selected when either its files are chosen
-      // (non-empty folder path) or it sits in chosenEmptyFolderIds (empty
-      // folder or one that is still loading its content).
+      // Cascade only when the parent folder itself is fully chosen: either it
+      // is an explicitly-selected empty folder, or ALL of its files are selected.
+      // Partial selection (e.g. a single file inside the folder) must not trigger
+      // cascade into sub-folders.
+      const { fullyChosenFolderIds } = getPartialAndFullyChosenFolders(
+        allFolders,
+        allFiles,
+        chosenFileIds,
+        emptyFolderIds,
+        chosenEmptyFolderIds,
+      );
+
       const parentIsSelected =
-        chosenFileIds.some((id) => id.startsWith(normalizedParentId)) ||
         chosenEmptyFolderIds.some(
           (id) => addTrailingSlashIfAbsent(id) === normalizedParentId,
-        );
+        ) || fullyChosenFolderIds.includes(parentFolderId);
 
       if (!parentIsSelected) return EMPTY;
 


### PR DESCRIPTION
**Description:**

Regression was found: previously uploaded files are added unexpectedly

upload any file into input filed (e.g. Text1.txt)
remove the file from input field (click on 'x') -> refresh the browser
in input field click on Clip icon -> on Attach files modal click on New -> Upload files
upload file (e.g. Text2.txt) -> click on Attach
Note that in input field apper two files: Text2.txt (ok) and Text1.txt (bug)

Issues:

- Issue #5673

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
