### PR TITLE
chore(chat): minor fixes for key prop, PWA meta tag and tooltip state

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,3 +7,6 @@ helm
 .env.local
 .git
 docs
+dist
+.nx
+.rollup.cache

--- a/apps/chat/src/components/Chat/ChatInput/ChatInputAttachments.tsx
+++ b/apps/chat/src/components/Chat/ChatInput/ChatInputAttachments.tsx
@@ -43,6 +43,7 @@ export const ChatInputAttachments = ({
       ))}
       {files?.map((file) => (
         <ChatInputFileAttachment
+          key={file.id}
           file={file}
           onUnselectFile={onUnselectFile}
           onRetryFile={onRetryFile}

--- a/apps/chat/src/components/Common/Tooltip.tsx
+++ b/apps/chat/src/components/Common/Tooltip.tsx
@@ -251,7 +251,7 @@ export function Tooltip({
 }: TooltipOptions) {
   if (hideTooltip || !tooltip)
     return (
-      <span className={triggerClassName} data-qa={dataQa}>
+      <span className={triggerClassName} data-qa={dataQa} data-state="closed">
         {children}
       </span>
     );

--- a/apps/chat/src/pages/_document.tsx
+++ b/apps/chat/src/pages/_document.tsx
@@ -22,6 +22,7 @@ function Document(props: Props) {
         )}
 
         <meta name="apple-mobile-web-app-capable" content="yes" />
+        <meta name="mobile-web-app-capable" content="yes" />
         <meta
           name="apple-mobile-web-app-title"
           content={process.env.NEXT_PUBLIC_APP_NAME || 'DIAL'}


### PR DESCRIPTION
**Description:**

Minor UI fixes: add missing React `key` prop on `ChatInputFileAttachment` list items, add `mobile-web-app-capable` meta tag for Android PWA support, and add consistent `data-state="closed"` attribute on Tooltip fallback span.

Issues:

- Issue #N/A

**UI changes**

No visual changes. These are correctness and consistency fixes:
- `mobile-web-app-capable` meta tag enables full-screen standalone mode on Android (matching existing iOS support)
- `key` prop fix prevents potential React reconciliation bugs in attachment lists
- `data-state="closed"` ensures consistent attribute presence on tooltip triggers when tooltip is disabled

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs