### PR TITLE
fix(chat): hide `.dial_folder` from all display entities lists (Issue #6354)

### DIFF
--- a/apps/chat/src/store/models/models.selectors.ts
+++ b/apps/chat/src/store/models/models.selectors.ts
@@ -1,6 +1,7 @@
 import { createSelector } from '@reduxjs/toolkit';
 
 import { sortItemsVersions } from '@/src/utils/app/common';
+import { withoutFileManagerPlaceholderByName } from '@/src/utils/app/file';
 import {
   getGroupMarketplaceEntityKey,
   groupMarketplaceEntityAndSaveOrder,
@@ -54,7 +55,9 @@ const selectModels = createSelector(
     const filteredHidden = shouldShowHiddenEntities(hiddenEntityTag, showHidden)
       ? models
       : filterHiddenEntities(models, hiddenEntityTag);
-    const sortedResponse = sortBy(filteredHidden, (model) =>
+    const withoutPlaceholder =
+      withoutFileManagerPlaceholderByName(filteredHidden);
+    const sortedResponse = sortBy(withoutPlaceholder, (model) =>
       model.name.toLowerCase(),
     );
     const sortedAgents = groupMarketplaceEntityAndSaveOrder(
@@ -94,8 +97,10 @@ const selectModelTopics = createSelector(
     const filteredHidden = shouldShowHiddenEntities(hiddenEntityTag, showHidden)
       ? models
       : filterHiddenEntities(models, hiddenEntityTag);
+    const withoutPlaceholder =
+      withoutFileManagerPlaceholderByName(filteredHidden);
     return sortBy(
-      uniq(filteredHidden?.flatMap((model) => model.topics ?? []) ?? []),
+      uniq(withoutPlaceholder?.flatMap((model) => model.topics ?? []) ?? []),
       (topic) => topic.toLowerCase(),
     );
   },

--- a/apps/chat/src/store/prompts/prompts.selectors.ts
+++ b/apps/chat/src/store/prompts/prompts.selectors.ts
@@ -5,6 +5,7 @@ import {
   isSectionFilterMatched,
   isVersionFilterMatched,
 } from '@/src/utils/app/common';
+import { withoutFileManagerPlaceholderByName } from '@/src/utils/app/file';
 import {
   getFilteredFolders,
   getNextDefaultName,
@@ -39,7 +40,8 @@ import { ShareEntity } from '@epam/ai-dial-shared';
 
 const rootSelector = (state: RootState) => state.prompts;
 
-const selectPrompts = (state: RootState) => rootSelector(state).prompts;
+const selectPrompts = (state: RootState) =>
+  withoutFileManagerPlaceholderByName(rootSelector(state).prompts);
 
 const selectSearchTerm = (state: RootState) => rootSelector(state).searchTerm;
 

--- a/apps/chat/src/store/prompts/prompts.selectors.ts
+++ b/apps/chat/src/store/prompts/prompts.selectors.ts
@@ -40,8 +40,9 @@ import { ShareEntity } from '@epam/ai-dial-shared';
 
 const rootSelector = (state: RootState) => state.prompts;
 
-const selectPrompts = (state: RootState) =>
-  withoutFileManagerPlaceholderByName(rootSelector(state).prompts);
+const selectPrompts = createSelector([rootSelector], (state) =>
+  withoutFileManagerPlaceholderByName(state.prompts),
+);
 
 const selectSearchTerm = (state: RootState) => rootSelector(state).searchTerm;
 

--- a/apps/chat/src/store/toolset/toolset.selectors.ts
+++ b/apps/chat/src/store/toolset/toolset.selectors.ts
@@ -1,6 +1,7 @@
 import { createSelector } from '@reduxjs/toolkit';
 
 import { sortItemsVersions } from '@/src/utils/app/common';
+import { withoutFileManagerPlaceholderByName } from '@/src/utils/app/file';
 import {
   getGroupMarketplaceEntityKey,
   groupMarketplaceEntityAndSaveOrder,
@@ -21,7 +22,9 @@ const selectInitialized = (state: RootState) => rootSelector(state).initialized;
 const selectToolsetsMap = (state: RootState) => rootSelector(state).toolsetsMap;
 
 const selectToolsets = createSelector([selectToolsetsMap], (toolsetsMap) => {
-  const toolsets = uniq(Object.values(toolsetsMap)) as ToolsetModel[];
+  const toolsets = withoutFileManagerPlaceholderByName(
+    uniq(Object.values(toolsetsMap)) as ToolsetModel[],
+  );
   const sortedToolsets = sortBy(toolsets, (toolset) =>
     toolset.name.toLowerCase(),
   );

--- a/apps/chat/src/utils/app/__tests__/file.test.ts
+++ b/apps/chat/src/utils/app/__tests__/file.test.ts
@@ -1,8 +1,62 @@
 import { describe, expect, it } from 'vitest';
 
-import { formatFileSize, isAbsoluteUrl, prepareFileName } from '../file';
+import { TEMP_FILE_NAME_IN_FILE_MANAGER } from '@/src/constants/file';
+
+import {
+  formatFileSize,
+  isAbsoluteUrl,
+  prepareFileName,
+  withoutFileManagerPlaceholderByName,
+} from '../file';
 
 describe('File utility methods', () => {
+  describe('withoutFileManagerPlaceholderByName', () => {
+    it('removes placeholder by exact name', () => {
+      const items = [
+        { id: '1', name: 'real' },
+        { id: '2', name: TEMP_FILE_NAME_IN_FILE_MANAGER },
+        { id: '3', name: '.other' },
+      ];
+      expect(withoutFileManagerPlaceholderByName(items)).toEqual([
+        { id: '1', name: 'real' },
+        { id: '3', name: '.other' },
+      ]);
+    });
+
+    it('removes application-like rows when last path segment is .dial_folder or variant', () => {
+      const marker = `${TEMP_FILE_NAME_IN_FILE_MANAGER}__`;
+      const items = [
+        {
+          id: 'applications/public/111/real-app',
+          name: 'applications/public/111/real-app',
+        },
+        {
+          id: `applications/public/111/${marker}`,
+          name: `applications/public/111/${marker}`,
+        },
+      ];
+      expect(withoutFileManagerPlaceholderByName(items)).toEqual([items[0]]);
+    });
+
+    it('removes toolset-like rows when id ends with .dial_folder variant', () => {
+      const marker = `${TEMP_FILE_NAME_IN_FILE_MANAGER}__`;
+      const items = [
+        { id: 'toolsets/public/123/my-tool', name: 'My tool' },
+        { id: `toolsets/public/123/${marker}`, name: 'ignored' },
+      ];
+      expect(withoutFileManagerPlaceholderByName(items)).toEqual([items[0]]);
+    });
+
+    it('removes row when only id tail is a placeholder', () => {
+      const marker = `${TEMP_FILE_NAME_IN_FILE_MANAGER}__`;
+      expect(
+        withoutFileManagerPlaceholderByName([
+          { id: `toolsets/public/99/${marker}`, name: 'Visible name' },
+        ]),
+      ).toEqual([]);
+    });
+  });
+
   it.each([
     ['http://test.com'],
     ['https://test.com'],

--- a/apps/chat/src/utils/app/file.ts
+++ b/apps/chat/src/utils/app/file.ts
@@ -160,6 +160,43 @@ export const getDialFilesWithInvalidFileType = (
       );
 };
 
+const isFileManagerPlaceholderLastSegment = (
+  segment: string | undefined,
+): boolean => {
+  if (!segment) {
+    return false;
+  }
+  return (
+    segment === TEMP_FILE_NAME_IN_FILE_MANAGER ||
+    segment.startsWith(TEMP_FILE_NAME_IN_FILE_MANAGER)
+  );
+};
+
+const lastSegmentOrWhole = (value: string | undefined): string => {
+  if (value === undefined || value === '') {
+    return '';
+  }
+  return getFileName(value) ?? value;
+};
+
+/**
+ * Drops UI Kit FileManager folder markers from lists.
+ * Matches exact `.dial_folder` or suffix variants (e.g. `.dial_folder__`) on the
+ * last path segment of `name` and/or `id`.
+ */
+export function withoutFileManagerPlaceholderByName<
+  T extends { name?: string; id?: string },
+>(items: T[]): T[] {
+  return items.filter((item) => {
+    const nameTail = lastSegmentOrWhole(item.name);
+    const idTail = lastSegmentOrWhole(item.id);
+    return (
+      !isFileManagerPlaceholderLastSegment(nameTail) &&
+      !isFileManagerPlaceholderLastSegment(idTail)
+    );
+  });
+}
+
 export const getFilesWithInvalidFileType = (
   files: File[],
   allowedFileTypes: string[],


### PR DESCRIPTION
**Description:**

- Add filtering for all entities (excluding `Conversations`) to hide `.dial_folder` service entity from all components.

Issues:

- Issue #6354 


**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
