### PR TITLE
fix(chat): fix rules set on a folder do not appear when Admin updates publishing request (Issue #5833)

### DIFF
--- a/apps/chat/src/components/Chat/Publish/PublicationHandler/PublicationHandler.tsx
+++ b/apps/chat/src/components/Chat/Publish/PublicationHandler/PublicationHandler.tsx
@@ -231,20 +231,21 @@ export function PublicationHandler({ publication, onSubmit }: Props) {
     PublishRequestFieldsNames.PUBLISH_TO_URL,
   );
 
-  const rulesPath = !isReview ? editedPublishToUrl : publication.targetFolder;
+  const rulesPath =
+    !isReview || isEditMode ? editedPublishToUrl : publication.targetFolder;
 
   const rules = useAppSelector((state) =>
     PublicationSelectors.selectRulesByPath(state, rulesPath),
   );
 
   useEffect(() => {
-    if (rules && !isReview) {
+    if (rules && (!isReview || isEditMode)) {
       formMethods.setValue(
         PublishRequestFieldsNames.RULES,
         rules[rulesPath] ?? [],
       );
     }
-  }, [formMethods, rulesPath, rules, isReview]);
+  }, [formMethods, rulesPath, rules, isReview, isEditMode]);
 
   useEffect(() => {
     if (!isEditMode) {


### PR DESCRIPTION
**Description:**

- Fix rules set on a folder do not appear when Admin updates publishing request.
- Allow to change rules in `Edit` mode for Admin.

Issues:

- Issue #5833 

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
