### PR TITLE
fix(chat): fix the text is entered at the end of the message not at cursor position (Issue #6466)

### DIFF
--- a/apps/chat/src/components/Chat/ChatInput/ChatInputMessage.tsx
+++ b/apps/chat/src/components/Chat/ChatInput/ChatInputMessage.tsx
@@ -11,6 +11,7 @@ import React, {
 import classNames from 'classnames';
 
 import { usePromptSelection } from '@/src/hooks/usePromptSelection';
+import { useTextareaInsertInPosition } from '@/src/hooks/useTextareaInsertInPosition';
 import { useTokenizer } from '@/src/hooks/useTokenizer';
 import { useTranslation } from '@/src/hooks/useTranslation';
 import { useVoiceRecorder } from '@/src/hooks/useVoiceRecorder';
@@ -204,18 +205,6 @@ export const ChatInputMessage = Inversify.register(
       clearAudioBlob,
     } = useVoiceRecorder(supportedAudioTypes);
 
-    useEffect(() => {
-      if (!audioBlob) return;
-
-      dispatch(
-        ChatActions.handleVoiceRecording({
-          audioBlob,
-          fileExtension: voiceFileExtension,
-        }),
-      );
-      clearAudioBlob();
-    }, [audioBlob, voiceFileExtension, dispatch, clearAudioBlob]);
-
     const shouldRegenerate =
       isLastMessageError ||
       (isLastAssistantMessageEmpty && !messageIsStreaming);
@@ -281,6 +270,34 @@ export const ChatInputMessage = Inversify.register(
       isLoading,
       selectedPrompt,
     } = usePromptSelection(maxTokensLength, modelTokenizer, '');
+
+    const { getCursorPosition } = useTextareaInsertInPosition(
+      textareaRef,
+      content,
+      setContent,
+    );
+
+    useEffect(() => {
+      if (!audioBlob) return;
+
+      const selection = isAsrMode ? getCursorPosition() : undefined;
+
+      dispatch(
+        ChatActions.handleVoiceRecording({
+          audioBlob,
+          fileExtension: voiceFileExtension,
+          selection,
+        }),
+      );
+      clearAudioBlob();
+    }, [
+      audioBlob,
+      voiceFileExtension,
+      dispatch,
+      clearAudioBlob,
+      isAsrMode,
+      getCursorPosition,
+    ]);
 
     const isSchemaValueValid = useMemo(() => {
       const schema =
@@ -546,6 +563,13 @@ export const ChatInputMessage = Inversify.register(
       );
     }, []);
 
+    const handleStopRecording = useCallback(() => {
+      if (isAsrMode) {
+        dispatch(ChatActions.setIsTranscribing(true));
+      }
+      stopRecording();
+    }, [isAsrMode, stopRecording, dispatch]);
+
     const tooltipContent = (): string => {
       if (isDisabledInputFeature && disabledInputFeatureData?.description) {
         return disabledInputFeatureData.description;
@@ -677,7 +701,7 @@ export const ChatInputMessage = Inversify.register(
               ref={micButtonRef}
               isRecording={isRecording}
               onStartRecording={startRecording}
-              onStopRecording={stopRecording}
+              onStopRecording={handleStopRecording}
               error={voiceError}
               disabled={isMicDisabled}
             />

--- a/apps/chat/src/components/Chat/ChatMessage/ChatMessageContent/UserMessage.tsx
+++ b/apps/chat/src/components/Chat/ChatMessage/ChatMessageContent/UserMessage.tsx
@@ -12,10 +12,12 @@ import classNames from 'classnames';
 
 import { useChatUploadFiles } from '@/src/hooks/useChatUploadFiles';
 import { useFilePaste } from '@/src/hooks/useFilePaste';
+import { useTextareaInsertInPosition } from '@/src/hooks/useTextareaInsertInPosition';
 import { useTranslation } from '@/src/hooks/useTranslation';
 import { useVoiceRecorder } from '@/src/hooks/useVoiceRecorder';
 
 import {
+  getTranscriptTextToInsert,
   isEntityNameOrPathInvalid,
   replaceStringRange,
 } from '@/src/utils/app/common';
@@ -182,6 +184,11 @@ export const UserMessage = memo(function UserMessage({
   );
 
   const [messageContent, setMessageContent] = useState(message.content);
+  const { insertTextAtCursor } = useTextareaInsertInPosition(
+    textareaRef,
+    messageContent,
+    setMessageContent,
+  );
   const [formValue, setFormValue] = useState(currentFormValue);
   const [isTyping, setIsTyping] = useState<boolean>(false);
   const [shouldScroll, setShouldScroll] = useState(false);
@@ -579,13 +586,29 @@ export const UserMessage = memo(function UserMessage({
       return;
     }
 
-    setMessageContent((prev) =>
-      prev.trim()
-        ? `${prev} ${userMessageTranscript.trim()}`
-        : userMessageTranscript.trim(),
-    );
+    const textarea = textareaRef.current;
+
+    if (textarea) {
+      const beforeCursor = messageContent.substring(0, textarea.selectionStart);
+      const textToInsert = getTranscriptTextToInsert(
+        beforeCursor,
+        userMessageTranscript,
+      );
+
+      if (textToInsert) {
+        insertTextAtCursor(textToInsert);
+      }
+    } else {
+      const trimmedTranscript = userMessageTranscript.trim();
+      if (trimmedTranscript) {
+        setMessageContent((prev) =>
+          prev.trim() ? `${prev} ${trimmedTranscript}` : trimmedTranscript,
+        );
+      }
+    }
+
     dispatch(ChatActions.clearUserMessageTranscript());
-  }, [dispatch, userMessageTranscript]);
+  }, [dispatch, insertTextAtCursor, messageContent, userMessageTranscript]);
 
   useEffect(() => {
     if (!userMessageVoiceAttachmentId) {

--- a/apps/chat/src/hooks/__tests__/useTextareaInsertInPosition.test.tsx
+++ b/apps/chat/src/hooks/__tests__/useTextareaInsertInPosition.test.tsx
@@ -1,0 +1,153 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { act, renderHook } from '@testing-library/react';
+
+import { RefObject, createRef } from 'react';
+
+import { useTextareaInsertInPosition } from '@/src/hooks/useTextareaInsertInPosition';
+
+const createTextareaRef = (
+  value: string,
+  selection: { start: number; end: number },
+): RefObject<HTMLTextAreaElement> => {
+  const textarea = document.createElement('textarea');
+  textarea.value = value;
+  document.body.appendChild(textarea);
+  textarea.setSelectionRange(selection.start, selection.end);
+  return { current: textarea };
+};
+
+describe('useTextareaInsertInPosition', () => {
+  let requestAnimationFrameSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    requestAnimationFrameSpy = vi
+      .spyOn(window, 'requestAnimationFrame')
+      .mockImplementation((callback) => {
+        callback(0);
+        return 0;
+      });
+  });
+
+  afterEach(() => {
+    requestAnimationFrameSpy.mockRestore();
+    document.body.replaceChildren();
+  });
+
+  describe('getCursorPosition', () => {
+    it('should return selection start and end from the textarea', () => {
+      // Arrange
+      const textareaRef = createTextareaRef('hello world', {
+        start: 3,
+        end: 7,
+      });
+      const { result } = renderHook(() =>
+        useTextareaInsertInPosition(textareaRef, 'hello world', vi.fn()),
+      );
+
+      // Act
+      const position = result.current.getCursorPosition();
+
+      // Assert
+      expect(position).toEqual({ start: 3, end: 7 });
+    });
+
+    it('should return zero positions when textarea ref is missing', () => {
+      // Arrange
+      const textareaRef = createRef<HTMLTextAreaElement>();
+      const { result } = renderHook(() =>
+        useTextareaInsertInPosition(textareaRef, 'hello world', vi.fn()),
+      );
+
+      // Act
+      const position = result.current.getCursorPosition();
+
+      // Assert
+      expect(position).toEqual({ start: 0, end: 0 });
+    });
+  });
+
+  describe('insertTextAtCursor', () => {
+    it('should not update text when textarea ref is missing', () => {
+      // Arrange
+      const textareaRef = createRef<HTMLTextAreaElement>();
+      const setText = vi.fn();
+      const { result } = renderHook(() =>
+        useTextareaInsertInPosition(textareaRef, 'hello world', setText),
+      );
+
+      // Act
+      act(() => {
+        result.current.insertTextAtCursor('!');
+      });
+
+      // Assert
+      expect(setText).not.toHaveBeenCalled();
+    });
+
+    it('should insert text at the cursor when nothing is selected', () => {
+      // Arrange
+      const textareaRef = createTextareaRef('hello world', {
+        start: 5,
+        end: 5,
+      });
+      const setText = vi.fn();
+      const { result } = renderHook(() =>
+        useTextareaInsertInPosition(textareaRef, 'hello world', setText),
+      );
+
+      // Act
+      act(() => {
+        result.current.insertTextAtCursor('!!!');
+      });
+
+      // Assert
+      expect(setText).toHaveBeenCalledWith('hello!!! world');
+    });
+
+    it('should replace the selected range with inserted text', () => {
+      // Arrange
+      const textareaRef = createTextareaRef('hello world', {
+        start: 6,
+        end: 11,
+      });
+      const setText = vi.fn();
+      const { result } = renderHook(() =>
+        useTextareaInsertInPosition(textareaRef, 'hello world', setText),
+      );
+
+      // Act
+      act(() => {
+        result.current.insertTextAtCursor('universe');
+      });
+
+      // Assert
+      expect(setText).toHaveBeenCalledWith('hello universe');
+    });
+
+    it('should restore cursor position and focus the textarea after insert', () => {
+      // Arrange
+      const textareaRef = createTextareaRef('hello world', {
+        start: 5,
+        end: 5,
+      });
+      const setSelectionRange = vi.fn();
+      const focus = vi.fn();
+      textareaRef.current!.setSelectionRange = setSelectionRange;
+      textareaRef.current!.focus = focus;
+      const setText = vi.fn();
+      const { result } = renderHook(() =>
+        useTextareaInsertInPosition(textareaRef, 'hello world', setText),
+      );
+
+      // Act
+      act(() => {
+        result.current.insertTextAtCursor('!!!');
+      });
+
+      // Assert
+      expect(setSelectionRange).toHaveBeenCalledWith(8, 8);
+      expect(focus).toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/chat/src/hooks/useTextareaInsertInPosition.tsx
+++ b/apps/chat/src/hooks/useTextareaInsertInPosition.tsx
@@ -1,0 +1,54 @@
+import { RefObject, useCallback } from 'react';
+
+/**
+ * Custom hook for inserting text at the cursor position in a textarea
+ * @param textareaRef - Ref to the textarea element
+ * @param text - The text to insert
+ * @param setText - Function to set the text in the textarea
+ * @returns An object with the insertTextAtCursor function and the getCursorPosition function
+ */
+
+export const useTextareaInsertInPosition = (
+  textareaRef: RefObject<HTMLTextAreaElement | null>,
+  text: string,
+  setText: (text: string) => void,
+) => {
+  const insertTextAtCursor = useCallback(
+    (textToInsert: string) => {
+      const textarea = textareaRef.current;
+      if (!textarea) return;
+
+      const startPos = textarea.selectionStart;
+      const endPos = textarea.selectionEnd;
+
+      const beforeCursor = text.substring(0, startPos);
+      const afterCursor = text.substring(endPos);
+      const newText = beforeCursor + textToInsert + afterCursor;
+
+      setText(newText);
+
+      // Restore cursor position
+      requestAnimationFrame(() => {
+        const newCursorPos = startPos + textToInsert.length;
+        textarea.setSelectionRange(newCursorPos, newCursorPos);
+        textarea.focus();
+      });
+    },
+    [text, textareaRef, setText],
+  );
+
+  const getCursorPosition = useCallback(() => {
+    const textarea = textareaRef.current;
+    if (!textarea) return { start: 0, end: 0 };
+
+    return {
+      start: textarea.selectionStart,
+      end: textarea.selectionEnd,
+    };
+  }, [textareaRef]);
+
+  return {
+    insertTextAtCursor,
+    getCursorPosition,
+  };
+};

--- a/apps/chat/src/store/chat/chat.epics.ts
+++ b/apps/chat/src/store/chat/chat.epics.ts
@@ -11,6 +11,7 @@ import {
 
 import { combineEpics, ofType } from 'redux-observable';
 
+import { buildContentWithTranscriptAtSelection } from '@/src/utils/app/common';
 import { ApplicationService } from '@/src/utils/app/data/application-service';
 import {
   createVoiceQuickAttachment,
@@ -370,10 +371,13 @@ const transcriptionSuccessEpic: AppEpic = (action$, state$) =>
     switchMap(({ payload }) => {
       const { transcript } = payload;
       if (!transcript.trim()) {
-        return of(
-          UIActions.showErrorToast({
-            message: translate(errorsMessages.transcriptionFailed),
-          }),
+        return concat(
+          of(ChatActions.clearAsrInsertionContext()),
+          of(
+            UIActions.showErrorToast({
+              message: translate(errorsMessages.transcriptionFailed),
+            }),
+          ),
         );
       }
 
@@ -381,24 +385,38 @@ const transcriptionSuccessEpic: AppEpic = (action$, state$) =>
         ConversationsSelectors.selectSelectedConversations(state$.value);
 
       if (!selectedConversations.length) {
-        return EMPTY;
+        return of(ChatActions.clearAsrInsertionContext());
       }
 
-      const existingInput = ChatSelectors.selectInputContent(state$.value);
-      const combinedContent = existingInput.trim()
-        ? `${existingInput.trim()} ${transcript.trim()}`
-        : transcript.trim();
+      const asrInsertionContext = ChatSelectors.selectAsrInsertionContext(
+        state$.value,
+      );
+      const baseInput =
+        asrInsertionContext?.inputSnapshot ??
+        ChatSelectors.selectInputContent(state$.value);
+      const selection = asrInsertionContext?.selection ?? {
+        start: baseInput.length,
+        end: baseInput.length,
+      };
+      const combinedContent = buildContentWithTranscriptAtSelection(
+        baseInput,
+        transcript,
+        selection,
+      );
 
       const selectedFiles = FilesSelectors.selectSelectedFiles(state$.value);
       const selectedFolders = FilesSelectors.selectSelectedFolders(
         state$.value,
       );
 
-      return sendMessage(selectedConversations, {
-        role: Role.User,
-        content: combinedContent,
-        custom_content: getUserCustomContent(selectedFiles, selectedFolders),
-      });
+      return concat(
+        of(ChatActions.clearAsrInsertionContext()),
+        sendMessage(selectedConversations, {
+          role: Role.User,
+          content: combinedContent,
+          custom_content: getUserCustomContent(selectedFiles, selectedFolders),
+        }),
+      );
     }),
   );
 

--- a/apps/chat/src/store/chat/chat.reducer.ts
+++ b/apps/chat/src/store/chat/chat.reducer.ts
@@ -6,7 +6,7 @@ import { isEntityIdPublic } from '@/src/utils/app/publications';
 import { EntityInfo, EntityType } from '@/src/types/common';
 import { ModalState } from '@/src/types/modal';
 
-import { ChatState } from './chat.types';
+import { ChatState, TextSelection } from './chat.types';
 
 import { MessageFormSchema, MessageFormValueType } from '@epam/ai-dial-shared';
 
@@ -170,8 +170,21 @@ export const chatSlice = createSlice({
     },
     handleVoiceRecording: (
       state,
-      _action: PayloadAction<{ audioBlob: Blob; fileExtension: string }>,
-    ) => state,
+      {
+        payload,
+      }: PayloadAction<{
+        audioBlob: Blob;
+        fileExtension: string;
+        selection?: TextSelection;
+      }>,
+    ) => {
+      state.asrInsertionContext = payload.selection
+        ? {
+            inputSnapshot: state.inputContent,
+            selection: payload.selection,
+          }
+        : undefined;
+    },
     handleUserMessageVoiceRecording: (
       state,
       _action: PayloadAction<{ audioBlob: Blob; fileExtension: string }>,
@@ -214,9 +227,17 @@ export const chatSlice = createSlice({
     transcriptionFailed: (state) => {
       state.isTranscribing = false;
       state.isAsrFlowActive = false;
+      state.asrInsertionContext = undefined;
     },
     clearAsrFlow: (state) => {
       state.isAsrFlowActive = false;
+      state.asrInsertionContext = undefined;
+    },
+    clearAsrInsertionContext: (state) => {
+      state.asrInsertionContext = undefined;
+    },
+    setIsTranscribing: (state, { payload }: PayloadAction<boolean>) => {
+      state.isTranscribing = payload;
     },
   },
 });

--- a/apps/chat/src/store/chat/chat.selectors.ts
+++ b/apps/chat/src/store/chat/chat.selectors.ts
@@ -101,6 +101,9 @@ const selectIsUserMessageTranscribing = (state: RootState) =>
 const selectIsAsrFlowActive = (state: RootState) =>
   rootSelector(state).isAsrFlowActive;
 
+const selectAsrInsertionContext = (state: RootState) =>
+  rootSelector(state).asrInsertionContext;
+
 export const ChatSelectors = {
   selectInputContent,
   selectInputContentTemplateMapping,
@@ -109,6 +112,7 @@ export const ChatSelectors = {
   selectIsTranscribing,
   selectIsUserMessageTranscribing,
   selectIsAsrFlowActive,
+  selectAsrInsertionContext,
   selectChatFormValue,
   selectUploadedConfigurationSchemas,
   selectConfigurationSchemaByModelId,

--- a/apps/chat/src/store/chat/chat.types.ts
+++ b/apps/chat/src/store/chat/chat.types.ts
@@ -3,6 +3,16 @@ import { ModalState } from '@/src/types/modal';
 
 import { MessageFormSchema, MessageFormValue } from '@epam/ai-dial-shared';
 
+export interface TextSelection {
+  start: number;
+  end: number;
+}
+
+export interface AsrInsertionContext {
+  inputSnapshot: string;
+  selection: TextSelection;
+}
+
 export interface ChatState {
   inputContent: string;
   inputContentTemplateMapping?: { substituted: string; original: string };
@@ -18,4 +28,5 @@ export interface ChatState {
   isTranscribing: boolean;
   isUserMessageTranscribing: boolean;
   isAsrFlowActive: boolean;
+  asrInsertionContext?: AsrInsertionContext;
 }

--- a/apps/chat/src/utils/app/__tests__/common.test.ts
+++ b/apps/chat/src/utils/app/__tests__/common.test.ts
@@ -3,6 +3,7 @@ import { beforeAll, describe, expect, it, vi } from 'vitest';
 import {
   addTrailingSlashIfAbsent,
   arraysHaveSameElements,
+  buildContentWithTranscriptAtSelection,
   combineEntities,
   doesHaveDotsInTheEnd,
   extractNameFromEmail,
@@ -13,6 +14,7 @@ import {
   getDefaultEntityProps,
   getLastPathSegment,
   getSafeRedirectUrl,
+  getTranscriptTextToInsert,
   groupAllVersions,
   hasInvalidNameInPath,
   isEntityNameInvalid,
@@ -230,6 +232,75 @@ describe('utils/app/common.ts', () => {
 
     it('replaceStringRange: replaces [start, end) range', () => {
       expect(replaceStringRange('hello world', 'X', 6, 11)).toBe('hello X');
+    });
+
+    describe('getTranscriptTextToInsert', () => {
+      it('returns empty string when transcript is whitespace only', () => {
+        expect(getTranscriptTextToInsert('hello', '   \n  ')).toBe('');
+      });
+
+      it('returns trimmed transcript when nothing precedes cursor', () => {
+        expect(getTranscriptTextToInsert('', '  hi there ')).toBe('hi there');
+      });
+
+      it('returns trimmed transcript when preceding text is whitespace only', () => {
+        expect(getTranscriptTextToInsert('   ', 'hi')).toBe('hi');
+      });
+
+      it('prepends a space when preceding text ends without a space', () => {
+        expect(getTranscriptTextToInsert('hello', 'world')).toBe(' world');
+      });
+
+      it('does not prepend a space when preceding text already ends with a space', () => {
+        expect(getTranscriptTextToInsert('hello ', 'world')).toBe('world');
+      });
+    });
+
+    describe('buildContentWithTranscriptAtSelection', () => {
+      it('inserts transcript at the cursor with leading space when needed', () => {
+        expect(
+          buildContentWithTranscriptAtSelection('hello world', 'there', {
+            start: 5,
+            end: 5,
+          }),
+        ).toBe('hello there world');
+      });
+
+      it('replaces the selected range with the transcript', () => {
+        expect(
+          buildContentWithTranscriptAtSelection('hello brave world', 'new', {
+            start: 6,
+            end: 11,
+          }),
+        ).toBe('hello new world');
+      });
+
+      it('appends without leading space when text already ends with a space', () => {
+        expect(
+          buildContentWithTranscriptAtSelection('hello ', 'world', {
+            start: 6,
+            end: 6,
+          }),
+        ).toBe('hello world');
+      });
+
+      it('returns the input when the transcript is empty', () => {
+        expect(
+          buildContentWithTranscriptAtSelection('hello', '   ', {
+            start: 5,
+            end: 5,
+          }),
+        ).toBe('hello');
+      });
+
+      it('clamps out-of-range selection indices to the input length', () => {
+        expect(
+          buildContentWithTranscriptAtSelection('hi', 'there', {
+            start: 50,
+            end: 80,
+          }),
+        ).toBe('hi there');
+      });
     });
 
     it('getLastPathSegment: returns last segment or empty string', () => {

--- a/apps/chat/src/utils/app/common.ts
+++ b/apps/chat/src/utils/app/common.ts
@@ -403,6 +403,38 @@ export const replaceStringRange = (
   return currentString.slice(0, start) + value + currentString.slice(end);
 };
 
+export const getTranscriptTextToInsert = (
+  beforeCursor: string,
+  transcript: string,
+) => {
+  const trimmedTranscript = transcript.trim();
+
+  if (!trimmedTranscript) {
+    return '';
+  }
+
+  const needsLeadingSpace =
+    beforeCursor.trim().length > 0 && !beforeCursor.endsWith(' ');
+
+  return needsLeadingSpace ? ` ${trimmedTranscript}` : trimmedTranscript;
+};
+
+export const buildContentWithTranscriptAtSelection = (
+  input: string,
+  transcript: string,
+  selection: { start: number; end: number },
+) => {
+  const clampedStart = Math.max(0, Math.min(selection.start, input.length));
+  const clampedEnd = Math.max(
+    clampedStart,
+    Math.min(selection.end, input.length),
+  );
+  const beforeCursor = input.substring(0, clampedStart);
+  const textToInsert = getTranscriptTextToInsert(beforeCursor, transcript);
+
+  return replaceStringRange(input, textToInsert, clampedStart, clampedEnd);
+};
+
 export const getLastPathSegment = (path: string) => path.split('/').pop() ?? '';
 
 export const addTrailingSlashIfAbsent = (id: string) =>


### PR DESCRIPTION
## Description of changes

<!-- Please explain the changes you made right below this line. -->
- Fix text is blinking when user stops recording and transcribing starts in input message box at the bottom of the chat.
- Fix the text is entered at the end of the message though the cursor is set somewhere in the middle.

## Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #6466 


## Checklist

- [x] the pull request name ends with `(Issue #<ISSUE_ID>)` (comma-separated list of issues)
- [x] I confirm that I don't share any confidential information like API keys or any other secrets and private URLs

<details>
  <summary>PR title cheatsheet</summary>

`<type>[optional scope]: <description>`

1. type (required)
    - `feat` - A new feature
    - `fix` - A bug fix
    - `docs` - Documentation only changes
    - `test` - Adding missing tests or correcting existing tests
    - `ci` - Changes to our CI configuration files and scripts
    - `chore` - Other changes that are minor and/or not user-facing
2. scope (optional, current repo suggestions below)
    - `chat`
    - `overlay`
    - `shared`
    - `sandbox-overlay`
    - `visualizer-connector`

</details>
