### PR TITLE
fix(chat): fix error fails when unshare selected 'Shared with me`  folder with files (Issue 6326)

### DIFF
--- a/apps/chat/src/components/FileManager/hooks/useFileManager.tsx
+++ b/apps/chat/src/components/FileManager/hooks/useFileManager.tsx
@@ -314,7 +314,10 @@ export const useFileManager = ({
   useEffect(() => {
     if (currentPath && !isRootId(currentPath) && !isMovingFiles) {
       const folder = folders.find((folder) => folder.id === currentPath);
-      if (
+      if (!folder) {
+        const parentId = getFolderIdFromEntityId(currentPath);
+        setCurrentPath(parentId);
+      } else if (
         folder?.status !== UploadStatus.LOADED &&
         folder?.status !== UploadStatus.LOADING
       ) {


### PR DESCRIPTION
**Description:**

- Fix error fails when unshare selected 'Shared with me`  folder with files.

Issues:

- Issue #6326 

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
