### PR TITLE
fix(chat): show copy url button only for agents that support mcp (Issue #6383)

### DIFF
--- a/apps/chat/src/components/AppsEditor/EditorForm/CodeAppForm.tsx
+++ b/apps/chat/src/components/AppsEditor/EditorForm/CodeAppForm.tsx
@@ -12,6 +12,7 @@ import { useTranslation } from '@/src/hooks/useTranslation';
 
 import { getSharedTooltip } from '@/src/utils/app/application';
 import { castToString } from '@/src/utils/app/common';
+import { doesAgentSupportMcp } from '@/src/utils/app/models';
 import { isEntityIdPublic } from '@/src/utils/app/publications';
 
 import { FileFolderInterface } from '@/src/types/files';
@@ -220,10 +221,12 @@ export const CodeAppForm = () => {
         tooltip={isAppPublic ? PUBLIC_APP_TOOLTIP : ''}
       />
 
-      <CopyUrlButton
-        id={appDetails?.id ?? ''}
-        label={t(CommonI18nKeys.CopyApplicationEndpointURL)}
-      />
+      {doesAgentSupportMcp(appDetails) && (
+        <CopyUrlButton
+          id={appDetails.id}
+          label={t(CommonI18nKeys.CopyApplicationEndpointURL)}
+        />
+      )}
     </div>
   );
 };

--- a/apps/chat/src/components/AppsEditor/EditorForm/CustomAppForm.tsx
+++ b/apps/chat/src/components/AppsEditor/EditorForm/CustomAppForm.tsx
@@ -11,6 +11,7 @@ import classNames from 'classnames';
 import { usePreventSpaceHandlers } from '@/src/hooks/usePreventSpaceHandlers';
 import { useTranslation } from '@/src/hooks/useTranslation';
 
+import { doesAgentSupportMcp } from '@/src/utils/app/models';
 import { isEntityIdPublic } from '@/src/utils/app/publications';
 
 import { Translation } from '@/src/types/translation';
@@ -142,10 +143,12 @@ export const CustomAppForm = () => {
         tooltip={isAppPublic ? PUBLIC_APP_TOOLTIP : ''}
       />
 
-      <CopyUrlButton
-        id={appDetails?.id ?? ''}
-        label={t(CommonI18nKeys.CopyApplicationEndpointURL)}
-      />
+      {doesAgentSupportMcp(appDetails) && (
+        <CopyUrlButton
+          id={appDetails.id}
+          label={t(CommonI18nKeys.CopyApplicationEndpointURL)}
+        />
+      )}
     </div>
   );
 };

--- a/apps/chat/src/components/AppsEditor/EditorForm/ExternalAppForm.tsx
+++ b/apps/chat/src/components/AppsEditor/EditorForm/ExternalAppForm.tsx
@@ -4,6 +4,7 @@ import { useFormContext, useFormState, useWatch } from 'react-hook-form';
 import { usePreventSpaceHandlers } from '@/src/hooks/usePreventSpaceHandlers';
 import { useTranslation } from '@/src/hooks/useTranslation';
 
+import { doesAgentSupportMcp } from '@/src/utils/app/models';
 import { isEntityIdPublic } from '@/src/utils/app/publications';
 
 import { Translation } from '@/src/types/translation';
@@ -73,10 +74,12 @@ export const ExternalAppForm = () => {
         tooltip={isAppPublic ? PUBLIC_APP_TOOLTIP : ''}
       />
 
-      <CopyUrlButton
-        id={appDetails?.id ?? ''}
-        label={t(CommonI18nKeys.CopyApplicationEndpointURL)}
-      />
+      {doesAgentSupportMcp(appDetails) && (
+        <CopyUrlButton
+          id={appDetails.id}
+          label={t(CommonI18nKeys.CopyApplicationEndpointURL)}
+        />
+      )}
     </div>
   );
 };

--- a/apps/chat/src/components/AppsEditor/EditorForm/QuickApp2Form/QuickApp2Form.tsx
+++ b/apps/chat/src/components/AppsEditor/EditorForm/QuickApp2Form/QuickApp2Form.tsx
@@ -16,7 +16,10 @@ import {
   getSharedTooltip,
 } from '@/src/utils/app/application';
 import { getFilesAndFoldersFromUrls } from '@/src/utils/app/file';
-import { doesModelAllowTemperature } from '@/src/utils/app/models';
+import {
+  doesAgentSupportMcp,
+  doesModelAllowTemperature,
+} from '@/src/utils/app/models';
 import { isEntityIdPublic } from '@/src/utils/app/publications';
 
 import { FileSourceType } from '@/src/types/files';
@@ -378,15 +381,17 @@ export const QuickApp2Form: FC<AppsEditorProps> = ({ onAutoSave }) => {
         </div>
       </FormCollapsibleSection>
 
-      <div className="flex flex-col gap-4 px-5 py-4">
-        <h5 className="text-base font-semibold text-primary">
-          {t(CommonI18nKeys.ConnectApplication)}
-        </h5>
-        <CopyUrlButton
-          id={appDetails?.id ?? ''}
-          label={t(CommonI18nKeys.CopyApplicationEndpointURL)}
-        />
-      </div>
+      {doesAgentSupportMcp(appDetails) && (
+        <div className="flex flex-col gap-4 px-5 py-4">
+          <h5 className="text-base font-semibold text-primary">
+            {t(CommonI18nKeys.ConnectApplication)}
+          </h5>
+          <CopyUrlButton
+            id={appDetails.id}
+            label={t(CommonI18nKeys.CopyApplicationEndpointURL)}
+          />
+        </div>
+      )}
     </div>
   );
 };

