### PR TITLE
fix(overlay): enable microphone access in overlay when voice input is enabled

### DIFF
--- a/libs/overlay/src/lib/ChatOverlay.ts
+++ b/libs/overlay/src/lib/ChatOverlay.ts
@@ -10,6 +10,7 @@ import {
   DeleteMessageResponse,
   ExportConversationRequest,
   ExportConversationResponse,
+  Feature,
   GetConversationsResponse,
   GetMessagesResponse,
   GetSelectedConversationsResponse,
@@ -105,6 +106,25 @@ export class ChatOverlay {
   }
 
   /**
+   * Builds the iframe permissions policy string based on enabled features
+   * @returns {string} permissions policy string for the iframe `allow` attribute
+   */
+  protected getIframePermissions(): string {
+    const permissions = ['clipboard-write'];
+
+    const features = this.options.enabledFeatures;
+    const hasVoiceInput = Array.isArray(features)
+      ? features.includes(Feature.VoiceInput)
+      : typeof features === 'string' && features.includes(Feature.VoiceInput);
+
+    if (hasVoiceInput) {
+      permissions.push('microphone');
+    }
+
+    return permissions.join('; ');
+  }
+
+  /**
    * Creates iframe add set initial options to it
    * @returns {HTMLIFrameElement} reference to iframe element
    */
@@ -112,7 +132,7 @@ export class ChatOverlay {
     const iframe = document.createElement('iframe');
 
     iframe.src = this.options.domain;
-    iframe.allow = 'clipboard-write';
+    iframe.allow = this.getIframePermissions();
     iframe.name = 'overlay';
     iframe.ariaLabel = 'Chat overlay';
 

--- a/libs/overlay/src/lib/ChatOverlay.ts
+++ b/libs/overlay/src/lib/ChatOverlay.ts
@@ -112,16 +112,26 @@ export class ChatOverlay {
   protected getIframePermissions(): string {
     const permissions = ['clipboard-write'];
 
-    const features = this.options.enabledFeatures;
-    const hasVoiceInput = Array.isArray(features)
-      ? features.includes(Feature.VoiceInput)
-      : typeof features === 'string' && features.includes(Feature.VoiceInput);
-
-    if (hasVoiceInput) {
+    if (this.hasFeature(Feature.VoiceInput)) {
       permissions.push('microphone');
     }
 
     return permissions.join('; ');
+  }
+
+  /**
+   * Checks if a specific feature is included in the enabled features list
+   * @param feature {Feature} feature to check
+   * @returns {boolean} true if the feature is enabled
+   */
+  protected hasFeature(feature: Feature): boolean {
+    const features = this.options.enabledFeatures;
+
+    if (Array.isArray(features)) {
+      return features.includes(feature);
+    }
+
+    return typeof features === 'string' && features.includes(feature);
   }
 
   /**


### PR DESCRIPTION
**Description:**

Add conditional `microphone` permission to overlay iframe when `VoiceInput` feature is enabled. Previously, the iframe's `allow` attribute did not include `microphone`, causing a `Permissions policy violation: microphone is not allowed in this document` error when attempting to use voice input (ASR) in overlay mode. The `microphone` permission is now granted only when `Feature.VoiceInput` is present in `enabledFeatures`.

Issues:

- Issue #N/A

**UI changes**

No visual changes. When `VoiceInput` feature is enabled in overlay options, the voice recording button now works correctly inside the iframe. Without this fix, clicking the mic button resulted in a permissions policy violation and the recording would not start.

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs

