### PR TITLE
chore: trigger security review on label add

### DIFF
--- a/.github/workflows/security-review.yml
+++ b/.github/workflows/security-review.yml
@@ -2,7 +2,7 @@ name: Security Review
 
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [opened, synchronize, labeled]
     branches: [development-1.0]
 
 jobs:


### PR DESCRIPTION
## Summary
- Adds \`labeled\` to the security-review workflow's \`pull_request\` activity types.
- Closes the UX gap where applying the \`security-review\` label after PR creation (including via \`gh pr create --label\`, which applies labels in a separate API call) did not fire the workflow.
- Job-level \`if: contains(... 'security-review')\` continues to gate execution, so other label changes start the workflow but the job skips immediately.

## Context
Observed on test PR #6753: the initial \`opened\` event fired with an empty labels array (label was applied a moment later), so the job was skipped. A subsequent push made it run because \`synchronize\` saw the label present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)