--- a/apps/chat/src/components/AppsEditor/EditorForm/QuickAppForm.tsx
+++ b/apps/chat/src/components/AppsEditor/EditorForm/QuickAppForm.tsx
@@ -9,6 +9,7 @@ import {
 import { useTranslation } from '@/src/hooks/useTranslation';
 
 import { getSharedTooltip } from '@/src/utils/app/application';
+import { doesAgentSupportMcp } from '@/src/utils/app/models';
 import { isEntityIdPublic } from '@/src/utils/app/publications';
 
 import { Toolsets } from '@/src/types/applications';
@@ -204,10 +205,12 @@ export const QuickAppForm = () => {
         )}
       />
 
-      <CopyUrlButton
-        id={appDetails?.id ?? ''}
-        label={t(CommonI18nKeys.CopyApplicationEndpointURL)}
-      />
+      {doesAgentSupportMcp(appDetails) && (
+        <CopyUrlButton
+          id={appDetails.id}
+          label={t(CommonI18nKeys.CopyApplicationEndpointURL)}
+        />
+      )}
     </div>
   );
 };

--- a/apps/chat/src/hooks/useAgentMenuItems.ts
+++ b/apps/chat/src/hooks/useAgentMenuItems.ts
@@ -25,6 +25,7 @@ import {
   isQuickApp2,
 } from '@/src/utils/app/application';
 import { isMyApplication } from '@/src/utils/app/id';
+import { doesAgentSupportMcp } from '@/src/utils/app/models';
 import { isEntityIdPublic } from '@/src/utils/app/publications';
 import { canWriteSharedWithMe } from '@/src/utils/app/share';
 
@@ -124,7 +125,8 @@ export const useAgentMenuItems = ({
       {
         name: t(MarketplaceI18nKeys.Connect),
         dataQa: 'toolset-connect',
-        display: disabledActions?.connect !== true,
+        display:
+          disabledActions?.connect !== true && doesAgentSupportMcp(entity),
         Icon: IconPlugConnected,
         onClick: handleConnect,
       },

--- a/apps/chat/src/types/models.ts
+++ b/apps/chat/src/types/models.ts
@@ -2,7 +2,11 @@ import { ApplicationStatus } from '@/src/types/applications';
 
 import { EntityType } from './common';
 
-import { EntityPublicationInfo, ShareEntity } from '@epam/ai-dial-shared';
+import {
+  EntityPublicationInfo,
+  ShareEntity,
+  ToolsetTransportType,
+} from '@epam/ai-dial-shared';
 import { TiktokenEncoding } from 'tiktoken';
 
 export type ModelsMap = Partial<Record<string, DialAIEntityModel>>;
@@ -55,6 +59,14 @@ export interface CoreAIEntity<T = EntityType.Model> {
   };
   viewer_url?: string;
   editor_url?: string;
+
+  mcp?: {
+    endpoint: string;
+    transport: ToolsetTransportType;
+    allowedTools?: string[];
+    configDelivery?: string;
+    forwardPerRequestKey?: boolean;
+  };
 }
 
 export interface DialAIEntityFeatures {
@@ -112,6 +124,14 @@ export interface DialAIEntityModel
 
   viewerUrl?: string;
   editorUrl?: string;
+
+  mcp?: {
+    endpoint: string;
+    transport: ToolsetTransportType;
+    allowedTools?: string[];
+    configDelivery?: string;
+    forwardPerRequestKey?: boolean;
+  };
 }
 
 export interface InstalledModel {

--- a/apps/chat/src/utils/app/models.ts
+++ b/apps/chat/src/utils/app/models.ts
@@ -115,3 +115,7 @@ export const shouldShowHiddenEntities = (
   hiddenEntityTag?: string,
   showHidden?: boolean,
 ) => !hiddenEntityTag || !hiddenEntityTag.length || showHidden;
+
+export const doesAgentSupportMcp = (
+  entity?: DialAIEntityModel,
+): entity is DialAIEntityModel => !!entity?.mcp;

--- a/apps/chat/src/utils/server/get-sorted-entities.ts
+++ b/apps/chat/src/utils/server/get-sorted-entities.ts
@@ -176,6 +176,7 @@ export const getSortedEntities = async (
       }),
       ...(entity.viewer_url && { viewerUrl: entity.viewer_url }),
       ...(entity.editor_url && { editorUrl: entity.editor_url }),
+      ...(entity.mcp && { mcp: entity.mcp }),
     });
   }
 


### PR DESCRIPTION
**Description:**

- introduce new field **mcp** for ai entity models
- show copy link buttons only for agents that support mcp

Issues:

- Issue #6383

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
