### PR TITLE
fix(chat): CIAM support for AzureB2CProvider, Issue #6594

### DIFF
--- a/apps/chat/src/utils/auth/auth-providers.ts
+++ b/apps/chat/src/utils/auth/auth-providers.ts
@@ -130,6 +130,12 @@ const getAzureB2CProvider = (config: ProviderConfig) =>
           },
         },
         token: tokenConfig,
+        profile: (profile) => ({
+          id: profile.sub,
+          name: profile.name,
+          email:
+            (profile as { email?: string }).email ?? profile.emails?.[0],
+        }),
       })
     : undefined;
 

--- a/apps/chat/src/utils/auth/auth-providers.ts
+++ b/apps/chat/src/utils/auth/auth-providers.ts
@@ -133,8 +133,7 @@ const getAzureB2CProvider = (config: ProviderConfig) =>
         profile: (profile) => ({
           id: profile.sub,
           name: profile.name,
-          email:
-            (profile as { email?: string }).email ?? profile.emails?.[0],
+          email: (profile as { email?: string }).email ?? profile.emails?.[0],
         }),
       })
     : undefined;


### PR DESCRIPTION
**Description:**

CIAM emits `email` (singular) instead of `emails` (plural) with string instead of list of strings. It fails auth flow with following error:

```
OAuthProfile: {
   aud: '<redacted>',
   iss: 'https://<redacted>.ciamlogin.com/<redacted>/v2.0',
   iat: 1777425739,
   nbf: 1777425739,
   exp: 1777429639,
   email: 'Aleksandr_Chikovani@<redacted>',
   groups: [
     '<redacted>',
     '<redacted>'
   ],
   idp: 'https://sts.windows.net/<redacted>/',
   name: 'Aleksandr Chikovani',
   oid: '<redacted>',
   preferred_username: 'Aleksandr_Chikovani@<redacted>',
   rh: '<redacted>',
   sid: '<redacted>',
   sub: '<redacted>',
   tid: '<redacted>',
   uti: '<redacted>',
   ver: '2.0'
  },
  message: "Cannot read properties of undefined (reading '0')"
}
```

Issues:

- Issue #6594

**UI changes**

n/a

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
