### PR TITLE
fix(chat): fix 404 on view published toolset by admin (Issue #4837)

### DIFF
--- a/apps/chat/src/hooks/useToolsetActions.ts
+++ b/apps/chat/src/hooks/useToolsetActions.ts
@@ -12,6 +12,7 @@ import { Translation } from '@/src/types/translation';
 import {
   MarketplaceActions,
   PublicationActions,
+  ToolsetActions,
   UIActions,
 } from '@/src/store/actions';
 import { useAppDispatch } from '@/src/store/hooks';
@@ -65,6 +66,7 @@ export const useToolsetMenuActions = (toolset: ToolsetModel) => {
     (e: React.MouseEvent) => {
       e.preventDefault();
       e.stopPropagation();
+      dispatch(ToolsetActions.setToolsetDetails());
       void router.push({
         pathname: Routes.ToolsetEditor,
         query: {
@@ -75,7 +77,7 @@ export const useToolsetMenuActions = (toolset: ToolsetModel) => {
         },
       });
     },
-    [router, toolset.reference],
+    [router, toolset.reference, dispatch],
   );
 
   const handlePublish = useCallback(


### PR DESCRIPTION
**Description:**

- fix 404 when admin opens toolset in editor view right after approving publication request

Issues:

- Issue #4837

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
