### PR TITLE
fix(chat): fix temporary path displaying and search results update (Issue #5790)

### DIFF
--- a/apps/chat/src/components/FileManager/hooks/useFileManager.tsx
+++ b/apps/chat/src/components/FileManager/hooks/useFileManager.tsx
@@ -146,6 +146,8 @@ export const useFileManager = ({
   const isCopyingFiles = useAppSelector(FilesSelectors.selectIsCopyingFiles);
   const isMovingFiles = useAppSelector(FilesSelectors.selectIsMovingFiles);
   const movingFilesCountRef = useRef<number>(0);
+  const prevIsCopyingRef = useRef(false);
+  const prevIsMovingRef = useRef(false);
 
   const fileMetadata = useAppSelector(FilesSelectors.selectFileMetadata);
   const files = useAppSelector(FilesSelectors.selectFiles);
@@ -267,6 +269,17 @@ export const useFileManager = ({
     }
     return tabs?.filter((tab) => availableTabs.has(tab.id));
   }, [availableTabs, tabs]);
+
+  useEffect(() => {
+    const copyJustFinished = prevIsCopyingRef.current && !isCopyingFiles;
+    const moveJustFinished = prevIsMovingRef.current && !isMovingFiles;
+    prevIsCopyingRef.current = isCopyingFiles;
+    prevIsMovingRef.current = isMovingFiles;
+
+    if ((copyJustFinished || moveJustFinished) && isSearching && currentPath) {
+      dispatch(FilesActions.getFullListing({ folderPath: currentPath }));
+    }
+  }, [isCopyingFiles, isMovingFiles, isSearching, currentPath, dispatch]);
 
   useEffect(() => {
     if (currentPath && !isRootId(currentPath) && !isMovingFiles) {

--- a/apps/chat/src/store/files/files.epics.ts
+++ b/apps/chat/src/store/files/files.epics.ts
@@ -312,6 +312,7 @@ const getFullListingEpic: AppEpic = (action$, state$) =>
           FilesActions.getFullListingSuccess({
             folderPath,
             files: [],
+            fromCache: true,
           }),
         );
       }
@@ -653,11 +654,10 @@ const copyFilesEpic: AppEpic = (action$) =>
                   request: payload,
                 }),
               ),
-              of(
-                FilesActions.getFilesWithFolders({
-                  id: payload.destinationFolder,
-                }),
-              ),
+              from([
+                FilesActions.getFolders({ id: payload.destinationFolder }),
+                FilesActions.getFiles({ id: payload.destinationFolder }),
+              ]),
             ),
           ),
           catchError((error) => {
@@ -704,16 +704,14 @@ const moveFilesEpic: AppEpic = (action$) =>
 
             if (payload.destinationFolder !== payload.sourceFolder) {
               actions.push(
-                FilesActions.getFilesWithFolders({
-                  id: payload.sourceFolder,
-                }),
+                FilesActions.getFolders({ id: payload.sourceFolder }),
+                FilesActions.getFiles({ id: payload.sourceFolder }),
               );
             }
 
             actions.push(
-              FilesActions.getFilesWithFolders({
-                id: payload.destinationFolder,
-              }),
+              FilesActions.getFolders({ id: payload.destinationFolder }),
+              FilesActions.getFiles({ id: payload.destinationFolder }),
             );
 
             return from(actions);
@@ -754,11 +752,10 @@ const deleteFilesEpic: AppEpic = (action$) =>
                 request: payload,
               }),
             ),
