### PR TITLE
fix(chat): fix Shared files disappeared from folders after switching between File Manager tabs (Issue #6638)

### DIFF
--- a/apps/chat/src/store/files/__tests__/files.reducers.test.ts
+++ b/apps/chat/src/store/files/__tests__/files.reducers.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from 'vitest';
+
+import { DialFile } from '@/src/types/files';
+
+import { FilesActions, filesSlice } from '../files.reducers';
+
+const makeFile = (partial: Partial<DialFile>): DialFile =>
+  ({
+    id: 'files/test/file.txt',
+    name: 'file.txt',
+    folderId: 'files/test',
+    contentLength: 1,
+    contentType: 'text/plain',
+    ...partial,
+  }) as DialFile;
+
+describe('files.reducers addSharedFiles', () => {
+  it('keeps nested shared descendants under active shared roots', () => {
+    const activeRoot = 'files/test/shared-root';
+    const state = {
+      ...filesSlice.getInitialState(),
+      sharedWithMeFilesAndFoldersIds: [activeRoot],
+      files: [
+        makeFile({
+          id: `${activeRoot}/old-root-file.txt`,
+          folderId: activeRoot,
+          sharedWithMe: true,
+          isRootSharedItem: true,
+        }),
+        makeFile({
+          id: `${activeRoot}/nested/kept.txt`,
+          folderId: `${activeRoot}/nested`,
+          sharedWithMe: true,
+        }),
+        makeFile({
+          id: 'files/test/private/not-shared.txt',
+          folderId: 'files/test/private',
+          sharedWithMe: false,
+        }),
+      ],
+    };
+
+    const nextState = filesSlice.reducer(
+      state,
+      FilesActions.addSharedFiles({
+        files: [
+          makeFile({
+            id: `${activeRoot}/new-root-file.txt`,
+            folderId: activeRoot,
+            sharedWithMe: true,
+            isRootSharedItem: true,
+          }),
+        ],
+      }),
+    );
+
+    expect(nextState.files.map((f) => f.id)).toEqual(
+      expect.arrayContaining([
+        `${activeRoot}/nested/kept.txt`,
+        `${activeRoot}/new-root-file.txt`,
+        'files/test/private/not-shared.txt',
+      ]),
+    );
+    expect(nextState.files.map((f) => f.id)).not.toContain(
+      `${activeRoot}/old-root-file.txt`,
+    );
+  });
+
+  it('removes stale nested shared descendants for revoked roots', () => {
+    const activeRoot = 'files/test/active-root';
+    const revokedRoot = 'files/test/revoked-root';
+    const state = {
+      ...filesSlice.getInitialState(),
+      sharedWithMeFilesAndFoldersIds: [activeRoot],
+      files: [
+        makeFile({
+          id: `${activeRoot}/nested/kept.txt`,
+          folderId: `${activeRoot}/nested`,
+          sharedWithMe: true,
+        }),
+        makeFile({
+          id: `${revokedRoot}/nested/stale.txt`,
+          folderId: `${revokedRoot}/nested`,
+          sharedWithMe: true,
+        }),
+      ],
+    };
+
+    const nextState = filesSlice.reducer(
+      state,
+      FilesActions.addSharedFiles({
+        files: [
+          makeFile({
+            id: `${activeRoot}/root.txt`,
+            folderId: activeRoot,
+            sharedWithMe: true,
+            isRootSharedItem: true,
+          }),
+        ],
+      }),
+    );
+
+    expect(nextState.files.map((f) => f.id)).toContain(
+      `${activeRoot}/nested/kept.txt`,
+    );
+    expect(nextState.files.map((f) => f.id)).not.toContain(
+      `${revokedRoot}/nested/stale.txt`,
+    );
+  });
+
+  it('replaces previously stored root shared files without duplicates', () => {
+    const activeRoot = 'files/test/shared-root';
+    const state = {
+      ...filesSlice.getInitialState(),
+      sharedWithMeFilesAndFoldersIds: [activeRoot],
+      files: [
+        makeFile({
+          id: `${activeRoot}/root.txt`,
+          name: 'stale-name.txt',
+          folderId: activeRoot,
+          contentLength: 5,
+          sharedWithMe: true,
+          isRootSharedItem: true,
+        }),
+      ],
+    };
+
+    const nextState = filesSlice.reducer(
+      state,
+      FilesActions.addSharedFiles({
+        files: [
+          makeFile({
+            id: `${activeRoot}/root.txt`,
+            name: 'fresh-name.txt',
+            folderId: activeRoot,
+            contentLength: 10,
+            sharedWithMe: true,
+            isRootSharedItem: true,
+          }),
+        ],
+      }),
+    );
+
+    const rootItems = nextState.files.filter(
+      (file) => file.id === `${activeRoot}/root.txt`,
+    );
+    expect(rootItems).toHaveLength(1);
+    expect(rootItems[0].name).toBe('fresh-name.txt');
+    expect(rootItems[0].contentLength).toBe(10);
+  });
+});

--- a/apps/chat/src/store/files/files.reducers.ts
+++ b/apps/chat/src/store/files/files.reducers.ts
@@ -762,14 +762,33 @@ export const filesSlice = createSlice({
         payload,
       }: PayloadAction<{ files: DialFile[]; reviewBuckets?: string[] }>,
     ) => {
-      //remove sharedWithMe files from state except those on review to have the latest state from API
-      const filteredFiles = state.files.filter(
-        (file) =>
-          !file.sharedWithMe ||
+      const sharedWithMeRootIds = new Set(state.sharedWithMeFilesAndFoldersIds);
+      const belongsToActiveSharedRoot = (file: DialFile) =>
+        Array.from(sharedWithMeRootIds).some((rootId) =>
+          file.id.startsWith(`${rootId}/`),
+        );
+
+      // Keep nested shared descendants under active roots, but always replace root shared items
+      // with latest API payload to avoid stale root-level data after tab switches.
+      const filteredFiles = state.files.filter((file) => {
+        if (!file.sharedWithMe) {
+          return true;
+        }
+
+        if (
           payload.reviewBuckets?.some(
             (reviewBucket) => getEntityBucket(file) === reviewBucket,
-          ),
-      );
+          )
+        ) {
+          return true;
+        }
+
+        if (file.isRootSharedItem) {
+          return false;
+        }
+
+        return belongsToActiveSharedRoot(file);
+      });
       state.files = combineEntities(payload.files, filteredFiles);
     },
     resetAllFoldersStatus: (state) => {

--- a/apps/chat/src/store/share/share.epics.ts
+++ b/apps/chat/src/store/share/share.epics.ts
@@ -1086,6 +1086,8 @@ const getSharedListingSuccessEpic: AppEpic = (action$, state$, { router }) =>
 
           const sharedWithMeFileIds = files.map((f) => f.id);
           const sharedWithMeFolderIds = folders.map((f) => f.id);
+          // Keep this action before addSharedFiles: files reducer uses the fresh
+          // sharedWithMe ids to preserve valid nested descendants and clean stale ones.
           actions.push(
             FilesActions.setSharedWithMeFilesAndFoldersIds({
               ids: [...sharedWithMeFileIds, ...sharedWithMeFolderIds],


### PR DESCRIPTION
**Description:**

- Fix Shared files disappeared from folders after switching between File Manager tabs.
- Fix add `addSharedFiles` reducer to avoid removing files with fresh listing.

Issues:

- Issue #6638 


**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
