### PR TITLE
fix(chat): fix quick app instructions field color and fix mobile headers in marketplace (Issues #6360, #3791)

### DIFF
--- a/apps/chat/src/components/Common/MarkdownEditor/MarkdownEditor.tsx
+++ b/apps/chat/src/components/Common/MarkdownEditor/MarkdownEditor.tsx
@@ -36,6 +36,10 @@ export const DialMarkdownEditor: FC<DialMarkdownEditorProps> = ({
             backgroundColor: 'transparent',
             '--color-canvas-default': 'transparent',
             '--md-editor-background-color': 'var(--bg-layer-1)',
+            '--color-fg-default': 'var(--text-secondary)',
+            '--color-fg-muted': 'var(--text-secondary)',
+            '--color-accent-fg': 'var(--text-accent-primary)',
+            '--color-neutral-muted': 'var(--bg-layer-2)',
           } as CSSProperties
         }
       />

--- a/apps/chat/src/components/Marketplace/MarketplaceEntitiesList/MarketplaceEntitiesTable/MarketplaceEntitiesTable.tsx
+++ b/apps/chat/src/components/Marketplace/MarketplaceEntitiesList/MarketplaceEntitiesTable/MarketplaceEntitiesTable.tsx
@@ -9,6 +9,8 @@ import React, {
   useState,
 } from 'react';
 
+import classNames from 'classnames';
+
 import { useMarketplaceBannerVisibility } from '@/src/hooks/useMarketplaceBannerVisibility';
 import { useResizeObserver } from '@/src/hooks/useResizeObserver';
 import { useScreenState } from '@/src/hooks/useScreenState';
@@ -84,10 +86,11 @@ interface DataRowContainerProps {
   children: ReactNode;
   width: number;
   height: number;
+  className?: string;
 }
 
 const DataRowContainer = forwardRef<HTMLDivElement, DataRowContainerProps>(
-  ({ children, width, height }, ref) => {
+  ({ children, width, height, className }, ref) => {
     return (
       <div
         ref={ref}
@@ -95,7 +98,10 @@ const DataRowContainer = forwardRef<HTMLDivElement, DataRowContainerProps>(
           height: `${height}px`,
           width: `${width}px`,
         }}
-        className="no-scrollbar relative flex w-full shrink divide-y divide-secondary overflow-x-auto overflow-y-hidden"
+        className={classNames(
+          'no-scrollbar relative flex w-full shrink divide-y divide-secondary overflow-x-auto overflow-y-hidden',
+          className,
+        )}
       >
         {children}
       </div>
@@ -261,12 +267,14 @@ export const MarketplaceEntitiesTable: React.FC<
 
   const virtualRows = rowVirtualizer.getVirtualItems();
   const listHeight = rowVirtualizer.getTotalSize();
-
+  const sentinelWidth = leftColumnWidth + rightColumnWidth;
   const virtualRowsProps = useMemo(
     () => ({
       virtualRows,
       allEntities,
       suggestedResults,
+      measureElement: rowVirtualizer.measureElement,
+      sentinelWidth,
       rowProps: {
         hoveredRowId,
         onClick: onCardClick,
@@ -279,6 +287,8 @@ export const MarketplaceEntitiesTable: React.FC<
       virtualRows,
       allEntities,
       suggestedResults,
+      rowVirtualizer.measureElement,
+      sentinelWidth,
       hoveredRowId,
       onCardClick,
       onBookmarkClick,
@@ -299,6 +309,7 @@ export const MarketplaceEntitiesTable: React.FC<
           ref={leftColumnDataRef}
           width={leftColumnWidth}
           height={listHeight}
+          className="!overflow-visible"
         >
           <VirtualRowsRenderer {...virtualRowsProps} isLeftSide />
         </DataRowContainer>

--- a/apps/chat/src/components/Marketplace/MarketplaceEntitiesList/MarketplaceEntitiesTable/VirtualRowsRenderer.tsx
+++ b/apps/chat/src/components/Marketplace/MarketplaceEntitiesList/MarketplaceEntitiesTable/VirtualRowsRenderer.tsx
@@ -1,4 +1,4 @@
-import { VirtualItem } from '@tanstack/react-virtual';
+import { VirtualItem, Virtualizer } from '@tanstack/react-virtual';
 import { FC, ReactNode } from 'react';
 
 import classNames from 'classnames';
@@ -23,6 +23,8 @@ interface DataRowItemProps {
   children: ReactNode;
   isNextSentinel: boolean;
   isPrevSentinel: boolean;
+  measureElement?: Virtualizer<HTMLDivElement, Element>['measureElement'];
+  sentinelWidth?: number;
 }
 
 const DataRowItem: FC<DataRowItemProps> = ({
@@ -32,23 +34,29 @@ const DataRowItem: FC<DataRowItemProps> = ({
   children,
   isNextSentinel,
   isPrevSentinel,
+  measureElement,
+  sentinelWidth,
 }) => {
   const isSentinel = isString(entity);
+  const shouldStretchSentinel = isSentinel && !!sentinelWidth;
 
   return (
     <div
+      ref={isSentinel ? measureElement : undefined}
+      data-index={virtualRow.index}
       className={classNames(
         suggestedResults.length &&
           !isSentinel &&
           entity.id === suggestedResults[0].id &&
           '!border-t-0',
         (isSentinel || isPrevSentinel) && '!border-t-0',
-        isSentinel && 'flex items-end',
         isNextSentinel && '!border-b !border-b-secondary',
-        'absolute left-0 top-0 w-full',
+        'absolute left-0 top-0',
+        shouldStretchSentinel ? '' : 'w-full',
       )}
       style={{
-        height: `${virtualRow.size}px`,
+        ...(isSentinel ? null : { height: `${virtualRow.size}px` }),
+        ...(shouldStretchSentinel ? { width: `${sentinelWidth}px` } : null),
         transform: `translateY(${virtualRow.start}px)`,
       }}
     >
@@ -107,6 +115,8 @@ interface VirtualRowRendererProps {
   suggestedResults: MarketplaceEntity[];
   rowProps: RowProps;
   isLeftSide?: boolean;
+  measureElement?: Virtualizer<HTMLDivElement, Element>['measureElement'];
+  sentinelWidth?: number;
 }
 
 export const VirtualRowsRenderer: FC<VirtualRowRendererProps> = ({
@@ -115,6 +125,8 @@ export const VirtualRowsRenderer: FC<VirtualRowRendererProps> = ({
   suggestedResults,
   rowProps,
   isLeftSide,
+  measureElement,
+  sentinelWidth,
 }) => {
   return (
     <>
@@ -131,6 +143,8 @@ export const VirtualRowsRenderer: FC<VirtualRowRendererProps> = ({
             isNextSentinel={isNextSentinel}
             isPrevSentinel={isPrevSentinel}
             virtualRow={virtualRow}
+            measureElement={isLeftSide ? measureElement : undefined}
+            sentinelWidth={isLeftSide ? sentinelWidth : undefined}
           >
             <VirtualRowView
               entity={entity}

--- a/apps/chat/src/components/Marketplace/MarketplaceEntitiesList/MarketplaceEntitiesTiles/MarketplaceEntitiesTiles.tsx
+++ b/apps/chat/src/components/Marketplace/MarketplaceEntitiesList/MarketplaceEntitiesTiles/MarketplaceEntitiesTiles.tsx
@@ -7,8 +7,6 @@ import React, {
   useState,
 } from 'react';
 
-import classNames from 'classnames';
-
 import { useMarketplaceBannerVisibility } from '@/src/hooks/useMarketplaceBannerVisibility';
 import { useResizeObserver } from '@/src/hooks/useResizeObserver';
 import { useScreenState } from '@/src/hooks/useScreenState';
@@ -207,16 +205,16 @@ export const MarketplaceEntitiesTiles: React.FC<
             const rowEntities = range(colsCount).map(
               (i) => allEntities[virtualRow.index * colsCount + i],
             );
+            const isHeaderRow = isString(rowEntities[0]);
 
             return (
               <div
                 key={virtualRow.key}
-                className={classNames(
-                  'absolute left-0 top-0 grid min-w-full',
-                  isString(rowEntities[0]) && 'flex items-end',
-                )}
+                ref={isHeaderRow ? rowVirtualizer.measureElement : undefined}
+                data-index={virtualRow.index}
+                className="absolute left-0 top-0 grid min-w-full"
                 style={{
-                  height: `${virtualRow.size}px`,
+                  ...(isHeaderRow ? null : { height: `${virtualRow.size}px` }),
                   transform: `translateY(${virtualRow.start}px)`,
                   gridTemplateColumns: `repeat(${colsCount}, minmax(0, 1fr))`,
                   gap: `${gap}px`,

--- a/apps/chat/src/components/Marketplace/MarketplaceEntitiesList/SentinelRow.tsx
+++ b/apps/chat/src/components/Marketplace/MarketplaceEntitiesList/SentinelRow.tsx
@@ -12,8 +12,8 @@ export function SentinelRow({ children, dataQa, isTable }: Props) {
   return (
     <h2
       className={classNames(
-        'col-span-full flex items-center pb-2 text-xl font-semibold',
-        isTable && 'pl-4',
+        'col-span-full pb-2 text-xl font-semibold',
+        isTable && 'pl-4 pt-4',
       )}
       data-qa={dataQa}
     >

--- a/apps/chat/src/components/Marketplace/MarketplaceEntitiesList/SuggestedMessage.tsx
+++ b/apps/chat/src/components/Marketplace/MarketplaceEntitiesList/SuggestedMessage.tsx
@@ -42,7 +42,7 @@ export const SuggestedMessage: React.FC<SuggestedMessageProps> = ({
         </span>
       </div>
       <span
-        className="mb-4 mt-5 text-xl md:mt-6 lg:mt-8"
+        className="mb-4 mt-5 text-xl font-semibold md:mt-6 lg:mt-8"
         data-qa="marketplace-suggestions-label"
       >
         {t(MarketplaceI18nKeys.SuggestedResults)}


### PR DESCRIPTION
**Description:**

fix quick app instructions field color
fix mobile headers in marketplace

Issues:

- Issue #6360
- Issue #3791

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