-            of(
-              FilesActions.getFilesWithFolders({
-                id: payload.folderUrl,
-              }),
-            ),
+            from([
+              FilesActions.getFolders({ id: payload.folderUrl }),
+              FilesActions.getFiles({ id: payload.folderUrl }),
+            ]),
           );
         }),
         catchError(() => {

--- a/apps/chat/src/store/files/files.reducers.ts
+++ b/apps/chat/src/store/files/files.reducers.ts
@@ -45,13 +45,22 @@ import xor from 'lodash-es/xor';
 
 const invalidateSearchCacheForFile = (state: FilesState, fileId: string) => {
   const parts = fileId.split('/');
-
   for (let i = parts.length - 1; i >= 0; i--) {
     const folderPath = parts.slice(0, i).join('/');
     if (folderPath && state.searchListingMetadata[folderPath]) {
       delete state.searchListingMetadata[folderPath];
     }
   }
+};
+
+const invalidateSearchCacheForFolder = (
+  state: FilesState,
+  folderId: string,
+) => {
+  if (state.searchListingMetadata[folderId]) {
+    delete state.searchListingMetadata[folderId];
+  }
+  invalidateSearchCacheForFile(state, folderId);
 };
 
 const initialState: FilesState = {
@@ -339,28 +348,59 @@ export const filesSlice = createSlice({
       }: PayloadAction<{
         folderPath: string;
         files: DialFile[];
+        fromCache?: boolean;
       }>,
     ) => {
       state.isLoadingSearchListing = false;
 
-      const existingFileIds = new Set(state.files.map((f) => f.id));
-      const existingFolderIds = new Set(state.folders.map((f) => f.id));
-      const newFiles = payload.files.filter(
-        (f) =>
-          !existingFileIds.has(f.id) &&
-          !f.folderId.endsWith(`/${CLIENTDATA_PATH}`),
-      );
-      const newFolders = uniq(
-        newFiles.flatMap((f) => getParentFolderIdsFromFolderId(f.folderId)),
-      )
-        .filter((id) => !existingFolderIds.has(id))
-        .map((id) => getFolderFromId(id, FeatureType.File));
-
-      if (newFiles.length > 0) {
-        state.files = [...state.files, ...newFiles];
+      if (payload.fromCache) {
+        return;
       }
-      if (newFolders.length > 0) {
-        state.folders = [...state.folders, ...newFolders];
+
+      const folderPath = payload.folderPath;
+
+      if (payload.files.length > 0) {
+        const freshFileIds = new Set(
+          payload.files
+            .filter((f) => !f.folderId.endsWith(`/${CLIENTDATA_PATH}`))
+            .map((f) => f.id),
+        );
+        const outsideFiles = state.files.filter(
+          (f) =>
+            f.folderId !== folderPath &&
+            !f.folderId.startsWith(`${folderPath}/`),
+        );
+        const inScopeFiles = payload.files.filter(
+          (f) => !f.folderId.endsWith(`/${CLIENTDATA_PATH}`),
+        );
+        const uploadingInScope = state.files.filter(
+          (f) =>
+            !f.serverSynced &&
+            (f.folderId === folderPath ||
+              f.folderId.startsWith(`${folderPath}/`)) &&
+            !freshFileIds.has(f.id),
+        );
+
+        state.files = [...outsideFiles, ...inScopeFiles, ...uploadingInScope];
+
+        const existingFolderIds = new Set(state.folders.map((f) => f.id));
+        const newFolders = uniq(
+          inScopeFiles.flatMap((f) =>
+            getParentFolderIdsFromFolderId(f.folderId),
+          ),
+        )
+          .filter((id) => !existingFolderIds.has(id))
+          .map((id) => getFolderFromId(id, FeatureType.File));
+
+        if (newFolders.length > 0) {
+          state.folders = [...state.folders, ...newFolders];
+        }
+      } else {
+        state.files = state.files.filter(
+          (f) =>
+            f.folderId !== folderPath &&
+            !f.folderId.startsWith(`${folderPath}/`),
+        );
       }
 
       state.searchListingMetadata[payload.folderPath] = {
@@ -537,6 +577,8 @@ export const filesSlice = createSlice({
         newId: newFolderId,
         oldId: targetFolder.id,
       };
+      invalidateSearchCacheForFolder(state, payload.folderId);
+      invalidateSearchCacheForFolder(state, newFolderId);
     },
     renameFolderSuccess: (
       state,
@@ -791,7 +833,9 @@ export const filesSlice = createSlice({
     },
     copyFilesSuccess: (
       state,
-      _action: PayloadAction<{
+      {
+        payload,
+      }: PayloadAction<{
         result: FileOperationsResult<MoveModel>;
         request: {
           files: DialCopiedItem[];
@@ -801,6 +845,13 @@ export const filesSlice = createSlice({
       }>,
     ) => {
       state.isCopyingFiles = false;
+      invalidateSearchCacheForFolder(state, payload.request.destinationFolder);
+      if (payload.request.sourceFolder) {
+        invalidateSearchCacheForFolder(state, payload.request.sourceFolder);
+      }
+      payload.result.results.forEach((file) => {
+        invalidateSearchCacheForFile(state, file.data.destinationUrl);
+      });
     },
     copyFilesFail: (
       state,
@@ -867,6 +918,18 @@ export const filesSlice = createSlice({
       }>,
     ) => {
       state.isMovingFiles = false;
+      const movedFileSourceUrls = new Set(
+        payload.request.files
+          .filter((f) => f.nodeType !== DialFileNodeType.FOLDER)
+          .map((f) => f.sourceUrl),
+      );
+
+      if (movedFileSourceUrls.size > 0) {
+        state.files = state.files.filter((f) => !movedFileSourceUrls.has(f.id));
+      }
+
+      invalidateSearchCacheForFolder(state, payload.request.sourceFolder);
+      invalidateSearchCacheForFolder(state, payload.request.destinationFolder);
       payload.result.results.forEach((file) => {
         invalidateSearchCacheForFile(state, file.data.sourceUrl);
         invalidateSearchCacheForFile(state, file.data.destinationUrl);


### PR DESCRIPTION
**Description:**

Temporary path is displayed when create new folder for Move to action for items from search results.
Search result should be updated when search-phrase is entered, and user duplicates, deletes, renames, copies to.
When Move to file from search results, then new path in not displayed.

Issues:

- Issue #5790

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
