### PR TITLE
fix(chat): hide review tab for not admin, show document urls in review for admin (Issues #6373, #6387)

### DIFF
--- a/apps/chat/src/components/AppsEditor/EditorForm/QuickApp2Form/QuickApp2Form.tsx
+++ b/apps/chat/src/components/AppsEditor/EditorForm/QuickApp2Form/QuickApp2Form.tsx
@@ -8,12 +8,18 @@ import {
 
 import classNames from 'classnames';
 
+import { useIsPublicationReview } from '@/src/hooks/useIsPublicationReview';
 import { useTranslation } from '@/src/hooks/useTranslation';
 
-import { getSharedTooltip } from '@/src/utils/app/application';
+import {
+  getQuickApp2Config,
+  getSharedTooltip,
+} from '@/src/utils/app/application';
+import { getFilesAndFoldersFromUrls } from '@/src/utils/app/file';
 import { doesModelAllowTemperature } from '@/src/utils/app/models';
 import { isEntityIdPublic } from '@/src/utils/app/publications';
 
+import { FileSourceType } from '@/src/types/files';
 import { Translation } from '@/src/types/translation';
 
 import { useAppSelector } from '@/src/store/hooks';
@@ -56,6 +62,7 @@ import { MultipleComboBox } from '@/src/components/Common/MultipleComboBox';
 import { ToggleSwitch } from '@/src/components/Common/ToggleSwitch/ToggleSwitch';
 import { ToolsetLinkButton } from '@/src/components/Marketplace/ToolsetLinkButton';
 
+import { FeatureType, UploadStatus } from '@epam/ai-dial-shared';
 import uniq from 'lodash-es/uniq';
 
 const FilesSelectorField = withErrorMessage(withLabel(FilesSelector));
@@ -67,6 +74,13 @@ const StartersBehaviourField = withLabel(StartersBehaviourRadioGroup);
 const ToggleSwitchField = withLabel(ToggleSwitch);
 const CopyUrlButton = withLabel(ToolsetLinkButton);
 
+const adminFilesFilter = new Set([
+  FileSourceType.MY_FILES,
+  FileSourceType.SHARED_WITH_ME,
+  FileSourceType.PUBLIC,
+  FileSourceType.REVIEW_FILES,
+]);
+
 const getItemLabel = (item: unknown): string => item as string;
 
 interface AppsEditorProps {
@@ -76,6 +90,7 @@ interface AppsEditorProps {
 export const QuickApp2Form: FC<AppsEditorProps> = ({ onAutoSave }) => {
   const { t } = useTranslation(Translation.Marketplace);
 
+  const isPublicationReview = useIsPublicationReview();
   const appDetails = useAppSelector(
     ApplicationSelectors.selectApplicationDetail,
   );
@@ -115,6 +130,17 @@ export const QuickApp2Form: FC<AppsEditorProps> = ({ onAutoSave }) => {
     : !hasStarters
       ? t(MarketplaceI18nKeys.AtLeastOneStarterIsRequiredToEnableSettings)
       : '';
+  const filesFilter = isPublicationReview ? adminFilesFilter : undefined;
+
+  const reviewFilesAndFolders = useMemo(() => {
+    if (!isPublicationReview || !appDetails) return undefined;
+
+    return getFilesAndFoldersFromUrls(
+      getQuickApp2Config(appDetails).contexts.map(({ url }) => url),
+      FeatureType.File,
+      UploadStatus.LOADED,
+    );
+  }, [appDetails, isPublicationReview]);
 
   return (
     <div
@@ -210,6 +236,8 @@ export const QuickApp2Form: FC<AppsEditorProps> = ({ onAutoSave }) => {
                 appDetails?.isShared ? CONFIRM_DOCUMENT_VALUES : undefined
               }
               tooltip={isAppPublicTooltip}
+              filesFilter={filesFilter}
+              additionalFilesAndFolders={reviewFilesAndFolders}
             />
           )}
         />

--- a/apps/chat/src/components/Common/FilesSelector/FilesSelector.tsx
+++ b/apps/chat/src/components/Common/FilesSelector/FilesSelector.tsx
@@ -4,7 +4,7 @@ import React, { MouseEvent, useCallback, useState } from 'react';
 import { useTranslation } from '@/src/hooks/useTranslation';
 
 import { ConfirmDialogValueTypes } from '@/src/types/common';
-import { FileSourceType } from '@/src/types/files';
+import { DialFile, FileSourceType } from '@/src/types/files';
 import { Translation } from '@/src/types/translation';
 
 import { FilesI18nKeys } from '@/src/constants/i18n';
@@ -16,6 +16,7 @@ import { ConfirmDialog } from '../ConfirmDialog';
 import { NoFiles } from './NoFiles';
 import { SelectedFile } from './SelectedFile';
 
+import { FolderInterface } from '@epam/ai-dial-shared';
 import { DialLinkButton } from '@epam/ai-dial-ui-kit';
 
 interface Props {
@@ -29,6 +30,10 @@ interface Props {
   tooltip?: string;
   onRemoveFile?: (document: string) => void;
   onAddFiles?: (documents: string[]) => void;
+  additionalFilesAndFolders?: {
+    files: DialFile[];
+    folders?: FolderInterface[];
+  };
 }
 
 export const FilesSelector: React.FC<Props> = ({
@@ -42,6 +47,7 @@ export const FilesSelector: React.FC<Props> = ({
   tooltip,
   onAddFiles,
   onRemoveFile,
+  additionalFilesAndFolders,
 }) => {
   const { t } = useTranslation(Translation.Files);
 
@@ -142,6 +148,7 @@ export const FilesSelector: React.FC<Props> = ({
             forceShowSelectCheckBox
             sourceFilters={filesFilter}
             warningMessage={confirmDialogValues?.description}
+            additionalFilesAndFolders={additionalFilesAndFolders}
           />
         )}
         {confirmDialogValues && confirmDialogOpen && (

--- a/apps/chat/src/components/FileManager/hooks/useFileManager.tsx
+++ b/apps/chat/src/components/FileManager/hooks/useFileManager.tsx
@@ -25,6 +25,7 @@ import { hasWritePermission } from '@/src/utils/app/share';
 import { getEntityBucket } from '@/src/utils/app/shared-utils';
 import { translate } from '@/src/utils/app/translation';
 
+import { DialFile as LocalDialFileType } from '@/src/types/files';
 import { RootState } from '@/src/types/store';
 import { Translation } from '@/src/types/translation';
 
@@ -50,7 +51,11 @@ import {
 
 import { FilesUploadingModalOptions } from '../FilesUploadingModal';
 
-import { FeatureType, UploadStatus } from '@epam/ai-dial-shared';
+import {
+  FeatureType,
+  FolderInterface,
+  UploadStatus,
+} from '@epam/ai-dial-shared';
 import {
   ButtonVariant,
   DialCopiedItem,
@@ -65,6 +70,7 @@ import {
 } from '@epam/ai-dial-ui-kit';
 import cloneDeep from 'lodash-es/cloneDeep';
 import groupBy from 'lodash-es/groupBy';
+import uniqBy from 'lodash-es/uniqBy';
 
 const formatSharedPath = (path: string | undefined | null) => {
   if (!path) return path;
@@ -126,6 +132,10 @@ interface UseFileManagerOptions {
   toolbarOptions?: ToolbarOptions;
   availableTabs?: Set<string>;
   reviewBucket?: string;
+  additionalFilesAndFolders?: {
+    files: LocalDialFileType[];
+    folders?: FolderInterface[];
+  };
 }
 
 export const useFileManager = ({
@@ -133,6 +143,7 @@ export const useFileManager = ({
   toolbarOptions: externalToolbarOptions,
   availableTabs = defaultAvailableTabs,
   reviewBucket,
+  additionalFilesAndFolders,
 }: UseFileManagerOptions = {}) => {
   const dispatch = useAppDispatch();
 
@@ -156,8 +167,22 @@ export const useFileManager = ({
   const prevIsMovingRef = useRef(false);
 
   const fileMetadata = useAppSelector(FilesSelectors.selectFileMetadata);
-  const files = useAppSelector(FilesSelectors.selectFiles);
-  const folders = useAppSelector(FilesSelectors.selectFolders);
+  const _files = useAppSelector(FilesSelectors.selectFiles);
+  const _folders = useAppSelector(FilesSelectors.selectFolders);
+
+  const files = useMemo(
+    () =>
+      uniqBy([..._files, ...(additionalFilesAndFolders?.files ?? [])], 'id'),
+    [_files, additionalFilesAndFolders?.files],
+  );
+  const folders = useMemo(
+    () =>
+      uniqBy(
+        [..._folders, ...(additionalFilesAndFolders?.folders ?? [])],
+        'id',
+      ),
+    [_folders, additionalFilesAndFolders?.folders],
+  );
 
   const sharedWithMeIds = useAppSelector(
     FilesSelectors.selectSharedWithMeFilesAndFoldersIds,

--- a/apps/chat/src/components/FileManager/hooks/useFileManager.tsx
+++ b/apps/chat/src/components/FileManager/hooks/useFileManager.tsx
@@ -115,6 +115,12 @@ const dateOptions = {
   day: '2-digit' as const,
 };
 
+const defaultAvailableTabs = new Set([
+  DialFileManagerTabs.MyFiles,
+  DialFileManagerTabs.Shared,
+  DialFileManagerTabs.Organization,
+]);
+
 interface UseFileManagerOptions {
   actionLabelsOptions?: UseFileManagerActionLabelsOptions;
   toolbarOptions?: ToolbarOptions;
@@ -125,7 +131,7 @@ interface UseFileManagerOptions {
 export const useFileManager = ({
   actionLabelsOptions,
   toolbarOptions: externalToolbarOptions,
-  availableTabs,
+  availableTabs = defaultAvailableTabs,
   reviewBucket,
 }: UseFileManagerOptions = {}) => {
   const dispatch = useAppDispatch();

--- a/apps/chat/src/components/Files/AttachButton.tsx
+++ b/apps/chat/src/components/Files/AttachButton.tsx
@@ -8,6 +8,7 @@ import {
 } from '@tabler/icons-react';
 import { JSX, useCallback, useMemo, useState } from 'react';
 
+import { useIsPublicationReview } from '@/src/hooks/useIsPublicationReview';
 import { useTranslation } from '@/src/hooks/useTranslation';
 
 import { getQuickAttachmentsSavingPath } from '@/src/utils/app/conversation';
@@ -18,12 +19,7 @@ import { DisplayMenuItemProps } from '@/src/types/menu';
 import { Translation } from '@/src/types/translation';
 
 import { useAppSelector } from '@/src/store/hooks';
-import {
-  AuthSelectors,
-  ConversationsSelectors,
-  ModelsSelectors,
-  PublicationSelectors,
-} from '@/src/store/selectors';
+import { ConversationsSelectors, ModelsSelectors } from '@/src/store/selectors';
 
 import { ChatI18nKeys } from '@/src/constants/i18n';
 import { DEFAULT_ICON_SIZES } from '@/src/constants/icons';
@@ -65,14 +61,6 @@ export const AttachButton = ({
   onAddLinkToMessage,
 }: Props) => {
   const { t } = useTranslation(Translation.Chat);
-
-  const selectedConversationIds = useAppSelector(
-    ConversationsSelectors.selectSelectedConversationsIds,
-  );
-  const resourcesToReview = useAppSelector(
-    PublicationSelectors.selectResourcesToReview,
-  );
-  const isAdmin = useAppSelector(AuthSelectors.selectIsAdmin);
   const messageIsStreaming = useAppSelector(
     ConversationsSelectors.selectIsConversationsStreaming,
   );
@@ -92,6 +80,8 @@ export const AttachButton = ({
   const canAttachLinks = useAppSelector(
     ConversationsSelectors.selectCanAttachLink,
   );
+
+  const isPublicationReview = useIsPublicationReview();
 
   const [isPreUploadDialogOpened, setIsPreUploadDialogOpened] = useState(false);
   const [isSelectFilesDialogOpened, setIsSelectFilesDialogOpened] =
@@ -122,16 +112,9 @@ export const AttachButton = ({
     [onSelectAlreadyUploaded],
   );
 
-  const isApproveRequiredEntity = useMemo(
-    () =>
-      resourcesToReview.some((r) =>
-        selectedConversationIds.includes(r.reviewUrl),
-      ),
-    [resourcesToReview, selectedConversationIds],
-  );
-
-  const sourceFilters =
-    isApproveRequiredEntity && isAdmin ? reviewFilesFilter : defaultFilesFilter;
+  const sourceFilters = isPublicationReview
+    ? reviewFilesFilter
+    : defaultFilesFilter;
 
   const menuItems: DisplayMenuItemProps[] = useMemo(
     () =>

--- a/apps/chat/src/components/Files/FileManagerModal.tsx
+++ b/apps/chat/src/components/Files/FileManagerModal.tsx
@@ -13,7 +13,7 @@ import {
 import { isParentFolderSelected } from '@/src/utils/app/folders';
 import { isHiddenEntity } from '@/src/utils/app/search';
 
-import { FileSourceType } from '@/src/types/files';
+import { DialFile, FileSourceType } from '@/src/types/files';
 import { ModalState } from '@/src/types/modal';
 import { ToastType } from '@/src/types/toasts';
 import { Translation } from '@/src/types/translation';
@@ -31,6 +31,7 @@ import { Modal } from '@/src/components/Common/Modal';
 import { FilesUploadingModal } from '@/src/components/FileManager/FilesUploadingModal';
 import { OperationLoaderModal } from '@/src/components/FileManager/OperationLoaderModal';
 
+import { FolderInterface } from '@epam/ai-dial-shared';
 import {
   ButtonVariant,
   DialFileAcceptType,
@@ -55,6 +56,10 @@ interface Props {
   sourceFilters?: Set<FileSourceType>;
   warningMessage?: string;
   maxSelectableFileSize?: number;
+  additionalFilesAndFolders?: {
+    files: DialFile[];
+    folders?: FolderInterface[];
+  };
 }
 
 export const FileManagerModal = memo(
@@ -72,6 +77,7 @@ export const FileManagerModal = memo(
     sourceFilters,
     warningMessage,
     maxSelectableFileSize,
+    additionalFilesAndFolders,
   }: Props) => {
     const dispatch = useAppDispatch();
     const { t } = useTranslation(Translation.Chat);
@@ -325,6 +331,7 @@ export const FileManagerModal = memo(
       },
       availableTabs,
       reviewBucket,
+      additionalFilesAndFolders,
     });
 
     return (

--- a/apps/chat/src/hooks/useIsPublicationReview.ts
+++ b/apps/chat/src/hooks/useIsPublicationReview.ts
@@ -1,0 +1,34 @@
+import { useMemo } from 'react';
+
+import { AuthSelectors } from '@/src/store/auth/auth.selectors';
+import { ConversationsSelectors } from '@/src/store/conversations/conversations.selectors';
+import { useAppSelector } from '@/src/store/hooks';
+import { PublicationSelectors } from '@/src/store/publication/publication.selectors';
+import { ApplicationSelectors, ToolsetSelectors } from '@/src/store/selectors';
+
+export const useIsPublicationReview = () => {
+  const isAdmin = useAppSelector(AuthSelectors.selectIsAdmin);
+  const resourcesToReview = useAppSelector(
+    PublicationSelectors.selectResourcesToReview,
+  );
+  const selectedConversationIds = useAppSelector(
+    ConversationsSelectors.selectSelectedConversationsIds,
+  );
+  const application = useAppSelector(
+    ApplicationSelectors.selectApplicationDetail,
+  );
+  const toolset = useAppSelector(ToolsetSelectors.selectToolsetDetails);
+
+  const isReviewEntity = useMemo(
+    () =>
+      resourcesToReview.some(
+        (r) =>
+          selectedConversationIds.includes(r.reviewUrl) ||
+          application?.id === r.reviewUrl ||
+          toolset?.id === r.reviewUrl,
+      ),
+    [application?.id, resourcesToReview, selectedConversationIds, toolset?.id],
+  );
+
+  return isAdmin && isReviewEntity;
+};

--- a/apps/chat/src/utils/app/file.ts
+++ b/apps/chat/src/utils/app/file.ts
@@ -44,6 +44,7 @@ import {
 } from '@epam/ai-dial-ui-kit';
 import escapeRegExp from 'lodash-es/escapeRegExp';
 import uniq from 'lodash-es/uniq';
+import uniqBy from 'lodash-es/uniqBy';
 import { extensions, lookup } from 'mime-types';
 
 export function triggerDownload(url: string, name: string): void {
@@ -240,7 +241,7 @@ export const getFilesWithInvalidFileSize = (
   return files.filter((file) => file.size > sizeLimit);
 };
 
-const parseAttachmentUrl = (url: string) => {
+export const parseAttachmentUrl = (url: string) => {
   const decodedUrl = ApiUtils.decodeApiUrl(url);
   const lastIndexSlash = decodedUrl.lastIndexOf('/');
 
@@ -633,4 +634,45 @@ export const getRootFolderPlaceholderName = (bucket: string): string => {
   }
 
   return translate(ChatI18nKeys.SharedWithMeFiles, { ns: Translation.Chat });
+};
+
+export const getFilesAndFoldersFromUrls = (
+  urls: string[],
+  featureType: FeatureType,
+  uploadStatus?: UploadStatus,
+) => {
+  const files: DialFile[] = [];
+  const folders: FolderInterface[] = [];
+
+  urls.forEach((url) => {
+    const { absolutePath, name } = parseAttachmentUrl(url);
+
+    files.push({
+      id: url,
+      name,
+      contentType: getMimeTypeByFileName(name),
+      folderId: absolutePath,
+      absolutePath,
+    } as DialFile);
+
+    const {
+      apiKey,
+      bucket,
+      name: folderName,
+      parentPath,
+    } = splitEntityId(absolutePath);
+
+    folders.push({
+      id: absolutePath,
+      name: folderName,
+      type: featureType,
+      folderId: constructPath(apiKey, bucket, parentPath),
+      status: uploadStatus,
+    });
+  });
+
+  return {
+    files: uniqBy(files, 'id'),
+    folders: uniqBy(folders, 'id'),
+  };
 };


### PR DESCRIPTION
**Description:**

- hide review tab by default
- show document relative url files in review tab for publishing application

Issues:

- Issue #6373 
- Issue #6387 

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
