### PR TITLE
fix(chat): fix aborting subscribe request on redirect (Issue #6465)

### DIFF
--- a/apps/chat/src/components/Chat/Chat.tsx
+++ b/apps/chat/src/components/Chat/Chat.tsx
@@ -42,6 +42,7 @@ import { useAppDispatch, useAppSelector } from '@/src/store/hooks';
 import {
   ApplicationTypesSchemasSelectors,
   AuthSelectors,
+  ChatEventsSelectors,
   ChatSelectors,
   ConversationsSelectors,
   ModelsSelectors,
@@ -1134,6 +1135,12 @@ export function Chat({ isPreview }: ChatProps) {
   const applicationTypeSchemas = useAppSelector(
     ApplicationTypesSchemasSelectors.selectAllSchemas,
   );
+  const isChatEventsEnabled = useAppSelector((state) =>
+    SettingsSelectors.isFeatureEnabled(state, Feature.LiveChatInteraction),
+  );
+  const isSubscribing = useAppSelector(ChatEventsSelectors.selectIsSubscribing);
+
+  const showIsSubscribingLoader = isChatEventsEnabled && isSubscribing;
 
   const isNoMessages = selectedConversations.every(
     ({ messages }) => !messages?.length,
@@ -1219,7 +1226,8 @@ export function Chat({ isPreview }: ChatProps) {
     !areSelectedConversationsLoaded ||
     !isInstalledModelsInitialized ||
     loadingConfigurationSchemas.length ||
-    isPublicationUpdating
+    isPublicationUpdating ||
+    showIsSubscribingLoader
   ) {
     return <Loader />;
   }

--- a/apps/chat/src/store/chat-events/chat-events.epics.ts
+++ b/apps/chat/src/store/chat-events/chat-events.epics.ts
@@ -2,6 +2,7 @@ import {
   EMPTY,
   catchError,
   concat,
+  exhaustMap,
   filter,
   forkJoin,
   map,
@@ -51,6 +52,18 @@ const mapChatEventFromApi = (event: ChatEvent): ChatEvent => ({
   },
 });
 
+const initEpic: AppEpic = (action$, state$) =>
+  action$.pipe(
+    ofType(ChatEventsActions.init.type),
+    filter(() => !ChatEventsSelectors.selectIsInitialized(state$.value)),
+    switchMap(() =>
+      concat(
+        of(ChatEventsActions.subscribe()),
+        of(ChatEventsActions.initFinish()),
+      ),
+    ),
+  );
+
 const subscribeEpic: AppEpic = (action$, state$) =>
   action$.pipe(
     ofType(ChatEventsActions.subscribe.type),
@@ -62,7 +75,7 @@ const subscribeEpic: AppEpic = (action$, state$) =>
           Feature.LiveChatInteraction,
         ),
     ),
-    switchMap(({ payload }) => {
+    exhaustMap(({ payload }) => {
       const channelId = ChatEventsSelectors.selectChannelId(state$.value);
       const decoder = new TextDecoder();
       let retryAttempt = payload?.retryAttempt ?? 0;
@@ -288,6 +301,7 @@ const declineAllEventsFailureEpic: AppEpic = (action$) =>
   );
 
 export const ChatEventsEpics = combineEpics(
+  initEpic,
   subscribeEpic,
   reconnectEpic,
   unsubscribeEpic,

--- a/apps/chat/src/store/chat-events/chat-events.reducer.ts
+++ b/apps/chat/src/store/chat-events/chat-events.reducer.ts
@@ -11,7 +11,9 @@ import { ChatEventsState } from '@/src/store/chat-events/chat-events.types';
 import omit from 'lodash-es/omit';
 
 const initialState: ChatEventsState = {
+  initialized: false,
   isSubscribed: false,
+  isSubscribing: false,
   isReporting: false,
   events: {},
 };
@@ -20,22 +22,31 @@ export const chatEventsSlice = createSlice({
   name: 'chat-events',
   initialState,
   reducers: {
+    init: (state) => state,
+    initFinish: (state) => {
+      state.initialized = true;
+    },
     subscribe: (
       state,
       _action: PayloadAction<{ retryAttempt?: number } | undefined>,
-    ) => state,
+    ) => {
+      state.isSubscribing = true;
+    },
     subscribeFailure: (
       state,
       _action: PayloadAction<{ retryAttempt?: number } | undefined>,
     ) => {
       state.isSubscribed = false;
+      state.isSubscribing = false;
     },
     unsubscribe: (state) => state,
     setChannelId: (state, { payload }: PayloadAction<string>) => {
       state.channelId = payload;
+      state.isSubscribing = false;
     },
     setIsSubscribed: (state, { payload }: PayloadAction<boolean>) => {
       state.isSubscribed = payload;
+      state.isSubscribing = false;
     },
     addEvents: (state, { payload }: PayloadAction<ChatEvent[]>) => {
       const newEvents = { ...state.events };

--- a/apps/chat/src/store/chat-events/chat-events.selectors.ts
+++ b/apps/chat/src/store/chat-events/chat-events.selectors.ts
@@ -4,8 +4,14 @@ import { RootState } from '@/src/types/store';
 
 const rootSelector = (state: RootState) => state.chatEvents;
 
+const selectIsInitialized = (state: RootState) =>
+  rootSelector(state).initialized;
+
 const selectIsSubscribed = (state: RootState) =>
   rootSelector(state).isSubscribed;
+
+const selectIsSubscribing = (state: RootState) =>
+  rootSelector(state).isSubscribing;
 
 const selectIsReporting = (state: RootState) => rootSelector(state).isReporting;
 
@@ -18,7 +24,9 @@ const selectEventsList = createSelector([selectEvents], (events) =>
 );
 
 export const ChatEventsSelectors = {
+  selectIsInitialized,
   selectIsSubscribed,
+  selectIsSubscribing,
   selectChannelId,
   selectEvents,
   selectEventsList,

--- a/apps/chat/src/store/chat-events/chat-events.types.ts
+++ b/apps/chat/src/store/chat-events/chat-events.types.ts
@@ -1,7 +1,9 @@
 import { ChatEvent } from '@/src/types/chat-events';
 
 export interface ChatEventsState {
+  initialized: boolean;
   isSubscribed: boolean;
+  isSubscribing: boolean;
   isReporting: boolean;
   channelId?: string;
   events: Record<string, ChatEvent>;

--- a/apps/chat/src/store/settings/settings.epics.ts
+++ b/apps/chat/src/store/settings/settings.epics.ts
@@ -80,7 +80,7 @@ const getInitActions = (page?: PageType): Observable<AppAction>[] => {
         of(PublicationActions.init()),
         of(ApplicationTypesSchemasActions.init()),
         of(ToolsetActions.init()),
-        of(ChatEventsActions.subscribe()),
+        of(ChatEventsActions.init()),
       ];
     case PageType.AppsEditor:
       return [
@@ -91,7 +91,7 @@ const getInitActions = (page?: PageType): Observable<AppAction>[] => {
         of(ConversationsActions.init()),
         of(ApplicationTypesSchemasActions.init()),
         of(ToolsetActions.init()),
-        of(ChatEventsActions.subscribe()),
+        of(ChatEventsActions.init()),
       ];
     default:
       return [


### PR DESCRIPTION
**Description:**

- add initialized state for chat events
- add loader while subscribing
- ignore subscribe actions when already in process

Issues:

- Issue #6465 

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
