### PR TITLE
fix(chat): fix hidden files for attach disabling (Issue #6260)

### DIFF
--- a/apps/chat/src/components/Files/FileManagerModal.tsx
+++ b/apps/chat/src/components/Files/FileManagerModal.tsx
@@ -270,6 +270,15 @@ export const FileManagerModal = memo(
       t,
     ]);
 
+    const getDisabledTooltip = useCallback(
+      (row: { name?: string; path?: string }) => {
+        if (isHiddenEntity(row)) {
+          return t(ChatI18nKeys.AttachingHiddenFilesIsNotAllowed);
+        }
+      },
+      [t],
+    );
+
     const availableTabs = useMemo(() => {
       if (!sourceFilters) return undefined;
 
@@ -424,6 +433,7 @@ export const FileManagerModal = memo(
               onCreateFolderValidate={handleRenameValidation}
               sharedWithMeIds={sharedWithMeIds}
               uploadEnabled={uploadEnabled}
+              getDisabledTooltip={getDisabledTooltip}
               hideSearchPathItemName
               autoSelectUploadedItems
             />

--- a/apps/chat/src/constants/i18n.ts
+++ b/apps/chat/src/constants/i18n.ts
@@ -822,6 +822,7 @@ export enum ChatI18nKeys {
   AttachFoldersAndUploadedFiles = 'Attach folders and uploaded files',
   AttachUploadedFiles = 'Attach uploaded files',
   Attach = 'Attach',
+  AttachingHiddenFilesIsNotAllowed = 'Attaching hidden files is not allowed.',
   Address = 'Address',
   PasteLink = 'Paste link',
   Title = 'Title',

--- a/apps/chat/src/utils/app/search.ts
+++ b/apps/chat/src/utils/app/search.ts
@@ -24,8 +24,12 @@ export const doesEntityContainSearchTerm = (
     .includes(searchTerm.toLowerCase().trim());
 };
 
-export const isHiddenEntity = (entity: { name: string }) =>
-  entity?.name?.startsWith('.');
+export const isHiddenEntity = (entity: { name?: string; path?: string }) => {
+  if (entity.path) {
+    return entity.path.split('/').some((part) => part.startsWith('.'));
+  }
+  return !!entity?.name?.startsWith('.');
+};
 
 export const isSearchTermMatched = (entity: ShareEntity, searchTerm?: string) =>
   !searchTerm || doesEntityContainSearchTerm(entity, searchTerm);


### PR DESCRIPTION
## Description of changes

Hidden files and files from hidden folder should be disabled (with tooltip-explanation) on 'Attach files' modal. Such files should be available in 'File manager' opened from the panel.

## Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #6260 

## UI changes

<img width="593" height="110" alt="Снимок экрана — 2026-05-19 в 18 26 28" src="https://github.com/user-attachments/assets/13aef04c-f8e6-4dc0-ab92-0c3327176490" />

## Checklist

- [x] the pull request name ends with `(Issue #<ISSUE_ID>)` (comma-separated list of issues)
- [x] I confirm that I don't share any confidential information like API keys or any other secrets and private URLs

<details>
  <summary>PR title cheatsheet</summary>

`<type>[optional scope]: <description>`

1. type (required)
    - `feat` - A new feature
    - `fix` - A bug fix
    - `docs` - Documentation only changes
    - `test` - Adding missing tests or correcting existing tests
    - `ci` - Changes to our CI configuration files and scripts
    - `chore` - Other changes that are minor and/or not user-facing
2. scope (optional, current repo suggestions below)
    - `chat`
    - `overlay`
    - `shared`
    - `sandbox-overlay`
    - `visualizer-connector`

</details>
