### PR TITLE
fix(chat): do not save parameters in quick app 2 if temperature feature is disabled (Issue #6449)

### DIFF
--- a/apps/chat/src/components/AppsEditor/form.ts
+++ b/apps/chat/src/components/AppsEditor/form.ts
@@ -50,7 +50,6 @@ import {
 import {
   DEFAULT_APPLICATION_NAME,
   DEFAULT_TEMPERATURE,
-  FALLBACK_TEMPERATURE,
 } from '@/src/constants/default-ui-settings';
 import { formErrors } from '@/src/constants/form-errors';
 import { CommonI18nKeys } from '@/src/constants/i18n';
@@ -820,7 +819,7 @@ export const getApplicationPayload = ({
       const temperatureToUse =
         model && isDialAiEntityModel(model) && doesModelAllowTemperature(model)
           ? data.temperature
-          : FALLBACK_TEMPERATURE;
+          : undefined;
       const starters = data.starters
         .filter((starter) => starter.text.trim() && starter.title.trim())
         .map(({ title, text }) => ({ title, text }));
@@ -838,9 +837,9 @@ export const getApplicationPayload = ({
           orchestrator: {
             deployment: {
               name: model?.id ?? data.model,
-              parameters: {
-                temperature: temperatureToUse,
-              },
+              ...(temperatureToUse && {
+                parameters: { temperature: temperatureToUse },
+              }),
             },
             system_prompt: {
               type: 'custom',


### PR DESCRIPTION
**Description:**

do not save parameters in quick app 2 if temperature feature is disabled

Issues:

- Issue #6449

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
