### PR TITLE
fix(chat): fix bytes are used in the error message for long entity name (Issue #6803)

### DIFF
--- a/apps/chat-e2e/src/testData/expectedConstants.ts
+++ b/apps/chat-e2e/src/testData/expectedConstants.ts
@@ -310,7 +310,7 @@ export const ExpectedConstants = {
   goToMyWorkspaceButtonLabel: 'Go to My workspace',
   goToDialMarketplaceButtonLabel: 'Go to DIAL Marketplace',
   publishRequestNameMaxLengthErrorMessage:
-    'Request name should be at most 255 bytes (UTF-8) long',
+    'The Request name is too long. Please shorten it and try again.',
   publishRequestNameIsRequired: 'This field is required',
   defaultAgentLabel: 'Default agent',
   lastUsedAgentLabel: 'Last used agent',

--- a/apps/chat/src/constants/form-errors.ts
+++ b/apps/chat/src/constants/form-errors.ts
@@ -1,5 +1,4 @@
 import { notAllowedSymbols } from '@/src/utils/app/file';
-import { getResourceMaxSegmentBytes } from '@/src/utils/app/resource-limits';
 import { translate } from '@/src/utils/app/translation';
 
 import { Translation } from '@/src/types/translation';
@@ -8,9 +7,9 @@ import { MIN_ENTITY_LENGTH } from './default-ui-settings';
 
 export const formErrors = {
   required: translate('This field is required'),
-  notValidString: (name = 'Name', maxBytes?: number) =>
+  notValidString: (name = 'Name') =>
     translate(
-      `${name} should be ${MIN_ENTITY_LENGTH} to ${maxBytes ?? getResourceMaxSegmentBytes()} bytes (UTF-8) long and should not contain special characters`,
+      `${name} cannot be empty, too long, or contain special characters.`,
     ),
   hasSpecialCharacters: (name = 'Name') =>
     translate(
@@ -18,10 +17,8 @@ export const formErrors = {
     ),
   tooShort: (name = 'Name', minLength = MIN_ENTITY_LENGTH) =>
     translate(`${name} should be at least ${minLength} characters long`),
-  tooLong: (name = 'Name', maxBytes?: number) =>
-    translate(
-      `${name} should be at most ${maxBytes ?? getResourceMaxSegmentBytes()} bytes (UTF-8) long`,
-    ),
+  tooLong: (name = 'Name') =>
+    translate(`The ${name} is too long. Please shorten it and try again.`),
   noDotInTheEnd: (name = 'Name') =>
     translate(`Using a dot at the end of a ${name} is not permitted.`),
   noDotInTheStart: (name = 'Name') =>

--- a/apps/chat/src/constants/validation-helpers.ts
+++ b/apps/chat/src/constants/validation-helpers.ts
@@ -46,10 +46,7 @@ export const getEntityNameSchema = (options: {
         options.skipMaxBytesCheck ||
         getUtf8BytesLength(options.buildNameForByteValidation?.(str) ?? str) <=
           (options.maxBytes ?? getResourceMaxSegmentBytes()),
-      formErrors.tooLong(
-        options.name,
-        options.maxBytes ?? getResourceMaxSegmentBytes(),
-      ),
+      formErrors.tooLong(options.name),
     )
     .refine(
       (str) =>
@@ -92,7 +89,7 @@ export const MarketplaceEntityBaseSchema = zodValidation
       ctx.addIssue({
         code: 'custom',
         path: ['name'],
-        message: formErrors.tooLong('Name', maxSegmentBytes),
+        message: formErrors.tooLong('Name'),
       });
     }
   });

--- a/apps/chat/src/utils/app/forms.ts
+++ b/apps/chat/src/utils/app/forms.ts
@@ -135,7 +135,7 @@ export const getStringValidationErrors = ({
       buildNameForByteValidation?.(trimmedValue) ?? trimmedValue,
     ) > resolvedMaxBytes
   ) {
-    errors.push(formErrors.tooLong(label, resolvedMaxBytes));
+    errors.push(formErrors.tooLong(label));
   }
 
   if (doesHaveNotAllowedSymbols(trimmedValue)) {


### PR DESCRIPTION
## Description of changes

<!-- Please explain the changes you made right below this line. -->
- Fix bytes are used in the error message for long folder name and long file name, chat name and other objects

## Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #6803 

## UI changes

<img width="645" height="180" alt="image" src="https://github.com/user-attachments/assets/7e998ce6-cd8a-4555-b3ea-5fa82780d390" />

## Checklist

- [x] the pull request name ends with `(Issue #<ISSUE_ID>)` (comma-separated list of issues)
- [x] I confirm that I don't share any confidential information like API keys or any other secrets and private URLs

<details>
  <summary>PR title cheatsheet</summary>

`<type>[optional scope]: <description>`

1. type (required)
    - `feat` - A new feature
    - `fix` - A bug fix
    - `docs` - Documentation only changes
    - `test` - Adding missing tests or correcting existing tests
    - `ci` - Changes to our CI configuration files and scripts
    - `chore` - Other changes that are minor and/or not user-facing
2. scope (optional, current repo suggestions below)
    - `chat`
    - `overlay`
    - `shared`
    - `sandbox-overlay`
    - `visualizer-connector`

</details>
