### PR TITLE
fix(chat): allowed tools added via JSON editor are not saved (Issue #6151)

### DIFF
--- a/apps/chat/src/components/AppsEditor/form.ts
+++ b/apps/chat/src/components/AppsEditor/form.ts
@@ -69,6 +69,7 @@ import {
 } from '@/src/constants/validation-helpers';
 
 import { ShareEntity } from '@epam/ai-dial-shared';
+import omit from 'lodash-es/omit';
 import sortBy from 'lodash-es/sortBy';
 import uniq from 'lodash-es/uniq';
 import { nanoid } from 'nanoid';
@@ -668,14 +669,17 @@ export const getQuickApp2Toolsets = ({
     }>(
       (acc, agentAndToolset) => {
         const entity = allEntitiesMap[agentAndToolset.id];
+        const toolData = agentAndToolset.tool ?? {};
         if (!entity) {
           if (isApplicationId(agentAndToolset.id)) {
             acc.dialDeploymentsToolsets.push({
+              ...omit(toolData, ['isDeploymentTool', 'name']),
               type: DialDeploymentToolsetToolTypes.DialDeploymentSimple,
               deployment_id: ApiUtils.encodeApiUrl(agentAndToolset.id),
             });
           } else if (isToolsetId(agentAndToolset.id)) {
             acc.dialMCPToolsets.push({
+              ...omit(toolData, ['isDeploymentTool', 'name']),
               dial_id: ApiUtils.encodeApiUrl(agentAndToolset.id),
               type: ToolsetTypes.DialMcp,
             });
@@ -694,11 +698,13 @@ export const getQuickApp2Toolsets = ({
 
         if (isDialAiEntityModel(entity)) {
           acc.dialDeploymentsToolsets.push({
+            ...omit(toolData, ['isDeploymentTool', 'name']),
             type: DialDeploymentToolsetToolTypes.DialDeploymentSimple,
             deployment_id: ApiUtils.encodeApiUrl(entity.id),
           });
         } else {
           acc.dialMCPToolsets.push({
+            ...omit(toolData, ['isDeploymentTool', 'name']),
             dial_id: ApiUtils.encodeApiUrl(entity.id),
             type: ToolsetTypes.DialMcp,
           });


### PR DESCRIPTION
**Description:**

- fix saving additional fields of mcp and deployment toolsets added via json

Issues:

- Issue #6151

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
