### PR TITLE
chore: add security review workflow for development-1.0 branch

### DIFF
--- a/.github/workflows/security-review.yml
+++ b/.github/workflows/security-review.yml
@@ -1,0 +1,42 @@
+name: Security Review
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+    branches: [development-1.0]
+
+jobs:
+  security-review:
+    if: |
+      github.base_ref == 'development-1.0' &&
+      contains(github.event.pull_request.labels.*.name, 'security-review')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Validate API key
+        run: |
+          if [ -z "${{ secrets.ANTHROPIC_API_KEY }}" ]; then
+            echo "::error::ANTHROPIC_API_KEY secret is not set or empty"
+            exit 1
+          fi
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Run Security Review
+        id: review
+        uses: anthropics/claude-code-security-review@0c6a49f1fa56a1d472575da86a94dbc1edb78eda
+        with:
+          claude-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
+          comment-pr: true
+          run-every-commit: true
+          claude-model: ${{ vars.CLAUDE_MODEL || 'claude-sonnet-4-6' }}
+
+      - name: Comment when no findings
+        if: steps.review.outputs.findings-count == '0'
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            ✅ Security review: no issues found.


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/security-review.yml` — a Claude-powered security review job scoped to PRs targeting `development-1.0`.
- Runs only when the PR is labeled `security-review`, guarded by both the trigger-level `branches:` filter and a job-level `github.base_ref` check.
- Pins all actions by SHA: `actions/checkout@v6.0.2`, `anthropics/claude-code-security-review@<main>`, `peter-evans/create-or-update-comment@v5.0.0`.
- Posts a `✅ Security review: no issues found.` comment when the action reports `findings-count == 0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)