### PR TITLE
feat(chat): add time awareness setting for quick app (Issue #6516)

### DIFF
--- a/apps/chat/public/locales/en/marketplace.json
+++ b/apps/chat/public/locales/en/marketplace.json
@@ -179,5 +179,8 @@
   "Connect via": "Connect via",
   "Apply changes": "Apply changes",
   "MCP": "MCP",
-  "Chat Completion": "Chat Completion"
+  "Chat Completion": "Chat Completion",
+  "Agent settings": "Agent settings",
+  "Agent-wide behavior switches that apply to every conversation.": "Agent-wide behavior switches that apply to every conversation.",
+  "Time awareness": "Time awareness"
 }

--- a/apps/chat/src/components/AppsEditor/EditorForm/QuickApp2Form/QuickApp2Form.tsx
+++ b/apps/chat/src/components/AppsEditor/EditorForm/QuickApp2Form/QuickApp2Form.tsx
@@ -468,6 +468,27 @@ export const QuickApp2Form: FC<AppsEditorProps> = ({ onAutoSave }) => {
         </div>
       </FormCollapsibleSection>
 
+      <FormCollapsibleSection
+        name={t(MarketplaceI18nKeys.AgentSettings)}
+        description={t(MarketplaceI18nKeys.AgentSettingsDescription)}
+        dataQa="agent-settings-section"
+      >
+        <Controller
+          name="timestamp"
+          control={control}
+          render={({ field }) => (
+            <ToggleSwitch
+              isOn={field.value}
+              handleSwitch={() => field.onChange(!field.value)}
+              switchOnText="ON"
+              switchOFFText="OFF"
+              additionalText={t(MarketplaceI18nKeys.TimeAwareness)}
+              className="flex items-center gap-2"
+            />
+          )}
+        />
+      </FormCollapsibleSection>
+
       {doesAgentSupportMcp(appDetails) && !!dialCoreExternalUrl && (
         <div className="flex flex-col gap-4 px-5 py-4">
           <h5 className="text-base font-semibold text-primary">

--- a/apps/chat/src/components/AppsEditor/form.ts
+++ b/apps/chat/src/components/AppsEditor/form.ts
@@ -239,6 +239,7 @@ export const QuickApp2Schema = zodValidation
       .array(zodValidation.string())
       .optional(),
     agentSkills: zodValidation.array(zodValidation.string()),
+    timestamp: zodValidation.boolean(),
   })
   .superRefine((data, ctx) => {
     if (data.isJsonView) {
@@ -465,6 +466,10 @@ const getQuickApp2FormData = (
       ? defaultModelId // use default quick app model
       : (toolSupportingModelIds?.[0] ?? ''); // use first from list
   }
+  const timestamp =
+    'timestamp' in (appProperties?.features ?? {})
+      ? !!appProperties?.features?.timestamp
+      : true;
 
   return {
     type: AppsEditorSchemaTypes.QuickApp2,
@@ -502,6 +507,7 @@ const getQuickApp2FormData = (
     agentSkills: (appProperties?.skills ?? [])
       .filter((s): s is DialPromptSkill => s.type === 'dial-prompt')
       .map((s) => ApiUtils.decodeApiUrl(s.url)),
+    timestamp,
   };
 };
 
@@ -916,6 +922,13 @@ export const getApplicationPayload = ({
               }),
             ),
           }),
+          features: {
+            timestamp: data.timestamp
+              ? {
+                  injection_strategy: 'tool_call',
+                }
+              : null,
+          },
           ...(starters.length
             ? {
                 conversation_starters: {

--- a/apps/chat/src/constants/i18n.ts
+++ b/apps/chat/src/constants/i18n.ts
@@ -1112,4 +1112,7 @@ export enum MarketplaceI18nKeys {
   ApplyChanges = 'Apply changes',
   MCP = 'MCP',
   ChatCompletion = 'Chat Completion',
+  AgentSettings = 'Agent settings',
+  AgentSettingsDescription = 'Agent-wide behavior switches that apply to every conversation.',
+  TimeAwareness = 'Time awareness',
 }

--- a/apps/chat/src/types/quick-apps.ts
+++ b/apps/chat/src/types/quick-apps.ts
@@ -109,6 +109,11 @@ export interface QuickApp2Config {
   input_attachment_types?: string[];
   max_input_attachments?: number;
   skills?: DialPromptSkill[];
+  features?: {
+    timestamp?: {
+      injection_strategy: 'tool_call';
+    } | null;
+  };
 }
 
 export function isDialDeploymentToolset(


### PR DESCRIPTION
## Description of changes

- add agent settings section and time awareness switch

## Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #6516

## UI changes

<img width="769" height="153" alt="Screenshot 2026-05-20 at 12 53 08" src="https://github.com/user-attachments/assets/1934b01f-ec21-45ef-92c7-ecea7f5d9c3b" />


## Checklist

- [x] the pull request name ends with `(Issue #<ISSUE_ID>)` (comma-separated list of issues)
- [x] I confirm that I don't share any confidential information like API keys or any other secrets and private URLs
