### PR TITLE
feat(chat): add error message for the image if attachment was deleted (Issue #820)

### DIFF
--- a/apps/chat/public/locales/en/errors.json
+++ b/apps/chat/public/locales/en/errors.json
@@ -8,5 +8,6 @@
   "{{name}} \"{{newName}}\" already exists in this folder.": "{{name}} \"{{newName}}\" already exists in this folder.",
   "URL is not correct": "URL is not correct",
   "URL must start with a valid protocol": "URL must start with a valid protocol",
-  "Endpoint cannot end with . or //": "Endpoint cannot end with . or //"
+  "Endpoint cannot end with . or //": "Endpoint cannot end with . or //",
+  "Image not available.": "Image not available."
 }

--- a/apps/chat/public/locales/en/errors.json
+++ b/apps/chat/public/locales/en/errors.json
@@ -9,5 +9,5 @@
   "URL is not correct": "URL is not correct",
   "URL must start with a valid protocol": "URL must start with a valid protocol",
   "Endpoint cannot end with . or //": "Endpoint cannot end with . or //",
-  "Image not available.": "Image not available."
+  "The image has been deleted, does not exist, or you do not have access to it.": "The image has been deleted, does not exist, or you do not have access to it."
 }

--- a/apps/chat/src/components/Chat/MessageAttachment.tsx
+++ b/apps/chat/src/components/Chat/MessageAttachment.tsx
@@ -40,11 +40,12 @@ import {
   stopBubbling,
 } from '@/src/constants/chat';
 import { FOLDER_ATTACHMENT_CONTENT_TYPE } from '@/src/constants/folders';
-import { ChatI18nKeys } from '@/src/constants/i18n';
+import { ChatI18nKeys, ErrorsI18nKeys } from '@/src/constants/i18n';
 import { DEFAULT_ICON_SIZES } from '@/src/constants/icons';
 
 import { PdfPreviewModal } from '@/src/components/Chat/PdfAttachment/PdfPreviewModal';
 import { withErrorBoundary } from '@/src/components/Common/ErrorBoundary';
+import { ErrorMessage } from '@/src/components/Common/ErrorMessage';
 import { Spinner } from '@/src/components/Common/Spinner';
 import { Tooltip } from '@/src/components/Common/Tooltip';
 import { ChatMDComponent } from '@/src/components/Markdown/ChatMDComponent';
@@ -70,7 +71,7 @@ const getSourceDataUrl = (attachment: Attachment): string | undefined => {
   if (attachment.url) {
     return getMappedAttachmentUrl(attachment.url);
   }
-  if (attachment.data) {
+  if (attachment.data?.trim()) {
     return `data:${attachment.type};base64,${attachment.data}`;
   }
 };
@@ -79,6 +80,40 @@ const AttachmentSourceRenderer = ({
   attachment,
 }: AttachmentDataRendererProps) => {
   return <source src={getSourceDataUrl(attachment)} type={attachment.type} />;
+};
+
+const ImageAttachmentRenderer = ({
+  attachment,
+  isFullScreen,
+}: {
+  attachment: Attachment;
+  isFullScreen?: boolean;
+}) => {
+  const { t } = useTranslation(Translation.Chat);
+  const [isImageValid, setIsImageValid] = useState(true);
+  const imageUrl = getSourceDataUrl(attachment);
+  if (!imageUrl) {
+    return <ErrorMessage error={t(ErrorsI18nKeys.ImageNotAvailable)} />;
+  }
+  const onImageError = () => {
+    setIsImageValid(false);
+  };
+  if (!isImageValid) {
+    return <ErrorMessage error={t(ErrorsI18nKeys.ImageNotAvailable)} />;
+  }
+  return (
+    <img
+      src={imageUrl}
+      className={classNames(
+        'm-0',
+        isFullScreen
+          ? 'size-auto max-h-full max-w-full object-contain'
+          : 'aspect-auto w-full',
+      )}
+      alt="Attachment image"
+      onError={onImageError}
+    />
+  );
 };
 
 const AttachmentDataRenderer = ({
@@ -103,15 +138,9 @@ const AttachmentDataRenderer = ({
 
   if (IMAGE_TYPES_SET.has(attachment.type)) {
     return (
-      <img
-        src={getSourceDataUrl(attachment)}
-        className={classNames(
-          'm-0',
-          isFullScreen
-            ? 'size-auto max-h-full max-w-full object-contain'
-            : 'aspect-auto w-full',
-        )}
-        alt="Attachment image"
+      <ImageAttachmentRenderer
+        attachment={attachment}
+        isFullScreen={isFullScreen}
       />
     );
   }

--- a/apps/chat/src/components/Chat/MessageAttachment.tsx
+++ b/apps/chat/src/components/Chat/MessageAttachment.tsx
@@ -93,13 +93,17 @@ const ImageAttachmentRenderer = ({
   const [isImageValid, setIsImageValid] = useState(true);
   const imageUrl = getSourceDataUrl(attachment);
   if (!imageUrl) {
-    return <ErrorMessage error={t(ErrorsI18nKeys.ImageNotAvailable)} />;
+    return (
+      <ErrorMessage error={t(ErrorsI18nKeys.ImageIsDeletedDoesNotExist)} />
+    );
   }
   const onImageError = () => {
     setIsImageValid(false);
   };
   if (!isImageValid) {
-    return <ErrorMessage error={t(ErrorsI18nKeys.ImageNotAvailable)} />;
+    return (
+      <ErrorMessage error={t(ErrorsI18nKeys.ImageIsDeletedDoesNotExist)} />
+    );
   }
   return (
     <img

--- a/apps/chat/src/constants/i18n.ts
+++ b/apps/chat/src/constants/i18n.ts
@@ -338,6 +338,7 @@ export enum ErrorsI18nKeys {
   UrlIsNotCorrect = 'URL is not correct',
   UrlMustStartWithValidProtocol = 'URL must start with a valid protocol',
   EndpointCannotEndWithDotOrDoubleSlash = 'Endpoint cannot end with . or //',
+  ImageNotAvailable = 'Image not available.',
 }
 
 // sidebar.json

--- a/apps/chat/src/constants/i18n.ts
+++ b/apps/chat/src/constants/i18n.ts
@@ -338,7 +338,7 @@ export enum ErrorsI18nKeys {
   UrlIsNotCorrect = 'URL is not correct',
   UrlMustStartWithValidProtocol = 'URL must start with a valid protocol',
   EndpointCannotEndWithDotOrDoubleSlash = 'Endpoint cannot end with . or //',
-  ImageNotAvailable = 'Image not available.',
+  ImageIsDeletedDoesNotExist = 'The image has been deleted, does not exist, or you do not have access to it.',
 }
 
 // sidebar.json


### PR DESCRIPTION
**Description:**

- Add error message for the image if attachment was deleted

Issues:

- Issue #820 

**UI changes**

<img width="1010" height="262" alt="image" src="https://github.com/user-attachments/assets/d0e7552c-8b77-4ccd-9dbf-7329aa07cea0" />

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
