### PR TITLE
feat(overlay): Add floating action buttons when (Issue #6710)

### DIFF
--- a/apps/chat/src/components/Buttons/ToggleSidebarButton.tsx
+++ b/apps/chat/src/components/Buttons/ToggleSidebarButton.tsx
@@ -10,7 +10,11 @@ import { Translation } from '@/src/types/translation';
 
 import MoveLeftIcon from '@/public/images/icons/move-left.svg';
 import MoveRightIcon from '@/public/images/icons/move-right.svg';
-import { DialButton } from '@epam/ai-dial-ui-kit';
+import {
+  ButtonAppearance,
+  ButtonVariant,
+  DialButton,
+} from '@epam/ai-dial-ui-kit';
 
 interface Props {
   iconSize: number;
@@ -21,6 +25,7 @@ interface Props {
   rightSide?: boolean;
   isOverlay?: boolean;
   filterIndicator?: boolean;
+  isFloatingToggle?: boolean;
 }
 
 export const ToggleSidebarButton: React.FC<Props> = ({
@@ -32,6 +37,7 @@ export const ToggleSidebarButton: React.FC<Props> = ({
   rightSide = false,
   isOverlay = false,
   filterIndicator = false,
+  isFloatingToggle = false,
 }) => {
   const { t } = useTranslation(Translation.Header);
 
@@ -49,7 +55,9 @@ export const ToggleSidebarButton: React.FC<Props> = ({
     <div className="relative">
       <Icon
         className={classNames(
-          'text-secondary hover:text-accent-primary',
+          isFloatingToggle
+            ? 'text-secondary'
+            : 'text-secondary hover:text-accent-primary',
           rightSide && 'rotate-180',
         )}
         width={iconSize}
@@ -60,16 +68,25 @@ export const ToggleSidebarButton: React.FC<Props> = ({
       )}
     </div>
   );
+
   return (
     <DialButton
       className={classNames(
-        'flex h-full shrink-0 items-center justify-center px-3',
-        isOverlay ? 'md:px-3' : 'md:px-5',
+        isFloatingToggle
+          ? 'size-10 shrink-0 p-0'
+          : [
+              'flex h-full shrink-0 items-center justify-center px-3',
+              isOverlay ? 'md:px-3' : 'md:px-5',
+            ],
       )}
       tooltipProps={{ isTriggerClickable: true, tooltip: t(tooltip) }}
       data-qa={dataQa}
       onClick={handleToggle}
       iconBefore={IconContent}
+      {...(isFloatingToggle && {
+        appearance: ButtonAppearance.Outlined,
+        variant: ButtonVariant.Neutral,
+      })}
     />
   );
 };

--- a/apps/chat/src/components/Chat/ChatHeader/Header.tsx
+++ b/apps/chat/src/components/Chat/ChatHeader/Header.tsx
@@ -7,6 +7,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import classNames from 'classnames';
 
+import { useFloatingPanelTogglePadding } from '@/src/hooks/useFloatingPanelTogglePadding';
 import { usePublicVersionGroupId } from '@/src/hooks/usePublicVersionGroupIdFromPublicEntity';
 import { useScreenState } from '@/src/hooks/useScreenState';
 import { useTranslation } from '@/src/hooks/useTranslation';
@@ -108,6 +109,7 @@ export const ChatHeader = Inversify.register(
     const enabledFeatures = useAppSelector(
       SettingsSelectors.selectEnabledFeatures,
     );
+    const floatingPanelTogglePadding = useFloatingPanelTogglePadding();
     const selectedConversations = useAppSelector(
       ConversationsSelectors.selectSelectedConversations,
     );
@@ -195,6 +197,7 @@ export const ChatHeader = Inversify.register(
             'sticky top-0 z-10 flex w-full min-w-0 items-center justify-center gap-2 bg-layer-2 px-3 py-2 text-sm md:flex-wrap md:px-0 lg:flex-row',
             isChatHeaderBorderEnabled && 'border-b border-secondary',
             isChatFullWidth && 'px-3 md:px-5 lg:flex-nowrap',
+            floatingPanelTogglePadding,
           )}
           data-qa="chat-header"
         >

--- a/apps/chat/src/components/Header/FloatingPanelToggles.tsx
+++ b/apps/chat/src/components/Header/FloatingPanelToggles.tsx
@@ -1,0 +1,72 @@
+import { useSidebarPanelToggles } from '@/src/hooks/useSidebarPanelToggles';
+
+import { useAppSelector } from '@/src/store/hooks';
+import { SettingsSelectors } from '@/src/store/selectors';
+
+import { HeaderI18nKeys } from '@/src/constants/i18n';
+
+import { ToggleSidebarButton } from '@/src/components/Buttons/ToggleSidebarButton';
+
+import { Feature } from '@epam/ai-dial-shared';
+
+export const FloatingPanelToggles = () => {
+  const enabledFeatures = useAppSelector(
+    SettingsSelectors.selectEnabledFeatures,
+  );
+
+  const {
+    showChatbar,
+    showPromptbar,
+    isOverlay,
+    headerIconSize,
+    handleToggleChatbar,
+    handleTogglePromtbar,
+  } = useSidebarPanelToggles();
+
+  const showConversationsToggle = enabledFeatures.has(
+    Feature.ConversationsPanelToggle,
+  );
+  const showPromptsToggle = enabledFeatures.has(Feature.PromptsPanelToggle);
+
+  if (
+    enabledFeatures.has(Feature.Header) ||
+    (!showConversationsToggle && !showPromptsToggle)
+  ) {
+    return null;
+  }
+
+  return (
+    <div
+      className="pointer-events-none absolute inset-x-0 top-0 z-30 flex justify-between p-2"
+      data-qa="floating-panel-toggles"
+    >
+      {showConversationsToggle && (
+        <div className="pointer-events-auto">
+          <ToggleSidebarButton
+            iconSize={headerIconSize}
+            tooltip={HeaderI18nKeys.Conversations}
+            isOpened={showChatbar}
+            onToggle={handleToggleChatbar}
+            dataQa="left-panel-toggle"
+            isOverlay={isOverlay}
+            isFloatingToggle
+          />
+        </div>
+      )}
+      {showPromptsToggle && (
+        <div className="pointer-events-auto">
+          <ToggleSidebarButton
+            iconSize={headerIconSize}
+            tooltip={HeaderI18nKeys.Prompts}
+            isOpened={showPromptbar}
+            onToggle={handleTogglePromtbar}
+            dataQa="right-panel-toggle"
+            rightSide
+            isOverlay={isOverlay}
+            isFloatingToggle
+          />
+        </div>
+      )}
+    </div>
+  );
+};

--- a/apps/chat/src/components/Header/Header.tsx
+++ b/apps/chat/src/components/Header/Header.tsx
@@ -1,19 +1,8 @@
-import { useCallback, useState } from 'react';
+import { useSidebarPanelToggles } from '@/src/hooks/useSidebarPanelToggles';
 
-import { useWindowResizeEvent } from '@/src/hooks/useWindowResizeEvent';
+import { useAppSelector } from '@/src/store/hooks';
+import { SettingsSelectors } from '@/src/store/selectors';
 
-import { isSmallScreen, isTabletScreen } from '@/src/utils/app/mobile';
-import { centralChatWidth, getNewSidebarWidth } from '@/src/utils/app/sidebar';
-
-import { UIActions } from '@/src/store/actions';
-import { useAppDispatch, useAppSelector } from '@/src/store/hooks';
-import { SettingsSelectors, UISelectors } from '@/src/store/selectors';
-
-import { CENTRAL_CHAT_MIN_WIDTH } from '@/src/constants/chat';
-import {
-  DEFAULT_HEADER_ICON_SIZE,
-  OVERLAY_HEADER_ICON_SIZE,
-} from '@/src/constants/default-ui-settings';
 import { HeaderI18nKeys } from '@/src/constants/i18n';
 
 import { ToggleSidebarButton } from '@/src/components/Buttons/ToggleSidebarButton';
@@ -25,92 +14,18 @@ import { Inversify } from '@epam/ai-dial-modulify-ui';
 import { Feature } from '@epam/ai-dial-shared';
 
 export const Header = Inversify.register('Header', () => {
-  const showChatbar = useAppSelector(UISelectors.selectShowChatbar);
-  const showPromptbar = useAppSelector(UISelectors.selectShowPromptbar);
-
-  const isOverlay = useAppSelector(SettingsSelectors.selectIsOverlay);
-
-  const [windowWidth, setWindowWidth] = useState<number | undefined>(() => {
-    if (typeof window !== 'undefined') {
-      return window.innerWidth;
-    }
-  });
-
-  const chatbarWidth = useAppSelector(UISelectors.selectChatbarWidth);
-  const promptbarWidth = useAppSelector(UISelectors.selectPromptbarWidth);
-
-  const dispatch = useAppDispatch();
-
   const enabledFeatures = useAppSelector(
     SettingsSelectors.selectEnabledFeatures,
   );
 
-  const handleToggleChatbar = useCallback(() => {
-    if (!showChatbar && isTabletScreen()) {
-      dispatch(UIActions.setShowPromptbar(false));
-    }
-
-    if (!showChatbar && isSmallScreen()) {
-      dispatch(UIActions.setIsProfileOpen(false));
-    }
-
-    if (!showChatbar && !isTabletScreen()) {
-      if (!windowWidth) return;
-      const calculatedChatWidth = centralChatWidth({
-        oppositeSidebarWidth: promptbarWidth,
-        windowWidth,
-        currentSidebarWidth: chatbarWidth,
-      });
-
-      if (calculatedChatWidth < CENTRAL_CHAT_MIN_WIDTH) {
-        const newPromptbarWidth = getNewSidebarWidth({
-          windowWidth,
-          oppositeSidebarWidth: chatbarWidth,
-        });
-        dispatch(UIActions.setPromptbarWidth(newPromptbarWidth));
-      }
-    }
-
-    dispatch(UIActions.setShowChatbar(!showChatbar));
-  }, [chatbarWidth, dispatch, promptbarWidth, showChatbar, windowWidth]);
-
-  const handleTogglePromtbar = useCallback(() => {
-    if (!showPromptbar && isTabletScreen()) {
-      dispatch(UIActions.setShowChatbar(false));
-    }
-
-    if (!showPromptbar && isSmallScreen()) {
-      dispatch(UIActions.setIsProfileOpen(false));
-    }
-
-    if (!showPromptbar && !isTabletScreen()) {
-      if (!windowWidth) return;
-      const calculatedChatWidth = centralChatWidth({
-        oppositeSidebarWidth: chatbarWidth,
-        windowWidth,
-        currentSidebarWidth: promptbarWidth,
-      });
-
-      if (calculatedChatWidth < CENTRAL_CHAT_MIN_WIDTH) {
-        const newChatbarWidth = getNewSidebarWidth({
-          windowWidth,
-          oppositeSidebarWidth: promptbarWidth,
-        });
-        dispatch(UIActions.setChatbarWidth(newChatbarWidth));
-      }
-    }
-
-    dispatch(UIActions.setShowPromptbar(!showPromptbar));
-  }, [chatbarWidth, dispatch, promptbarWidth, showPromptbar, windowWidth]);
-
-  const headerIconSize = isOverlay
-    ? OVERLAY_HEADER_ICON_SIZE
-    : DEFAULT_HEADER_ICON_SIZE;
-
-  const handleResize = useCallback(() => {
-    setWindowWidth(window.innerWidth);
-  }, []);
-  useWindowResizeEvent(handleResize);
+  const {
+    showChatbar,
+    showPromptbar,
+    isOverlay,
+    headerIconSize,
+    handleToggleChatbar,
+    handleTogglePromtbar,
+  } = useSidebarPanelToggles();
 
   return (
     <BaseHeader

--- a/apps/chat/src/hooks/useFloatingPanelTogglePadding.ts
+++ b/apps/chat/src/hooks/useFloatingPanelTogglePadding.ts
@@ -1,0 +1,41 @@
+import { useMemo } from 'react';
+
+import { useAppSelector } from '@/src/store/hooks';
+import { SettingsSelectors } from '@/src/store/selectors';
+
+import { Feature } from '@epam/ai-dial-shared';
+
+/** 40px toggle + 8px container padding (p-2) on each side */
+export const FLOATING_PANEL_TOGGLE_SIDE_OFFSET_PX = 48;
+
+export const useFloatingPanelTogglePadding = () => {
+  const enabledFeatures = useAppSelector(
+    SettingsSelectors.selectEnabledFeatures,
+  );
+
+  return useMemo(() => {
+    if (enabledFeatures.has(Feature.Header)) {
+      return '';
+    }
+
+    const classes: string[] = [];
+
+    const hasFloatingPanelToggles =
+      enabledFeatures.has(Feature.ConversationsPanelToggle) ||
+      enabledFeatures.has(Feature.PromptsPanelToggle);
+
+    if (hasFloatingPanelToggles) {
+      classes.push('!py-4');
+    }
+
+    if (enabledFeatures.has(Feature.ConversationsPanelToggle)) {
+      classes.push('!pl-12', 'md:!pl-12');
+    }
+
+    if (enabledFeatures.has(Feature.PromptsPanelToggle)) {
+      classes.push('!pr-12', 'md:!pr-12');
+    }
+
+    return classes.join(' ');
+  }, [enabledFeatures]);
+};

--- a/apps/chat/src/hooks/useSidebarPanelToggles.ts
+++ b/apps/chat/src/hooks/useSidebarPanelToggles.ts
@@ -1,0 +1,108 @@
+import { useCallback, useState } from 'react';
+
+import { useWindowResizeEvent } from '@/src/hooks/useWindowResizeEvent';
+
+import { isSmallScreen, isTabletScreen } from '@/src/utils/app/mobile';
+import { centralChatWidth, getNewSidebarWidth } from '@/src/utils/app/sidebar';
+
+import { UIActions } from '@/src/store/actions';
+import { useAppDispatch, useAppSelector } from '@/src/store/hooks';
+import { SettingsSelectors, UISelectors } from '@/src/store/selectors';
+
+import { CENTRAL_CHAT_MIN_WIDTH } from '@/src/constants/chat';
+import {
+  DEFAULT_HEADER_ICON_SIZE,
+  OVERLAY_HEADER_ICON_SIZE,
+} from '@/src/constants/default-ui-settings';
+
+export const useSidebarPanelToggles = () => {
+  const showChatbar = useAppSelector(UISelectors.selectShowChatbar);
+  const showPromptbar = useAppSelector(UISelectors.selectShowPromptbar);
+  const isOverlay = useAppSelector(SettingsSelectors.selectIsOverlay);
+  const chatbarWidth = useAppSelector(UISelectors.selectChatbarWidth);
+  const promptbarWidth = useAppSelector(UISelectors.selectPromptbarWidth);
+
+  const dispatch = useAppDispatch();
+
+  const [windowWidth, setWindowWidth] = useState<number | undefined>(() => {
+    if (typeof window !== 'undefined') {
+      return window.innerWidth;
+    }
+  });
+
+  const handleToggleChatbar = useCallback(() => {
+    if (!showChatbar && isTabletScreen()) {
+      dispatch(UIActions.setShowPromptbar(false));
+    }
+
+    if (!showChatbar && isSmallScreen()) {
+      dispatch(UIActions.setIsProfileOpen(false));
+    }
+
+    if (!showChatbar && !isTabletScreen()) {
+      if (!windowWidth) return;
+      const calculatedChatWidth = centralChatWidth({
+        oppositeSidebarWidth: promptbarWidth,
+        windowWidth,
+        currentSidebarWidth: chatbarWidth,
+      });
+
+      if (calculatedChatWidth < CENTRAL_CHAT_MIN_WIDTH) {
+        const newPromptbarWidth = getNewSidebarWidth({
+          windowWidth,
+          oppositeSidebarWidth: chatbarWidth,
+        });
+        dispatch(UIActions.setPromptbarWidth(newPromptbarWidth));
+      }
+    }
+
+    dispatch(UIActions.setShowChatbar(!showChatbar));
+  }, [chatbarWidth, dispatch, promptbarWidth, showChatbar, windowWidth]);
+
+  const handleTogglePromtbar = useCallback(() => {
+    if (!showPromptbar && isTabletScreen()) {
+      dispatch(UIActions.setShowChatbar(false));
+    }
+
+    if (!showPromptbar && isSmallScreen()) {
+      dispatch(UIActions.setIsProfileOpen(false));
+    }
+
+    if (!showPromptbar && !isTabletScreen()) {
+      if (!windowWidth) return;
+      const calculatedChatWidth = centralChatWidth({
+        oppositeSidebarWidth: chatbarWidth,
+        windowWidth,
+        currentSidebarWidth: promptbarWidth,
+      });
+
+      if (calculatedChatWidth < CENTRAL_CHAT_MIN_WIDTH) {
+        const newChatbarWidth = getNewSidebarWidth({
+          windowWidth,
+          oppositeSidebarWidth: promptbarWidth,
+        });
+        dispatch(UIActions.setChatbarWidth(newChatbarWidth));
+      }
+    }
+
+    dispatch(UIActions.setShowPromptbar(!showPromptbar));
+  }, [chatbarWidth, dispatch, promptbarWidth, showPromptbar, windowWidth]);
+
+  const headerIconSize = isOverlay
+    ? OVERLAY_HEADER_ICON_SIZE
+    : DEFAULT_HEADER_ICON_SIZE;
+
+  const handleResize = useCallback(() => {
+    setWindowWidth(window.innerWidth);
+  }, []);
+  useWindowResizeEvent(handleResize);
+
+  return {
+    showChatbar,
+    showPromptbar,
+    isOverlay,
+    headerIconSize,
+    handleToggleChatbar,
+    handleTogglePromtbar,
+  };
+};

--- a/apps/chat/src/pages/index.tsx
+++ b/apps/chat/src/pages/index.tsx
@@ -15,6 +15,7 @@ import { Migration } from '@/src/components/Chat/Migration/Migration';
 import { MigrationFailedWindow } from '@/src/components/Chat/Migration/MigrationFailedModal';
 import { ImportExportLoader } from '@/src/components/Chatbar/ImportExportLoader';
 import { AnnouncementsBanner } from '@/src/components/Common/AnnouncementBanner';
+import { FloatingPanelToggles } from '@/src/components/Header/FloatingPanelToggles';
 import { Header } from '@/src/components/Header/Header';
 
 import { useCustomizations } from '@/src/customizations';
@@ -78,8 +79,9 @@ function Home() {
           failedMigratedPrompts={failedMigratedPrompts}
         />
       ) : (
-        <div className="flex size-full flex-col sm:pt-0">
+        <div className="relative flex size-full flex-col sm:pt-0">
           {enabledFeatures.has(Feature.Header) && <Header />}
+          <FloatingPanelToggles />
           <div className="flex min-h-0 w-full flex-1 overflow-auto">
             <div className="flex size-full flex-col">
               <AnnouncementsBanner />

--- a/libs/shared/src/types/features.ts
+++ b/libs/shared/src/types/features.ts
@@ -4,6 +4,8 @@ export enum Feature {
   Footer = 'footer', // Display app footer
   ConversationsSection = 'conversations-section', // Display conversations sidebar
   PromptsSection = 'prompts-section', // Display prompts sidebar
+  ConversationsPanelToggle = 'conversations-panel-toggle', // Show conversations panel toggle in the corner without app header
+  PromptsPanelToggle = 'prompts-panel-toggle', // Show prompts panel toggle in the corner without app header
   ShowConversationsSectionByDefault = 'showConversationsSectionByDefault', // show conversations sidebar by default on desktop
   ShowPromptsSectionByDefault = 'showPromptsSectionByDefault', // show prompts sidebar by default on desktop
   ShowLayoutDividers = 'show-layout-dividers', // show dividers between chat and sidebars


### PR DESCRIPTION
…g is disabled

## Description of changes

Summary
Adds optional sidebar panel toggles that render in the top corners without the DIAL app header. Intended for overlay embed scenarios where the host app already provides its own header (especially on mobile).

Changes
Feature flags (libs/shared)
conversations-panel-toggle — show conversations panel toggle in the top-left corner without header
prompts-panel-toggle — show prompts panel toggle in the top-right corner without header
These flags are independent of header. Sidebars still require conversations-section / prompts-section.

UI
FloatingPanelToggles — renders corner toggle buttons when header is off and at least one panel-toggle flag is enabled
useSidebarPanelToggles — shared toggle logic for chatbar/promptbar (extracted from Header)
Header — refactored to use useSidebarPanelToggles; behavior unchanged when header is enabled
ToggleSidebarButton — new isFloatingToggle prop: 40×40 square button, Outlined + Neutral variant (no blue icon hover for floating toggles)

## Applicable issues

- fixes #6710, #5741

## UI changes
<img width="1204" height="877" alt="Screenshot 2026-05-20 at 16 04 29" src="https://github.com/user-attachments/assets/9b8b8062-1154-41ae-b821-76baa9440192" />
<img width="407" height="802" alt="Screenshot 2026-05-20 at 16 04 55" src="https://github.com/user-attachments/assets/299e8a3c-8c32-4624-bee9-93176a67767f" />

## Checklist

- [x] the pull request name ends with `(Issue #<ISSUE_ID>)` (comma-separated list of issues)
- [x] I confirm that I don't share any confidential information like API keys or any other secrets and private URLs

<details>
  <summary>PR title cheatsheet</summary>

`<type>[optional scope]: <description>`

1. type (required)
    - `feat` - A new feature
    - `fix` - A bug fix
    - `docs` - Documentation only changes
    - `test` - Adding missing tests or correcting existing tests
    - `ci` - Changes to our CI configuration files and scripts
    - `chore` - Other changes that are minor and/or not user-facing
2. scope (optional, current repo suggestions below)
    - `chat`
    - `overlay`
    - `shared`
    - `sandbox-overlay`
    - `visualizer-connector`

</details>
