### PR TITLE
fix(chat): fix arrow is removed from shared folder when refresh page in `File Manager` (Issue #6303)

### DIFF
--- a/apps/chat/src/store/files/files.reducers.ts
+++ b/apps/chat/src/store/files/files.reducers.ts
@@ -69,6 +69,7 @@ const initialState: FilesState = {
   folders: [],
   selectedFilesIds: [],
   sharedFileIds: [],
+  sharedFolderIds: [],
 
   chosenFileIds: [],
   chosenEmptyFoldersIds: [],
@@ -463,8 +464,15 @@ export const filesSlice = createSlice({
           f.temporary,
       );
 
+      const sharedFolderIdSet = new Set(state.sharedFolderIds);
+      const foldersWithSharedFlag = payload.folders.map((folder) =>
+        sharedFolderIdSet.has(folder.id)
+          ? { ...folder, isShared: true }
+          : folder,
+      );
+
       state.folders = combineEntities(
-        payload.folders,
+        foldersWithSharedFlag,
         filteredState.map((f) =>
           f.id === payload.folderId ? { ...f, status: UploadStatus.LOADED } : f,
         ),
@@ -711,6 +719,27 @@ export const filesSlice = createSlice({
       }>,
     ) => {
       state.sharedFileIds = payload.ids;
+    },
+    setSharedFolderIds: (
+      state,
+      {
+        payload,
+      }: PayloadAction<{
+        ids: string[];
+      }>,
+    ) => {
+      const prevSet = new Set(state.sharedFolderIds);
+      const nextSet = new Set(payload.ids);
+      state.sharedFolderIds = payload.ids;
+      state.folders = state.folders.map((folder) => {
+        if (nextSet.has(folder.id)) {
+          return { ...folder, isShared: true };
+        }
+        if (prevSet.has(folder.id) && !nextSet.has(folder.id)) {
+          return { ...folder, isShared: false };
+        }
+        return folder;
+      });
     },
     addSharedFiles: (
       state,

--- a/apps/chat/src/store/files/files.types.ts
+++ b/apps/chat/src/store/files/files.types.ts
@@ -24,6 +24,7 @@ export interface FilesState {
   newAddedFolderId?: string;
   lastRenamedParentFolder?: { oldId: string; newId: string };
   sharedFileIds: string[];
+  sharedFolderIds: string[];
 
   loadingFileMetadata: boolean;
   fileMetadata: UIKitDialFile | null;

--- a/apps/chat/src/store/share/share.epics.ts
+++ b/apps/chat/src/store/share/share.epics.ts
@@ -975,6 +975,12 @@ const getSharedListingSuccessEpic: AppEpic = (action$, state$) =>
           );
 
           actions.push(
+            FilesActions.setSharedFolderIds({
+              ids: payload.resources.folders.map((folder) => folder.id),
+            }),
+          );
+
+          actions.push(
             ...(payload.resources.folders
               .map((item) => {
                 const isShared = folders.find((res) => res.id === item.id);


### PR DESCRIPTION
**Description:**

- Fix arrow is removed from shared folder when refresh page in `File Manager`

Issues:

- Issue #6303 


**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
