### PR TITLE
feat(chat): User message align-end layout (feature flag)(Issue #6775)

### DIFF
--- a/apps/chat/src/components/Chat/ChatMessage/ChatMessageContent/ChatMessageContent.tsx
+++ b/apps/chat/src/components/Chat/ChatMessage/ChatMessageContent/ChatMessageContent.tsx
@@ -18,7 +18,12 @@ import { AssistantMessage } from '@/src/components/Chat/ChatMessage/ChatMessageC
 import { UserMessage } from '@/src/components/Chat/ChatMessage/ChatMessageContent/UserMessage';
 import { ModelIcon } from '@/src/components/Chatbar/ModelIcon';
 
-import { Message, Role, onLikeMessageHandler } from '@epam/ai-dial-shared';
+import {
+  Feature,
+  Message,
+  Role,
+  onLikeMessageHandler,
+} from '@epam/ai-dial-shared';
 
 interface Props {
   message: Message;
@@ -77,13 +82,17 @@ export function ChatMessageContent({
   const modelsMap = useAppSelector(ModelsSelectors.selectModelsMap);
   const isChatFullWidth = useAppSelector(UISelectors.selectIsChatFullWidth);
   const isOverlay = useAppSelector(SettingsSelectors.selectIsOverlay);
-
+  const isUserMessageAlignEndEnabled = useAppSelector((state) =>
+    SettingsSelectors.isFeatureEnabled(state, Feature.UserMessageAlignEnd),
+  );
   const messageRef = useRef<HTMLDivElement>(null);
 
   const isAssistant = message.role === Role.Assistant;
   const isShowResponseLoader: boolean =
     !!conversation.isMessageStreaming && isLastMessage;
   const isUser = message.role === Role.User;
+  const alignUserMessageEnd =
+    isUser && !isEditing && isUserMessageAlignEndEnabled;
 
   const chatIconSize = isOverlay
     ? OVERLAY_ICON_SIZE
@@ -112,13 +121,18 @@ export function ChatMessageContent({
           'm-auto flex h-full md:gap-6 md:py-6 lg:px-0',
           !isChatFullWidth && 'md:max-w-2xl xl:max-w-3xl',
           isMobileOrOverlay ? 'p-3' : 'p-4',
+          alignUserMessageEnd && 'flex-row-reverse justify-end',
         )}
       >
         <div className="font-bold" data-qa="message-icon">
           <div
             className={classNames(
               'flex justify-center',
-              isMobileOrOverlay ? 'mr-2.5' : 'mx-2.5',
+              alignUserMessageEnd
+                ? 'ms-2.5'
+                : isMobileOrOverlay
+                  ? 'mr-2.5'
+                  : 'mx-2.5',
             )}
           >
             {isAssistant ? (
@@ -138,7 +152,10 @@ export function ChatMessageContent({
         </div>
 
         <div
-          className="mt-[-2px] w-full min-w-0 shrink"
+          className={classNames(
+            'mt-[-2px] w-full min-w-0 shrink',
+            alignUserMessageEnd && 'text-end',
+          )}
           data-qa="message-content"
         >
           {isUser ? (
@@ -150,6 +167,7 @@ export function ChatMessageContent({
               conversation={conversation}
               isEditing={isEditing}
               isEditingTemplates={isEditingTemplates}
+              isAlignedToEnd={alignUserMessageEnd}
               withButtons={withButtons}
               editDisabled={editDisabled}
               onToggleEditing={onToggleEditing}

--- a/apps/chat/src/components/Chat/ChatMessage/ChatMessageContent/UserMessage.tsx
+++ b/apps/chat/src/components/Chat/ChatMessage/ChatMessageContent/UserMessage.tsx
@@ -87,6 +87,7 @@ interface UserMessageProps {
   allMessages: Message[];
   isEditing: boolean;
   isEditingTemplates: boolean;
+  isAlignedToEnd?: boolean;
   withButtons?: boolean;
   editDisabled?: boolean;
   onToggleEditing: (value: boolean) => void;
@@ -107,6 +108,7 @@ export const UserMessage = memo(function UserMessage({
   allMessages,
   isEditing,
   isEditingTemplates,
+  isAlignedToEnd,
   withButtons,
   editDisabled,
   onToggleEditing,
@@ -783,7 +785,12 @@ export const UserMessage = memo(function UserMessage({
 
   return (
     <>
-      <div className="relative mr-2 flex w-full flex-col gap-5">
+      <div
+        className={classNames('relative flex w-full flex-col gap-5', {
+          'me-2': isAlignedToEnd,
+          'mr-2': !isAlignedToEnd,
+        })}
+      >
         <UserSchema
           formValue={currentFormValue}
           messageIndex={messageIndex}

--- a/libs/shared/src/types/features.ts
+++ b/libs/shared/src/types/features.ts
@@ -35,6 +35,7 @@ export enum Feature {
   EditAllAssistantContent = 'edit-all-assistant-message', // allow edit all assistant messages
 
   // Edit user message
+  UserMessageAlignEnd = 'user-message-align-end', // Align user messages to the inline end (right in LTR)
   HideEditUserMessage = 'hide-edit-user-message', // Hide editing button of user message
 
   // Regenerate assistant message


### PR DESCRIPTION
## Description of changes

Today, user and assistant messages share the same left-aligned layout. Users expect their own messages on the opposite side from the assistant’s replies. With upcoming RTL support, alignment must use logical CSS properties (start / end, ms / me, text-end, justify-end) so the layout mirrors correctly when dir="rtl" is set on the app container.

Proposed solution
New feature flag in Feature enum:

UserMessageAlignEnd (user-message-align-end)
Enabled via ENABLED_FEATURES (same mechanism as other DIAL Chat features).
When the flag is enabled (and the message is not in edit mode):

User message row: flex-row-reverse, justify-end, text-end
Icon spacing: logical margin (ms-2.5)
Assistant messages: unchanged (default left/start alignment).
When the flag is disabled:

Current layout is preserved (all messages left-aligned).
Edit mode:

User message editing keeps full-width layout (no end alignment) for usable textarea and actions.

## Applicable issues

- fixes #6775

## UI changes
<img width="1799" height="1000" alt="Screenshot 2026-05-19 at 17 46 38" src="https://github.com/user-attachments/assets/9f72a589-61ab-401a-82ca-1d0b59d56b66" />

## Checklist

- [x] the pull request name ends with `(Issue #<ISSUE_ID>)` (comma-separated list of issues)
- [x] I confirm that I don't share any confidential information like API keys or any other secrets and private URLs

<details>
  <summary>PR title cheatsheet</summary>

`<type>[optional scope]: <description>`

1. type (required)
    - `feat` - A new feature
    - `fix` - A bug fix
    - `docs` - Documentation only changes
    - `test` - Adding missing tests or correcting existing tests
    - `ci` - Changes to our CI configuration files and scripts
    - `chore` - Other changes that are minor and/or not user-facing
2. scope (optional, current repo suggestions below)
    - `chat`
    - `overlay`
    - `shared`
    - `sandbox-overlay`
    - `visualizer-connector`

</details>
