### PR TITLE
feat(chat): add plain text response settings for conversations (Issue #130)

### DIFF
--- a/apps/chat/public/locales/en/chat.json
+++ b/apps/chat/public/locales/en/chat.json
@@ -351,5 +351,8 @@
   "Server is taking too long to respond due to either poor internet connection or excessive load. Please check your internet connection and try again. You also may try different model.": "Server is taking too long to respond due to either poor internet connection or excessive load. Please check your internet connection and try again. You also may try different model.",
   "Conversation is too large to process.": "Conversation is too large to process.",
   "Sorry, we were unable to process your request at this time due to a server error. Please try again later. Thank you for your patience and understanding.": "Sorry, we were unable to process your request at this time due to a server error. Please try again later. Thank you for your patience and understanding.",
-  "Error happened during answering. Please check your internet connection and try again.": "Error happened during answering. Please check your internet connection and try again."
+  "Error happened during answering. Please check your internet connection and try again.": "Error happened during answering. Please check your internet connection and try again.",
+  "Response format": "Response format",
+  "Markdown": "Markdown",
+  "Plain text": "Plain text"
 }

--- a/apps/chat/src/components/Chat/Chat.tsx
+++ b/apps/chat/src/components/Chat/Chat.tsx
@@ -505,6 +505,7 @@ const ChatView = memo(({ isPreview, customViewer }: ChatViewProps) => {
               prompt: temporarySettings.prompt,
               temperature: temporarySettings.temperature,
               isShared: temporarySettings.isShared,
+              responseFormat: temporarySettings.responseFormat,
             },
           }),
         );
