### PR TITLE
fix(chat): support mouse wheel scrolling in system prompt options #6294

### DIFF
--- a/apps/chat/src/components/Chat/ChatInput/PromptList.tsx
+++ b/apps/chat/src/components/Chat/ChatInput/PromptList.tsx
@@ -1,5 +1,5 @@
 import { useDismiss, useFloating, useInteractions } from '@floating-ui/react';
-import { FC, useEffect } from 'react';
+import { FC, useEffect, useRef } from 'react';
 
 import classNames from 'classnames';
 
@@ -79,9 +79,30 @@ export const PromptList: FC<Props> = ({
   const dismiss = useDismiss(context);
   const { getFloatingProps } = useInteractions([dismiss]);
 
+  const isMouseInteraction = useRef(false);
+
   useEffect(() => {
-    if (refs.floating.current) {
-      refs.floating.current.scrollTop = activePromptIndex * 30;
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (['ArrowDown', 'ArrowUp', 'Tab'].includes(e.key)) {
+        isMouseInteraction.current = false;
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, []);
+
+  useEffect(() => {
+    if (
+      activePromptIndex !== -1 &&
+      refs.floating.current &&
+      !isMouseInteraction.current
+    ) {
+      const activeItem = refs.floating.current.children[
+        activePromptIndex
+      ] as HTMLElement;
+      if (activeItem) {
+        activeItem.scrollIntoView({ block: 'nearest' });
+      }
     }
   }, [activePromptIndex, refs.floating]);
 
@@ -99,7 +120,10 @@ export const PromptList: FC<Props> = ({
           key={prompt.id}
           activePromptIndex={activePromptIndex}
           onSelect={onSelect}
-          onMouseEnter={onMouseEnter}
+          onMouseEnter={(idx) => {
+            isMouseInteraction.current = true;
+            onMouseEnter(idx);
+          }}
         />
       ))}
     </ul>


### PR DESCRIPTION
**Description:**

This PR resolves an issue where mouse wheel scrolling is intercepted by the `onMouseEnter` event in the system prompt dropdown list. When a user scrolled, items entering the hover state triggered `scrollIntoView`, which forcefully interrupted the native smooth scroll momentum. 

To resolve this properly, I added an interaction tracker (`isMouseInteraction` ref) to distinguish between keyboard events and mouse hover behaviors. Now, `scrollIntoView` is explicitly invoked only during keyboard navigation (Arrow Up/Down/Tab keys), allowing the dropdown list to respond natively and smoothly to the mouse wheel scroll.

Issues:

- Issue #6294 

**UI changes**

_No visual UI design changes. This is purely a UX interactions fix to enable native mouse wheel scrolling without stuttering._

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
