### PR TITLE
ci: better changelog generation based on conventional commits

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,17 +9,19 @@ updates:
     # Disable version updates, keep security updates only
     open-pull-requests-limit: 0
     commit-message:
-      # Prefix all commit messages with "chore: "
       prefix: "chore"
+      include: scope
   - package-ecosystem: "github-actions"
-    directory: "/"
+    directories:
+      - "/"
+      - ".github/actions/**"
     schedule:
       interval: "weekly"
       day: "wednesday"
       time: "09:00"
     commit-message:
-      # Prefix all commit messages with "chore: "
-      prefix: "chore"
+      prefix: "ci"
+      include: scope
     groups:
       ai-dial-ci:
         applies-to: version-updates

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,3 +15,24 @@
 
 - [ ] the pull request name ends with `(Issue #<ISSUE_ID>)` (comma-separated list of issues)
 - [ ] I confirm that I don't share any confidential information like API keys or any other secrets and private URLs
+
+<details>
+  <summary>PR title cheatsheet</summary>
+
+`<type>[optional scope]: <description>`
+
+1. type (required)
+    - `feat` - A new feature
+    - `fix` - A bug fix
+    - `docs` - Documentation only changes
+    - `test` - Adding missing tests or correcting existing tests
+    - `ci` - Changes to our CI configuration files and scripts
+    - `chore` - Other changes that are minor and/or not user-facing
+2. scope (optional, current repo suggestions below)
+    - `chat`
+    - `overlay`
+    - `shared`
+    - `sandbox-overlay`
+    - `visualizer-connector`
+
+</details>

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,18 +1,17 @@
-**Description:**
+## Description of changes
 
-<SHORT_DESCRIPTION>
+<!-- Please explain the changes you made right below this line. -->
 
-Issues:
+## Applicable issues
 
-- Issue #<TICKET_ID>
+<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
+- fixes #<ISSUE_ID>
 
-**UI changes**
+## UI changes
 
 <Please, provide Screenshots or Figma links>
 
-**Checklist:**
+## Checklist
 
-- [ ] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
-- [ ] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
-- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
-- [ ] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
+- [ ] the pull request name ends with `(Issue #<ISSUE_ID>)` (comma-separated list of issues)
+- [ ] I confirm that I don't share any confidential information like API keys or any other secrets and private URLs

--- a/.github/workflows/deploy-development.yml
+++ b/.github/workflows/deploy-development.yml
@@ -24,7 +24,7 @@ jobs:
             gitlab-project-id: "3016"
 
     name: Deploy to ${{ matrix.environment-name }}
-    uses: epam/ai-dial-ci/.github/workflows/deploy-development.yml@4.0.1
+    uses: epam/ai-dial-ci/.github/workflows/deploy-development.yml@4.2.0
     with:
       gitlab-project-id: ${{ matrix.gitlab-project-id }}
       environment-name: ${{ matrix.environment-name }}

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -16,6 +16,6 @@ concurrency:
 
 jobs:
   pr-title-check:
-    uses: epam/ai-dial-ci/.github/workflows/pr-title-check.yml@4.0.1
+    uses: epam/ai-dial-ci/.github/workflows/pr-title-check.yml@4.2.0
     secrets:
       ACTIONS_BOT_TOKEN: ${{ secrets.ACTIONS_BOT_TOKEN }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   run_tests:
-    uses: epam/ai-dial-ci/.github/workflows/node_pr.yml@4.0.1
+    uses: epam/ai-dial-ci/.github/workflows/node_pr.yml@4.2.0
     secrets: inherit
     with:
       node-version: 24

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,9 +21,10 @@ concurrency:
 
 jobs:
   release:
-    uses: epam/ai-dial-ci/.github/workflows/node_release.yml@4.0.1
+    uses: epam/ai-dial-ci/.github/workflows/node_release.yml@4.2.0
     with:
       promote: ${{ github.event_name == 'workflow_dispatch' && inputs.promote }}
       node-version: 24
       maximize-build-space: true
+      draft-stable-releases: true
     secrets: inherit


### PR DESCRIPTION
- bump `epam/ai-dial-ci` to version with extended conventional commits spec support
- enable creation of GitHub releases for "stable" versions as drafts
- enable dependabot version updates for composite actions (`test-chat`, `test-overlay`)
- adjust dependabot commit message settings to match new conventional commit types and scopes
- edit PR template by removing excessive conventional commit requirements from checklist