@@ -634,7 +635,6 @@ const ChatView = memo(({ isPreview, customViewer }: ChatViewProps) => {
     ) {
       textareaRef.current?.focus();
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [enabledFeatures, selectedConversationsIds]);
 
   useEffect(() => {

--- a/apps/chat/src/components/Chat/ChatMessage/ChatMessageContent/AssistantMessage.tsx
+++ b/apps/chat/src/components/Chat/ChatMessage/ChatMessageContent/AssistantMessage.tsx
@@ -45,6 +45,7 @@ import { AdjustedTextarea } from '../AdjustedTextarea';
 import { OverlayMessageCustomButtons } from './OverlayMessageCustomButtons';
 
 import {
+  ConversationResponseFormat,
   Feature,
   Message,
   MessageFormValue,
@@ -356,6 +357,10 @@ export const AssistantMessage = memo(function AssistantMessage({
           <ChatMDComponent
             isShowResponseLoader={isShowResponseLoader}
             content={isSafari ? throttledContent : message.content}
+            plainTextMode={
+              conversation.responseFormat ===
+              ConversationResponseFormat.PlainText
+            }
           />
         )}
         {codeWarning &&

--- a/apps/chat/src/components/Chat/ChatSettings/ChatSettingsModal.tsx
+++ b/apps/chat/src/components/Chat/ChatSettings/ChatSettingsModal.tsx
@@ -5,9 +5,8 @@ import classNames from 'classnames';
 import { useTranslation } from '@/src/hooks/useTranslation';
 
 import { isCreatedMarketplaceEntity } from '@/src/utils/app/marketplace';
-import { doesModelHaveSettings } from '@/src/utils/app/models';
 
-import { Conversation } from '@/src/types/chat';
+import { Conversation, ConversationsTemporarySettings } from '@/src/types/chat';
 import { ModalState } from '@/src/types/modal';
 import { DialAIEntityModel } from '@/src/types/models';
 import { Translation } from '@/src/types/translation';
@@ -24,18 +23,14 @@ import { Modal } from '@/src/components/Common/Modal';
 
 import { ConversationSettings } from './ConversationSettings';
 
+import { ConversationResponseFormat } from '@epam/ai-dial-shared';
 import { DialPrimaryButton } from '@epam/ai-dial-ui-kit';
 
 interface ChatSettingsViewProps {
   conversation: Conversation;
   onChangeSettings: (
     conv: Conversation,
-    args: {
-      modelId: string;
-      prompt: string;
-      temperature: number;
-      isShared: boolean;
-    },
+    args: ConversationsTemporarySettings,
   ) => void;
 }
 
@@ -47,6 +42,9 @@ const ChatSettingsView = ({
   const [currentTemperature, setCurrentTemperature] = useState(
     conversation.temperature,
   );
+  const [responseFormat, setResponseFormat] = useState(
+    conversation.responseFormat ?? ConversationResponseFormat.Markdown,
+  );
 
   const prompts = useAppSelector(PromptsSelectors.selectPrompts);
 
@@ -56,8 +54,15 @@ const ChatSettingsView = ({
       prompt: currentPrompt,
       temperature: currentTemperature,
       isShared: !!conversation.isShared,
+      responseFormat,
     });
-  }, [conversation, currentPrompt, currentTemperature, onChangeSettings]);
+  }, [
+    conversation,
+    currentPrompt,
+    currentTemperature,
+    onChangeSettings,
+    responseFormat,
+  ]);
 
   useEffect(() => {
     handleChangeSettings();
@@ -71,6 +76,8 @@ const ChatSettingsView = ({
       temperature={currentTemperature}
       onChangePrompt={setCurrentPrompt}
       onChangeTemperature={setCurrentTemperature}
+      responseFormat={responseFormat}
+      onChangeResponseFormat={setResponseFormat}
     />
   );
 };
@@ -82,12 +89,7 @@ interface Props {
   onClose: () => void;
   onChangeSettings: (
     conv: Conversation,
-    args: {
-      modelId: string;
-      prompt: string;
-      temperature: number;
-      isShared: boolean;
-    },
+    args: ConversationsTemporarySettings,
   ) => void;
   onApplySettings: () => void;
 }
@@ -114,7 +116,7 @@ export const ChatSettings = ({
       .map((conv) => modelsMap[conv.model.id])
       .filter(Boolean) as DialAIEntityModel[];
 
-    return allowedModels.some((model) => doesModelHaveSettings(model));
+    return !!allowedModels.length;
   }, [conversations, modelsMap]);
 
   return (

--- a/apps/chat/src/components/Chat/ChatSettings/ConversationSettings.tsx
+++ b/apps/chat/src/components/Chat/ChatSettings/ConversationSettings.tsx
@@ -19,10 +19,13 @@ import { ModelsSelectors } from '@/src/store/selectors';
 
 import { ChatI18nKeys } from '@/src/constants/i18n';
 
+import { ResponseFormat } from '@/src/components/Chat/ChatSettings/ResponseFormat';
+
 import { SystemPrompt } from './SystemPrompt';
 import { TemperatureSlider } from './Temperature';
 
 import { Inversify } from '@epam/ai-dial-modulify-ui';
+import { ConversationResponseFormat } from '@epam/ai-dial-shared';
 
 interface SettingContainerProps {
   children: ReactNode;
@@ -31,10 +34,12 @@ interface SettingContainerProps {
 interface Props {
   prompt: string | undefined;
   temperature: number | undefined;
+  responseFormat: ConversationResponseFormat;
   prompts: Prompt[];
   conversation: Conversation;
   onChangePrompt: (prompt: string) => void;
   onChangeTemperature: (temperature: number) => void;
+  onChangeResponseFormat: (responseFormat: ConversationResponseFormat) => void;
 }
 
 function FieldContainer({ children }: SettingContainerProps) {
@@ -72,10 +77,12 @@ export const ConversationSettings = Inversify.register(
   ({
     prompts,
     prompt,
+    responseFormat,
     temperature,
     conversation,
     onChangePrompt,
     onChangeTemperature,
+    onChangeResponseFormat,
   }: Props) => {
     const { t } = useTranslation(Translation.Chat);
 
@@ -93,11 +100,28 @@ export const ConversationSettings = Inversify.register(
     }
 
     if (!doesModelHaveSettings(model)) {
-      return <EmptySettings />;
+      return (
+        <SettingContainer>
+          <FieldContainer>
+            <ResponseFormat
+              value={responseFormat}
+              onChange={onChangeResponseFormat}
+              disabled={isPlayback}
+            />
+          </FieldContainer>
+        </SettingContainer>
+      );
     }
 
     return (
       <SettingContainer>
+        <FieldContainer>
+          <ResponseFormat
+            value={responseFormat}
+            onChange={onChangeResponseFormat}
+            disabled={isPlayback}
+          />
+        </FieldContainer>
         {model.type === EntityType.Model &&
           doesModelAllowSystemPrompt(model) && (
             <FieldContainer>

--- a/apps/chat/src/components/Chat/ChatSettings/ResponseFormat.tsx
+++ b/apps/chat/src/components/Chat/ChatSettings/ResponseFormat.tsx
@@ -1,0 +1,65 @@
+import { FC, useCallback } from 'react';
+
+import { useTranslation } from '@/src/hooks/useTranslation';
+
+import { translate } from '@/src/utils/app/translation';
+
+import { Translation } from '@/src/types/translation';
+
+import { ChatI18nKeys } from '@/src/constants/i18n';
+
+import { DisableOverlay } from '@/src/components/Common/DisableOverlay';
+
+import { ConversationResponseFormat } from '@epam/ai-dial-shared';
+import {
+  DialRadioGroup,
+  RadioButtonWithContent,
+  RadioGroupOrientation,
+} from '@epam/ai-dial-ui-kit';
+
+const radioButtons: RadioButtonWithContent[] = [
+  {
+    id: ConversationResponseFormat.Markdown,
+    name: translate(ChatI18nKeys.Markdown, { ns: Translation.Chat }),
+  },
+  {
+    id: ConversationResponseFormat.PlainText,
+    name: translate(ChatI18nKeys.PlainText, { ns: Translation.Chat }),
+  },
+];
+
+interface ResponseFormatProps {
+  value: ConversationResponseFormat;
+  onChange: (value: ConversationResponseFormat) => void;
+  disabled?: boolean;
+}
+
+export const ResponseFormat: FC<ResponseFormatProps> = ({
+  value,
+  onChange,
+  disabled,
+}) => {
+  const { t } = useTranslation(Translation.Chat);
+
+  const handleChange = useCallback(
+    (id: string) => {
+      onChange(id as ConversationResponseFormat);
+    },
+    [onChange],
+  );
+
+  return (
+    <div className="flex flex-col" data-qa="response-format-container">
+      <label className="mb-4 text-left">{t(ChatI18nKeys.ResponseFormat)}</label>
+      {disabled && <DisableOverlay />}
+
+      <DialRadioGroup
+        elementId="response-format-toggler"
+        radioButtons={radioButtons}
+        activeRadioButton={value}
+        orientation={RadioGroupOrientation.Column}
+        onChange={handleChange}
+      />
+    </div>
+  );
+};

--- a/apps/chat/src/components/Markdown/ChatMDComponent.tsx
+++ b/apps/chat/src/components/Markdown/ChatMDComponent.tsx
@@ -44,6 +44,7 @@ interface ChatMDComponentProps {
   isShowResponseLoader: boolean;
   content: string;
   isInner?: boolean;
+  plainTextMode?: boolean;
 }
 
 const transformUri = (src: string): string => {
@@ -227,6 +228,7 @@ export const ChatMDComponent = memo(
     isShowResponseLoader,
     content,
     isInner = false,
+    plainTextMode = false,
   }: ChatMDComponentProps) => {
     const isChatFullWidth = useAppSelector(UISelectors.selectIsChatFullWidth);
     const isOverlay = useAppSelector(SettingsSelectors.selectIsOverlay);
@@ -246,6 +248,14 @@ export const ChatMDComponent = memo(
     );
 
     const processedContent = preprocessLaTeX(content);
+
+    if (plainTextMode) {
+      return (
+        <div className={mdClassNames}>
+          {`${processedContent}${isShowResponseLoader ? modelCursorSignWithBackquote : ''}`}
+        </div>
+      );
+    }
 
     return (
       <MemoizedReactMarkdown

--- a/apps/chat/src/constants/i18n.ts
+++ b/apps/chat/src/constants/i18n.ts
@@ -853,6 +853,9 @@ export enum ChatI18nKeys {
   ConversationTooLargeToProcess = 'Conversation is too large to process.',
   GeneralServerError = 'Sorry, we were unable to process your request at this time due to a server error. Please try again later. Thank you for your patience and understanding.',
   GeneralClientError = 'Error happened during answering. Please check your internet connection and try again.',
+  ResponseFormat = 'Response format',
+  Markdown = 'Markdown',
+  PlainText = 'Plain text',
 }
 
 // files.json

--- a/apps/chat/src/types/chat.ts
+++ b/apps/chat/src/types/chat.ts
@@ -1,6 +1,10 @@
 import { DialAIEntityModel } from '@/src/types/models';
 
-import { Conversation, Message } from '@epam/ai-dial-shared';
+import {
+  Conversation,
+  ConversationResponseFormat,
+  Message,
+} from '@epam/ai-dial-shared';
 
 // Reexporting Conversation to not change entire codebase
 export type { Conversation } from '@epam/ai-dial-shared';
@@ -36,6 +40,7 @@ export interface ConversationsTemporarySettings {
   prompt: string;
   temperature: number;
   isShared: boolean;
+  responseFormat: ConversationResponseFormat;
 }
 
 export interface PrepareNameOptions {

--- a/apps/chat/src/utils/app/__tests__/importExports.test.ts
+++ b/apps/chat/src/utils/app/__tests__/importExports.test.ts
@@ -22,6 +22,7 @@ import {
 
 import {
   Conversation,
+  ConversationResponseFormat,
   ExportFormatV1,
   ExportFormatV2,
   ExportFormatV4,
@@ -119,6 +120,7 @@ describe('cleanData Functions', () => {
     selectedAddons: [],
     folderId: getConversationRootId(bucket),
     updatedAt: expect.any(Number),
+    responseFormat: ConversationResponseFormat.Markdown,
   };
 
   describe('cleaning v1 data', () => {

--- a/apps/chat/src/utils/app/clean.ts
+++ b/apps/chat/src/utils/app/clean.ts
@@ -16,6 +16,7 @@ import { getConversationRootId } from './id';
 import {
   Attachment,
   ConversationEntityModel,
+  ConversationResponseFormat,
   Message,
   Stage,
 } from '@epam/ai-dial-shared';
@@ -111,6 +112,8 @@ export const cleanConversation = (
       },
     }),
     customViewState: conversation.customViewState,
+    responseFormat:
+      conversation.responseFormat ?? ConversationResponseFormat.Markdown,
   };
 
   return cleanConversation;

--- a/libs/shared/src/types/chat.ts
+++ b/libs/shared/src/types/chat.ts
@@ -177,10 +177,16 @@ export interface Playback {
   customViewState?: Record<string, unknown>;
 }
 
+export enum ConversationResponseFormat {
+  PlainText = 'Plain text',
+  Markdown = 'Markdown',
+}
+
 export interface Conversation extends ShareEntity, ConversationInfo {
   messages: Message[];
   prompt: string;
   temperature: number;
+  responseFormat?: ConversationResponseFormat;
   /**
    * @deprecated but required by core validation
    */


### PR DESCRIPTION
**Description:**

- add new **responseFormat** field in conversation model
- add response format configuration toggle in chat settings

Issues:

- Issue #130

**UI changes**

<img width="541" height="281" alt="Screenshot 2026-04-15 at 18 51 40" src="https://github.com/user-attachments/assets/12a010fd-db49-4df0-aa7d-9ef50dd60ec7" />


**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
