### PR TITLE
fix(chat): fix allow to send (un)publish request for rules' changes only (Issue #5844).

### DIFF
--- a/apps/chat/src/components/Chat/Publish/PublicationHandler/PublicationHandler.tsx
+++ b/apps/chat/src/components/Chat/Publish/PublicationHandler/PublicationHandler.tsx
@@ -13,6 +13,7 @@ import {
 import { getFolderIdFromEntityId } from '@/src/utils/app/folders';
 import {
   getIdWithoutFeatureType,
+  getIdWithoutTemporaryBucket,
   isApplicationId,
   isConversationId,
   isFileId,
@@ -36,6 +37,7 @@ import {
 import { Translation } from '@/src/types/translation';
 
 import { PublicationActions } from '@/src/store/actions';
+import { FoldersSelectors } from '@/src/store/folders/folders.selectors';
 import { useAppDispatch, useAppSelector } from '@/src/store/hooks';
 import {
   AuthSelectors,
@@ -158,6 +160,9 @@ export function PublicationHandler({ publication, onSubmit }: Props) {
   );
   const areConversationsWithContentUploading = useAppSelector(
     ConversationsSelectors.selectAreConversationsWithContentUploading,
+  );
+  const temporaryFolders = useAppSelector(
+    FoldersSelectors.selectTemporaryFolders,
   );
 
   const [isCompareModalOpened, setIsCompareModalOpened] = useState(false);
@@ -351,17 +356,27 @@ export function PublicationHandler({ publication, onSubmit }: Props) {
   ]);
 
   const hasUserChangedRules = useMemo(() => {
-    return !isEqual(
-      rules[isReview ? publication.targetFolder : editedPublishToUrl] ?? [],
-      (isReview ? newRules : rulesOnEdit) ?? [],
+    const isTemporaryFolder = temporaryFolders.some(
+      (folder) =>
+        getIdWithoutTemporaryBucket(folder.id) ===
+        getIdWithoutFeatureType(editedPublishToUrl),
+    );
+    return (
+      (initialState.publishToUrl !== editedPublishToUrl && isTemporaryFolder) ||
+      !isEqual(
+        rules[isReview ? publication.targetFolder : editedPublishToUrl] ?? [],
+        (isReview ? newRules : rulesOnEdit) ?? [],
+      )
     );
   }, [
     editedPublishToUrl,
+    initialState.publishToUrl,
     isReview,
     newRules,
     publication.targetFolder,
     rules,
     rulesOnEdit,
+    temporaryFolders,
   ]);
 
   const maxPublishToDepth = useMemo(() => {

--- a/apps/chat/src/components/Chat/Publish/PublicationHandler/PublicationHandlerFooter.tsx
+++ b/apps/chat/src/components/Chat/Publish/PublicationHandler/PublicationHandlerFooter.tsx
@@ -456,13 +456,14 @@ export const PublicationHandlerFooter = ({
       if (isDraftRuleFilterOpen) {
         return ChatI18nKeys.AcceptOrRejectRulesChanges;
       }
-      return !isValid
-        ? formError
-        : !selectedPublicationItems.length
-          ? 'Nothing is selected and rules have not changed'
-          : areNoChanges
-            ? 'Nothing is selected and rules have not changed'
-            : "Request can't be published as some items are invalid";
+      if (!isValid) {
+        return formError;
+      }
+      if (areNoChanges) {
+        return 'Nothing is selected and rules have not changed';
+      }
+
+      return "Request can't be published as some items are invalid";
     }
 
     return selectedInvalidEntities.length
@@ -482,17 +483,13 @@ export const PublicationHandlerFooter = ({
     areNoChanges,
     isValid,
     formError,
-    selectedPublicationItems.length,
     isDraftRuleFilterOpen,
   ]);
 
   const isApproveOrSendDisabled =
     (isApproveDisabled && !publishModel) ||
     (publishModel &&
-      (isEditInvalid ||
-        !isValid ||
-        !selectedPublicationItems.length ||
-        isDraftRuleFilterOpen));
+      (isEditInvalid || !isValid || areNoChanges || isDraftRuleFilterOpen));
 
   const getSubmitBtnText = useCallback(() => {
     if (publishModel) {

--- a/apps/chat/src/utils/app/id.ts
+++ b/apps/chat/src/utils/app/id.ts
@@ -130,6 +130,9 @@ export const isRootEntity = (id: string) => {
 export const getIdWithoutFeatureType = (id: string) =>
   id.split('/').slice(1).join('/');
 
+export const getIdWithoutTemporaryBucket = (id: string) =>
+  id.split('/').slice(2).join('/');
+
 export const areEntitiesBucketsTheSame = (
   firstId: string,
   secondId: string,


### PR DESCRIPTION
**Description:**

- Fix allow to send (un)publish request for rules' changes only

Issues:

- Issue #5844 


**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
