### PR TITLE
fix(chat): fix long subscribe request in Firefox browser (Issue #6500)

### DIFF
--- a/apps/chat/src/pages/api/client-channels/subscribe.ts
+++ b/apps/chat/src/pages/api/client-channels/subscribe.ts
@@ -97,6 +97,8 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
 
     res.flushHeaders?.();
 
+    res.write(': init\n\n');
+
     reader = upstreamResponse.body.getReader();
 
     while (!clientClosed) {


### PR DESCRIPTION
**Description:**

- add init chunk to fix Firefox (and potentially other browsers) which does not get 200 status on flushHeaders

Issues:

- Issue #6500

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
