### PR TITLE
fix(chat): fix in agent response in edit mode there are no attachments and Clip icon (Issue 6014)

### DIFF
--- a/apps/chat/src/components/Chat/ChatMessage/ChatMessageContent/AssistantMessage.tsx
+++ b/apps/chat/src/components/Chat/ChatMessage/ChatMessageContent/AssistantMessage.tsx
@@ -1,3 +1,4 @@
+import { IconPaperclip } from '@tabler/icons-react';
 import React, {
   memo,
   useCallback,
@@ -10,35 +11,58 @@ import { isSafari } from 'react-device-detect';
 
 import classNames from 'classnames';
 
+import { useChatUploadFiles } from '@/src/hooks/useChatUploadFiles';
+import { useFilePaste } from '@/src/hooks/useFilePaste';
 import { useTranslation } from '@/src/hooks/useTranslation';
 
-import { isEntityNameOrPathInvalid } from '@/src/utils/app/common';
+import {
+  isEntityNameOrPathInvalid,
+  replaceStringRange,
+} from '@/src/utils/app/common';
 import { isPlaybackConversation } from '@/src/utils/app/conversation';
 import {
+  getDialFilesFromAttachments,
+  getDialFoldersFromAttachments,
+  getDialLinksFromAttachments,
+  getUserCustomContent,
+} from '@/src/utils/app/file';
+import {
+  getConfigurationSchema,
   getConfigurationValue,
   getMessageFormValue,
   isMessageInputDisabled,
 } from '@/src/utils/app/form-schema';
+import { isFolderId } from '@/src/utils/app/id';
 import { isEntityReadOnly } from '@/src/utils/app/permissions';
 import { getEntitiesFromTemplateMapping } from '@/src/utils/app/prompts';
+import { ApiUtils } from '@/src/utils/server/api';
 
 import { Conversation } from '@/src/types/chat';
+import { DialFile, DialLink, FileFolderInterface } from '@/src/types/files';
+import { FolderInterface } from '@/src/types/folder';
 import { Translation } from '@/src/types/translation';
 
-import { useAppSelector } from '@/src/store/hooks';
+import { FilesActions } from '@/src/store/actions';
+import { useAppDispatch, useAppSelector } from '@/src/store/hooks';
 import {
+  ConversationsSelectors,
+  FilesSelectors,
   PublicationSelectors,
   SettingsSelectors,
   UISelectors,
 } from '@/src/store/selectors';
 
+import { FOLDER_ATTACHMENT_CONTENT_TYPE } from '@/src/constants/folders';
 import { ChatI18nKeys } from '@/src/constants/i18n';
+import { DEFAULT_ICON_SIZES } from '@/src/constants/icons';
 
+import { ChatInputAttachments } from '@/src/components/Chat/ChatInput/ChatInputAttachments';
 import { MessageAssistantButtons } from '@/src/components/Chat/ChatMessage/MessageButtons';
 import { AssistantSchema } from '@/src/components/Chat/ChatMessage/MessageSchema/MessageSchema';
 import { MessageAttachments } from '@/src/components/Chat/MessageAttachments';
 import { MessageStages } from '@/src/components/Chat/MessageStages';
 import { ErrorMessage } from '@/src/components/Common/ErrorMessage';
+import { AttachButton } from '@/src/components/Files/AttachButton';
 import { ChatMDComponent } from '@/src/components/Markdown/ChatMDComponent';
 
 import { AdjustedTextarea } from '../AdjustedTextarea';
@@ -49,10 +73,12 @@ import {
   Feature,
   Message,
   MessageFormValue,
+  UploadStatus,
   onLikeMessageHandler,
 } from '@epam/ai-dial-shared';
 import { DialNeutralButton, DialPrimaryButton } from '@epam/ai-dial-ui-kit';
 import isEqual from 'lodash-es/isEqual';
+import uniq from 'lodash-es/uniq';
 import throttle from 'lodash/throttle';
 
 const SAFARI_THROTTLE_TIMEOUT = 100;
@@ -85,10 +111,24 @@ const AssistantMessageEditor = memo(function AssistantMessageEditor({
   onEdit,
 }: AssistantMessageEditorProps) {
   const { t } = useTranslation(Translation.Chat);
+  const dispatch = useAppDispatch();
 
   const currentFormValue = useMemo(
     () => getMessageFormValue(message) ?? getConfigurationValue(message),
     [message],
+  );
+
+  const isOverlay = useAppSelector(SettingsSelectors.selectIsOverlay);
+  const files = useAppSelector(FilesSelectors.selectFiles);
+  const folders = useAppSelector(FilesSelectors.selectFolders);
+  const canAttachFolders = useAppSelector(
+    ConversationsSelectors.selectCanAttachFolders,
+  );
+  const canAttachFiles = useAppSelector(
+    ConversationsSelectors.selectCanAttachFile,
+  );
+  const canAttachLinks = useAppSelector(
+    ConversationsSelectors.selectCanAttachLink,
   );
 
   const anchorRef = useRef<HTMLDivElement>(null);
@@ -96,11 +136,105 @@ const AssistantMessageEditor = memo(function AssistantMessageEditor({
   const [messageContent, setMessageContent] = useState(message.content);
   const [formValue, setFormValue] = useState(currentFormValue);
   const [isTyping, setIsTyping] = useState<boolean>(false);
+  const [selectedDialLinks, setSelectedDialLinks] = useState<DialLink[]>([]);
 
-  const isOverlay = useAppSelector(SettingsSelectors.selectIsOverlay);
+  const mappedEditableAttachments = useMemo(() => {
+    return [
+      ...(getDialFoldersFromAttachments(
+        message.custom_content?.attachments,
+      ) as unknown as Omit<DialFile, 'contentLength'>[]),
+      ...getDialFilesFromAttachments(message.custom_content?.attachments),
+    ];
+  }, [message.custom_content?.attachments]);
+
+  const mappedEditableAttachmentsIds = useMemo(() => {
+    return mappedEditableAttachments.map(({ id }) => id);
+  }, [mappedEditableAttachments]);
+
+  const [newEditableAttachmentsIds, setNewEditableAttachmentsIds] = useState<
+    string[]
+  >(mappedEditableAttachmentsIds);
+
+  const newEditableAttachments = useMemo(() => {
+    const newIds = newEditableAttachmentsIds.filter(
+      (id) => !mappedEditableAttachmentsIds.includes(id),
+    );
+    const newFiles = newIds
+      .map((id) => files.find((file) => file.id === id))
+      .filter(Boolean) as DialFile[];
+
+    const newFolders = newIds
+      .map(
+        (id) => canAttachFolders && folders.find((folder) => folder.id === id),
+      )
+      .filter(Boolean)
+      .map((folder) => ({
+        ...folder,
+        contentType: FOLDER_ATTACHMENT_CONTENT_TYPE,
+      })) as DialFile[];
+
+    return mappedEditableAttachments
+      .filter(({ id }) => newEditableAttachmentsIds.includes(id))
+      .concat(newFiles)
+      .concat(newFolders);
+  }, [
+    canAttachFolders,
+    files,
+    folders,
+    mappedEditableAttachments,
+    mappedEditableAttachmentsIds,
+    newEditableAttachmentsIds,
+  ]);
+
+  const fileAttachments = useMemo(
+    () =>
+      newEditableAttachments.filter(
+        (f) => f.contentType !== FOLDER_ATTACHMENT_CONTENT_TYPE,
+      ),
+    [newEditableAttachments],
+  );
+
+  const folderAttachments = useMemo(
+    () =>
+      canAttachFolders
+        ? (newEditableAttachments.filter(
+            (f) => f.contentType === FOLDER_ATTACHMENT_CONTENT_TYPE,
+          ) as unknown as FileFolderInterface[])
+        : undefined,
+    [canAttachFolders, newEditableAttachments],
+  );
+
+  const isUploadingAttachmentPresent = useMemo(
+    () =>
+      newEditableAttachments.some(
+        (item) => item.status === UploadStatus.LOADING,
+      ),
+    [newEditableAttachments],
+  );
+
+  const isContentEmptyAndNoAttachments = useMemo(
+    () =>
+      messageContent.trim().length <= 0 && newEditableAttachments.length <= 0,
+    [messageContent, newEditableAttachments],
+  );
+
+  const selectedFileIds = useMemo(
+    () =>
+      newEditableAttachments.map((f) =>
+        f.contentType === FOLDER_ATTACHMENT_CONTENT_TYPE
+          ? ApiUtils.decodeApiUrl(f.id).replace(new RegExp('^metadata/'), '') +
+            '/'
+          : ApiUtils.decodeApiUrl(f.id),
+      ),
+    [newEditableAttachments],
+  );
 
   const isInputDisabled = isMessageInputDisabled(messageIndex, allMessages);
-  const isInputHidden = isInputDisabled && !message.content;
+  const isInputHidden =
+    isInputDisabled &&
+    !messageContent &&
+    !newEditableAttachments.length &&
+    !selectedDialLinks.length;
 
   const handleInputChange = useCallback(
     (event: React.ChangeEvent<HTMLTextAreaElement>) => {
@@ -110,21 +244,55 @@ const AssistantMessageEditor = memo(function AssistantMessageEditor({
   );
 
   const handleEditMessage = useCallback(
-    (formValue?: MessageFormValue, newContent?: string) => {
+    (formValueArg?: MessageFormValue, newContent?: string) => {
       if (!conversation || !onEdit) return;
 
+      const attachments = getUserCustomContent(
+        newEditableAttachments.filter(
+          (a) =>
+            !(a as unknown as FolderInterface).type &&
+            a.contentType !== FOLDER_ATTACHMENT_CONTENT_TYPE,
+        ),
+        newEditableAttachments.filter(
+          (a) =>
+            !!(a as unknown as FolderInterface).type ||
+            a.contentType === FOLDER_ATTACHMENT_CONTENT_TYPE,
+        ) as unknown as FolderInterface[],
+        selectedDialLinks,
+      );
+
+      const isAttachmentsSame = isEqual(
+        message.custom_content?.attachments,
+        attachments?.attachments,
+      );
       const isFormValueChanged = !isEqual(
         getMessageFormValue(message) ?? getConfigurationValue(message),
-        formValue,
+        formValueArg,
       );
       const isContentChanged =
         message.content !== (newContent ?? messageContent);
 
-      if (isContentChanged || isFormValueChanged) {
+      if (isContentChanged || !isAttachmentsSame || isFormValueChanged) {
         onEdit(
           {
             ...message,
             content: newContent ?? messageContent,
+            custom_content: {
+              ...message.custom_content,
+              attachments:
+                message.custom_content?.attachments && !attachments
+                  ? []
+                  : attachments?.attachments,
+              ...(formValueArg &&
+                (getConfigurationSchema(message)
+                  ? {
+                      configuration_value: formValueArg,
+                      configuration_schema: getConfigurationSchema(message),
+                    }
+                  : {
+                      form_value: formValueArg,
+                    })),
+            },
             templateMapping: getEntitiesFromTemplateMapping(
               message.templateMapping,
             ).filter(([key]) => messageContent.includes(key)),
@@ -132,16 +300,19 @@ const AssistantMessageEditor = memo(function AssistantMessageEditor({
           messageIndex,
           conversation.id,
         );
+        setSelectedDialLinks([]);
       }
       onToggleEditing(false);
     },
     [
       message,
       messageContent,
+      newEditableAttachments,
       onToggleEditing,
       conversation,
       onEdit,
       messageIndex,
+      selectedDialLinks,
     ],
   );
 
@@ -159,14 +330,127 @@ const AssistantMessageEditor = memo(function AssistantMessageEditor({
 
   const handleCancelEditing = useCallback(() => {
     setMessageContent(message.content);
+    setNewEditableAttachmentsIds(mappedEditableAttachmentsIds);
+    const links = getDialLinksFromAttachments(
+      message.custom_content?.attachments,
+    );
+    setSelectedDialLinks(links);
     onToggleEditing(false);
-  }, [onToggleEditing, message.content]);
+  }, [
+    mappedEditableAttachmentsIds,
+    message.content,
+    message.custom_content?.attachments,
+    onToggleEditing,
+  ]);
+
+  const handleAddLinkToMessage = useCallback((link: DialLink) => {
+    setSelectedDialLinks((links) => links.concat([link]));
+  }, []);
+
+  const handleUnselectLink = useCallback((unselectedIndex: number) => {
+    setSelectedDialLinks((links) =>
+      links.filter((_link, index) => unselectedIndex !== index),
+    );
+  }, []);
+
+  const handleUnselectFile = useCallback(
+    (fileId: string) => {
+      dispatch(FilesActions.uploadFileCancel({ id: fileId }));
+      const fid = isFolderId(fileId) ? fileId.slice(0, -1) : fileId;
+      setNewEditableAttachmentsIds((ids) => ids.filter((id) => id !== fid));
+    },
+    [dispatch],
+  );
+
+  const handleRetry = useCallback(
+    (fileId: string) => {
+      return () => dispatch(FilesActions.reuploadFile({ fileId }));
+    },
+    [dispatch],
+  );
+
+  const handleSelectAlreadyUploaded = useCallback((result: string[]) => {
+    const uniqueFilesIds = uniq(result);
+    setNewEditableAttachmentsIds(
+      uniqueFilesIds.map((id) => (isFolderId(id) ? id.slice(0, -1) : id)),
+    );
+  }, []);
+
+  const handleUploadFromDevice = useCallback(
+    (
+      selectedFiles: Required<Pick<DialFile, 'fileContent' | 'id' | 'name'>>[],
+      folderPath: string | undefined,
+    ) => {
+      selectedFiles.forEach((file) => {
+        dispatch(
+          FilesActions.uploadFile({
+            fileContent: file.fileContent,
+            id: file.id,
+            relativePath: folderPath,
+            name: file.name,
+          }),
+        );
+      });
+
+      setNewEditableAttachmentsIds((ids) =>
+        uniq(ids.concat(selectedFiles.map(({ id }) => id))),
+      );
+    },
+    [dispatch],
+  );
+
+  const uploadPastedFiles = useChatUploadFiles({
+    selectedAttachmentsAmount: newEditableAttachments.length,
+    skipSelect: true,
+  });
+
+  const handleUploadPastedFiles = useCallback(
+    (
+      pasteFiles: File[],
+      textContent?: string,
+      selection?: { start: number; end: number },
+    ) => {
+      if (canAttachFiles) {
+        uploadPastedFiles(pasteFiles)?.then((newFiles) => {
+          setNewEditableAttachmentsIds((ids) =>
+            uniq(ids.concat(newFiles.map(({ id }) => id))),
+          );
+        });
+      }
+      if (textContent) {
+        setMessageContent((prev) =>
+          selection
+            ? replaceStringRange(
+                prev,
+                textContent,
+                selection.start,
+                selection.end,
+              )
+            : textContent,
+        );
+      }
+    },
+    [uploadPastedFiles, canAttachFiles],
+  );
+
+  useFilePaste(textareaRef, handleUploadPastedFiles);
 
   useEffect(() => {
     setMessageContent(message.content);
     setFormValue(currentFormValue);
     onSetShouldScroll(true);
   }, [currentFormValue, message.content, onSetShouldScroll]);
+
+  useEffect(() => {
+    const links = getDialLinksFromAttachments(
+      message.custom_content?.attachments,
+    );
+    setSelectedDialLinks(links);
+  }, [message.custom_content?.attachments]);
+
+  useEffect(() => {
+    setNewEditableAttachmentsIds(mappedEditableAttachmentsIds);
+  }, [mappedEditableAttachmentsIds]);
 
   useEffect(() => {
     if (shouldScroll) {
@@ -203,10 +487,54 @@ const AssistantMessageEditor = memo(function AssistantMessageEditor({
               overflow: 'hidden',
             }}
           />
+
+          {(newEditableAttachments.length > 0 ||
+            selectedDialLinks.length > 0) && (
+            <div
+              className="mb-2.5 grid max-h-[100px] grid-cols-1 gap-1 overflow-auto sm:grid-cols-2 md:grid-cols-3"
+              data-qa="attachment-container"
+            >
+              <ChatInputAttachments
+                files={fileAttachments}
+                folders={folderAttachments}
+                links={selectedDialLinks}
+                onUnselectFile={handleUnselectFile}
+                onRetryFile={handleRetry}
+                onUnselectLink={handleUnselectLink}
+              />
+            </div>
+          )}
         </div>
       )}
 
-      <div className="flex items-center justify-end">
+      <div
+        className={classNames(
+          'flex items-center',
+          !canAttachFiles && !canAttachFolders && !canAttachLinks
+            ? 'justify-end'
+            : 'justify-between',
+        )}
+      >
+        <div className="size-[34px]">
+          <AttachButton
+            contextMenuPlacement="bottom-start"
+            TriggerCustomRenderer={
+              <div className="flex size-[34px] cursor-pointer items-center justify-center rounded hover:bg-accent-primary-alpha">
+                <IconPaperclip
+                  strokeWidth="1.5"
+                  size={DEFAULT_ICON_SIZES.STANDARD}
+                  width={DEFAULT_ICON_SIZES.STANDARD}
+                  height={DEFAULT_ICON_SIZES.STANDARD}
+                />
+              </div>
+            }
+            selectedFilesIds={selectedFileIds}
+            onSelectAlreadyUploaded={handleSelectAlreadyUploaded}
+            onUploadFromDevice={handleUploadFromDevice}
+            onAddLinkToMessage={handleAddLinkToMessage}
+          />
+        </div>
+
         <div className="relative flex gap-3">
           <DialNeutralButton
             label={t(ChatI18nKeys.Cancel)}
@@ -218,7 +546,9 @@ const AssistantMessageEditor = memo(function AssistantMessageEditor({
             <DialPrimaryButton
               label={t(ChatI18nKeys.SaveAndSubmit)}
               onClick={() => handleEditMessage(formValue, messageContent)}
-              disabled={!messageContent}
+              disabled={
+                isUploadingAttachmentPresent || isContentEmptyAndNoAttachments
+              }
               data-qa="save-and-submit"
             />
           )}


### PR DESCRIPTION
**Description:**

- Fix in agent response in edit mode there are no attachments and Clip icon.

Issues:

- Issue #6014

**UI changes**

<img width="969" height="417" alt="image" src="https://github.com/user-attachments/assets/ea850e15-2ca2-4649-8014-8ee94b221f85" />

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
