### PR TITLE
fix(chat): fix confirmation dialog is not shown on attempt to unshare/remove access file (Issue #5971)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ COPY package*.json ./
 
 # ---- Dependencies ----
 FROM base AS build_dependencies
-RUN npm ci
+RUN npm ci --legacy-peer-deps
 
 # ---- Build ----
 FROM build_dependencies AS build
@@ -18,7 +18,7 @@ FROM build AS run_dependencies
 WORKDIR /app/dist/apps/chat
 COPY /tools /app/dist/apps/chat/tools
 COPY /patches /app/dist/apps/chat/patches
-RUN npm i
+RUN npm i --legacy-peer-deps
 RUN node tools/patch-nextjs.js
 
 # ---- Production ----

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ COPY package*.json ./
 
 # ---- Dependencies ----
 FROM base AS build_dependencies
-RUN npm ci --legacy-peer-deps
+RUN npm ci
 
 # ---- Build ----
 FROM build_dependencies AS build
@@ -18,7 +18,7 @@ FROM build AS run_dependencies
 WORKDIR /app/dist/apps/chat
 COPY /tools /app/dist/apps/chat/tools
 COPY /patches /app/dist/apps/chat/patches
-RUN npm i --legacy-peer-deps
+RUN npm i
 RUN node tools/patch-nextjs.js
 
 # ---- Production ----

--- a/apps/chat-e2e/src/core/dialSharedWithMeFixtures.ts
+++ b/apps/chat-e2e/src/core/dialSharedWithMeFixtures.ts
@@ -7,7 +7,6 @@ import {
   ChatMessages,
   Compare,
   ConfirmationDialog,
-  ConfirmationPopup,
   ConversationSettingsModal,
   ConversationToCompare,
   Dropdown,
@@ -197,7 +196,7 @@ const dialSharedWithMeTest = dialTest.extend<{
   additionalShareUserFileManagerModalToolbar: FileManagerToolbar;
   additionalShareUserFileManagerModalCollapsibleSidebar: FileManagerCollapsibleSidebar;
   additionalShareUserFileManagerModalFoldersTree: FoldersTree;
-  additionalShareUserFileManagerDeleteItemConfirmationPopup: ConfirmationPopup;
+  additionalShareUserFileManagerUnshareItemConfirmationPopup: ConfirmationDialog;
   additionalShareUserFileManagerModalFoldersTreeAssertion: FoldersTreeAssertion;
 }>({
   beforeAdditionalShareUserTestCleanup: [
@@ -1055,13 +1054,13 @@ const dialSharedWithMeTest = dialTest.extend<{
       additionalShareUserFileManagerModalCollapsibleSidebar.getFoldersTree();
     await use(additionalShareUserFileManagerModalFoldersTree);
   },
-  additionalShareUserFileManagerDeleteItemConfirmationPopup: async (
+  additionalShareUserFileManagerUnshareItemConfirmationPopup: async (
     { additionalShareUserPage },
     use,
   ) => {
-    const additionalShareUserFileManagerDeleteItemConfirmationPopup =
-      new ConfirmationPopup(additionalShareUserPage, 'Delete');
-    await use(additionalShareUserFileManagerDeleteItemConfirmationPopup);
+    const additionalShareUserFileManagerUnshareItemConfirmationPopup =
+      new ConfirmationDialog(additionalShareUserPage);
+    await use(additionalShareUserFileManagerUnshareItemConfirmationPopup);
   },
   additionalShareUserFileManagerModalFoldersTreeAssertion: async (
     { additionalShareUserFileManagerModalFoldersTree },

--- a/apps/chat-e2e/src/testData/expectedConstants.ts
+++ b/apps/chat-e2e/src/testData/expectedConstants.ts
@@ -126,8 +126,6 @@ export const ExpectedConstants = {
     'We are sorry, but the link you are trying to access has expired or does not exist.',
   copyUrlTooltip: 'Copy URL',
   removeAccessTitle: 'Confirm unsharing',
-  unshareFileTitle: 'Confirm unsharing file',
-  unshareFileMessage: 'Are you sure that you want to unshare this file?',
   attachments: 'Attachments',
   responseContentPattern: /(?<="content":")[^"^$]+/g,
   responseFileUrlPattern: /(?<="url":")[^"$]+/g,

--- a/apps/chat-e2e/src/tests/shareConversationWithContent.test.ts
+++ b/apps/chat-e2e/src/tests/shareConversationWithContent.test.ts
@@ -585,6 +585,7 @@ dialSharedWithMeTest(
     additionalShareUserSharedWithMeConversations,
     additionalShareUserChatMessages,
     localStorageManager,
+    confirmationDialog,
   }) => {
     dialSharedWithMeTest.slow();
     setTestIds('EPMRTC-3518', 'EPMRTC-3102', 'EPMRTC-3101', 'EPMRTC-5524');
@@ -688,17 +689,17 @@ dialSharedWithMeTest(
           Attachment.cloudImageName,
         );
         await rowLocator.hover();
-        await rowDotsMenu.click();
+        +(await rowDotsMenu.click());
         await fileManagerGridRowDropdownMenu.selectItem(
           MenuOptions.removeAccess,
           {
-            isHttpMethodTriggered: true,
-            triggeredHttpMethod: 'POST',
-            apiHost: API.revokeAccessHost,
+            isHttpMethodTriggered: false,
           },
         );
-        //TODO: enable when fixed https://github.com/epam/ai-dial-chat/issues/5971
-        //await confirmationDialog.confirm({ triggeredHttpMethod: 'POST' });
+        await confirmationDialog.confirm({
+          triggeredHttpMethod: 'POST',
+          triggeredHttpHost: API.revokeAccessHost,
+        });
         await fileManagerGridAssertion.assertGridFileSharedState(
           Attachment.cloudImageName,
           'hidden',
@@ -794,13 +795,13 @@ dialSharedWithMeTest(
         await fileManagerGridRowDropdownMenu.selectItem(
           MenuOptions.removeAccess,
           {
-            isHttpMethodTriggered: true,
-            triggeredHttpMethod: 'POST',
-            apiHost: API.revokeAccessHost,
+            isHttpMethodTriggered: false,
           },
         );
-        //TODO: enable when fixed https://github.com/epam/ai-dial-chat/issues/5971
-        //await confirmationDialog.confirm({ triggeredHttpMethod: 'POST' });
+        await confirmationDialog.confirm({
+          triggeredHttpMethod: 'POST',
+          triggeredHttpHost: API.revokeAccessHost,
+        });
         await fileManagerGridAssertion.assertGridFileSharedState(
           Attachment.sunImageName,
           'hidden',

--- a/apps/chat-e2e/src/tests/shareCustomApp.test.ts
+++ b/apps/chat-e2e/src/tests/shareCustomApp.test.ts
@@ -736,31 +736,29 @@ dialSharedWithMeTest(
         await additionalShareUserFileManagerGridRowDropdownMenu.selectItem(
           MenuOptions.unshare,
           {
-            isHttpMethodTriggered: true,
-            triggeredHttpMethod: 'POST',
-            apiHost: API.discardShareWithMeItem,
+            isHttpMethodTriggered: false,
           },
         );
-        //TODO: enable when fixed https://github.com/epam/ai-dial-chat/issues/5971
-        // await additionalShareUserConfirmationDialogAssertion.assertElementState(
-        //   additionalShareUserConfirmationDialog,
-        //   'visible',
-        // );
-        // await additionalShareUserConfirmationDialogAssertion.assertConfirmationDialogTitle(
-        //   ExpectedConstants.unshareFileTitle,
-        // );
-        // await additionalShareUserConfirmationDialogAssertion.assertConfirmationMessage(
-        //   ExpectedConstants.unshareFileMessage,
-        // );
+        await additionalShareUserConfirmationDialogAssertion.assertElementState(
+          additionalShareUserConfirmationDialog,
+          'visible',
+        );
+        await additionalShareUserConfirmationDialogAssertion.assertConfirmationDialogTitle(
+          ExpectedConstants.removeAccessTitle,
+        );
+        await additionalShareUserConfirmationDialogAssertion.assertConfirmationMessage(
+          ExpectedConstants.removeYourAccessMessage(iconName),
+        );
       },
     );
 
     await dialSharedWithMeTest.step(
       'Confirm unsharing and verify the icon is removed from "Shared with me" tab',
       async () => {
-        // await additionalShareUserConfirmationDialog.confirm({
-        //   triggeredHttpMethod: 'POST',
-        // });
+        await additionalShareUserConfirmationDialog.confirm({
+          triggeredHttpMethod: 'POST',
+          triggeredHttpHost: API.discardShareWithMeItem,
+        });
         await additionalShareUserFileManagerGridAssertion.assertGridRowByNameState(
           iconName,
           'hidden',

--- a/apps/chat-e2e/src/tests/sharedFilesAttachments.test.ts
+++ b/apps/chat-e2e/src/tests/sharedFilesAttachments.test.ts
@@ -523,6 +523,7 @@ dialSharedWithMeTest(
     additionalShareUserFileManagerNavigationPanel,
     additionalShareUserDownloadAssertion,
     localStorageManager,
+    additionalShareUserFileManagerUnshareItemConfirmationPopup,
   }) => {
     dialSharedWithMeTest.slow();
     setTestIds(
@@ -920,32 +921,28 @@ dialSharedWithMeTest(
         await additionalShareUserFileManagerGridRowDropdownMenu.selectItem(
           MenuOptions.unshare,
           {
-            isHttpMethodTriggered: true,
-            triggeredHttpMethod: 'POST',
-            apiHost: API.discardShareWithMeItem,
+            isHttpMethodTriggered: false,
           },
         );
-        //TODO: enable when fixed https://github.com/epam/ai-dial-chat/issues/5971
-        // await additionalShareUserFileManagerDeleteItemConfirmationPopup
-        //   .getCloseButton()
-        //   .click();
-        // await additionalShareUserFileManagerGridAssertion.assertGridRowByNameState(
-        //   user1ImageInRequest1,
-        //   'visible',
-        // );
-        // await fileRow.hover();
-        // await dotsMenu.click();
-        // await additionalShareUserFileManagerGridRowDropdownMenu.selectItem(
-        //   MenuOptions.delete,
-        //   {
-        //     isHttpMethodTriggered: false,
-        //   },
-        // );
-        // await additionalShareUserFileManagerDeleteItemConfirmationPopup.confirm(
-        //   {
-        //     triggeredHttpMethod: 'POST',
-        //   },
-        // );
+        await additionalShareUserFileManagerUnshareItemConfirmationPopup.cancelButton.click();
+        await additionalShareUserFileManagerGridAssertion.assertGridRowByNameState(
+          user1ImageInRequest1,
+          'visible',
+        );
+        await fileRow.hover();
+        await dotsMenu.click();
+        await additionalShareUserFileManagerGridRowDropdownMenu.selectItem(
+          MenuOptions.unshare,
+          {
+            isHttpMethodTriggered: false,
+          },
+        );
+        await additionalShareUserFileManagerUnshareItemConfirmationPopup.confirm(
+          {
+            triggeredHttpMethod: 'POST',
+            triggeredHttpHost: API.discardShareWithMeItem,
+          },
+        );
         await additionalShareUserFileManagerGridAssertion.assertGridRowByNameState(
           user1ImageInRequest1,
           'hidden',
@@ -989,13 +986,13 @@ dialSharedWithMeTest(
             CheckboxState.checked,
           );
         }
-        await additionalShareUserFileManagerToolbar.unshareEntities();
-        //TODO: enable when fixed https://github.com/epam/ai-dial-chat/issues/5971
-        // await additionalShareUserFileManagerDeleteItemConfirmationPopup.confirm(
-        //   {
-        //     triggeredHttpMethod: 'POST',
-        //   },
-        // );
+        await additionalShareUserFileManagerToolbar.getUnshareButton().click();
+        await additionalShareUserFileManagerUnshareItemConfirmationPopup.confirm(
+          {
+            triggeredHttpMethod: 'POST',
+            triggeredHttpHost: API.discardShareWithMeItem,
+          },
+        );
         for (const file of imagesToDelete) {
           await additionalShareUserFileManagerGridAssertion.assertGridRowByNameState(
             file,

--- a/apps/chat-e2e/src/ui/webElements/fileManager/fileManagerToolbar.ts
+++ b/apps/chat-e2e/src/ui/webElements/fileManager/fileManagerToolbar.ts
@@ -137,15 +137,4 @@ export class FileManagerToolbar extends BaseElement {
   public organizationTab = this.getToolbarTabs().tabByName(
     FileManagerToolbarTabs.Organization,
   );
-
-  public async unshareEntities() {
-    const respPromise = this.page.waitForResponse(
-      (resp) =>
-        resp.ok() &&
-        resp.request().method() === 'POST' &&
-        resp.url().includes(API.discardShareWithMeItem),
-    );
-    await this.getUnshareButton().click();
-    await respPromise;
-  }
 }

--- a/apps/chat/src/components/Common/UnshareDialog.tsx
+++ b/apps/chat/src/components/Common/UnshareDialog.tsx
@@ -1,7 +1,8 @@
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 
 import { useTranslation } from '@/src/hooks/useTranslation';
 
+import { dispatchFileManagerUnshareFromEnrichedItems } from '@/src/utils/app/file-manager-unshare-dispatch';
 import { isConversationId } from '@/src/utils/app/id';
 import { EnumMapper } from '@/src/utils/app/mappers';
 import { isMyBucket, splitEntityId } from '@/src/utils/app/shared-utils';
@@ -19,6 +20,15 @@ import { ConfirmDialog } from '@/src/components/Common/ConfirmDialog';
 
 import { withRenderWhen } from './RenderWhen';
 
+function getDialPathDisplayName(path: string) {
+  const { name } = parseEntityApiKey(splitEntityId(path).name, {
+    parseVersion: true,
+    parseModel: isConversationId(path),
+  });
+
+  return name ?? path;
+}
+
 function UnshareDialogView() {
   const { t } = useTranslation(Translation.Common);
   const dispatch = useAppDispatch();
@@ -26,6 +36,9 @@ function UnshareDialogView() {
   const unshareEntity = useAppSelector(ShareSelectors.selectUnshareModel);
   const unshareResourceId = useAppSelector(
     ShareSelectors.selectUnshareResourceId,
+  );
+  const unshareFileManagerItems = useAppSelector(
+    ShareSelectors.selectUnshareFileManagerItems,
   );
   const shareResourceName = useAppSelector(
     ShareSelectors.selectShareResourceName,
@@ -35,32 +48,110 @@ function UnshareDialogView() {
   );
   const isFolder = useAppSelector(ShareSelectors.selectShareIsFolder);
 
-  const resourceId = unshareEntity?.id ?? unshareResourceId ?? '';
+  const isFileManagerUnshare = !!unshareFileManagerItems?.length;
 
-  const { bucket } = splitEntityId(resourceId);
-  const isAuthor = isMyBucket(bucket);
-  const { name } = parseEntityApiKey(splitEntityId(resourceId).name, {
-    parseVersion: true,
-    parseModel: isConversationId(resourceId),
-  });
+  const fileManagerDescription = useMemo(() => {
+    if (!unshareFileManagerItems?.length) {
+      return null;
+    }
 
-  const description = t(
-    isAuthor
-      ? CommonI18nKeys.ConfirmRemoveAllUsersAccess
-      : CommonI18nKeys.ConfirmRemoveYourAccess,
-    {
-      name: name ?? shareResourceName,
-    },
-  );
+    const discardPaths = unshareFileManagerItems
+      .filter((item) => item.sharedWithMe)
+      .map((item) => item.path);
+    const revokePaths = unshareFileManagerItems
+      .filter((item) => item.isShared)
+      .map((item) => item.path);
+
+    const joinNames = (paths: string[]) => {
+      const labels = paths.map(getDialPathDisplayName);
+      const head = labels.slice(0, 5).join(', ');
+
+      return labels.length > 5 ? `${head}…` : head;
+    };
+
+    const hasDiscard = discardPaths.length > 0;
+    const hasRevoke = revokePaths.length > 0;
+
+    if (!hasDiscard && !hasRevoke) {
+      return t(CommonI18nKeys.ConfirmRemoveYourAccess, {
+        name: joinNames(unshareFileManagerItems.map((item) => item.path)),
+      });
+    }
+
+    if (hasDiscard && hasRevoke) {
+      return `${t(CommonI18nKeys.ConfirmRemoveYourAccess, {
+        name: joinNames(discardPaths),
+      })} ${t(CommonI18nKeys.ConfirmRemoveAllUsersAccess, {
+        name: joinNames(revokePaths),
+      })}`;
+    }
+
+    if (hasDiscard) {
+      return t(CommonI18nKeys.ConfirmRemoveYourAccess, {
+        name: joinNames(discardPaths),
+      });
+    }
+
+    return t(CommonI18nKeys.ConfirmRemoveAllUsersAccess, {
+      name: joinNames(revokePaths),
+    });
+  }, [t, unshareFileManagerItems]);
+
+  const singleResourceDescription = useMemo(() => {
+    if (isFileManagerUnshare) {
+      return null;
+    }
+
+    const resourceId = unshareEntity?.id ?? unshareResourceId ?? '';
+    const { bucket } = splitEntityId(resourceId);
+    const isAuthor = isMyBucket(bucket);
+    const { name } = parseEntityApiKey(splitEntityId(resourceId).name, {
+      parseVersion: true,
+      parseModel: isConversationId(resourceId),
+    });
+
+    return t(
+      isAuthor
+        ? CommonI18nKeys.ConfirmRemoveAllUsersAccess
+        : CommonI18nKeys.ConfirmRemoveYourAccess,
+      {
+        name: name ?? shareResourceName,
+      },
+    );
+  }, [
+    isFileManagerUnshare,
+    shareResourceName,
+    t,
+    unshareEntity,
+    unshareResourceId,
+  ]);
+
+  const description =
+    isFileManagerUnshare && fileManagerDescription !== null
+      ? fileManagerDescription
+      : (singleResourceDescription ?? '');
 
   const handleConfirmUnshare = useCallback(
     (confirmation: boolean) => {
       if (!confirmation) {
-        dispatch(
-          unshareEntity
-            ? ShareActions.setUnshareEntity(undefined)
-            : ShareActions.setUnshareResourceId(undefined),
+        if (unshareEntity) {
+          dispatch(ShareActions.setUnshareEntity(undefined));
+        } else if (unshareResourceId) {
+          dispatch(ShareActions.setUnshareResourceId(undefined));
+        } else if (unshareFileManagerItems?.length) {
+          dispatch(ShareActions.setUnshareFileManagerItems(undefined));
+        }
+
+        return;
+      }
+
+      if (unshareFileManagerItems?.length) {
+        dispatchFileManagerUnshareFromEnrichedItems(
+          dispatch,
+          unshareFileManagerItems,
         );
+        dispatch(ShareActions.setUnshareFileManagerItems(undefined));
+
         return;
       }
 
@@ -103,7 +194,14 @@ function UnshareDialogView() {
         dispatch(ShareActions.setUnshareEntity(undefined));
       }
     },
-    [dispatch, shareFeatureType, isFolder, unshareEntity, unshareResourceId],
+    [
+      dispatch,
+      isFolder,
+      shareFeatureType,
+      unshareEntity,
+      unshareFileManagerItems,
+      unshareResourceId,
+    ],
   );
 
   return (
@@ -121,6 +219,11 @@ function UnshareDialogView() {
 export const UnshareDialog = withRenderWhen((state) => {
   const unshareModel = ShareSelectors.selectUnshareModel(state);
   const unshareResource = ShareSelectors.selectUnshareResourceId(state);
+  const fileManagerItems = ShareSelectors.selectUnshareFileManagerItems(state);
 
-  return !!unshareModel || !!unshareResource;
+  return (
+    !!unshareModel ||
+    !!unshareResource ||
+    !!(fileManagerItems && fileManagerItems.length > 0)
+  );
 })(UnshareDialogView);

--- a/apps/chat/src/components/FileManager/FileManager.tsx
+++ b/apps/chat/src/components/FileManager/FileManager.tsx
@@ -72,9 +72,9 @@ export const FileManager: React.FC = () => {
     handleUploadFiles,
     handleCreateFolder,
     handleUploadArchive,
-    handleUnshareFiles,
+    handleOpenUnshareFilesDialog,
+    handleOpenRemoveFilesAccessDialog,
     handleRenameValidation,
-    handleRemoveAccess,
 
     sharedWithMeIds,
 
@@ -124,8 +124,8 @@ export const FileManager: React.FC = () => {
           onUploadFiles={handleUploadFiles}
           onCreateFolder={handleCreateFolder}
           onUploadArchive={handleUploadArchive}
-          onUnshareFiles={handleUnshareFiles}
-          onRemoveFilesAccess={handleRemoveAccess}
+          onUnshareFiles={handleOpenUnshareFilesDialog}
+          onRemoveFilesAccess={handleOpenRemoveFilesAccessDialog}
           onRenameValidate={handleRenameValidation}
           onCreateFolderValidate={handleRenameValidation}
           sharedWithMeIds={sharedWithMeIds}

--- a/apps/chat/src/components/FileManager/hooks/useFileManager.tsx
+++ b/apps/chat/src/components/FileManager/hooks/useFileManager.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useStore } from 'react-redux';
 
 import {
   UseFileManagerActionLabelsOptions,
@@ -14,6 +15,7 @@ import {
   filterFilesByFilters,
   filterFoldersByFilters,
 } from '@/src/utils/app/file-manager-adapter';
+import { dispatchOpenFileManagerUnshareDialog } from '@/src/utils/app/file-manager-unshare-dispatch';
 import { getFolderIdFromEntityId } from '@/src/utils/app/folders';
 import { getFileRootId, getRootId, isRootId } from '@/src/utils/app/id';
 import {
@@ -28,7 +30,6 @@ import { translate } from '@/src/utils/app/translation';
 import { RootState } from '@/src/types/store';
 import { Translation } from '@/src/types/translation';
 
-import { ShareActions } from '@/src/store/actions';
 import { FilesActions } from '@/src/store/files/files.reducers';
 import { FilesSelectors } from '@/src/store/files/files.selectors';
 import { useAppDispatch, useAppSelector } from '@/src/store/hooks';
@@ -64,7 +65,6 @@ import {
   useDialFileManagerTabs,
 } from '@epam/ai-dial-ui-kit';
 import cloneDeep from 'lodash-es/cloneDeep';
-import groupBy from 'lodash-es/groupBy';
 
 const formatSharedPath = (path: string | undefined | null) => {
   if (!path) return path;
@@ -129,6 +129,7 @@ export const useFileManager = ({
   reviewBucket,
 }: UseFileManagerOptions = {}) => {
   const dispatch = useAppDispatch();
+  const store = useStore<RootState>();
 
   const { t } = useTranslation(Translation.SideBar);
 
@@ -878,62 +879,28 @@ export const useFileManager = ({
     [dispatch],
   );
 
-  const handleUnshareFiles = useCallback(
+  const handleOpenUnshareFilesDialog = useCallback(
     (items: { path: string; nodeType?: string }[]) => {
-      const grouped = groupBy(items, (item) =>
-        item.nodeType === DialFileNodeType.FOLDER ? 'folders' : 'files',
+      dispatchOpenFileManagerUnshareDialog(
+        dispatch,
+        () => store.getState(),
+        items,
+        'unshare-files',
       );
-
-      if (grouped.folders?.length) {
-        dispatch(
-          ShareActions.discardSharedWithMe({
-            resourceIds: grouped.folders.map((f) => f.path),
-            featureType: FeatureType.File,
-            isFolder: true,
-          }),
-        );
-      }
-
-      if (grouped.files?.length) {
-        dispatch(
-          ShareActions.discardSharedWithMe({
-            resourceIds: grouped.files.map((f) => f.path),
-            featureType: FeatureType.File,
-            isFolder: false,
-          }),
-        );
-      }
     },
-    [dispatch],
+    [dispatch, store],
   );
 
-  const handleRemoveAccess = useCallback(
+  const handleOpenRemoveFilesAccessDialog = useCallback(
     (items: { path: string; nodeType?: string }[]) => {
-      const grouped = groupBy(items, (item) =>
-        item.nodeType === DialFileNodeType.FOLDER ? 'folders' : 'files',
+      dispatchOpenFileManagerUnshareDialog(
+        dispatch,
+        () => store.getState(),
+        items,
+        'remove-access',
       );
-
-      if (grouped.folders?.length) {
-        dispatch(
-          ShareActions.revokeAccess({
-            resourceIds: grouped.folders.map(({ path }) => path),
-            featureType: FeatureType.File,
-            isFolder: true,
-          }),
-        );
-      }
-
-      if (grouped.files?.length) {
-        dispatch(
-          ShareActions.revokeAccess({
-            resourceIds: grouped.files.map(({ path }) => path),
-            featureType: FeatureType.File,
-            isFolder: false,
-          }),
-        );
-      }
     },
-    [dispatch],
+    [dispatch, store],
   );
 
   const handleRenameValidation = useCallback(
@@ -1011,12 +978,12 @@ export const useFileManager = ({
     handleMoveFiles,
     handleDeleteFiles,
     handleDownloadFiles,
-    handleRemoveAccess,
     handleTableFileClick,
     handleUploadFiles,
     handleCreateFolder,
     handleUploadArchive,
-    handleUnshareFiles,
+    handleOpenUnshareFilesDialog,
+    handleOpenRemoveFilesAccessDialog,
     handleRenameValidation,
     sharedWithMeIds,
 

--- a/apps/chat/src/components/FileManager/hooks/useFileManager.tsx
+++ b/apps/chat/src/components/FileManager/hooks/useFileManager.tsx
@@ -1,5 +1,4 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { useStore } from 'react-redux';
 
 import {
   UseFileManagerActionLabelsOptions,
@@ -28,7 +27,7 @@ import { getEntityBucket } from '@/src/utils/app/shared-utils';
 import { translate } from '@/src/utils/app/translation';
 
 import { DialFile as LocalDialFileType } from '@/src/types/files';
-import { RootState } from '@/src/types/store';
+import type { RootState } from '@/src/types/store';
 import { Translation } from '@/src/types/translation';
 
 import { FilesActions } from '@/src/store/files/files.reducers';
@@ -146,7 +145,6 @@ export const useFileManager = ({
   additionalFilesAndFolders,
 }: UseFileManagerOptions = {}) => {
   const dispatch = useAppDispatch();
-  const store = useStore<RootState>();
 
   const { t } = useTranslation(Translation.SideBar);
 
@@ -914,24 +912,24 @@ export const useFileManager = ({
     (items: { path: string; nodeType?: string }[]) => {
       dispatchOpenFileManagerUnshareDialog(
         dispatch,
-        () => store.getState(),
+
         items,
         'unshare-files',
       );
     },
-    [dispatch, store],
+    [dispatch],
   );
 
   const handleOpenRemoveFilesAccessDialog = useCallback(
     (items: { path: string; nodeType?: string }[]) => {
       dispatchOpenFileManagerUnshareDialog(
         dispatch,
-        () => store.getState(),
+
         items,
         'remove-access',
       );
     },
-    [dispatch, store],
+    [dispatch],
   );
 
   const handleRenameValidation = useCallback(

--- a/apps/chat/src/store/share/share.reducers.ts
+++ b/apps/chat/src/store/share/share.reducers.ts
@@ -10,7 +10,7 @@ import { ModalState } from '@/src/types/modal';
 import { Prompt } from '@/src/types/prompt';
 import { ShareRelations } from '@/src/types/share';
 
-import { ShareState } from './share.types';
+import { ShareState, UnshareFileManagerItem } from './share.types';
 
 import {
   ConversationInfo,
@@ -32,6 +32,7 @@ const initialState: ShareState = {
   isPrompt: undefined,
   unshareResourceId: undefined,
   unshareEntity: undefined,
+  unshareFileManagerItems: undefined,
 
   shareResourceName: undefined,
   shareResourceId: undefined,
@@ -176,12 +177,28 @@ export const shareSlice = createSlice({
       { payload }: PayloadAction<Omit<ShareEntity, 'folderId'> | undefined>,
     ) => {
       state.unshareEntity = payload;
+      if (payload) {
+        state.unshareFileManagerItems = undefined;
+      }
     },
     setUnshareResourceId: (
       state,
       { payload }: PayloadAction<string | undefined>,
     ) => {
       state.unshareResourceId = payload;
+      if (payload) {
+        state.unshareFileManagerItems = undefined;
+      }
+    },
+    setUnshareFileManagerItems: (
+      state,
+      { payload }: PayloadAction<UnshareFileManagerItem[] | undefined>,
+    ) => {
+      state.unshareFileManagerItems = payload;
+      if (payload?.length) {
+        state.unshareEntity = undefined;
+        state.unshareResourceId = undefined;
+      }
     },
     acceptShareInvitation: (
       state,

--- a/apps/chat/src/store/share/share.selectors.ts
+++ b/apps/chat/src/store/share/share.selectors.ts
@@ -47,6 +47,9 @@ const selectUnshareModel = (state: RootState) =>
 const selectUnshareResourceId = (state: RootState) =>
   rootSelector(state).unshareResourceId;
 
+const selectUnshareFileManagerItems = (state: RootState) =>
+  rootSelector(state).unshareFileManagerItems;
+
 const selectIsResourceShared = (state: RootState) =>
   rootSelector(state).isShared;
 
@@ -63,5 +66,6 @@ export const ShareSelectors = {
   selectSharePermissions,
   selectUnshareModel,
   selectUnshareResourceId,
+  selectUnshareFileManagerItems,
   selectIsResourceShared,
 };

--- a/apps/chat/src/store/share/share.types.ts
+++ b/apps/chat/src/store/share/share.types.ts
@@ -8,6 +8,13 @@ import {
   UploadStatus,
 } from '@epam/ai-dial-shared';
 
+export interface UnshareFileManagerItem {
+  path: string;
+  nodeType?: string;
+  sharedWithMe?: boolean;
+  isShared?: boolean;
+}
+
 export interface ShareState {
   status: UploadStatus;
   error: ErrorMessage | undefined;
@@ -26,4 +33,5 @@ export interface ShareState {
   sharePermissions?: SharePermission[];
   unshareResourceId?: string;
   isShared?: boolean;
+  unshareFileManagerItems?: UnshareFileManagerItem[];
 }

--- a/apps/chat/src/utils/app/__tests__/file-manager-unshare-dispatch.test.ts
+++ b/apps/chat/src/utils/app/__tests__/file-manager-unshare-dispatch.test.ts
@@ -1,0 +1,212 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  dispatchDiscardSharedWithMeForDialItems,
+  dispatchFileManagerUnshareFromEnrichedItems,
+  dispatchOpenFileManagerUnshareDialog,
+  dispatchRevokeAccessForDialItems,
+  enrichUnshareFileManagerItems,
+} from '@/src/utils/app/file-manager-unshare-dispatch';
+
+import type { DialFile, FileFolderInterface } from '@/src/types/files';
+import type { RootState } from '@/src/types/store';
+
+import { ShareActions } from '@/src/store/actions';
+import { filesSlice } from '@/src/store/files/files.reducers';
+
+import { FeatureType } from '@epam/ai-dial-shared';
+import { DialFileNodeType } from '@epam/ai-dial-ui-kit';
+
+function rootStateWithEntities(
+  files: DialFile[],
+  folders: FileFolderInterface[],
+): RootState {
+  return {
+    files: {
+      ...filesSlice.getInitialState(),
+      files,
+      folders,
+    },
+  } as unknown as RootState;
+}
+
+describe('file-manager-unshare-dispatch', () => {
+  it('dispatchDiscardSharedWithMeForDialItems and dispatchRevokeAccessForDialItems no-op when empty and group folders vs files', () => {
+    const dispatch = vi.fn();
+
+    dispatchDiscardSharedWithMeForDialItems(dispatch, []);
+    dispatchRevokeAccessForDialItems(dispatch, []);
+    expect(dispatch).not.toHaveBeenCalled();
+
+    const items = [
+      { path: 'folder-a/', nodeType: DialFileNodeType.FOLDER },
+      { path: 'files/bucket/file.txt', nodeType: DialFileNodeType.ITEM },
+    ];
+
+    dispatchDiscardSharedWithMeForDialItems(dispatch, items);
+    expect(dispatch).toHaveBeenCalledTimes(2);
+    expect(dispatch.mock.calls[0][0]).toEqual(
+      ShareActions.discardSharedWithMe({
+        resourceIds: ['folder-a/'],
+        featureType: FeatureType.File,
+        isFolder: true,
+      }),
+    );
+    expect(dispatch.mock.calls[1][0]).toEqual(
+      ShareActions.discardSharedWithMe({
+        resourceIds: ['files/bucket/file.txt'],
+        featureType: FeatureType.File,
+        isFolder: false,
+      }),
+    );
+
+    dispatch.mockClear();
+    dispatchRevokeAccessForDialItems(dispatch, items);
+    expect(dispatch).toHaveBeenCalledTimes(2);
+    expect(dispatch.mock.calls[0][0]).toEqual(
+      ShareActions.revokeAccess({
+        resourceIds: ['folder-a/'],
+        featureType: FeatureType.File,
+        isFolder: true,
+      }),
+    );
+    expect(dispatch.mock.calls[1][0]).toEqual(
+      ShareActions.revokeAccess({
+        resourceIds: ['files/bucket/file.txt'],
+        featureType: FeatureType.File,
+        isFolder: false,
+      }),
+    );
+  });
+
+  it('dispatchFileManagerUnshareFromEnrichedItems sends discard for sharedWithMe and revoke for isShared', () => {
+    const dispatch = vi.fn();
+
+    dispatchFileManagerUnshareFromEnrichedItems(dispatch, [
+      {
+        path: 'files/bucket/a.txt',
+        nodeType: DialFileNodeType.ITEM,
+        sharedWithMe: true,
+        isShared: false,
+      },
+      {
+        path: 'files/bucket/b.txt',
+        nodeType: DialFileNodeType.ITEM,
+        sharedWithMe: false,
+        isShared: true,
+      },
+    ]);
+
+    expect(dispatch).toHaveBeenCalledTimes(2);
+    expect(dispatch.mock.calls[0][0]).toEqual(
+      ShareActions.discardSharedWithMe({
+        resourceIds: ['files/bucket/a.txt'],
+        featureType: FeatureType.File,
+        isFolder: false,
+      }),
+    );
+    expect(dispatch.mock.calls[1][0]).toEqual(
+      ShareActions.revokeAccess({
+        resourceIds: ['files/bucket/b.txt'],
+        featureType: FeatureType.File,
+        isFolder: false,
+      }),
+    );
+  });
+
+  it('enrichUnshareFileManagerItems applies source defaults and store entity flags', () => {
+    const empty = rootStateWithEntities([], []);
+
+    expect(
+      enrichUnshareFileManagerItems(empty, [{ path: 'x' }], 'unshare-files'),
+    ).toEqual([{ path: 'x', sharedWithMe: true, isShared: false }]);
+    expect(
+      enrichUnshareFileManagerItems(empty, [{ path: 'y' }], 'remove-access'),
+    ).toEqual([{ path: 'y', sharedWithMe: false, isShared: true }]);
+
+    const file = {
+      id: 'files/bucket/f.txt',
+      name: 'f.txt',
+      folderId: 'files/bucket',
+      sharedWithMe: true,
+      isShared: true,
+    } as DialFile;
+    const folder = {
+      id: 'files/bucket/sub/',
+      name: 'sub',
+      folderId: 'files/bucket',
+      sharedWithMe: false,
+      isShared: false,
+    } as FileFolderInterface;
+
+    const state = rootStateWithEntities([file], [folder]);
+
+    expect(
+      enrichUnshareFileManagerItems(
+        state,
+        [{ path: file.id, nodeType: DialFileNodeType.ITEM }],
+        'unshare-files',
+      ),
+    ).toEqual([
+      {
+        path: file.id,
+        nodeType: DialFileNodeType.ITEM,
+        sharedWithMe: true,
+        isShared: true,
+      },
+    ]);
+
+    expect(
+      enrichUnshareFileManagerItems(
+        state,
+        [{ path: folder.id, nodeType: DialFileNodeType.FOLDER }],
+        'remove-access',
+      ),
+    ).toEqual([
+      {
+        path: folder.id,
+        nodeType: DialFileNodeType.FOLDER,
+        sharedWithMe: false,
+        isShared: false,
+      },
+    ]);
+  });
+
+  it('dispatchOpenFileManagerUnshareDialog no-ops when empty and dispatches setUnshareFileManagerItems (unshare-files vs remove-access)', () => {
+    const dispatch = vi.fn();
+    const getState = () => rootStateWithEntities([], []);
+
+    dispatchOpenFileManagerUnshareDialog(
+      dispatch,
+      getState,
+      [],
+      'unshare-files',
+    );
+    expect(dispatch).not.toHaveBeenCalled();
+
+    dispatchOpenFileManagerUnshareDialog(
+      dispatch,
+      getState,
+      [{ path: 'only-path' }],
+      'unshare-files',
+    );
+    expect(dispatch).toHaveBeenCalledWith(
+      ShareActions.setUnshareFileManagerItems([
+        { path: 'only-path', sharedWithMe: true, isShared: false },
+      ]),
+    );
+
+    dispatch.mockClear();
+    dispatchOpenFileManagerUnshareDialog(
+      dispatch,
+      getState,
+      [{ path: 'revoke-path' }],
+      'remove-access',
+    );
+    expect(dispatch).toHaveBeenCalledWith(
+      ShareActions.setUnshareFileManagerItems([
+        { path: 'revoke-path', sharedWithMe: false, isShared: true },
+      ]),
+    );
+  });
+});

--- a/apps/chat/src/utils/app/__tests__/file-manager-unshare-dispatch.test.ts
+++ b/apps/chat/src/utils/app/__tests__/file-manager-unshare-dispatch.test.ts
@@ -8,27 +8,10 @@ import {
   enrichUnshareFileManagerItems,
 } from '@/src/utils/app/file-manager-unshare-dispatch';
 
-import type { DialFile, FileFolderInterface } from '@/src/types/files';
-import type { RootState } from '@/src/types/store';
-
 import { ShareActions } from '@/src/store/actions';
-import { filesSlice } from '@/src/store/files/files.reducers';
 
 import { FeatureType } from '@epam/ai-dial-shared';
 import { DialFileNodeType } from '@epam/ai-dial-ui-kit';
-
-function rootStateWithEntities(
-  files: DialFile[],
-  folders: FileFolderInterface[],
-): RootState {
-  return {
-    files: {
-      ...filesSlice.getInitialState(),
-      files,
-      folders,
-    },
-  } as unknown as RootState;
-}
 
 describe('file-manager-unshare-dispatch', () => {
   it('dispatchDiscardSharedWithMeForDialItems and dispatchRevokeAccessForDialItems no-op when empty and group folders vs files', () => {
@@ -114,98 +97,95 @@ describe('file-manager-unshare-dispatch', () => {
     );
   });
 
-  it('enrichUnshareFileManagerItems applies source defaults and store entity flags', () => {
-    const empty = rootStateWithEntities([], []);
+  it('enrichUnshareFileManagerItems maps paths and applies source flags only', () => {
+    expect(enrichUnshareFileManagerItems([], 'unshare-files')).toEqual([]);
 
     expect(
-      enrichUnshareFileManagerItems(empty, [{ path: 'x' }], 'unshare-files'),
-    ).toEqual([{ path: 'x', sharedWithMe: true, isShared: false }]);
-    expect(
-      enrichUnshareFileManagerItems(empty, [{ path: 'y' }], 'remove-access'),
-    ).toEqual([{ path: 'y', sharedWithMe: false, isShared: true }]);
-
-    const file = {
-      id: 'files/bucket/f.txt',
-      name: 'f.txt',
-      folderId: 'files/bucket',
-      sharedWithMe: true,
-      isShared: true,
-    } as DialFile;
-    const folder = {
-      id: 'files/bucket/sub/',
-      name: 'sub',
-      folderId: 'files/bucket',
-      sharedWithMe: false,
-      isShared: false,
-    } as FileFolderInterface;
-
-    const state = rootStateWithEntities([file], [folder]);
-
-    expect(
-      enrichUnshareFileManagerItems(
-        state,
-        [{ path: file.id, nodeType: DialFileNodeType.ITEM }],
-        'unshare-files',
-      ),
+      enrichUnshareFileManagerItems([{ path: 'x' }], 'unshare-files'),
     ).toEqual([
       {
-        path: file.id,
-        nodeType: DialFileNodeType.ITEM,
+        path: 'x',
+        nodeType: undefined,
         sharedWithMe: true,
+        isShared: false,
+      },
+    ]);
+    expect(
+      enrichUnshareFileManagerItems([{ path: 'y' }], 'remove-access'),
+    ).toEqual([
+      {
+        path: 'y',
+        nodeType: undefined,
+        sharedWithMe: false,
         isShared: true,
       },
     ]);
 
     expect(
       enrichUnshareFileManagerItems(
-        state,
-        [{ path: folder.id, nodeType: DialFileNodeType.FOLDER }],
+        [{ path: 'files/bucket/f.txt', nodeType: DialFileNodeType.ITEM }],
+        'unshare-files',
+      ),
+    ).toEqual([
+      {
+        path: 'files/bucket/f.txt',
+        nodeType: DialFileNodeType.ITEM,
+        sharedWithMe: true,
+        isShared: false,
+      },
+    ]);
+
+    expect(
+      enrichUnshareFileManagerItems(
+        [{ path: 'files/bucket/sub/', nodeType: DialFileNodeType.FOLDER }],
         'remove-access',
       ),
     ).toEqual([
       {
-        path: folder.id,
+        path: 'files/bucket/sub/',
         nodeType: DialFileNodeType.FOLDER,
         sharedWithMe: false,
-        isShared: false,
+        isShared: true,
       },
     ]);
   });
 
   it('dispatchOpenFileManagerUnshareDialog no-ops when empty and dispatches setUnshareFileManagerItems (unshare-files vs remove-access)', () => {
     const dispatch = vi.fn();
-    const getState = () => rootStateWithEntities([], []);
 
-    dispatchOpenFileManagerUnshareDialog(
-      dispatch,
-      getState,
-      [],
-      'unshare-files',
-    );
+    dispatchOpenFileManagerUnshareDialog(dispatch, [], 'unshare-files');
     expect(dispatch).not.toHaveBeenCalled();
 
     dispatchOpenFileManagerUnshareDialog(
       dispatch,
-      getState,
       [{ path: 'only-path' }],
       'unshare-files',
     );
     expect(dispatch).toHaveBeenCalledWith(
       ShareActions.setUnshareFileManagerItems([
-        { path: 'only-path', sharedWithMe: true, isShared: false },
+        {
+          path: 'only-path',
+          nodeType: undefined,
+          sharedWithMe: true,
+          isShared: false,
+        },
       ]),
     );
 
     dispatch.mockClear();
     dispatchOpenFileManagerUnshareDialog(
       dispatch,
-      getState,
       [{ path: 'revoke-path' }],
       'remove-access',
     );
     expect(dispatch).toHaveBeenCalledWith(
       ShareActions.setUnshareFileManagerItems([
-        { path: 'revoke-path', sharedWithMe: false, isShared: true },
+        {
+          path: 'revoke-path',
+          nodeType: undefined,
+          sharedWithMe: false,
+          isShared: true,
+        },
       ]),
     );
   });

--- a/apps/chat/src/utils/app/file-manager-unshare-dispatch.ts
+++ b/apps/chat/src/utils/app/file-manager-unshare-dispatch.ts
@@ -1,0 +1,136 @@
+import type { RootState } from '@/src/types/store';
+
+import { ShareActions } from '@/src/store/actions';
+import { FilesSelectors } from '@/src/store/files/files.selectors';
+import type { UnshareFileManagerItem } from '@/src/store/share/share.types';
+
+import type { AppDispatch } from '@/src/store';
+import { FeatureType } from '@epam/ai-dial-shared';
+import { DialFileNodeType } from '@epam/ai-dial-ui-kit';
+import groupBy from 'lodash-es/groupBy';
+
+export type FileManagerUnshareDialogSource = 'unshare-files' | 'remove-access';
+
+export function enrichUnshareFileManagerItems(
+  state: RootState,
+  items: { path: string; nodeType?: string }[],
+  source: FileManagerUnshareDialogSource,
+): UnshareFileManagerItem[] {
+  return items.map((item) => {
+    const isFolder = item.nodeType === DialFileNodeType.FOLDER;
+    const entity = isFolder
+      ? FilesSelectors.selectFolderById(state, item.path)
+      : FilesSelectors.selectFileById(state, item.path);
+
+    return {
+      path: item.path,
+      nodeType: item.nodeType,
+      sharedWithMe:
+        entity?.sharedWithMe ?? (source === 'unshare-files' ? true : false),
+      isShared: entity?.isShared ?? (source === 'remove-access' ? true : false),
+    };
+  });
+}
+
+export function dispatchOpenFileManagerUnshareDialog(
+  dispatch: AppDispatch,
+  getState: () => RootState,
+  items: { path: string; nodeType?: string }[],
+  source: FileManagerUnshareDialogSource,
+) {
+  if (!items.length) {
+    return;
+  }
+
+  dispatch(
+    ShareActions.setUnshareFileManagerItems(
+      enrichUnshareFileManagerItems(getState(), items, source),
+    ),
+  );
+}
+
+export type DialFileUnsharePathItem = {
+  path: string;
+  nodeType?: string;
+};
+
+export function dispatchDiscardSharedWithMeForDialItems(
+  dispatch: AppDispatch,
+  items: DialFileUnsharePathItem[],
+) {
+  if (!items.length) {
+    return;
+  }
+
+  const grouped = groupBy(items, (item) =>
+    item.nodeType === DialFileNodeType.FOLDER ? 'folders' : 'files',
+  );
+
+  if (grouped.folders?.length) {
+    dispatch(
+      ShareActions.discardSharedWithMe({
+        resourceIds: grouped.folders.map((f) => f.path),
+        featureType: FeatureType.File,
+        isFolder: true,
+      }),
+    );
+  }
+
+  if (grouped.files?.length) {
+    dispatch(
+      ShareActions.discardSharedWithMe({
+        resourceIds: grouped.files.map((f) => f.path),
+        featureType: FeatureType.File,
+        isFolder: false,
+      }),
+    );
+  }
+}
+
+export function dispatchRevokeAccessForDialItems(
+  dispatch: AppDispatch,
+  items: DialFileUnsharePathItem[],
+) {
+  if (!items.length) {
+    return;
+  }
+
+  const grouped = groupBy(items, (item) =>
+    item.nodeType === DialFileNodeType.FOLDER ? 'folders' : 'files',
+  );
+
+  if (grouped.folders?.length) {
+    dispatch(
+      ShareActions.revokeAccess({
+        resourceIds: grouped.folders.map(({ path }) => path),
+        featureType: FeatureType.File,
+        isFolder: true,
+      }),
+    );
+  }
+
+  if (grouped.files?.length) {
+    dispatch(
+      ShareActions.revokeAccess({
+        resourceIds: grouped.files.map(({ path }) => path),
+        featureType: FeatureType.File,
+        isFolder: false,
+      }),
+    );
+  }
+}
+
+export function dispatchFileManagerUnshareFromEnrichedItems(
+  dispatch: AppDispatch,
+  items: UnshareFileManagerItem[],
+) {
+  const discardItems = items
+    .filter((item) => item.sharedWithMe)
+    .map(({ path, nodeType }) => ({ path, nodeType }));
+  const revokeItems = items
+    .filter((item) => item.isShared)
+    .map(({ path, nodeType }) => ({ path, nodeType }));
+
+  dispatchDiscardSharedWithMeForDialItems(dispatch, discardItems);
+  dispatchRevokeAccessForDialItems(dispatch, revokeItems);
+}

--- a/apps/chat/src/utils/app/file-manager-unshare-dispatch.ts
+++ b/apps/chat/src/utils/app/file-manager-unshare-dispatch.ts
@@ -1,7 +1,4 @@
-import type { RootState } from '@/src/types/store';
-
 import { ShareActions } from '@/src/store/actions';
-import { FilesSelectors } from '@/src/store/files/files.selectors';
 import type { UnshareFileManagerItem } from '@/src/store/share/share.types';
 
 import type { AppDispatch } from '@/src/store';
@@ -12,29 +9,22 @@ import groupBy from 'lodash-es/groupBy';
 export type FileManagerUnshareDialogSource = 'unshare-files' | 'remove-access';
 
 export function enrichUnshareFileManagerItems(
-  state: RootState,
   items: { path: string; nodeType?: string }[],
   source: FileManagerUnshareDialogSource,
 ): UnshareFileManagerItem[] {
   return items.map((item) => {
-    const isFolder = item.nodeType === DialFileNodeType.FOLDER;
-    const entity = isFolder
-      ? FilesSelectors.selectFolderById(state, item.path)
-      : FilesSelectors.selectFileById(state, item.path);
-
     return {
       path: item.path,
       nodeType: item.nodeType,
-      sharedWithMe:
-        entity?.sharedWithMe ?? (source === 'unshare-files' ? true : false),
-      isShared: entity?.isShared ?? (source === 'remove-access' ? true : false),
+      sharedWithMe: source === 'unshare-files' ? true : false,
+      isShared: source === 'remove-access' ? true : false,
     };
   });
 }
 
 export function dispatchOpenFileManagerUnshareDialog(
   dispatch: AppDispatch,
-  getState: () => RootState,
+
   items: { path: string; nodeType?: string }[],
   source: FileManagerUnshareDialogSource,
 ) {
@@ -44,7 +34,7 @@ export function dispatchOpenFileManagerUnshareDialog(
 
   dispatch(
     ShareActions.setUnshareFileManagerItems(
-      enrichUnshareFileManagerItems(getState(), items, source),
+      enrichUnshareFileManagerItems(items, source),
     ),
   );
 }


### PR DESCRIPTION
**Description:**

- Fix confirmation dialog is not shown on attempt to unshare/remove access file.

Issues:

- Issue #5971 

**UI changes**

**Remove access:**
<img width="628" height="219" alt="image" src="https://github.com/user-attachments/assets/a71eb03b-c117-4f6e-a249-0da96ad9ccd6" />

**Unshare:**
<img width="627" height="218" alt="image" src="https://github.com/user-attachments/assets/59007c59-da80-440c-826b-51380a2db484" />


**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
