### PR TITLE
feat: Add Attachment component and use it for file selection in conversation input

### DIFF
--- a/.agents/skills/nestjs-chat-api/SKILL.md
+++ b/.agents/skills/nestjs-chat-api/SKILL.md
@@ -45,10 +45,10 @@ Use this skill for backend work in `apps/chat-api`. It is a router to the reposi
    - Run `npm run openapi`, inspect generated method/type names, then run `npm run openapi:check`.
 5. If adding public API behavior, add or update controller/service tests. Use `supertest` for request-level behavior and mock outbound clients or SDK methods.
 6. Use Nx for verification:
-   - `pnpm nx test chat-api`
-   - `pnpm nx lint chat-api`
-   - `pnpm nx build chat-api` when Nest startup, bundling, config, or module wiring is affected
-   - `pnpm nx build chat-api-client -- --skip-nx-cache` and `pnpm nx lint chat-api-client` when endpoint contracts changed
+   - `npm exec nx test chat-api`
+   - `npm exec nx lint chat-api`
+   - `npm exec nx build chat-api` when Nest startup, bundling, config, or module wiring is affected
+   - `npm exec nx build chat-api-client -- --skip-nx-cache` and `npm exec nx lint chat-api-client` when endpoint contracts changed
 
 ## Avoid
 

--- a/.claude/skills/figma/SKILL.md
+++ b/.claude/skills/figma/SKILL.md
@@ -58,7 +58,7 @@ Grep("ComponentName", path="libs/")
 
 After implementation:
 
-1. Run `pnpm nx lint <project>` — fix any lint errors before reporting done
+1. Run `npm exec nx lint <project>` — fix any lint errors before reporting done
 2. If the component has logic, add a unit test in the same lib
 3. If the dev server is running, open the component in the browser and compare with the Figma screenshot
 

--- a/.mcp.json
+++ b/.mcp.json
@@ -7,6 +7,10 @@
     "figma": {
       "type": "http",
       "url": "https://mcp.figma.com/mcp"
+    },
+    "ai-dial-ui-kit": {
+      "command": "node",
+      "args": ["./node_modules/@epam/ai-dial-ui-kit/dist/mcp-server.cjs"]
     }
   }
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,3 +64,20 @@ Default behavior:
 - In `libs/*` React component files, always use `FC<Props>` syntax: `export const MyComponent: FC<MyComponentProps> = ({ ... }) => { ... }`.
 - Component folders under `src/components/` must use PascalCase and match the component name (e.g., `RequireAuth/RequireAuth.tsx`). Tests go in a `tests/` subfolder inside the component folder.
 - Every exported symbol in `libs/*` (interfaces, enums, types, functions) must have a JSDoc comment. Each interface/type property must also have an inline `/** ... */` doc. Keep comments factual — describe what the value represents, not how it is used.
+
+## When working with @epam/ai-dial-ui-kit
+
+When implementing or modifying components, forms, or UI built with `@epam/ai-dial-ui-kit`, the `ai-dial-ui-kit` MCP server enables you to discover components, read exact prop signatures, access code examples, and understand design tokens and available utilities.
+
+## Component-First Development
+
+**Always prefer UI kit components over raw HTML elements.** Before reaching for native `<button>`, `<input>`, `<select>`, or other HTML elements:
+
+1. **Look for a UI kit component** — Check if a suitable `Dial*` component exists for your use case
+2. **Use raw elements only as last resort** — If and only if no UI kit component meets the requirements, use native HTML (and document why)
+
+## MCP Tools
+
+Use these two tools for all UI kit discovery and documentation needs: `searchEntity(entity, query?)` and `getEntityDetails(entity, name?)`. If you need to look up **ANYTHING** about the ui kit, use the MCP server. **Never** use rg/ls commands for the ui kit module inspection.
+
+> **Note:** Do not use `grep`, `glob`, `find`, or similar file system tools to discover components. The MCP tools provide accurate, structured metadata. File system searches miss examples, miss type information, and are slower.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@
 
 - For navigating/exploring the workspace, invoke the `nx-workspace` skill first - it has patterns for querying projects, targets, and dependencies
 - When running tasks (for example build, lint, test, e2e, etc.), always prefer running the task through `nx` (i.e. `nx run`, `nx run-many`, `nx affected`) instead of using the underlying tooling directly
-- Prefix nx commands with the workspace's package manager (e.g., `pnpm nx build`, `npm exec nx test`) - avoids using globally installed CLI
+- Prefix nx commands with the workspace's package manager (e.g., `npm exec nx build`, `npm exec nx test`) - avoids using globally installed CLI
 - You have access to the Nx MCP server and its tools, use them to help the user
 - For Nx plugin best practices, check `node_modules/@nx/<plugin>/PLUGIN.md`. Not all plugins have this file - proceed without it if unavailable.
 - NEVER guess CLI flags - always check nx_docs or `--help` first when unsure
@@ -55,6 +55,9 @@ Default behavior:
 - Before merge (or on explicit review requests), run the five-axis quality review.
 
 ## Local coding conventions
+
+- In `libs/**/*.tsx` files, **never** use `useTranslation` or `t()` from `react-i18next`. Pass all user-visible strings as props with English default values instead. i18n is the responsibility of the consuming app, not the lib.
+- In all `**/*.{ts,tsx}` files, **never** write ternary-in-ternary (nested conditional expressions). Use `if`/`else` blocks, early returns, or a `switch` statement instead.
 
 - In `utils` files, prefer arrow-function declarations (`const fn = (...) => {}`) over `function fn(...) {}`.
 - In `apps/*` React component files, name the component props type/interface `Props`.

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Chat 2.0 is a comprehensive chat application platform featuring:
 ## Prerequisites
 
 - **Node.js**: 24 or higher
-- **npm**: v9 or higher (or pnpm)
+- **npm**: v9 or higher
 - **Git**: Latest version
 
 ## Quick Start

--- a/apps/chat-api/AGENTS.md
+++ b/apps/chat-api/AGENTS.md
@@ -399,9 +399,9 @@ parseInt(value, 10))` + `@IsNumber()`.
 Per repo rule `incremental-implementation`, after each slice run:
 
 ```sh
-pnpm nx test  chat-api
-pnpm nx lint  chat-api
-pnpm nx build chat-api      # when bundling/Nest startup is affected
+npm exec nx test  chat-api
+npm exec nx lint  chat-api
+npm exec nx build chat-api      # when bundling/Nest startup is affected
 ```
 
 When adding or changing HTTP endpoints, also run:

--- a/apps/chat-api/README.md
+++ b/apps/chat-api/README.md
@@ -24,7 +24,7 @@ NestJS backend application for the chat platform. Provides REST API endpoints fo
 ## Prerequisites
 
 - Node.js 18+
-- npm or pnpm
+- npm
 - Access to AI DIAL core service
 - Access to themes configuration service
 

--- a/apps/chat/README.md
+++ b/apps/chat/README.md
@@ -36,7 +36,7 @@ A modern, responsive chat application built with React, TypeScript, and Tailwind
 ## Prerequisites
 
 - Node.js (v24 or higher)
-- npm or pnpm
+- npm
 
 ## Getting Started
 

--- a/apps/chat/src/components/ConversationView/ConversationView.tsx
+++ b/apps/chat/src/components/ConversationView/ConversationView.tsx
@@ -1,5 +1,6 @@
 import {
   MessageRole,
+  type Attachment,
   type Message as MessageType,
 } from '@epam/ai-dial-chat-shared';
 import { MessageBubble } from '@epam/ai-dial-conversation-messages';
@@ -27,6 +28,7 @@ interface Props {
   onStop?: () => void;
   onDeleteMessage?: (messageId: string) => void;
   onRegenerateMessage?: (messageId: string) => void;
+  onAttachmentsChange?: (attachments: Attachment[]) => void;
   placeholder: string;
   isAssistantTyping?: boolean;
 }
@@ -39,6 +41,7 @@ const ConversationView: FC<Props> = ({
   onStop,
   onDeleteMessage,
   onRegenerateMessage,
+  onAttachmentsChange,
   placeholder,
   isAssistantTyping = false,
 }) => {
@@ -177,6 +180,7 @@ const ConversationView: FC<Props> = ({
             onSend={onSend}
             onStop={onStop}
             isStreaming={isAssistantTyping}
+            onAttachmentsChange={onAttachmentsChange}
             placeholder={placeholder}
           />
         </Suspense>

--- a/apps/chat/src/i18n/locales/en.json
+++ b/apps/chat/src/i18n/locales/en.json
@@ -29,6 +29,12 @@
     "failedToLoadTheme": "Failed to load themes. Using default theme.",
     "failedToLoadLogo": "Failed to load logo"
   },
+  "conversationInput": {
+    "addMenu": { "ariaLabel": "Add" },
+    "attach": { "label": "Attach file" },
+    "attachment": { "remove": "Remove attachment", "retry": "Retry upload" },
+    "attachmentTray": { "label": "Attached files" }
+  },
   "auth": {
     "signOut": "Sign out",
     "signedInAs": "Signed in as {{email}}",

--- a/apps/chat/src/i18n/locales/en.json
+++ b/apps/chat/src/i18n/locales/en.json
@@ -17,6 +17,7 @@
     "comingSoon": "Catalog coming soon"
   },
   "actions": {
+    "add": "Add",
     "delete": "Delete",
     "cancel": "Cancel",
     "confirm": "Confirm"
@@ -30,7 +31,6 @@
     "failedToLoadLogo": "Failed to load logo"
   },
   "conversationInput": {
-    "addMenu": { "ariaLabel": "Add" },
     "attach": { "label": "Attach file" },
     "attachment": { "remove": "Remove attachment", "retry": "Retry upload" },
     "attachmentTray": { "label": "Attached files" }

--- a/apps/chat/src/pages/ConversationRoute/ConversationRoute.tsx
+++ b/apps/chat/src/pages/ConversationRoute/ConversationRoute.tsx
@@ -55,10 +55,7 @@ const ConversationRoute: FC = () => {
   );
 
   return (
-    <div
-      ref={inputRef}
-      className="flex flex-1 flex-col overflow-hidden overflow-y-auto"
-    >
+    <div ref={inputRef} className="flex flex-1 flex-col overflow-y-auto">
       <Suspense fallback={<RouteFallback />}>
         <div
           className="flex h-full flex-col items-center justify-center p-8"

--- a/apps/chat/src/pages/ConversationRoute/ConversationRoute.tsx
+++ b/apps/chat/src/pages/ConversationRoute/ConversationRoute.tsx
@@ -55,7 +55,10 @@ const ConversationRoute: FC = () => {
   );
 
   return (
-    <div ref={inputRef} className="flex flex-1 flex-col overflow-hidden">
+    <div
+      ref={inputRef}
+      className="flex flex-1 flex-col overflow-hidden overflow-y-auto"
+    >
       <Suspense fallback={<RouteFallback />}>
         <div
           className="flex h-full flex-col items-center justify-center p-8"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -497,7 +497,7 @@ Enforced by `@nx/enforce-module-boundaries` in `eslint.config.mjs`:
 |---|----------|--------|
 | 1 | Package prefix: `@epam/*` (short form, no `ai-dial-` in package name) | ✅ Accepted |
 | 2 | Monorepo tooling: **Nx 22** | ✅ Accepted |
-| 3 | Package manager: **pnpm workspaces** | ✅ Accepted |
+| 3 | Package manager: **npm workspaces** | ✅ Accepted |
 | 4 | UI framework: **React 19** (SPA) | ✅ Accepted |
 | 5 | Backend framework: **NestJS 11** (`apps/chat-api`) | ✅ Accepted |
 | 6 | Libs styling: **Tailwind CSS + SCSS Modules** (three-tier CSS var fallback) | ✅ Accepted |

--- a/libs/chat-shared/src/index.ts
+++ b/libs/chat-shared/src/index.ts
@@ -2,4 +2,5 @@ export * from './models/chat.js';
 export * from './models/theme.js';
 export * from './models/auth.js';
 export * from './models/dial-model.js';
+export * from './types/attachment.js';
 export * from './utils/merge-class.js';

--- a/libs/chat-shared/src/models/chat.ts
+++ b/libs/chat-shared/src/models/chat.ts
@@ -67,6 +67,46 @@ export interface StreamChunk {
   }>;
 }
 
+/** Discriminates the kind of content an attachment carries. */
+export enum AttachmentType {
+  /** Generic file attachment (non-image). */
+  File = 'file',
+  /** Raster or vector image. */
+  Image = 'image',
+  /** A saved prompt snippet. */
+  Prompt = 'prompt',
+  /** Text pasted directly by the user. */
+  Pasted = 'pasted',
+}
+
+/** Generic async-operation status, reusable for any request lifecycle. */
+export enum RequestStatus {
+  /** No request has been made yet. */
+  Idle = 'idle',
+  /** A request is in-flight. */
+  Loading = 'loading',
+  /** The most recent request failed. */
+  Error = 'error',
+}
+
+/** Represents a file or content item the user has attached to a message. */
+export interface Attachment {
+  /** Unique client-side identifier. */
+  id: string;
+  /** Display name (usually the original filename). */
+  name: string;
+  /** MIME type of the attachment (e.g. `'image/png'`, `'application/pdf'`). */
+  contentType: string;
+  /** The underlying `File` object selected by the user. */
+  file: File;
+  /** Content category used to select the correct icon and thumbnail. */
+  type: AttachmentType;
+  /** Upload / processing lifecycle state. */
+  status: RequestStatus;
+  /** Object URL for image preview; only set when `type === AttachmentType.Image`. */
+  previewUrl?: string;
+}
+
 /** A full conversation including its messages and configuration. */
 export interface Conversation {
   /** Unique conversation identifier. */

--- a/libs/chat-shared/src/models/chat.ts
+++ b/libs/chat-shared/src/models/chat.ts
@@ -1,3 +1,5 @@
+import { AttachmentType } from '../types/attachment.js';
+
 /** Metadata returned by the DIAL file/conversation listing API for a single resource node. */
 export interface ConversationMetadata {
   /** Display name of the resource. */
@@ -65,18 +67,6 @@ export interface StreamChunk {
     /** Zero-based index of this choice. */
     index: number;
   }>;
-}
-
-/** Discriminates the kind of content an attachment carries. */
-export enum AttachmentType {
-  /** Generic file attachment (non-image). */
-  File = 'file',
-  /** Raster or vector image. */
-  Image = 'image',
-  /** A saved prompt snippet. */
-  Prompt = 'prompt',
-  /** Text pasted directly by the user. */
-  Pasted = 'pasted',
 }
 
 /** Generic async-operation status, reusable for any request lifecycle. */

--- a/libs/chat-shared/src/types/attachment.ts
+++ b/libs/chat-shared/src/types/attachment.ts
@@ -1,0 +1,11 @@
+/** Discriminates the kind of content an attachment carries. */
+export enum AttachmentType {
+  /** Generic file attachment (non-image). */
+  File = 'file',
+  /** Raster or vector image. */
+  Image = 'image',
+  /** A saved prompt snippet. */
+  Prompt = 'prompt',
+  /** Text pasted directly by the user. */
+  Pasted = 'pasted',
+}

--- a/libs/conversation-input/package.json
+++ b/libs/conversation-input/package.json
@@ -20,6 +20,7 @@
     "react": "^19.0.0",
     "@epam/ai-dial-chat-shared": "0.0.1",
     "@epam/ai-dial-ui-kit": "0.10.0-dev.50",
-    "@tabler/icons-react": "^3.44.0"
+    "@tabler/icons-react": "^3.44.0",
+    "react-i18next": "^17.0.0"
   }
 }

--- a/libs/conversation-input/package.json
+++ b/libs/conversation-input/package.json
@@ -20,7 +20,6 @@
     "react": "^19.0.0",
     "@epam/ai-dial-chat-shared": "0.0.1",
     "@epam/ai-dial-ui-kit": "0.10.0-dev.50",
-    "@tabler/icons-react": "^3.44.0",
-    "react-i18next": "^17.0.0"
+    "@tabler/icons-react": "^3.44.0"
   }
 }

--- a/libs/conversation-input/src/components/AttachmentCard/AttachmentCard.module.scss
+++ b/libs/conversation-input/src/components/AttachmentCard/AttachmentCard.module.scss
@@ -1,0 +1,62 @@
+// Colors only — no layout, spacing, border-radius (those live in Tailwind)
+
+.card {
+  border-color: var(--ci-card-border, var(--stroke-secondary, #242c42));
+  background: var(--ci-card-bg, var(--bg-layer-0, #000000));
+}
+
+.cardError {
+  border-color: var(--ci-card-border-error, var(--stroke-error, #f76464));
+}
+
+.cardSelected {
+  border-color: var(
+    --ci-card-border-selected,
+    var(--stroke-accent-primary, #7da4ff)
+  );
+  background: var(
+    --ci-card-bg-selected,
+    var(--bg-accent-primary-alpha, #7da4ff26)
+  );
+}
+
+.cardPrompt,
+.cardPasted {
+  &:hover {
+    background: var(
+      --ci-card-bg-hover,
+      var(--controls-bg-neutral-hover, #242c42)
+    );
+  }
+}
+
+.name {
+  color: var(--ci-card-name, var(--text-primary, #eef1f7));
+}
+
+.meta {
+  color: var(--ci-card-meta, var(--text-secondary, #9fa6bd));
+}
+
+.loadingOverlay {
+  background: rgb(0 0 0 / 0.3);
+}
+
+.actionBtn {
+  background: transparent;
+  color: var(--ci-card-action-color, var(--text-primary, #eef1f7));
+}
+
+.card:focus-within {
+  outline: 1px solid var(--ci-card-focus-outline, var(--stroke-focus, #7da4ff));
+  outline-offset: 1px;
+}
+
+.removeBtnImage {
+  background: var(--ci-card-remove-bg, var(--bg-layer-2, #161b2d));
+  color: #fff;
+
+  &:hover {
+    background: var(--ci-card-remove-bg-hover, var(--bg-layer-3, #1d2439));
+  }
+}

--- a/libs/conversation-input/src/components/AttachmentCard/AttachmentCard.module.scss
+++ b/libs/conversation-input/src/components/AttachmentCard/AttachmentCard.module.scss
@@ -39,7 +39,7 @@
 }
 
 .loadingOverlay {
-  background: rgb(0 0 0 / 0.3);
+  background: var(--ci-loading-overlay-bg, var(--bg-blackout, #0c101db2));
 }
 
 .actionBtn {
@@ -54,7 +54,7 @@
 
 .removeBtnImage {
   background: var(--ci-card-remove-bg, var(--bg-layer-2, #161b2d));
-  color: #fff;
+  color: var(--ci-card-remove-color, var(--text-forced-white, #fff));
 
   &:hover {
     background: var(--ci-card-remove-bg-hover, var(--bg-layer-3, #1d2439));

--- a/libs/conversation-input/src/components/AttachmentCard/AttachmentCard.module.scss
+++ b/libs/conversation-input/src/components/AttachmentCard/AttachmentCard.module.scss
@@ -43,13 +43,11 @@
 }
 
 .actionBtn {
-  background: transparent;
   color: var(--ci-card-action-color, var(--text-primary, #eef1f7));
 }
 
 .card:focus-within {
-  outline: 1px solid var(--ci-card-focus-outline, var(--stroke-focus, #7da4ff));
-  outline-offset: 1px;
+  outline-color: var(--ci-card-focus-outline, var(--stroke-focus, #7da4ff));
 }
 
 .removeBtnImage {

--- a/libs/conversation-input/src/components/AttachmentCard/AttachmentCard.tsx
+++ b/libs/conversation-input/src/components/AttachmentCard/AttachmentCard.tsx
@@ -1,8 +1,4 @@
-import {
-  AttachmentType,
-  RequestStatus,
-  mergeClasses,
-} from '@epam/ai-dial-chat-shared';
+import { mergeClasses } from '@epam/ai-dial-chat-shared';
 import {
   DIAL_ICON_SIZE,
   DialEllipsisTooltip,
@@ -10,17 +6,10 @@ import {
   DialLoader,
   ElementSize,
 } from '@epam/ai-dial-ui-kit';
-import {
-  IconClipboard,
-  IconPhoto,
-  IconRefresh,
-  IconTerminal2,
-  IconX,
-} from '@tabler/icons-react';
-import { type FC, useMemo } from 'react';
-import { useTranslation } from 'react-i18next';
+import { IconRefresh, IconX } from '@tabler/icons-react';
+import { type CSSProperties, type FC, useMemo } from 'react';
 import type { AttachmentCardProps } from '../../models/AttachmentCard.js';
-import { getAttachmentIcon } from '../../utils/getAttachmentIcon.js';
+import { getAttachmentCardState } from '../../utils/getAttachmentCardState.js';
 import styles from './AttachmentCard.module.scss';
 
 export const AttachmentCard: FC<AttachmentCardProps> = ({
@@ -29,10 +18,21 @@ export const AttachmentCard: FC<AttachmentCardProps> = ({
   onRetry,
   selected,
   alwaysShowActions,
+  removeLabel = 'Remove attachment',
+  retryLabel = 'Retry upload',
+  colors,
+  typography,
   className,
 }) => {
-  const { t } = useTranslation();
-  const { id, name, contentType, type, status, previewUrl } = attachment;
+  const { id, name } = attachment;
+
+  const cssVars = {
+    ...(colors?.border && { '--ci-card-border': colors.border }),
+    ...(colors?.background && { '--ci-card-bg': colors.background }),
+    ...(colors?.nameText && { '--ci-card-name': colors.nameText }),
+    ...(colors?.metaText && { '--ci-card-meta': colors.metaText }),
+    borderRadius: colors?.borderRadius ?? '0.25rem',
+  } as CSSProperties;
 
   const {
     isLoading,
@@ -43,76 +43,21 @@ export const AttachmentCard: FC<AttachmentCardProps> = ({
     bottomLabel,
     cardColorClass,
     removeBtnClass,
-  } = useMemo(() => {
-    const loading = status === RequestStatus.Loading;
-    const error = status === RequestStatus.Error;
-    const image = type === AttachmentType.Image && !!previewUrl && !error;
-
-    const FileIcon = getAttachmentIcon(contentType);
-    const bottomIcon =
-      type === AttachmentType.Prompt
-        ? IconTerminal2
-        : type === AttachmentType.Pasted
-          ? IconClipboard
-          : type === AttachmentType.Image
-            ? IconPhoto
-            : FileIcon;
-
-    const ext = name.includes('.')
-      ? `.${name.slice(name.lastIndexOf('.') + 1).toLowerCase()}`
-      : contentType.split('/')[1]
-        ? `.${contentType.split('/')[1].toLowerCase()}`
-        : '';
-
-    const label =
-      type === AttachmentType.Prompt
-        ? 'Prompt'
-        : type === AttachmentType.Pasted
-          ? 'Pasted'
-          : type === AttachmentType.Image
-            ? 'Image'
-            : ext || name;
-
-    const colorClass = mergeClasses(
-      styles.card,
-      error && styles.cardError,
-      selected && styles.cardSelected,
-      !error &&
-        !selected &&
-        type === AttachmentType.Prompt &&
-        styles.cardPrompt,
-      !error &&
-        !selected &&
-        type === AttachmentType.Pasted &&
-        styles.cardPasted,
-    );
-
-    const removeBtn = image ? styles.removeBtnImage : styles.actionBtn;
-
-    return {
-      isLoading: loading,
-      isError: error,
-      isImage: image,
-      actionsVisible: error || alwaysShowActions,
-      BottomIcon: bottomIcon,
-      bottomLabel: label,
-      cardColorClass: colorClass,
-      removeBtnClass: removeBtn,
-    };
-  }, [
-    status,
-    type,
-    previewUrl,
-    contentType,
-    name,
-    selected,
-    alwaysShowActions,
-  ]);
+  } = useMemo(
+    () =>
+      getAttachmentCardState(
+        attachment,
+        selected ?? false,
+        alwaysShowActions ?? false,
+      ),
+    [attachment, selected, alwaysShowActions],
+  );
 
   return (
     <div
+      style={cssVars}
       className={mergeClasses(
-        'group relative flex h-[100px] w-[100px] flex-shrink-0 rounded border',
+        'group relative flex h-[100px] w-[100px] flex-shrink-0 border',
         cardColorClass,
         !isImage && 'flex-col gap-3 p-3',
         className,
@@ -120,7 +65,7 @@ export const AttachmentCard: FC<AttachmentCardProps> = ({
     >
       {isImage ? (
         <img
-          src={previewUrl}
+          src={attachment.previewUrl}
           alt={name}
           className="h-full w-full rounded object-cover"
         />
@@ -130,7 +75,8 @@ export const AttachmentCard: FC<AttachmentCardProps> = ({
           <div className="flex flex-1 items-start overflow-hidden">
             <span
               className={mergeClasses(
-                'dial-tiny-text line-clamp-3 max-w-[76px] break-words',
+                typography?.fontClassName ?? 'dial-tiny-text',
+                'line-clamp-3 max-w-[76px] break-words',
                 styles.name,
               )}
               title={name}
@@ -187,7 +133,7 @@ export const AttachmentCard: FC<AttachmentCardProps> = ({
               icon={<IconRefresh size={DIAL_ICON_SIZE.SM} aria-hidden />}
               size={ElementSize.Small}
               className={mergeClasses('h-6 w-6 rounded', styles.actionBtn)}
-              aria-label={t('conversationInput.attachment.retry')}
+              aria-label={retryLabel}
               onClick={() => onRetry(id)}
             />
           )}
@@ -195,7 +141,7 @@ export const AttachmentCard: FC<AttachmentCardProps> = ({
             icon={<IconX size={DIAL_ICON_SIZE.SM} aria-hidden />}
             size={ElementSize.Small}
             className={mergeClasses('h-6 w-6 rounded', removeBtnClass)}
-            aria-label={t('conversationInput.attachment.remove')}
+            aria-label={removeLabel}
             onClick={() => onRemove(id)}
           />
         </div>

--- a/libs/conversation-input/src/components/AttachmentCard/AttachmentCard.tsx
+++ b/libs/conversation-input/src/components/AttachmentCard/AttachmentCard.tsx
@@ -1,0 +1,205 @@
+import {
+  AttachmentType,
+  RequestStatus,
+  mergeClasses,
+} from '@epam/ai-dial-chat-shared';
+import {
+  DIAL_ICON_SIZE,
+  DialEllipsisTooltip,
+  DialGhostIconButton,
+  DialLoader,
+  ElementSize,
+} from '@epam/ai-dial-ui-kit';
+import {
+  IconClipboard,
+  IconPhoto,
+  IconRefresh,
+  IconTerminal2,
+  IconX,
+} from '@tabler/icons-react';
+import { type FC, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import type { AttachmentCardProps } from '../../models/AttachmentCard.js';
+import { getAttachmentIcon } from '../../utils/getAttachmentIcon.js';
+import styles from './AttachmentCard.module.scss';
+
+export const AttachmentCard: FC<AttachmentCardProps> = ({
+  attachment,
+  onRemove,
+  onRetry,
+  selected,
+  alwaysShowActions,
+  className,
+}) => {
+  const { t } = useTranslation();
+  const { id, name, contentType, type, status, previewUrl } = attachment;
+
+  const {
+    isLoading,
+    isError,
+    isImage,
+    actionsVisible,
+    BottomIcon,
+    bottomLabel,
+    cardColorClass,
+    removeBtnClass,
+  } = useMemo(() => {
+    const loading = status === RequestStatus.Loading;
+    const error = status === RequestStatus.Error;
+    const image = type === AttachmentType.Image && !!previewUrl && !error;
+
+    const FileIcon = getAttachmentIcon(contentType);
+    const bottomIcon =
+      type === AttachmentType.Prompt
+        ? IconTerminal2
+        : type === AttachmentType.Pasted
+          ? IconClipboard
+          : type === AttachmentType.Image
+            ? IconPhoto
+            : FileIcon;
+
+    const ext = name.includes('.')
+      ? `.${name.slice(name.lastIndexOf('.') + 1).toLowerCase()}`
+      : contentType.split('/')[1]
+        ? `.${contentType.split('/')[1].toLowerCase()}`
+        : '';
+
+    const label =
+      type === AttachmentType.Prompt
+        ? 'Prompt'
+        : type === AttachmentType.Pasted
+          ? 'Pasted'
+          : type === AttachmentType.Image
+            ? 'Image'
+            : ext || name;
+
+    const colorClass = mergeClasses(
+      styles.card,
+      error && styles.cardError,
+      selected && styles.cardSelected,
+      !error &&
+        !selected &&
+        type === AttachmentType.Prompt &&
+        styles.cardPrompt,
+      !error &&
+        !selected &&
+        type === AttachmentType.Pasted &&
+        styles.cardPasted,
+    );
+
+    const removeBtn = image ? styles.removeBtnImage : styles.actionBtn;
+
+    return {
+      isLoading: loading,
+      isError: error,
+      isImage: image,
+      actionsVisible: error || alwaysShowActions,
+      BottomIcon: bottomIcon,
+      bottomLabel: label,
+      cardColorClass: colorClass,
+      removeBtnClass: removeBtn,
+    };
+  }, [
+    status,
+    type,
+    previewUrl,
+    contentType,
+    name,
+    selected,
+    alwaysShowActions,
+  ]);
+
+  return (
+    <div
+      className={mergeClasses(
+        'group relative flex h-[100px] w-[100px] flex-shrink-0 rounded border',
+        cardColorClass,
+        !isImage && 'flex-col gap-3 p-3',
+        className,
+      )}
+    >
+      {isImage ? (
+        <img
+          src={previewUrl}
+          alt={name}
+          className="h-full w-full rounded object-cover"
+        />
+      ) : (
+        <>
+          {/* Top group: file name */}
+          <div className="flex flex-1 items-start overflow-hidden">
+            <span
+              className={mergeClasses(
+                'dial-tiny-text line-clamp-3 max-w-[76px] break-words',
+                styles.name,
+              )}
+              title={name}
+            >
+              {name}
+            </span>
+          </div>
+
+          {/* Bottom group: icon + label */}
+          <div className="flex flex-row items-center gap-1 overflow-hidden">
+            <BottomIcon
+              size={DIAL_ICON_SIZE.SM}
+              className={mergeClasses('shrink-0', styles.meta)}
+              aria-hidden
+            />
+            <DialEllipsisTooltip
+              text={bottomLabel}
+              className={mergeClasses(
+                'dial-tiny-text min-w-0 flex-1 truncate',
+                styles.meta,
+              )}
+            />
+          </div>
+        </>
+      )}
+
+      {isLoading && (
+        <span
+          className={mergeClasses(
+            'absolute inset-0 flex items-center justify-center rounded',
+            styles.loadingOverlay,
+          )}
+        >
+          <DialLoader
+            size={16}
+            fullWidth={false}
+            iconClassName="text-primary"
+            ariaLabel="Loading attachment"
+          />
+        </span>
+      )}
+
+      {!isLoading && (
+        <div
+          className={mergeClasses(
+            'absolute right-1 top-1 flex gap-1 transition-opacity',
+            actionsVisible
+              ? 'opacity-100'
+              : 'opacity-0 group-focus-within:opacity-100 group-hover:opacity-100',
+          )}
+        >
+          {isError && onRetry && (
+            <DialGhostIconButton
+              icon={<IconRefresh size={DIAL_ICON_SIZE.SM} aria-hidden />}
+              size={ElementSize.Small}
+              className={mergeClasses('h-6 w-6 rounded', styles.actionBtn)}
+              aria-label={t('conversationInput.attachment.retry')}
+              onClick={() => onRetry(id)}
+            />
+          )}
+          <DialGhostIconButton
+            icon={<IconX size={DIAL_ICON_SIZE.SM} aria-hidden />}
+            size={ElementSize.Small}
+            className={mergeClasses('h-6 w-6 rounded', removeBtnClass)}
+            aria-label={t('conversationInput.attachment.remove')}
+            onClick={() => onRemove(id)}
+          />
+        </div>
+      )}
+    </div>
+  );
+};

--- a/libs/conversation-input/src/components/AttachmentCard/AttachmentCard.tsx
+++ b/libs/conversation-input/src/components/AttachmentCard/AttachmentCard.tsx
@@ -57,7 +57,7 @@ export const AttachmentCard: FC<AttachmentCardProps> = ({
     <div
       style={cssVars}
       className={mergeClasses(
-        'group relative flex h-[100px] w-[100px] flex-shrink-0 border',
+        'group relative flex h-[100px] w-[100px] flex-shrink-0 border focus-within:outline focus-within:outline-1 focus-within:outline-offset-1',
         cardColorClass,
         !isImage && 'flex-col gap-3 p-3',
         className,
@@ -132,7 +132,7 @@ export const AttachmentCard: FC<AttachmentCardProps> = ({
             <DialGhostIconButton
               icon={<IconRefresh size={DIAL_ICON_SIZE.SM} aria-hidden />}
               size={ElementSize.Small}
-              className={mergeClasses('h-6 w-6 rounded', styles.actionBtn)}
+              className={mergeClasses('h-6 w-6 rounded bg-transparent', styles.actionBtn)}
               aria-label={retryLabel}
               onClick={() => onRetry(id)}
             />

--- a/libs/conversation-input/src/components/AttachmentCard/AttachmentCard.tsx
+++ b/libs/conversation-input/src/components/AttachmentCard/AttachmentCard.tsx
@@ -22,6 +22,7 @@ export const AttachmentCard: FC<AttachmentCardProps> = ({
   retryLabel = 'Retry upload',
   colors,
   typography,
+  roundedClassName = 'rounded',
   className,
 }) => {
   const { id, name } = attachment;
@@ -31,7 +32,6 @@ export const AttachmentCard: FC<AttachmentCardProps> = ({
     ...(colors?.background && { '--ci-card-bg': colors.background }),
     ...(colors?.nameText && { '--ci-card-name': colors.nameText }),
     ...(colors?.metaText && { '--ci-card-meta': colors.metaText }),
-    borderRadius: colors?.borderRadius ?? '0.25rem',
   } as CSSProperties;
 
   const {
@@ -58,6 +58,7 @@ export const AttachmentCard: FC<AttachmentCardProps> = ({
       style={cssVars}
       className={mergeClasses(
         'group relative flex h-[100px] w-[100px] flex-shrink-0 border focus-within:outline focus-within:outline-1 focus-within:outline-offset-1',
+        roundedClassName,
         cardColorClass,
         !isImage && 'flex-col gap-3 p-3',
         className,
@@ -67,7 +68,10 @@ export const AttachmentCard: FC<AttachmentCardProps> = ({
         <img
           src={attachment.previewUrl}
           alt={name}
-          className="h-full w-full rounded object-cover"
+          className={mergeClasses(
+            'h-full w-full object-cover',
+            roundedClassName,
+          )}
         />
       ) : (
         <>
@@ -106,7 +110,8 @@ export const AttachmentCard: FC<AttachmentCardProps> = ({
       {isLoading && (
         <span
           className={mergeClasses(
-            'absolute inset-0 flex items-center justify-center rounded',
+            'absolute inset-0 flex items-center justify-center',
+            roundedClassName,
             styles.loadingOverlay,
           )}
         >
@@ -132,7 +137,10 @@ export const AttachmentCard: FC<AttachmentCardProps> = ({
             <DialGhostIconButton
               icon={<IconRefresh size={DIAL_ICON_SIZE.SM} aria-hidden />}
               size={ElementSize.Small}
-              className={mergeClasses('h-6 w-6 rounded bg-transparent', styles.actionBtn)}
+              className={mergeClasses(
+                'h-6 w-6 rounded bg-transparent',
+                styles.actionBtn,
+              )}
               aria-label={retryLabel}
               onClick={() => onRetry(id)}
             />

--- a/libs/conversation-input/src/components/AttachmentCard/tests/AttachmentCard.spec.tsx
+++ b/libs/conversation-input/src/components/AttachmentCard/tests/AttachmentCard.spec.tsx
@@ -1,0 +1,103 @@
+import type { Attachment } from '@epam/ai-dial-chat-shared';
+import { AttachmentType, RequestStatus } from '@epam/ai-dial-chat-shared';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { AttachmentCard } from '../AttachmentCard.js';
+
+const makeAttachment = (overrides?: Partial<Attachment>): Attachment => ({
+  id: 'a1',
+  name: 'report.pdf',
+  contentType: 'application/pdf',
+  file: new File([''], 'report.pdf', { type: 'application/pdf' }),
+  type: AttachmentType.File,
+  status: RequestStatus.Idle,
+  ...overrides,
+});
+
+describe('AttachmentCard', () => {
+  it('renders the file name', () => {
+    render(<AttachmentCard attachment={makeAttachment()} onRemove={vi.fn()} />);
+    expect(screen.getByText('report.pdf')).toBeTruthy();
+  });
+
+  it('renders an img thumbnail for image attachments', () => {
+    const attachment = makeAttachment({
+      contentType: 'image/png',
+      type: AttachmentType.Image,
+      previewUrl: 'blob:preview',
+    });
+    const { container } = render(
+      <AttachmentCard attachment={attachment} onRemove={vi.fn()} />,
+    );
+    const img = container.querySelector('img');
+    expect(img).toBeTruthy();
+    expect(img?.src).toContain('blob:preview');
+  });
+
+  it('hides remove button during loading state', () => {
+    const attachment = makeAttachment({ status: RequestStatus.Loading });
+    render(<AttachmentCard attachment={attachment} onRemove={vi.fn()} />);
+    expect(
+      screen.queryByLabelText('conversationInput.attachment.remove'),
+    ).toBeNull();
+  });
+
+  it('shows remove button in idle state', () => {
+    render(<AttachmentCard attachment={makeAttachment()} onRemove={vi.fn()} />);
+    expect(
+      screen.getByLabelText('conversationInput.attachment.remove'),
+    ).toBeTruthy();
+  });
+
+  it('shows retry button in error state', () => {
+    const attachment = makeAttachment({ status: RequestStatus.Error });
+    render(
+      <AttachmentCard
+        attachment={attachment}
+        onRemove={vi.fn()}
+        onRetry={vi.fn()}
+      />,
+    );
+    expect(
+      screen.getByLabelText('conversationInput.attachment.retry'),
+    ).toBeTruthy();
+  });
+
+  it('calls onRemove with attachment id when remove is clicked', () => {
+    const onRemove = vi.fn();
+    render(
+      <AttachmentCard attachment={makeAttachment()} onRemove={onRemove} />,
+    );
+    fireEvent.click(
+      screen.getByLabelText('conversationInput.attachment.remove'),
+    );
+    expect(onRemove).toHaveBeenCalledWith('a1');
+  });
+
+  it('calls onRemove when remove button is activated via keyboard', () => {
+    const onRemove = vi.fn();
+    render(
+      <AttachmentCard attachment={makeAttachment()} onRemove={onRemove} />,
+    );
+    const btn = screen.getByLabelText('conversationInput.attachment.remove');
+    fireEvent.keyDown(btn, { key: 'Enter' });
+    fireEvent.click(btn);
+    expect(onRemove).toHaveBeenCalledWith('a1');
+  });
+
+  it('calls onRetry with attachment id when retry is clicked', () => {
+    const onRetry = vi.fn();
+    const attachment = makeAttachment({ status: RequestStatus.Error });
+    render(
+      <AttachmentCard
+        attachment={attachment}
+        onRemove={vi.fn()}
+        onRetry={onRetry}
+      />,
+    );
+    fireEvent.click(
+      screen.getByLabelText('conversationInput.attachment.retry'),
+    );
+    expect(onRetry).toHaveBeenCalledWith('a1');
+  });
+});

--- a/libs/conversation-input/src/components/AttachmentCard/tests/AttachmentCard.spec.tsx
+++ b/libs/conversation-input/src/components/AttachmentCard/tests/AttachmentCard.spec.tsx
@@ -38,14 +38,14 @@ describe('AttachmentCard', () => {
     const attachment = makeAttachment({ status: RequestStatus.Loading });
     render(<AttachmentCard attachment={attachment} onRemove={vi.fn()} />);
     expect(
-      screen.queryByLabelText('conversationInput.attachment.remove'),
+      screen.queryByLabelText('Remove attachment'),
     ).toBeNull();
   });
 
   it('shows remove button in idle state', () => {
     render(<AttachmentCard attachment={makeAttachment()} onRemove={vi.fn()} />);
     expect(
-      screen.getByLabelText('conversationInput.attachment.remove'),
+      screen.getByLabelText('Remove attachment'),
     ).toBeTruthy();
   });
 
@@ -59,7 +59,7 @@ describe('AttachmentCard', () => {
       />,
     );
     expect(
-      screen.getByLabelText('conversationInput.attachment.retry'),
+      screen.getByLabelText('Retry upload'),
     ).toBeTruthy();
   });
 
@@ -69,7 +69,7 @@ describe('AttachmentCard', () => {
       <AttachmentCard attachment={makeAttachment()} onRemove={onRemove} />,
     );
     fireEvent.click(
-      screen.getByLabelText('conversationInput.attachment.remove'),
+      screen.getByLabelText('Remove attachment'),
     );
     expect(onRemove).toHaveBeenCalledWith('a1');
   });
@@ -79,7 +79,7 @@ describe('AttachmentCard', () => {
     render(
       <AttachmentCard attachment={makeAttachment()} onRemove={onRemove} />,
     );
-    const btn = screen.getByLabelText('conversationInput.attachment.remove');
+    const btn = screen.getByLabelText('Remove attachment');
     fireEvent.keyDown(btn, { key: 'Enter' });
     fireEvent.click(btn);
     expect(onRemove).toHaveBeenCalledWith('a1');
@@ -96,7 +96,7 @@ describe('AttachmentCard', () => {
       />,
     );
     fireEvent.click(
-      screen.getByLabelText('conversationInput.attachment.retry'),
+      screen.getByLabelText('Retry upload'),
     );
     expect(onRetry).toHaveBeenCalledWith('a1');
   });

--- a/libs/conversation-input/src/components/AttachmentCard/tests/AttachmentCard.spec.tsx
+++ b/libs/conversation-input/src/components/AttachmentCard/tests/AttachmentCard.spec.tsx
@@ -37,16 +37,12 @@ describe('AttachmentCard', () => {
   it('hides remove button during loading state', () => {
     const attachment = makeAttachment({ status: RequestStatus.Loading });
     render(<AttachmentCard attachment={attachment} onRemove={vi.fn()} />);
-    expect(
-      screen.queryByLabelText('Remove attachment'),
-    ).toBeNull();
+    expect(screen.queryByLabelText('Remove attachment')).toBeNull();
   });
 
   it('shows remove button in idle state', () => {
     render(<AttachmentCard attachment={makeAttachment()} onRemove={vi.fn()} />);
-    expect(
-      screen.getByLabelText('Remove attachment'),
-    ).toBeTruthy();
+    expect(screen.getByLabelText('Remove attachment')).toBeTruthy();
   });
 
   it('shows retry button in error state', () => {
@@ -58,9 +54,7 @@ describe('AttachmentCard', () => {
         onRetry={vi.fn()}
       />,
     );
-    expect(
-      screen.getByLabelText('Retry upload'),
-    ).toBeTruthy();
+    expect(screen.getByLabelText('Retry upload')).toBeTruthy();
   });
 
   it('calls onRemove with attachment id when remove is clicked', () => {
@@ -68,9 +62,7 @@ describe('AttachmentCard', () => {
     render(
       <AttachmentCard attachment={makeAttachment()} onRemove={onRemove} />,
     );
-    fireEvent.click(
-      screen.getByLabelText('Remove attachment'),
-    );
+    fireEvent.click(screen.getByLabelText('Remove attachment'));
     expect(onRemove).toHaveBeenCalledWith('a1');
   });
 
@@ -95,9 +87,7 @@ describe('AttachmentCard', () => {
         onRetry={onRetry}
       />,
     );
-    fireEvent.click(
-      screen.getByLabelText('Retry upload'),
-    );
+    fireEvent.click(screen.getByLabelText('Retry upload'));
     expect(onRetry).toHaveBeenCalledWith('a1');
   });
 });

--- a/libs/conversation-input/src/components/AttachmentTray/AttachmentTray.tsx
+++ b/libs/conversation-input/src/components/AttachmentTray/AttachmentTray.tsx
@@ -1,0 +1,37 @@
+import { mergeClasses } from '@epam/ai-dial-chat-shared';
+import { type FC } from 'react';
+import { useTranslation } from 'react-i18next';
+import type { AttachmentTrayProps } from '../../models/AttachmentTray.js';
+import { AttachmentCard } from '../AttachmentCard/AttachmentCard.js';
+
+export const AttachmentTray: FC<AttachmentTrayProps> = ({
+  attachments,
+  onRemove,
+  onRetry,
+  className,
+}) => {
+  const { t } = useTranslation();
+
+  if (attachments.length === 0) return null;
+
+  return (
+    <div
+      role="list"
+      aria-label={t('conversationInput.attachmentTray.label')}
+      className={mergeClasses(
+        'flex w-full gap-2 overflow-x-auto p-1',
+        className,
+      )}
+    >
+      {attachments.map((attachment) => (
+        <div key={attachment.id} role="listitem">
+          <AttachmentCard
+            attachment={attachment}
+            onRemove={onRemove}
+            onRetry={onRetry}
+          />
+        </div>
+      ))}
+    </div>
+  );
+};

--- a/libs/conversation-input/src/components/AttachmentTray/AttachmentTray.tsx
+++ b/libs/conversation-input/src/components/AttachmentTray/AttachmentTray.tsx
@@ -1,6 +1,5 @@
 import { mergeClasses } from '@epam/ai-dial-chat-shared';
 import { type FC } from 'react';
-import { useTranslation } from 'react-i18next';
 import type { AttachmentTrayProps } from '../../models/AttachmentTray.js';
 import { AttachmentCard } from '../AttachmentCard/AttachmentCard.js';
 
@@ -8,16 +7,15 @@ export const AttachmentTray: FC<AttachmentTrayProps> = ({
   attachments,
   onRemove,
   onRetry,
+  ariaLabel = 'Attached files',
   className,
 }) => {
-  const { t } = useTranslation();
-
   if (attachments.length === 0) return null;
 
   return (
     <div
       role="list"
-      aria-label={t('conversationInput.attachmentTray.label')}
+      aria-label={ariaLabel}
       className={mergeClasses(
         'flex w-full gap-2 overflow-x-auto p-1',
         className,

--- a/libs/conversation-input/src/components/AttachmentTray/AttachmentTray.tsx
+++ b/libs/conversation-input/src/components/AttachmentTray/AttachmentTray.tsx
@@ -8,6 +8,8 @@ export const AttachmentTray: FC<AttachmentTrayProps> = ({
   onRemove,
   onRetry,
   ariaLabel = 'Attached files',
+  removeLabel,
+  retryLabel,
   className,
 }) => {
   if (attachments.length === 0) return null;
@@ -27,6 +29,8 @@ export const AttachmentTray: FC<AttachmentTrayProps> = ({
             attachment={attachment}
             onRemove={onRemove}
             onRetry={onRetry}
+            removeLabel={removeLabel}
+            retryLabel={retryLabel}
           />
         </div>
       ))}

--- a/libs/conversation-input/src/components/AttachmentTray/tests/AttachmentTray.spec.tsx
+++ b/libs/conversation-input/src/components/AttachmentTray/tests/AttachmentTray.spec.tsx
@@ -39,9 +39,7 @@ describe('AttachmentTray', () => {
         onRemove={onRemove}
       />,
     );
-    fireEvent.click(
-      screen.getByLabelText('Remove attachment'),
-    );
+    fireEvent.click(screen.getByLabelText('Remove attachment'));
     expect(onRemove).toHaveBeenCalledWith('1');
   });
 

--- a/libs/conversation-input/src/components/AttachmentTray/tests/AttachmentTray.spec.tsx
+++ b/libs/conversation-input/src/components/AttachmentTray/tests/AttachmentTray.spec.tsx
@@ -1,0 +1,56 @@
+import type { Attachment } from '@epam/ai-dial-chat-shared';
+import { AttachmentType, RequestStatus } from '@epam/ai-dial-chat-shared';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { AttachmentTray } from '../AttachmentTray.js';
+
+const makeAttachment = (id: string, name = 'file.pdf'): Attachment => ({
+  id,
+  name,
+  contentType: 'application/pdf',
+  file: new File([''], name, { type: 'application/pdf' }),
+  type: AttachmentType.File,
+  status: RequestStatus.Idle,
+});
+
+describe('AttachmentTray', () => {
+  it('returns null when attachments list is empty', () => {
+    const { container } = render(
+      <AttachmentTray attachments={[]} onRemove={vi.fn()} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders a card for each attachment', () => {
+    const attachments = [
+      makeAttachment('1', 'a.pdf'),
+      makeAttachment('2', 'b.pdf'),
+    ];
+    render(<AttachmentTray attachments={attachments} onRemove={vi.fn()} />);
+    expect(screen.getByText('a.pdf')).toBeTruthy();
+    expect(screen.getByText('b.pdf')).toBeTruthy();
+  });
+
+  it('forwards onRemove when a card remove button is clicked', () => {
+    const onRemove = vi.fn();
+    render(
+      <AttachmentTray
+        attachments={[makeAttachment('1', 'a.pdf')]}
+        onRemove={onRemove}
+      />,
+    );
+    fireEvent.click(
+      screen.getByLabelText('conversationInput.attachment.remove'),
+    );
+    expect(onRemove).toHaveBeenCalledWith('1');
+  });
+
+  it('disappears when last card is removed (empty list passed)', () => {
+    const { rerender, container } = render(
+      <AttachmentTray attachments={[makeAttachment('1')]} onRemove={vi.fn()} />,
+    );
+    expect(container.firstChild).not.toBeNull();
+    rerender(<AttachmentTray attachments={[]} onRemove={vi.fn()} />);
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/libs/conversation-input/src/components/AttachmentTray/tests/AttachmentTray.spec.tsx
+++ b/libs/conversation-input/src/components/AttachmentTray/tests/AttachmentTray.spec.tsx
@@ -40,7 +40,7 @@ describe('AttachmentTray', () => {
       />,
     );
     fireEvent.click(
-      screen.getByLabelText('conversationInput.attachment.remove'),
+      screen.getByLabelText('Remove attachment'),
     );
     expect(onRemove).toHaveBeenCalledWith('1');
   });

--- a/libs/conversation-input/src/components/ConversationInput/ConversationInput.spec.tsx
+++ b/libs/conversation-input/src/components/ConversationInput/ConversationInput.spec.tsx
@@ -25,11 +25,10 @@ describe('ConversationInput', () => {
     const { container } = render(<ConversationInput onSend={handleSend} />);
 
     const textarea = container.querySelector('textarea');
-    const button = container.querySelector('button');
 
-    if (textarea && button) {
+    if (textarea) {
       fireEvent.change(textarea, { target: { value: 'Test message' } });
-      fireEvent.click(button);
+      fireEvent.click(screen.getByLabelText('Send message'));
 
       expect(handleSend).toHaveBeenCalledWith('Test message');
     }
@@ -51,14 +50,10 @@ describe('ConversationInput', () => {
 
   it('should not send empty messages', () => {
     const handleSend = vi.fn();
-    const { container } = render(<ConversationInput onSend={handleSend} />);
+    render(<ConversationInput onSend={handleSend} />);
 
-    const button = container.querySelector('button');
-
-    if (button) {
-      fireEvent.click(button);
-      expect(handleSend).not.toHaveBeenCalled();
-    }
+    expect(screen.queryByLabelText('Send message')).toBeNull();
+    expect(handleSend).not.toHaveBeenCalled();
   });
 
   it('should hide welcome text when welcomeText prop is empty string', () => {

--- a/libs/conversation-input/src/components/ConversationInput/ConversationInput.tsx
+++ b/libs/conversation-input/src/components/ConversationInput/ConversationInput.tsx
@@ -8,6 +8,7 @@ export const ConversationInput: FC<ConversationInputProps> = ({
   onSend,
   onStop,
   isStreaming = false,
+  onAttachmentsChange,
   initialMessage = '',
   placeholder = 'Type a new prompt or use "/" to select one',
   welcomeText,
@@ -60,6 +61,7 @@ export const ConversationInput: FC<ConversationInputProps> = ({
         onSend={onSend}
         onStop={onStop}
         isStreaming={isStreaming}
+        onAttachmentsChange={onAttachmentsChange}
         placeholder={placeholder}
         colors={colors?.input}
         typography={typography?.input}

--- a/libs/conversation-input/src/components/Input/Input.module.scss
+++ b/libs/conversation-input/src/components/Input/Input.module.scss
@@ -1,9 +1,9 @@
 .wrapper {
   background: var(--ci-bg, var(--bg-layer-2, #161b2d));
-  border-color: var(--ci-border, #f3f6ff00);
+  border-color: var(--ci-border, var(--stroke-secondary, #f3f6ff00));
 
   &:focus-within {
-    border-color: var(--ci-border-focus, transparent);
+    border-color: var(--ci-border-focus, var(--stroke-focus, #7da4ff));
   }
 }
 

--- a/libs/conversation-input/src/components/Input/Input.tsx
+++ b/libs/conversation-input/src/components/Input/Input.tsx
@@ -161,7 +161,7 @@ export const Input: FC<InputProps> = ({
         >
           <DialGhostIconButton
             icon={<IconPlus size={BASE_ICON_SIZE} aria-hidden />}
-            aria-label={t('conversationInput.addMenu.ariaLabel')}
+            aria-label={t('actions.add')}
             className="size-10 flex-shrink-0"
           />
         </DialDropdown>

--- a/libs/conversation-input/src/components/Input/Input.tsx
+++ b/libs/conversation-input/src/components/Input/Input.tsx
@@ -1,6 +1,26 @@
-import { mergeClasses } from '@epam/ai-dial-chat-shared';
-import { CSSProperties, type FC, KeyboardEvent, useState } from 'react';
+import type { Attachment } from '@epam/ai-dial-chat-shared';
+import {
+  AttachmentType,
+  RequestStatus,
+  mergeClasses,
+} from '@epam/ai-dial-chat-shared';
+import {
+  BASE_ICON_SIZE,
+  DialDropdown,
+  DialGhostIconButton,
+} from '@epam/ai-dial-ui-kit';
+import { IconPaperclip, IconPlus } from '@tabler/icons-react';
+import {
+  CSSProperties,
+  type FC,
+  KeyboardEvent,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
+import { useTranslation } from 'react-i18next';
 import type { InputProps } from '../../models/Input.js';
+import { AttachmentTray } from '../AttachmentTray/AttachmentTray.js';
 import styles from './Input.module.scss';
 import { SendButton } from './SendButton.js';
 import { StopButton } from './StopButton.js';
@@ -11,12 +31,14 @@ export const Input: FC<InputProps> = ({
   onStop,
   isStreaming = false,
   onChange,
+  onAttachmentsChange,
   placeholder = 'Type a message...',
   ariaLabel,
   colors,
   typography,
   className,
 }) => {
+  const { t } = useTranslation();
   const cssVars = {
     ...(colors?.background && { '--ci-bg': colors.background }),
     ...(colors?.text && { '--ci-text': colors.text }),
@@ -38,6 +60,16 @@ export const Input: FC<InputProps> = ({
   } as CSSProperties;
 
   const [message, setMessage] = useState(initialMessage);
+  const [attachments, setAttachments] = useState<Attachment[]>([]);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    return () => {
+      attachments.forEach((a) => {
+        if (a.previewUrl) URL.revokeObjectURL(a.previewUrl);
+      });
+    };
+  }, []);
 
   const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
     if (e.key === 'Enter' && !e.shiftKey) {
@@ -49,35 +81,111 @@ export const Input: FC<InputProps> = ({
     }
   };
 
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = Array.from(e.target.files ?? []);
+    if (files.length === 0) return;
+
+    const newAttachments: Attachment[] = files.map((file) => {
+      const isImage = file.type.startsWith('image/');
+      const previewUrl = isImage ? URL.createObjectURL(file) : undefined;
+      return {
+        id: `${Date.now()}-${Math.random().toString(36).slice(2)}`,
+        name: file.name,
+        contentType: file.type,
+        file,
+        type: isImage ? AttachmentType.Image : AttachmentType.File,
+        status: RequestStatus.Idle,
+        previewUrl,
+      };
+    });
+
+    // Reset so the same file can be picked again
+    e.target.value = '';
+
+    setAttachments((prev) => {
+      const updated = [...prev, ...newAttachments];
+      onAttachmentsChange?.(updated);
+      return updated;
+    });
+  };
+
+  const handleRemove = (id: string) => {
+    setAttachments((prev) => {
+      const target = prev.find((a) => a.id === id);
+      if (target?.previewUrl) URL.revokeObjectURL(target.previewUrl);
+      const updated = prev.filter((a) => a.id !== id);
+      onAttachmentsChange?.(updated);
+      return updated;
+    });
+  };
+
   return (
     <div
       style={cssVars}
       className={mergeClasses(
         styles.wrapper,
-        'flex min-h-[56px] w-full max-w-[748px] items-center gap-2 rounded border px-3 py-2',
+        'flex min-h-[56px] w-full max-w-[748px] flex-col rounded border px-3 py-2',
         className,
       )}
     >
-      <textarea
-        className={mergeClasses(
-          styles.textarea,
-          'flex-1 resize-none bg-transparent outline-none',
-        )}
-        value={message}
-        onChange={(e) => {
-          setMessage(e.target.value);
-          onChange?.(e.target.value);
-        }}
-        onKeyDown={handleKeyDown}
-        placeholder={placeholder}
-        aria-label={ariaLabel}
-        rows={1}
-      />
-      {isStreaming ? (
-        <StopButton onStop={onStop} />
-      ) : (
-        message.trim() && <SendButton onSend={() => onSend?.(message)} />
+      {attachments.length > 0 && (
+        <AttachmentTray
+          attachments={attachments}
+          onRemove={handleRemove}
+          className="mb-2"
+        />
       )}
+      <div className="flex items-center gap-2">
+        <input
+          ref={fileInputRef}
+          type="file"
+          multiple
+          className="sr-only"
+          aria-hidden
+          tabIndex={-1}
+          onChange={handleFileChange}
+        />
+        <DialDropdown
+          matchReferenceWidth={false}
+          placement="bottom-start"
+          menu={{
+            items: [
+              {
+                key: 'attach',
+                label: t('conversationInput.attach.label'),
+                icon: <IconPaperclip size={BASE_ICON_SIZE} aria-hidden />,
+                onClick: () => fileInputRef.current?.click(),
+              },
+            ],
+          }}
+        >
+          <DialGhostIconButton
+            icon={<IconPlus size={BASE_ICON_SIZE} aria-hidden />}
+            aria-label={t('conversationInput.addMenu.ariaLabel')}
+            className="size-10 flex-shrink-0"
+          />
+        </DialDropdown>
+        <textarea
+          className={mergeClasses(
+            styles.textarea,
+            'flex-1 resize-none bg-transparent outline-none',
+          )}
+          value={message}
+          onChange={(e) => {
+            setMessage(e.target.value);
+            onChange?.(e.target.value);
+          }}
+          onKeyDown={handleKeyDown}
+          placeholder={placeholder}
+          aria-label={ariaLabel}
+          rows={1}
+        />
+        {isStreaming ? (
+          <StopButton onStop={onStop} />
+        ) : (
+          message.trim() && <SendButton onSend={() => onSend?.(message)} />
+        )}
+      </div>
     </div>
   );
 };

--- a/libs/conversation-input/src/components/Input/Input.tsx
+++ b/libs/conversation-input/src/components/Input/Input.tsx
@@ -35,6 +35,8 @@ export const Input: FC<InputProps> = ({
   ariaLabel,
   attachLabel = 'Attach file',
   addMenuLabel = 'Add',
+  removeLabel,
+  retryLabel,
   colors,
   typography,
   className,
@@ -132,6 +134,8 @@ export const Input: FC<InputProps> = ({
         <AttachmentTray
           attachments={attachments}
           onRemove={handleRemove}
+          removeLabel={removeLabel}
+          retryLabel={retryLabel}
           className="mb-2"
         />
       )}

--- a/libs/conversation-input/src/components/Input/Input.tsx
+++ b/libs/conversation-input/src/components/Input/Input.tsx
@@ -18,7 +18,6 @@ import {
   useRef,
   useState,
 } from 'react';
-import { useTranslation } from 'react-i18next';
 import type { InputProps } from '../../models/Input.js';
 import { AttachmentTray } from '../AttachmentTray/AttachmentTray.js';
 import styles from './Input.module.scss';
@@ -34,11 +33,12 @@ export const Input: FC<InputProps> = ({
   onAttachmentsChange,
   placeholder = 'Type a message...',
   ariaLabel,
+  attachLabel = 'Attach file',
+  addMenuLabel = 'Add',
   colors,
   typography,
   className,
 }) => {
-  const { t } = useTranslation();
   const cssVars = {
     ...(colors?.background && { '--ci-bg': colors.background }),
     ...(colors?.text && { '--ci-text': colors.text }),
@@ -152,7 +152,7 @@ export const Input: FC<InputProps> = ({
             items: [
               {
                 key: 'attach',
-                label: t('conversationInput.attach.label'),
+                label: attachLabel,
                 icon: <IconPaperclip size={BASE_ICON_SIZE} aria-hidden />,
                 onClick: () => fileInputRef.current?.click(),
               },
@@ -161,7 +161,7 @@ export const Input: FC<InputProps> = ({
         >
           <DialGhostIconButton
             icon={<IconPlus size={BASE_ICON_SIZE} aria-hidden />}
-            aria-label={t('actions.add')}
+            aria-label={addMenuLabel}
             className="size-10 flex-shrink-0"
           />
         </DialDropdown>

--- a/libs/conversation-input/src/components/Input/tests/Input.spec.tsx
+++ b/libs/conversation-input/src/components/Input/tests/Input.spec.tsx
@@ -147,9 +147,7 @@ describe('Input', () => {
     ) as HTMLInputElement;
     const file = new File(['content'], 'doc.pdf', { type: 'application/pdf' });
     fireEvent.change(fileInput, { target: { files: [file] } });
-    fireEvent.click(
-      screen.getByLabelText('Remove attachment'),
-    );
+    fireEvent.click(screen.getByLabelText('Remove attachment'));
     expect(screen.queryByText('doc.pdf')).toBeNull();
   });
 

--- a/libs/conversation-input/src/components/Input/tests/Input.spec.tsx
+++ b/libs/conversation-input/src/components/Input/tests/Input.spec.tsx
@@ -127,9 +127,7 @@ describe('Input', () => {
 
   it('should render the add menu button', () => {
     render(<Input />);
-    expect(
-      screen.getByLabelText('conversationInput.addMenu.ariaLabel'),
-    ).toBeTruthy();
+    expect(screen.getByLabelText('actions.add')).toBeTruthy();
   });
 
   it('should show an attachment card after a file is picked', () => {

--- a/libs/conversation-input/src/components/Input/tests/Input.spec.tsx
+++ b/libs/conversation-input/src/components/Input/tests/Input.spec.tsx
@@ -127,7 +127,7 @@ describe('Input', () => {
 
   it('should render the add menu button', () => {
     render(<Input />);
-    expect(screen.getByLabelText('actions.add')).toBeTruthy();
+    expect(screen.getByLabelText('Add')).toBeTruthy();
   });
 
   it('should show an attachment card after a file is picked', () => {
@@ -148,7 +148,7 @@ describe('Input', () => {
     const file = new File(['content'], 'doc.pdf', { type: 'application/pdf' });
     fireEvent.change(fileInput, { target: { files: [file] } });
     fireEvent.click(
-      screen.getByLabelText('conversationInput.attachment.remove'),
+      screen.getByLabelText('Remove attachment'),
     );
     expect(screen.queryByText('doc.pdf')).toBeNull();
   });

--- a/libs/conversation-input/src/components/Input/tests/Input.spec.tsx
+++ b/libs/conversation-input/src/components/Input/tests/Input.spec.tsx
@@ -1,11 +1,11 @@
-import { fireEvent, render } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import { Input } from '../Input.js';
 
 describe('Input', () => {
   it('should hide send button when textarea is empty', () => {
-    const { container } = render(<Input />);
-    expect(container.querySelector('button')).toBeNull();
+    render(<Input />);
+    expect(screen.queryByLabelText('Send message')).toBeNull();
   });
 
   it('should show send button when user types non-whitespace text', () => {
@@ -22,7 +22,7 @@ describe('Input', () => {
     const textarea = container.querySelector('textarea');
     if (textarea) {
       fireEvent.change(textarea, { target: { value: '   ' } });
-      expect(container.querySelector('button')).toBeNull();
+      expect(screen.queryByLabelText('Send message')).toBeNull();
     }
   });
 
@@ -70,14 +70,12 @@ describe('Input', () => {
     const handleSend = vi.fn();
     const { container } = render(<Input onSend={handleSend} />);
     const textarea = container.querySelector('textarea');
-    const button = container.querySelector('button');
     if (textarea) {
       fireEvent.change(textarea, { target: { value: 'Click send' } });
     }
-    if (button) {
-      fireEvent.click(button);
-      expect(handleSend).toHaveBeenCalledWith('Click send');
-    }
+    const sendButton = screen.getByLabelText('Send message');
+    fireEvent.click(sendButton);
+    expect(handleSend).toHaveBeenCalledWith('Click send');
   });
 
   it('should set --ci-bg and --ci-text CSS variables when colors prop is provided', () => {
@@ -125,5 +123,48 @@ describe('Input', () => {
     expect(
       container.querySelector('textarea')?.getAttribute('aria-label'),
     ).toBe('Message input');
+  });
+
+  it('should render the add menu button', () => {
+    render(<Input />);
+    expect(
+      screen.getByLabelText('conversationInput.addMenu.ariaLabel'),
+    ).toBeTruthy();
+  });
+
+  it('should show an attachment card after a file is picked', () => {
+    render(<Input />);
+    const fileInput = document.querySelector(
+      'input[type="file"]',
+    ) as HTMLInputElement;
+    const file = new File(['content'], 'doc.pdf', { type: 'application/pdf' });
+    fireEvent.change(fileInput, { target: { files: [file] } });
+    expect(screen.getByText('doc.pdf')).toBeTruthy();
+  });
+
+  it('should remove the card when the remove button is clicked', () => {
+    render(<Input />);
+    const fileInput = document.querySelector(
+      'input[type="file"]',
+    ) as HTMLInputElement;
+    const file = new File(['content'], 'doc.pdf', { type: 'application/pdf' });
+    fireEvent.change(fileInput, { target: { files: [file] } });
+    fireEvent.click(
+      screen.getByLabelText('conversationInput.attachment.remove'),
+    );
+    expect(screen.queryByText('doc.pdf')).toBeNull();
+  });
+
+  it('should call onAttachmentsChange when a file is added', () => {
+    const onAttachmentsChange = vi.fn();
+    render(<Input onAttachmentsChange={onAttachmentsChange} />);
+    const fileInput = document.querySelector(
+      'input[type="file"]',
+    ) as HTMLInputElement;
+    const file = new File(['content'], 'doc.pdf', { type: 'application/pdf' });
+    fireEvent.change(fileInput, { target: { files: [file] } });
+    expect(onAttachmentsChange).toHaveBeenCalledWith(
+      expect.arrayContaining([expect.objectContaining({ name: 'doc.pdf' })]),
+    );
   });
 });

--- a/libs/conversation-input/src/index.ts
+++ b/libs/conversation-input/src/index.ts
@@ -1,5 +1,7 @@
 export { ConversationInput } from './components/ConversationInput/ConversationInput.js';
 export { Input } from './components/Input/Input.js';
+export { AttachmentCard } from './components/AttachmentCard/AttachmentCard.js';
+export { AttachmentTray } from './components/AttachmentTray/AttachmentTray.js';
 export type {
   ConversationInputProps,
   ConversationInputColors,

--- a/libs/conversation-input/src/index.ts
+++ b/libs/conversation-input/src/index.ts
@@ -12,3 +12,11 @@ export type {
   InputColors,
   InputTypography,
 } from './models/Input.js';
+export type {
+  AttachmentCardProps,
+  AttachmentCardColors,
+  AttachmentCardTypography,
+} from './models/AttachmentCard.js';
+export type {
+  AttachmentTrayProps,
+} from './models/AttachmentTray.js';

--- a/libs/conversation-input/src/index.ts
+++ b/libs/conversation-input/src/index.ts
@@ -17,6 +17,4 @@ export type {
   AttachmentCardColors,
   AttachmentCardTypography,
 } from './models/AttachmentCard.js';
-export type {
-  AttachmentTrayProps,
-} from './models/AttachmentTray.js';
+export type { AttachmentTrayProps } from './models/AttachmentTray.js';

--- a/libs/conversation-input/src/models/AttachmentCard.ts
+++ b/libs/conversation-input/src/models/AttachmentCard.ts
@@ -10,8 +10,6 @@ export interface AttachmentCardColors {
   nameText?: string;
   /** Meta (type / label) text color. */
   metaText?: string;
-  /** Border radius applied to the card (e.g. `'0.25rem'`, `'8px'`). */
-  borderRadius?: string;
 }
 
 /** Typography overrides for the `AttachmentCard` component. */
@@ -40,6 +38,8 @@ export interface AttachmentCardProps {
   colors?: AttachmentCardColors;
   /** Typography overrides for text elements inside the card. */
   typography?: AttachmentCardTypography;
+  /** Tailwind border-radius utility class applied to the card and its inner layers (e.g. `'rounded'`, `'rounded-lg'`). */
+  roundedClassName?: string;
   /** Extra class name(s) merged onto the root element. */
   className?: string;
 }

--- a/libs/conversation-input/src/models/AttachmentCard.ts
+++ b/libs/conversation-input/src/models/AttachmentCard.ts
@@ -1,5 +1,25 @@
 import type { Attachment } from '@epam/ai-dial-chat-shared';
 
+/** CSS custom-property overrides for the `AttachmentCard` component. */
+export interface AttachmentCardColors {
+  /** Card border color in the default state. */
+  border?: string;
+  /** Card background color in the default state. */
+  background?: string;
+  /** File name text color. */
+  nameText?: string;
+  /** Meta (type / label) text color. */
+  metaText?: string;
+  /** Border radius applied to the card (e.g. `'0.25rem'`, `'8px'`). */
+  borderRadius?: string;
+}
+
+/** Typography overrides for the `AttachmentCard` component. */
+export interface AttachmentCardTypography {
+  /** Utility class applied to the file name text (e.g. `'dial-tiny-text'`, `'text-xs'`). */
+  fontClassName?: string;
+}
+
 /** Props accepted by the `AttachmentCard` component. */
 export interface AttachmentCardProps {
   /** The attachment data to display. */
@@ -12,6 +32,14 @@ export interface AttachmentCardProps {
   selected?: boolean;
   /** Forces action buttons to be always visible regardless of hover/focus state. */
   alwaysShowActions?: boolean;
+  /** Accessible label for the remove button. */
+  removeLabel?: string;
+  /** Accessible label for the retry button (error state only). */
+  retryLabel?: string;
+  /** Color overrides applied as CSS custom properties. */
+  colors?: AttachmentCardColors;
+  /** Typography overrides for text elements inside the card. */
+  typography?: AttachmentCardTypography;
   /** Extra class name(s) merged onto the root element. */
   className?: string;
 }

--- a/libs/conversation-input/src/models/AttachmentCard.ts
+++ b/libs/conversation-input/src/models/AttachmentCard.ts
@@ -1,0 +1,17 @@
+import type { Attachment } from '@epam/ai-dial-chat-shared';
+
+/** Props accepted by the `AttachmentCard` component. */
+export interface AttachmentCardProps {
+  /** The attachment data to display. */
+  attachment: Attachment;
+  /** Called when the user activates the remove button. */
+  onRemove: (id: string) => void;
+  /** Called when the user activates the retry button (error state only). */
+  onRetry?: (id: string) => void;
+  /** Renders the card in selected state (accent border + tinted background). */
+  selected?: boolean;
+  /** Forces action buttons to be always visible regardless of hover/focus state. */
+  alwaysShowActions?: boolean;
+  /** Extra class name(s) merged onto the root element. */
+  className?: string;
+}

--- a/libs/conversation-input/src/models/AttachmentTray.ts
+++ b/libs/conversation-input/src/models/AttachmentTray.ts
@@ -10,6 +10,10 @@ export interface AttachmentTrayProps {
   onRetry?: (id: string) => void;
   /** Accessible label for the tray region. */
   ariaLabel?: string;
+  /** Accessible label for each card's remove button. */
+  removeLabel?: string;
+  /** Accessible label for each card's retry button (error state only). */
+  retryLabel?: string;
   /** Extra class name(s) merged onto the root element. */
   className?: string;
 }

--- a/libs/conversation-input/src/models/AttachmentTray.ts
+++ b/libs/conversation-input/src/models/AttachmentTray.ts
@@ -1,0 +1,13 @@
+import type { Attachment } from '@epam/ai-dial-chat-shared';
+
+/** Props accepted by the `AttachmentTray` component. */
+export interface AttachmentTrayProps {
+  /** The list of attachments to display. */
+  attachments: Attachment[];
+  /** Called when the user removes an attachment card. */
+  onRemove: (id: string) => void;
+  /** Called when the user retries a failed attachment upload. */
+  onRetry?: (id: string) => void;
+  /** Extra class name(s) merged onto the root element. */
+  className?: string;
+}

--- a/libs/conversation-input/src/models/AttachmentTray.ts
+++ b/libs/conversation-input/src/models/AttachmentTray.ts
@@ -8,6 +8,8 @@ export interface AttachmentTrayProps {
   onRemove: (id: string) => void;
   /** Called when the user retries a failed attachment upload. */
   onRetry?: (id: string) => void;
+  /** Accessible label for the tray region. */
+  ariaLabel?: string;
   /** Extra class name(s) merged onto the root element. */
   className?: string;
 }

--- a/libs/conversation-input/src/models/ConversationInput.ts
+++ b/libs/conversation-input/src/models/ConversationInput.ts
@@ -1,3 +1,4 @@
+import type { Attachment } from '@epam/ai-dial-chat-shared';
 import type { InputColors, InputTypography } from './Input.js';
 
 /** CSS custom-property overrides for the `ConversationInput` component. */
@@ -40,6 +41,8 @@ export interface ConversationInputProps {
   onStop?: () => void;
   /** When `true`, shows a stop button instead of the send button and blocks Enter. */
   isStreaming?: boolean;
+  /** Called whenever the attachment list changes. */
+  onAttachmentsChange?: (attachments: Attachment[]) => void;
   /** Color overrides applied as CSS custom properties. */
   colors?: ConversationInputColors;
   /** Typography overrides for the welcome heading and input. */

--- a/libs/conversation-input/src/models/Input.ts
+++ b/libs/conversation-input/src/models/Input.ts
@@ -52,6 +52,10 @@ export interface InputProps {
   colors?: InputColors;
   /** Typography overrides applied as CSS custom properties. */
   typography?: InputTypography;
+  /** Label for the attach-file menu item. */
+  attachLabel?: string;
+  /** Accessible label for the add-menu trigger button. */
+  addMenuLabel?: string;
   /** Extra class name(s) merged onto the root wrapper element. */
   className?: string;
 }

--- a/libs/conversation-input/src/models/Input.ts
+++ b/libs/conversation-input/src/models/Input.ts
@@ -1,3 +1,5 @@
+import type { Attachment } from '@epam/ai-dial-chat-shared';
+
 /** CSS custom-property overrides for the `Input` component. */
 export interface InputColors {
   /** Input area background color. */
@@ -40,6 +42,8 @@ export interface InputProps {
   onStop?: () => void;
   /** When `true`, shows a stop button instead of the send button. */
   isStreaming?: boolean;
+  /** Called whenever the attachment list changes. */
+  onAttachmentsChange?: (attachments: Attachment[]) => void;
   /** Placeholder text shown when the textarea is empty. */
   placeholder?: string;
   /** `aria-label` applied to the textarea for screen readers. */

--- a/libs/conversation-input/src/models/Input.ts
+++ b/libs/conversation-input/src/models/Input.ts
@@ -56,6 +56,10 @@ export interface InputProps {
   attachLabel?: string;
   /** Accessible label for the add-menu trigger button. */
   addMenuLabel?: string;
+  /** Accessible label for each attachment card's remove button. */
+  removeLabel?: string;
+  /** Accessible label for each attachment card's retry button (error state only). */
+  retryLabel?: string;
   /** Extra class name(s) merged onto the root wrapper element. */
   className?: string;
 }

--- a/libs/conversation-input/src/test-setup.ts
+++ b/libs/conversation-input/src/test-setup.ts
@@ -1,0 +1,16 @@
+import { vi } from 'vitest';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+class IntersectionObserverMock {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+Object.defineProperty(window, 'IntersectionObserver', {
+  writable: true,
+  configurable: true,
+  value: IntersectionObserverMock,
+});

--- a/libs/conversation-input/src/test-setup.ts
+++ b/libs/conversation-input/src/test-setup.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-empty-function */
 class IntersectionObserverMock {
   observe() {}
   unobserve() {}

--- a/libs/conversation-input/src/test-setup.ts
+++ b/libs/conversation-input/src/test-setup.ts
@@ -1,9 +1,3 @@
-import { vi } from 'vitest';
-
-vi.mock('react-i18next', () => ({
-  useTranslation: () => ({ t: (key: string) => key }),
-}));
-
 class IntersectionObserverMock {
   observe() {}
   unobserve() {}

--- a/libs/conversation-input/src/utils/getAttachmentCardState.ts
+++ b/libs/conversation-input/src/utils/getAttachmentCardState.ts
@@ -1,0 +1,79 @@
+import type { Attachment } from '@epam/ai-dial-chat-shared';
+import {
+  AttachmentType,
+  RequestStatus,
+  mergeClasses,
+} from '@epam/ai-dial-chat-shared';
+import type { Icon } from '@tabler/icons-react';
+import { IconClipboard, IconPhoto, IconTerminal2 } from '@tabler/icons-react';
+import styles from '../components/AttachmentCard/AttachmentCard.module.scss';
+import { getAttachmentIcon } from './getAttachmentIcon.js';
+
+export interface AttachmentCardState {
+  isLoading: boolean;
+  isError: boolean;
+  isImage: boolean;
+  actionsVisible: boolean;
+  BottomIcon: Icon;
+  bottomLabel: string;
+  cardColorClass: string;
+  removeBtnClass: string;
+}
+
+const getBottomIcon = (attachment: Attachment): Icon => {
+  const { type, contentType } = attachment;
+  if (type === AttachmentType.Prompt) return IconTerminal2;
+  if (type === AttachmentType.Pasted) return IconClipboard;
+  if (type === AttachmentType.Image) return IconPhoto;
+  return getAttachmentIcon(contentType);
+};
+
+const getBottomLabel = (attachment: Attachment): string => {
+  const { type, name, contentType } = attachment;
+  if (type === AttachmentType.Prompt) return 'Prompt';
+  if (type === AttachmentType.Pasted) return 'Pasted';
+  if (type === AttachmentType.Image) return 'Image';
+
+  if (name.includes('.')) {
+    return `.${name.slice(name.lastIndexOf('.') + 1).toLowerCase()}`;
+  }
+  const subtype = contentType.split('/')[1];
+  return subtype ? `.${subtype.toLowerCase()}` : name;
+};
+
+export const getAttachmentCardState = (
+  attachment: Attachment,
+  selected: boolean,
+  alwaysShowActions: boolean,
+): AttachmentCardState => {
+  const { type, status, previewUrl } = attachment;
+
+  const isLoading = status === RequestStatus.Loading;
+  const isError = status === RequestStatus.Error;
+  const isImage = type === AttachmentType.Image && !!previewUrl && !isError;
+
+  const cardColorClass = mergeClasses(
+    styles.card,
+    isError && styles.cardError,
+    selected && styles.cardSelected,
+    !isError &&
+      !selected &&
+      type === AttachmentType.Prompt &&
+      styles.cardPrompt,
+    !isError &&
+      !selected &&
+      type === AttachmentType.Pasted &&
+      styles.cardPasted,
+  );
+
+  return {
+    isLoading,
+    isError,
+    isImage,
+    actionsVisible: isError || alwaysShowActions,
+    BottomIcon: getBottomIcon(attachment),
+    bottomLabel: getBottomLabel(attachment),
+    cardColorClass,
+    removeBtnClass: isImage ? styles.removeBtnImage : styles.actionBtn,
+  };
+};

--- a/libs/conversation-input/src/utils/getAttachmentIcon.ts
+++ b/libs/conversation-input/src/utils/getAttachmentIcon.ts
@@ -1,0 +1,126 @@
+import {
+  IconFile,
+  IconFileTypeBmp,
+  IconFileTypeCss,
+  IconFileTypeCsv,
+  IconFileTypeDoc,
+  IconFileTypeDocx,
+  IconFileTypeHtml,
+  IconFileTypeJpg,
+  IconFileTypeJs,
+  IconFileTypeJsx,
+  IconFileTypePdf,
+  IconFileTypePhp,
+  IconFileTypePng,
+  IconFileTypePpt,
+  IconFileTypeRs,
+  IconFileTypeSql,
+  IconFileTypeSvg,
+  IconFileTypeTs,
+  IconFileTypeTsx,
+  IconFileTypeTxt,
+  IconFileTypeVue,
+  IconFileTypeXls,
+  IconFileTypeXml,
+  IconFileTypeZip,
+  IconPhoto,
+  IconVideo,
+  IconMusic,
+} from '@tabler/icons-react';
+import type { Icon } from '@tabler/icons-react';
+
+/**
+ * Returns the appropriate Tabler icon component for a given MIME content type.
+ * Broad category checks (`startsWith`) run first; then a specific MIME switch
+ * covers as many known file types as possible. Falls back to `IconFile`.
+ */
+export const getAttachmentIcon = (contentType: string): Icon => {
+  // Broad category checks first
+  if (contentType.startsWith('image/')) {
+    switch (contentType) {
+      case 'image/jpeg':
+      case 'image/jpg':
+        return IconFileTypeJpg;
+      case 'image/png':
+        return IconFileTypePng;
+      case 'image/svg+xml':
+        return IconFileTypeSvg;
+      case 'image/bmp':
+        return IconFileTypeBmp;
+      default:
+        return IconPhoto;
+    }
+  }
+
+  if (contentType.startsWith('video/')) return IconVideo;
+  if (contentType.startsWith('audio/')) return IconMusic;
+
+  // Specific MIME type switch
+  switch (contentType) {
+    // Documents
+    case 'application/pdf':
+      return IconFileTypePdf;
+    case 'application/msword':
+    case 'application/vnd.ms-word':
+      return IconFileTypeDoc;
+    case 'application/vnd.openxmlformats-officedocument.wordprocessingml.document':
+      return IconFileTypeDocx;
+    case 'application/vnd.ms-powerpoint':
+      return IconFileTypePpt;
+    case 'application/vnd.openxmlformats-officedocument.presentationml.presentation':
+      return IconFileTypePpt;
+    case 'application/vnd.ms-excel':
+      return IconFileTypeXls;
+    case 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet':
+      return IconFileTypeXls;
+
+    // Archives
+    case 'application/zip':
+    case 'application/x-zip-compressed':
+    case 'application/x-rar-compressed':
+    case 'application/x-7z-compressed':
+    case 'application/gzip':
+    case 'application/x-tar':
+      return IconFileTypeZip;
+
+    // Data / markup
+    case 'text/csv':
+      return IconFileTypeCsv;
+    case 'text/plain':
+      return IconFileTypeTxt;
+    case 'text/html':
+    case 'application/xhtml+xml':
+      return IconFileTypeHtml;
+    case 'text/xml':
+    case 'application/xml':
+      return IconFileTypeXml;
+    case 'application/sql':
+    case 'text/x-sql':
+      return IconFileTypeSql;
+
+    // Web / code
+    case 'text/javascript':
+    case 'application/javascript':
+      return IconFileTypeJs;
+    case 'text/jsx':
+      return IconFileTypeJsx;
+    case 'application/typescript':
+    case 'text/typescript':
+      return IconFileTypeTs;
+    case 'text/tsx':
+      return IconFileTypeTsx;
+    case 'text/css':
+      return IconFileTypeCss;
+    case 'text/x-php':
+    case 'application/x-php':
+      return IconFileTypePhp;
+    case 'text/x-rustsrc':
+    case 'application/x-rust':
+      return IconFileTypeRs;
+    case 'text/x-vue':
+      return IconFileTypeVue;
+
+    default:
+      return IconFile;
+  }
+};

--- a/libs/conversation-input/tsconfig.spec.json
+++ b/libs/conversation-input/tsconfig.spec.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "outDir": "./out-tsc/vitest",
     "jsx": "react-jsx",
+    "lib": ["es2022", "dom"],
     "types": [
       "vitest/globals",
       "vitest/importMeta",
@@ -27,9 +28,5 @@
     "src/**/*.spec.jsx",
     "src/**/*.d.ts"
   ],
-  "references": [
-    {
-      "path": "./tsconfig.lib.json"
-    }
-  ]
+  "references": [{ "path": "./tsconfig.lib.json" }]
 }

--- a/libs/conversation-input/vite.config.mts
+++ b/libs/conversation-input/vite.config.mts
@@ -45,6 +45,7 @@ export default defineConfig(() => ({
         '@epam/ai-dial-chat-shared',
         '@epam/ai-dial-ui-kit',
         '@tabler/icons-react',
+        'react-i18next',
       ],
     },
   },
@@ -53,6 +54,7 @@ export default defineConfig(() => ({
     watch: false,
     globals: true,
     environment: 'jsdom',
+    setupFiles: ['./src/test-setup.ts'],
     include: ['{src,tests}/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
     reporters: ['default'],
     coverage: {

--- a/libs/conversation-input/vite.config.mts
+++ b/libs/conversation-input/vite.config.mts
@@ -45,7 +45,6 @@ export default defineConfig(() => ({
         '@epam/ai-dial-chat-shared',
         '@epam/ai-dial-ui-kit',
         '@tabler/icons-react',
-        'react-i18next',
       ],
     },
   },

--- a/libs/conversation-messages/src/components/Message/MessageActions.spec.tsx
+++ b/libs/conversation-messages/src/components/Message/MessageActions.spec.tsx
@@ -22,7 +22,7 @@ describe('MessageActions', () => {
         screen.queryByRole('button', { name: 'Copy response' }),
       ).toBeNull();
       expect(
-        screen.queryByRole('button', { name: 'Toggle markdown' }),
+        screen.queryByRole('button', { name: 'Copy as markdown' }),
       ).toBeNull();
       expect(
         screen.queryByRole('button', { name: 'Like response' }),
@@ -61,7 +61,7 @@ describe('MessageActions', () => {
         screen.getByRole('button', { name: 'Copy response' }),
       ).toBeTruthy();
       expect(
-        screen.getByRole('button', { name: 'Toggle markdown' }),
+        screen.getByRole('button', { name: 'Copy as markdown' }),
       ).toBeTruthy();
       expect(
         screen.getByRole('button', { name: 'Like response' }),
@@ -97,15 +97,13 @@ describe('MessageActions', () => {
       expect(onCopy).toHaveBeenCalledOnce();
     });
 
-    it('calls onToggleMarkdown when Markdown button is clicked', async () => {
-      const onToggleMarkdown = vi.fn();
-      render(
-        <MessageActions role="Agent" onToggleMarkdown={onToggleMarkdown} />,
-      );
+    it('calls onCopyMarkdown when Markdown button is clicked', async () => {
+      const onCopyMarkdown = vi.fn();
+      render(<MessageActions role="Agent" onCopyMarkdown={onCopyMarkdown} />);
       await userEvent.click(
-        screen.getByRole('button', { name: 'Toggle markdown' }),
+        screen.getByRole('button', { name: 'Copy as markdown' }),
       );
-      expect(onToggleMarkdown).toHaveBeenCalledOnce();
+      expect(onCopyMarkdown).toHaveBeenCalledOnce();
     });
 
     it('calls onLike when Like button is clicked', async () => {

--- a/openspec/changes/add-model-selection-context/proposal.md
+++ b/openspec/changes/add-model-selection-context/proposal.md
@@ -12,7 +12,7 @@ Users currently have no way to choose which AI model powers a conversation befor
 - **`ConversationRoute` updated** (`apps/chat/src/pages/ConversationRoute/ConversationRoute.tsx`) to consume `useModels()`, pass `<ModelSelectorButton>` as `rightControls`, and forward `selectedModelId` in `handleSend`.
 - **`conversations.api.ts` updated** (`apps/chat/src/server-api/conversations.api.ts`) to accept an optional `modelId` parameter and pass it to the generated client.
 - **Backend `CreateConversationDto` extended** with optional `modelId?: string` (`apps/chat-api/src/conversations/dto/create-conversation.dto.ts`). Inspection of the DTO confirms `modelId` is absent — this is the minimum backend change required to carry model identity to the conversation record. The field is optional to remain backward-compatible.
-- **Generated client regenerated** after the DTO change (`pnpm nx build chat-api-client --skip-nx-cache`).
+- **Generated client regenerated** after the DTO change (`npm exec nx build chat-api-client --skip-nx-cache`).
 - **New i18n keys** added to `apps/chat/src/i18n/locales/en.json` under the `models` domain.
 
 ## Capabilities

--- a/openspec/changes/add-model-selection-context/specs/model-selection-context/spec.md
+++ b/openspec/changes/add-model-selection-context/specs/model-selection-context/spec.md
@@ -156,7 +156,7 @@ When the user submits the initial chat input in `ConversationRoute`, the selecte
 - `modelId` validation: `@IsOptional()`, `@IsString()`, `@MaxLength(500)`.
 - No new error codes introduced; validation failures still return `400`.
 
-**Generated client note:** After the DTO change, `pnpm nx build chat-api-client --skip-nx-cache` must be run to regenerate the typed client. The wrapper `createConversation` in `apps/chat/src/server-api/conversations.api.ts` must be updated to accept and forward `modelId?: string`.
+**Generated client note:** After the DTO change, `npm exec nx build chat-api-client --skip-nx-cache` must be run to regenerate the typed client. The wrapper `createConversation` in `apps/chat/src/server-api/conversations.api.ts` must be updated to accept and forward `modelId?: string`.
 
 #### Scenario: Conversation created with a selected model
 

--- a/openspec/changes/add-model-selection-context/tasks.md
+++ b/openspec/changes/add-model-selection-context/tasks.md
@@ -44,7 +44,7 @@
 - [ ] 7.1 Add optional `modelId?: string` with `@IsOptional()`, `@IsString()`, and `@MaxLength(500)` decorators to `CreateConversationDto` in `apps/chat-api/src/conversations/dto/create-conversation.dto.ts`; add `@ApiPropertyOptional` for Swagger
 - [ ] 7.2 Update `ConversationService.createConversation()` in `apps/chat-api/src/conversations/conversation.service.ts` to accept and persist `modelId` on the created conversation record (field stored, not yet forwarded to DIAL Core)
 - [ ] 7.3 Update `ConversationController.createConversation()` to pass `dto.modelId` to the service call
-- [ ] 7.4 Regenerate the API client: `pnpm nx build chat-api-client --skip-nx-cache`
+- [ ] 7.4 Regenerate the API client: `npm exec nx build chat-api-client --skip-nx-cache`
 - [ ] 7.5 Update `createConversation()` in `apps/chat/src/server-api/conversations.api.ts` to accept `modelId?: string` and include it in `createConversationDto`
 
 ## 8. Add i18n keys
@@ -72,13 +72,13 @@
 
 ## 10. Final verification
 
-- [ ] 10.1 Run `pnpm nx lint conversation-input` — no lint errors in the lib after `rightControls` addition
-- [ ] 10.2 Run `pnpm nx build conversation-input` — lib builds cleanly
-- [ ] 10.3 Run `pnpm nx lint chat-api-client` — generated client passes lint after regeneration
-- [ ] 10.4 Run `pnpm nx build chat-api-client` — generated client builds cleanly
-- [ ] 10.5 Run `pnpm nx lint chat-api` — no lint errors in backend after DTO change
-- [ ] 10.6 Run `pnpm nx test chat-api` — all backend tests pass
-- [ ] 10.7 Run `pnpm nx build chat-api` — backend compiles cleanly
-- [ ] 10.8 Run `pnpm nx lint chat` — no lint errors in frontend after all changes
-- [ ] 10.9 Run `pnpm nx test chat` — all frontend tests pass
-- [ ] 10.10 Run `pnpm nx build chat` — frontend compiles cleanly
+- [ ] 10.1 Run `npm exec nx lint conversation-input` — no lint errors in the lib after `rightControls` addition
+- [ ] 10.2 Run `npm exec nx build conversation-input` — lib builds cleanly
+- [ ] 10.3 Run `npm exec nx lint chat-api-client` — generated client passes lint after regeneration
+- [ ] 10.4 Run `npm exec nx build chat-api-client` — generated client builds cleanly
+- [ ] 10.5 Run `npm exec nx lint chat-api` — no lint errors in backend after DTO change
+- [ ] 10.6 Run `npm exec nx test chat-api` — all backend tests pass
+- [ ] 10.7 Run `npm exec nx build chat-api` — backend compiles cleanly
+- [ ] 10.8 Run `npm exec nx lint chat` — no lint errors in frontend after all changes
+- [ ] 10.9 Run `npm exec nx test chat` — all frontend tests pass
+- [ ] 10.10 Run `npm exec nx build chat` — frontend compiles cleanly

--- a/openspec/changes/add-models-api/tasks.md
+++ b/openspec/changes/add-models-api/tasks.md
@@ -48,7 +48,7 @@
 
 ## 10. Verification
 
-- [x] 10.1 Run `pnpm nx test chat-api` — all models and deployments tests pass
-- [x] 10.2 Run `pnpm nx lint chat-api` — no lint errors
-- [x] 10.3 Run `pnpm nx build chat-api` — build succeeds
-- [x] 10.4 Run `pnpm nx affected --target=typecheck --base=origin/development` — no new type errors introduced
+- [x] 10.1 Run `npm exec nx test chat-api` — all models and deployments tests pass
+- [x] 10.2 Run `npm exec nx lint chat-api` — no lint errors
+- [x] 10.3 Run `npm exec nx build chat-api` — build succeeds
+- [x] 10.4 Run `npm exec nx affected --target=typecheck --base=origin/development` — no new type errors introduced

--- a/openspec/changes/archive/2026-05-14-add-ai-dial-typescript-sdk/tasks.md
+++ b/openspec/changes/archive/2026-05-14-add-ai-dial-typescript-sdk/tasks.md
@@ -10,7 +10,7 @@
 - [x] Uncomment `import { createSDK } from '@epam/ai-dial-typescript-sdk'`
 - [x] Uncomment `protected client: ReturnType<typeof createSDK>`
 - [x] Uncomment the `this.client = createSDK({ ... })` constructor body
-- [x] Verify TypeScript compiles with no errors: `pnpm nx build chat-api --skip-nx-cache`
+- [x] Verify TypeScript compiles with no errors: `npm exec nx build chat-api --skip-nx-cache`
 
 ---
 
@@ -24,7 +24,7 @@
   - Remove the TODO comment above these fields
 - [x] Update any downstream `configService.get(...)` calls that used `as string` casts for these two variables — cast is kept because ConfigService<T>.get() returns `T[key] | undefined` regardless of the required assertion
 - [x] Ensure `.env.local` or `.env` in the repo's dev setup documents these two variables — documented in `apps/chat-api/.env.template`
-- [x] Run validation test to confirm startup fails without `DIAL_CORE_URL`: `pnpm nx test chat-api`
+- [x] Run validation test to confirm startup fails without `DIAL_CORE_URL`: `npm exec nx test chat-api`
 
 ---
 
@@ -108,9 +108,9 @@
 
 ### 8. Build and lint verification
 
-- [x] Run `pnpm nx lint chat-api` — passes with 0 errors (11 pre-existing warnings)
-- [x] Run `pnpm nx test chat-api` — 7/9 test files pass (31 tests); 2 pre-existing theme test files fail due to missing `CACHE_MANAGER` mock setup (not caused by this change). Tests run with: `vitest run --config apps/chat-api/vitest.config.ts` from workspace root. `nx test` target exists but has an issue with Nx child-process environment vs direct vitest invocation.
-- [ ] Run `pnpm nx build chat-api` — build not yet verified
+- [x] Run `npm exec nx lint chat-api` — passes with 0 errors (11 pre-existing warnings)
+- [x] Run `npm exec nx test chat-api` — 7/9 test files pass (31 tests); 2 pre-existing theme test files fail due to missing `CACHE_MANAGER` mock setup (not caused by this change). Tests run with: `vitest run --config apps/chat-api/vitest.config.ts` from workspace root. `nx test` target exists but has an issue with Nx child-process environment vs direct vitest invocation.
+- [ ] Run `npm exec nx build chat-api` — build not yet verified
 
 ---
 

--- a/openspec/changes/archive/2026-05-16-add-input-component/tasks.md
+++ b/openspec/changes/archive/2026-05-16-add-input-component/tasks.md
@@ -30,6 +30,6 @@
 
 ## 5. Verification
 
-- [ ] 5.1 Run `pnpm nx lint conversation-input` — fix any reported issues
-- [ ] 5.2 Run `pnpm nx typecheck conversation-input` (or `pnpm nx build conversation-input`) — fix any type errors
-- [ ] 5.3 Run `pnpm nx test conversation-input` — all tests must pass
+- [ ] 5.1 Run `npm exec nx lint conversation-input` — fix any reported issues
+- [ ] 5.2 Run `npm exec nx typecheck conversation-input` (or `npm exec nx build conversation-input`) — fix any type errors
+- [ ] 5.3 Run `npm exec nx test conversation-input` — all tests must pass

--- a/openspec/changes/archive/2026-05-16-add-navigation-routing/tasks.md
+++ b/openspec/changes/archive/2026-05-16-add-navigation-routing/tasks.md
@@ -77,6 +77,6 @@
 
 ### 8. Verification
 
-- [ ] Run `pnpm nx lint chat` — fix any lint errors
-- [ ] Run `pnpm nx typecheck chat` — fix any type errors
-- [ ] Run `pnpm nx test chat` — all tests green
+- [ ] Run `npm exec nx lint chat` — fix any lint errors
+- [ ] Run `npm exec nx typecheck chat` — fix any type errors
+- [ ] Run `npm exec nx test chat` — all tests green

--- a/openspec/changes/archive/2026-05-21-connect-generated-api-client/tasks.md
+++ b/openspec/changes/archive/2026-05-21-connect-generated-api-client/tasks.md
@@ -4,7 +4,7 @@
 - [x] 1.2 Run `npm run openapi:check` and confirm it exits with zero — if not, fix OpenAPI annotations in `apps/chat-api` before proceeding (see design.md OQ-1 / backend annotation gap risk)
 - [x] 1.3 Run `npm exec nx build chat-api-client -- --skip-nx-cache` to confirm the generated client compiles cleanly
 - [x] 1.4 Run `npm exec nx lint chat-api-client` to confirm no lint errors in the generated client
-- [x] 1.5 Confirm `@epam/chat-api-client` is listed as a dependency in `apps/chat/package.json`; if not, add it and verify `pnpm nx graph` shows the `chat` → `chat-api-client` edge (resolves design.md OQ-2)
+- [x] 1.5 Confirm `@epam/chat-api-client` is listed as a dependency in `apps/chat/package.json`; if not, add it and verify `npm exec nx graph` shows the `chat` → `chat-api-client` edge (resolves design.md OQ-2)
 
 ## 2. Slice 1 — Client configuration factory
 

--- a/openspec/changes/archive/2026-05-22-conversation-attachments-ui/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-22-conversation-attachments-ui/.openspec.yaml
@@ -1,0 +1,4 @@
+schema: spec-driven
+created: 2026-05-21
+phase: 1
+status: implemented

--- a/openspec/changes/archive/2026-05-22-conversation-attachments-ui/design.md
+++ b/openspec/changes/archive/2026-05-22-conversation-attachments-ui/design.md
@@ -1,0 +1,71 @@
+## Context
+
+`libs/conversation-input` currently provides a text-only `Input` component with a send button. There is no concept of attachments anywhere in the codebase — `Message.content` is `string`, `InputProps` has no file-related props, and `libs/chat-shared` has no attachment types.
+
+The Figma designs define an `AttachmentCard` component with four type variants (File, Image, Prompt, Pasted) and six visual states (Default, Hover, Selected, Focus, Loading, Error). Cards render above the textarea in a horizontal `AttachmentTray`. This phase is UI-only: picking, previewing, and removing attachments. Upload and send wiring are explicitly deferred.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Add `Attachment` interface, `AttachmentType` enum, and shared `RequestStatus` enum (`idle | loading | error`) to `libs/chat-shared`.
+- Implement `AttachmentCard` in `libs/conversation-input` matching all Figma states and types.
+- Implement `AttachmentTray` (horizontal scroll list of cards) in `libs/conversation-input`.
+- Add a `+` (attach) button to `Input` that opens a hidden `<input type="file" multiple>` and adds selected files to an `Attachment[]` state.
+- Support removing any card from the tray via its `×` button.
+- Expose `onAttachmentsChange?(attachments: Attachment[]) => void` from `InputProps` and `ConversationInputProps`.
+- Generate `previewUrl` (via `URL.createObjectURL`) for image files; revoke it on removal or unmount.
+
+**Non-Goals:**
+
+- File upload to DIAL Core / backend — deferred to phase 2.
+- Modifying `onSend` signature or `MessageBubble` — deferred to phase 2.
+- "Dial file system", "Prompt library", "Add files from cloud" menu items — separate features.
+- Drag-and-drop reordering of attachments.
+- Multi-page PDF preview.
+- Any backend (`apps/chat-api`) changes.
+
+## Decisions
+
+### 1 — `Attachment` lives in `libs/chat-shared`
+
+The type will be reused by `libs/conversation-input` (produced) and `apps/chat` (consumed for send). `chat-shared` is the only lib allowed to have zero dependencies, making it the correct home.
+
+**Alternative considered:** define in `libs/conversation-input`. Rejected because `apps/chat` would then need to import a UI lib just to type-check the attachment list, violating the module boundary intent.
+
+### 2 — State stays inside `Input`, surfaced via callback
+
+`Attachment[]` is owned by `Input`'s local `useState`. The parent receives updates via `onAttachmentsChange`. This avoids lifting state into `ConversationView` before it is needed for send.
+
+**Alternative considered:** lift state to `ConversationView` immediately. Rejected as premature — the parent has no use for the list in this phase.
+
+### 3 — `AttachmentCard` and `AttachmentTray` are new components inside `libs/conversation-input`
+
+They are co-located with the input feature rather than placed in `libs/conversation-messages`. They will never be reused for rendering received messages (different design treatment applies there). Following the existing folder pattern: each component gets its own PascalCase subfolder under `libs/conversation-input/src/components/`.
+
+### 4 — Image preview via `URL.createObjectURL`, not FileReader/base64
+
+`createObjectURL` is synchronous, memory-efficient, and integrates cleanly with `useEffect` cleanup (`URL.revokeObjectURL`). Base64 encoding at preview time is wasteful and irrelevant since no upload happens in this phase.
+
+### 5 — File type icon mapped from `contentType` via a lookup, `@tabler/icons-react`
+
+A small `getFileTypeIcon(contentType: string): TablerIcon` utility maps MIME prefixes to icons (e.g. `text/csv` → `IconCsv`, `image/*` → `IconPhoto`, fallback → `IconFile`). No inline SVGs per project rules.
+
+### 6 — Shared `RequestStatus` enum, not an attachment-specific one
+
+`Attachment.status` uses a shared `RequestStatus` enum (`idle | loading | error`) defined in `libs/chat-shared`. The same enum is available for other async operations (uploads, fetches) across the codebase. The card renders the correct visual state from this prop. In phase 1 all new attachments default to `RequestStatus.Idle`; loading/error will be set by the upload hook in phase 2.
+
+### 7 — Attach trigger uses `DialDropdown` + `+` button, not a direct paperclip button
+
+The attach entry point is a `DialGhostIconButton` (`IconPlus`, 40×40, 18px icon) that opens a `DialDropdown` (`placement="bottom-start"`) with a single "Attach file" item. Clicking the item triggers the hidden `<input type="file">`.
+
+**Why a dropdown instead of a direct button:** Phase 2 will add further attachment sources (DIAL file system, prompt library, pasted content). A dropdown accommodates additional items without changing the trigger affordance or the surrounding layout. Switching from a direct-action button to a dropdown later would require a visible layout change and a spec update; establishing the pattern in phase 1 avoids that churn.
+
+**Why `IconPlus` instead of `IconPaperclip`:** The `+` icon signals "add something" generically, matching the dropdown metaphor. The paperclip icon is preserved as the icon on the "Attach file" dropdown item, keeping its conventional meaning at the point of action.
+
+## Risks / Trade-offs
+
+- **Object URL leak** → Mitigate by calling `URL.revokeObjectURL` in the remove handler and in a `useEffect` cleanup that iterates all image attachments on unmount.
+- **No file-type or size validation in phase 1** → Accept; validation belongs to the upload step (phase 2). In phase 1 any file can be picked but nothing is transmitted.
+- **`<input type="file">` cannot be fully styled** → Use a visually-hidden input triggered by a `<button>` (via `ref.current.click()`), which is the standard accessible pattern.
+- **`noUnusedParameters` in tsconfig strict** → `onAttachmentsChange` will be optional; when omitted the callback simply doesn't fire — no unused variable issue.

--- a/openspec/changes/archive/2026-05-22-conversation-attachments-ui/proposal.md
+++ b/openspec/changes/archive/2026-05-22-conversation-attachments-ui/proposal.md
@@ -1,0 +1,34 @@
+## Why
+
+Users need to attach files (images, documents, CSVs, etc.) to messages before sending them. Today the input only supports plain text, blocking multimodal workflows.
+
+This phase delivers the UI layer only — file picking, per-attachment card rendering with all states (default, hover, selected, focus, loading, error), and removal. Upload and send integration are follow-on work.
+
+## What Changes
+
+- New `AttachmentCard` component in `libs/conversation-input` renders a single attachment with states: default, hover, selected, focus, loading, error; supports types: file, image, prompt, pasted.
+- `AttachmentTray` renders the horizontal list of `AttachmentCard`s above the textarea.
+- `Input` gains an "attach" (+) button that opens a native file picker; selected files are held in local state as `Attachment[]`.
+- `InputProps` / `ConversationInputProps` gain `onAttachmentsChange?: (attachments: Attachment[]) => void` so the parent can observe the list.
+- Each card has a remove (×) button that deletes it from the list; error cards additionally show a retry (↺) icon.
+- Images render a thumbnail preview; other file types show a file-type icon + format label.
+- `libs/chat-shared` gains an `Attachment` interface (id, name, contentType, file, status, previewUrl?) and a shared `RequestStatus` enum.
+- No upload, no backend changes, no `onSend` signature change in this phase.
+
+## Capabilities
+
+### New Capabilities
+
+- `conversation-input-attachments`: The full attachment flow inside the conversation input — add menu (`+` dropdown), file picking, attachment card rendering (all states and types), horizontal tray, and `onAttachmentsChange` callback.
+
+### Modified Capabilities
+
+- (none — no existing spec requirements change in this phase)
+
+## Impact
+
+- `libs/chat-shared`: new `Attachment` interface, `AttachmentType` enum, and shared `RequestStatus` enum (`idle | loading | error`).
+- `libs/conversation-input`: new `AttachmentCard`, `AttachmentTray` components; `Input` updated with (+) button and tray; `InputProps` + `ConversationInputProps` extended.
+- `apps/chat`: `ConversationView` wires `onAttachmentsChange` (optional, no behaviour change yet).
+- No backend (`apps/chat-api`) changes.
+- No new npm dependencies required.

--- a/openspec/changes/archive/2026-05-22-conversation-attachments-ui/specs/add-menu/spec.md
+++ b/openspec/changes/archive/2026-05-22-conversation-attachments-ui/specs/add-menu/spec.md
@@ -1,0 +1,43 @@
+## ADDED Requirements
+
+### Requirement: Add menu button
+
+The `Input` component SHALL include a `+` button (`DialGhostIconButton`, 40×40, icon 18px `BASE_ICON_SIZE`) that opens a `DialDropdown` positioned below the trigger (`placement="bottom-start"`). The menu SHALL list available attachment and content sources. In phase 1 it contains a single item: "Attach file".
+
+#### Scenario: Plus button opens dropdown
+
+- **WHEN** the user clicks the `+` button
+- **THEN** a dropdown menu appears below it
+
+#### Scenario: Dropdown closes on outside click
+
+- **WHEN** the dropdown is open and the user clicks outside it
+- **THEN** the dropdown closes
+
+### Requirement: Add menu accessibility
+
+The `+` trigger button SHALL be keyboard accessible and labelled for screen readers.
+
+#### Scenario: Plus button aria-label
+
+- **WHEN** the `+` button is rendered
+- **THEN** it has `aria-label` sourced from i18n key `conversationInput.addMenu.ariaLabel`
+
+#### Scenario: Plus button keyboard activation
+
+- **WHEN** the `+` button has focus and the user presses Enter or Space
+- **THEN** the dropdown menu opens
+
+### Requirement: Add menu items
+
+Each menu item SHALL have a label, an icon, and an `onClick` handler. Items are extensible — future phases will add further sources without changing the trigger button or surrounding layout.
+
+#### Scenario: Attach file item
+
+- **WHEN** the dropdown is open
+- **THEN** a "Attach file" item is present, labelled from i18n key `conversationInput.attach.label`, with a paperclip icon (`IconPaperclip`)
+
+#### Scenario: Attach file item triggers file picker
+
+- **WHEN** the user clicks the "Attach file" item
+- **THEN** the native file picker opens (delegated to the `attachment-pick` capability)

--- a/openspec/changes/archive/2026-05-22-conversation-attachments-ui/specs/attachment-card/spec.md
+++ b/openspec/changes/archive/2026-05-22-conversation-attachments-ui/specs/attachment-card/spec.md
@@ -1,0 +1,58 @@
+## ADDED Requirements
+
+### Requirement: AttachmentCard renders file attachments
+
+The system SHALL render a card component for each pending attachment, displaying the file name, format label, and a type-appropriate icon. Card appearance SHALL vary by `AttachmentType`: `file` shows a file-type icon; `image` shows a thumbnail preview; `prompt` shows a prompt icon; `pasted` shows a clipboard icon.
+
+#### Scenario: File card default state
+
+- **WHEN** an attachment of type `file` with status `idle` is rendered
+- **THEN** the card displays the file name, the format extension label (e.g. `.csv`), and the appropriate `@tabler/icons-react` file icon
+
+#### Scenario: Image card shows thumbnail
+
+- **WHEN** an attachment of type `image` with a valid `previewUrl` is rendered
+- **THEN** the card displays the image thumbnail instead of an icon
+
+#### Scenario: Card in loading state
+
+- **WHEN** an attachment has status `loading`
+- **THEN** the card displays a spinner overlay and the remove button is hidden
+
+#### Scenario: Card in error state
+
+- **WHEN** an attachment has status `error`
+- **THEN** the card displays a red border, a retry icon (↺), and the remove button (×)
+
+#### Scenario: Card remove button on hover
+
+- **WHEN** the user hovers over a card with status `idle` or `error`
+- **THEN** a remove button (×) becomes visible on the card
+
+### Requirement: AttachmentCard is keyboard accessible
+
+The card SHALL be focusable and support keyboard interaction for removal.
+
+#### Scenario: Remove via keyboard
+
+- **WHEN** the card remove button has focus and the user presses Enter or Space
+- **THEN** the attachment is removed from the pending list
+
+#### Scenario: Card focus state
+
+- **WHEN** the card or its remove button receives keyboard focus
+- **THEN** a visible focus ring is displayed (matching the design's Focus state)
+
+### Requirement: AttachmentCard i18n
+
+All user-visible labels on the card SHALL use i18n keys.
+
+#### Scenario: Remove button aria-label
+
+- **WHEN** the card is rendered
+- **THEN** the remove button has `aria-label` sourced from i18n key `conversationInput.attachment.remove`
+
+#### Scenario: Retry button aria-label
+
+- **WHEN** a card in error state is rendered
+- **THEN** the retry icon button has `aria-label` sourced from i18n key `conversationInput.attachment.retry`

--- a/openspec/changes/archive/2026-05-22-conversation-attachments-ui/specs/attachment-pick/spec.md
+++ b/openspec/changes/archive/2026-05-22-conversation-attachments-ui/specs/attachment-pick/spec.md
@@ -1,0 +1,53 @@
+## ADDED Requirements
+
+### Requirement: File picker opens via add menu
+
+The `Input` component SHALL include a visually-hidden `<input type="file" multiple>` triggered programmatically when the "Attach file" item in the add menu is activated (see `add-menu` spec).
+
+#### Scenario: Multiple files selectable
+
+- **WHEN** the file picker opens
+- **THEN** the user can select one or more files simultaneously
+
+### Requirement: Selected files become Attachments
+
+Each file selected via the picker SHALL be converted to an `Attachment` with a unique `id`, `name`, `contentType`, `file` reference, and `status: RequestStatus.Idle`. Image files additionally receive a `previewUrl` generated via `URL.createObjectURL`.
+
+#### Scenario: Non-image file added
+
+- **WHEN** the user selects a non-image file (e.g. `.csv`)
+- **THEN** an `Attachment` with `type: AttachmentType.File`, `status: RequestStatus.Idle`, and no `previewUrl` is added to the list
+
+#### Scenario: Image file added with preview
+
+- **WHEN** the user selects an image file (MIME type starts with `image/`)
+- **THEN** an `Attachment` with `type: AttachmentType.Image` and a valid `previewUrl` (object URL) is added
+
+#### Scenario: Object URL revoked on removal
+
+- **WHEN** an `Attachment` with a `previewUrl` is removed
+- **THEN** `URL.revokeObjectURL` is called with that URL to prevent memory leaks
+
+#### Scenario: Object URLs revoked on unmount
+
+- **WHEN** the `Input` component unmounts while image attachments are present
+- **THEN** `URL.revokeObjectURL` is called for every `previewUrl` in the attachment list
+
+### Requirement: `onAttachmentsChange` callback
+
+The `Input` and `ConversationInput` components SHALL accept an optional `onAttachmentsChange` prop typed as `(attachments: Attachment[]) => void`. It SHALL be called whenever the attachment list changes (add or remove).
+
+#### Scenario: Callback fired on add
+
+- **WHEN** files are selected and converted to `Attachment`s
+- **THEN** `onAttachmentsChange` is called with the full updated list
+
+#### Scenario: Callback fired on remove
+
+- **WHEN** the user removes an attachment from the tray
+- **THEN** `onAttachmentsChange` is called with the remaining list
+
+#### Scenario: No callback — no error
+
+- **WHEN** `onAttachmentsChange` is not provided
+- **THEN** the component operates normally without throwing

--- a/openspec/changes/archive/2026-05-22-conversation-attachments-ui/specs/attachment-tray/spec.md
+++ b/openspec/changes/archive/2026-05-22-conversation-attachments-ui/specs/attachment-tray/spec.md
@@ -1,0 +1,43 @@
+## ADDED Requirements
+
+### Requirement: AttachmentTray renders the pending attachment list
+
+The system SHALL render a horizontally scrollable row of `AttachmentCard` components above the textarea when `PendingAttachment[]` is non-empty. The tray SHALL be hidden when the list is empty.
+
+#### Scenario: Tray visible with attachments
+
+- **WHEN** one or more attachments are in the pending list
+- **THEN** the `AttachmentTray` is rendered above the textarea with one `AttachmentCard` per attachment
+
+#### Scenario: Tray hidden when empty
+
+- **WHEN** the pending attachment list is empty
+- **THEN** the `AttachmentTray` is not rendered (returns null or is hidden from the DOM)
+
+#### Scenario: Tray scrolls horizontally
+
+- **WHEN** the number of cards exceeds the available horizontal width
+- **THEN** the tray scrolls horizontally and all cards remain accessible via scroll
+
+### Requirement: Removing a card updates the tray
+
+The system SHALL remove the corresponding card from the tray immediately when the user clicks or activates the remove button.
+
+#### Scenario: Remove card
+
+- **WHEN** the user clicks the remove (×) button on an `AttachmentCard`
+- **THEN** that card is removed from the tray and the `onAttachmentsChange` callback is called with the updated list
+
+#### Scenario: Last card removed hides tray
+
+- **WHEN** the user removes the last remaining card
+- **THEN** the tray is no longer rendered
+
+### Requirement: AttachmentTray accessibility
+
+The tray region SHALL be labelled for screen readers.
+
+#### Scenario: Tray ARIA label
+
+- **WHEN** the tray is rendered
+- **THEN** it has `role="list"` and `aria-label` sourced from i18n key `conversationInput.attachmentTray.label`

--- a/openspec/changes/archive/2026-05-22-conversation-attachments-ui/specs/conversation-input-attachments/spec.md
+++ b/openspec/changes/archive/2026-05-22-conversation-attachments-ui/specs/conversation-input-attachments/spec.md
@@ -1,0 +1,166 @@
+## ADDED Requirements
+
+---
+
+### Requirement: Add menu button
+
+The `Input` component SHALL include a `+` button (`DialGhostIconButton`, 40×40, icon 18px `BASE_ICON_SIZE`) that opens a `DialDropdown` positioned below the trigger (`placement="bottom-start"`). The menu lists available content sources; in phase 1 it contains a single item: "Attach file". Items are extensible — future phases add more sources without changing the trigger or surrounding layout.
+
+#### Scenario: Plus button opens dropdown
+
+- **WHEN** the user clicks the `+` button
+- **THEN** a dropdown menu appears below it
+
+#### Scenario: Dropdown closes on outside click
+
+- **WHEN** the dropdown is open and the user clicks outside it
+- **THEN** the dropdown closes
+
+#### Scenario: Plus button aria-label
+
+- **WHEN** the `+` button is rendered
+- **THEN** it has `aria-label` sourced from i18n key `conversationInput.addMenu.ariaLabel`
+
+#### Scenario: Plus button keyboard activation
+
+- **WHEN** the `+` button has focus and the user presses Enter or Space
+- **THEN** the dropdown menu opens
+
+#### Scenario: Attach file item
+
+- **WHEN** the dropdown is open
+- **THEN** an "Attach file" item is present, labelled from i18n key `conversationInput.attach.label`, with a paperclip icon
+
+#### Scenario: Attach file item triggers file picker
+
+- **WHEN** the user clicks the "Attach file" item
+- **THEN** the native file picker opens
+
+---
+
+### Requirement: File picking and Attachment creation
+
+The `Input` component SHALL include a visually-hidden `<input type="file" multiple>` triggered programmatically by the "Attach file" menu item. Each selected file SHALL be converted to an `Attachment` (`id`, `name`, `contentType`, `file`, `status: RequestStatus.Idle`). Image files additionally receive a `previewUrl` via `URL.createObjectURL`.
+
+#### Scenario: Multiple files selectable
+
+- **WHEN** the file picker opens
+- **THEN** the user can select one or more files simultaneously
+
+#### Scenario: Non-image file added
+
+- **WHEN** the user selects a non-image file (e.g. `.csv`)
+- **THEN** an `Attachment` with `type: AttachmentType.File` and no `previewUrl` is added to the list
+
+#### Scenario: Image file added with preview
+
+- **WHEN** the user selects an image file (MIME type starts with `image/`)
+- **THEN** an `Attachment` with `type: AttachmentType.Image` and a valid `previewUrl` is added
+
+#### Scenario: Object URL revoked on removal
+
+- **WHEN** an `Attachment` with a `previewUrl` is removed
+- **THEN** `URL.revokeObjectURL` is called with that URL
+
+#### Scenario: Object URLs revoked on unmount
+
+- **WHEN** the `Input` component unmounts while image attachments are present
+- **THEN** `URL.revokeObjectURL` is called for every `previewUrl` in the list
+
+---
+
+### Requirement: `onAttachmentsChange` callback
+
+`Input` and `ConversationInput` SHALL accept an optional `onAttachmentsChange?: (attachments: Attachment[]) => void` called whenever the attachment list changes.
+
+#### Scenario: Callback fired on add
+
+- **WHEN** files are selected and converted to `Attachment`s
+- **THEN** `onAttachmentsChange` is called with the full updated list
+
+#### Scenario: Callback fired on remove
+
+- **WHEN** the user removes an attachment from the tray
+- **THEN** `onAttachmentsChange` is called with the remaining list
+
+#### Scenario: No callback — no error
+
+- **WHEN** `onAttachmentsChange` is not provided
+- **THEN** the component operates normally without throwing
+
+---
+
+### Requirement: AttachmentCard renders pending attachments
+
+The system SHALL render a card component for each pending attachment, displaying the file name, format label, and a type-appropriate icon. `type: image` shows a thumbnail; all other types show a file-type icon from `getAttachmentIcon`.
+
+#### Scenario: File card default state
+
+- **WHEN** an attachment of type `file` with status `idle` is rendered
+- **THEN** the card displays the file name, format extension, and the matching `@tabler/icons-react` file icon
+
+#### Scenario: Image card shows thumbnail
+
+- **WHEN** an attachment of type `image` with a valid `previewUrl` is rendered
+- **THEN** the card displays the image thumbnail instead of an icon
+
+#### Scenario: Card in loading state
+
+- **WHEN** an attachment has status `loading`
+- **THEN** the card displays a spinner overlay and the remove button is hidden
+
+#### Scenario: Card in error state
+
+- **WHEN** an attachment has status `error`
+- **THEN** the card displays a red border, a retry button (↺), and the remove button (×)
+
+#### Scenario: Remove button on hover
+
+- **WHEN** the user hovers over a card with status `idle` or `error`
+- **THEN** a remove button (×) becomes visible
+
+#### Scenario: Remove via keyboard
+
+- **WHEN** the remove button has focus and the user presses Enter or Space
+- **THEN** the attachment is removed
+
+#### Scenario: Remove button aria-label
+
+- **WHEN** the card is rendered
+- **THEN** the remove button has `aria-label` sourced from i18n key `conversationInput.attachment.remove`
+
+#### Scenario: Retry button aria-label
+
+- **WHEN** a card in error state is rendered
+- **THEN** the retry button has `aria-label` sourced from i18n key `conversationInput.attachment.retry`
+
+---
+
+### Requirement: AttachmentTray renders the pending list
+
+The system SHALL render a horizontally scrollable row of `AttachmentCard` components above the textarea when the list is non-empty. The tray returns `null` when the list is empty.
+
+#### Scenario: Tray visible with attachments
+
+- **WHEN** one or more attachments are pending
+- **THEN** the `AttachmentTray` is rendered with one card per attachment
+
+#### Scenario: Tray hidden when empty
+
+- **WHEN** the pending list is empty
+- **THEN** the tray is not rendered
+
+#### Scenario: Tray scrolls horizontally
+
+- **WHEN** cards exceed the available width
+- **THEN** the tray scrolls horizontally
+
+#### Scenario: Last card removed hides tray
+
+- **WHEN** the user removes the last remaining card
+- **THEN** the tray is no longer rendered
+
+#### Scenario: Tray ARIA label
+
+- **WHEN** the tray is rendered
+- **THEN** it has `role="list"` and `aria-label` sourced from i18n key `conversationInput.attachmentTray.label`

--- a/openspec/changes/archive/2026-05-22-conversation-attachments-ui/tasks.md
+++ b/openspec/changes/archive/2026-05-22-conversation-attachments-ui/tasks.md
@@ -4,7 +4,7 @@
 - [x] 1.2 Add shared `RequestStatus` enum (`idle | loading | error`) to `libs/chat-shared/src/models/chat.ts` — reusable for any async operation, not attachment-specific
 - [x] 1.3 Add `Attachment` interface (`id`, `name`, `contentType`, `file`, `type: AttachmentType`, `status: RequestStatus`, `previewUrl?`) with JSDoc to `libs/chat-shared/src/models/chat.ts`
 - [x] 1.4 Export all new symbols from `libs/chat-shared/src/index.ts`
-- [x] 1.5 Verify: `pnpm nx typecheck chat-shared`
+- [x] 1.5 Verify: `npm exec nx typecheck chat-shared`
 
 ## 2. File-type icon utility (`libs/conversation-input`)
 
@@ -24,7 +24,7 @@
 - [x] 3.9 Add i18n keys `conversationInput.attachment.remove` and `conversationInput.attachment.retry` to `apps/chat/src/i18n/locales/en.json`
 - [x] 3.10 Create `AttachmentCard.module.scss` for any states not expressible with Tailwind alone (hover show/hide of button overlay)
 - [x] 3.11 Write unit tests in `AttachmentCard/tests/AttachmentCard.spec.tsx` covering: default render, image thumbnail, loading state hides remove, error state shows retry, remove callback, keyboard remove
-- [x] 3.12 Verify: `pnpm nx test conversation-input`
+- [x] 3.12 Verify: `npm exec nx test conversation-input`
 
 ## 4. `AttachmentTray` component (`libs/conversation-input`)
 
@@ -34,7 +34,7 @@
 - [x] 4.4 Add i18n key `conversationInput.attachmentTray.label` to `apps/chat/src/i18n/locales/en.json`
 - [x] 4.5 Apply `aria-label` from i18n key `conversationInput.attachmentTray.label` to the tray container
 - [x] 4.6 Write unit tests in `AttachmentTray/tests/AttachmentTray.spec.tsx` covering: renders cards, returns null when empty, remove callback forwarded, last card removal hides tray
-- [x] 4.7 Verify: `pnpm nx test conversation-input`
+- [x] 4.7 Verify: `npm exec nx test conversation-input`
 
 ## 5. Attach button & pending state in `Input` (`libs/conversation-input`)
 
@@ -49,23 +49,23 @@
 - [x] 5.9 Add `useEffect` cleanup that calls `URL.revokeObjectURL` for all image `previewUrl`s on unmount
 - [x] 5.10 Render `<AttachmentTray>` above the textarea when list is non-empty
 - [x] 5.11 Extend existing `Input` unit tests in `Input/tests/` to cover: attach button present, file picked adds card, remove removes card, object URL revoked on remove
-- [x] 5.12 Verify: `pnpm nx test conversation-input`
+- [x] 5.12 Verify: `npm exec nx test conversation-input`
 
 ## 6. Propagate prop through `ConversationInput` (`libs/conversation-input`)
 
 - [x] 6.1 Add `onAttachmentsChange?: (attachments: Attachment[]) => void` to `ConversationInputProps` in `libs/conversation-input/src/models/ConversationInput.ts`
 - [x] 6.2 Forward `onAttachmentsChange` from `ConversationInput.tsx` down to `<Input>`
-- [x] 6.3 Verify: `pnpm nx typecheck conversation-input`
+- [x] 6.3 Verify: `npm exec nx typecheck conversation-input`
 
 ## 7. Wire-up in `apps/chat` (optional observation)
 
 - [x] 7.1 In `ConversationView`, add `onAttachmentsChange` prop to `Props` (optional, `(attachments: Attachment[]) => void`)
 - [x] 7.2 Pass it through to `<ConversationInput onAttachmentsChange={onAttachmentsChange}>` (no-op if not provided)
-- [x] 7.3 Verify: `pnpm nx typecheck chat` and `pnpm nx build chat`
+- [x] 7.3 Verify: `npm exec nx typecheck chat` and `npm exec nx build chat`
 
 ## 8. Final verification
 
-- [ ] 8.1 Run `pnpm nx test conversation-input` — all tests pass
-- [ ] 8.2 Run `pnpm nx lint conversation-input` — no lint errors
-- [ ] 8.3 Run `pnpm nx typecheck chat-shared conversation-input chat` — no type errors
+- [ ] 8.1 Run `npm exec nx test conversation-input` — all tests pass
+- [ ] 8.2 Run `npm exec nx lint conversation-input` — no lint errors
+- [ ] 8.3 Run `npm exec nx typecheck chat-shared conversation-input chat` — no type errors
 - [ ] 8.4 Smoke-test in the browser: pick files, confirm cards render, hover shows ×, clicking × removes the card, tray disappears when last card is removed

--- a/openspec/changes/archive/2026-05-22-conversation-attachments-ui/tasks.md
+++ b/openspec/changes/archive/2026-05-22-conversation-attachments-ui/tasks.md
@@ -1,0 +1,71 @@
+## 1. Shared Types (`libs/chat-shared`)
+
+- [x] 1.1 Add `AttachmentType` enum (`file | image | prompt | pasted`) to `libs/chat-shared/src/models/chat.ts`
+- [x] 1.2 Add shared `RequestStatus` enum (`idle | loading | error`) to `libs/chat-shared/src/models/chat.ts` — reusable for any async operation, not attachment-specific
+- [x] 1.3 Add `Attachment` interface (`id`, `name`, `contentType`, `file`, `type: AttachmentType`, `status: RequestStatus`, `previewUrl?`) with JSDoc to `libs/chat-shared/src/models/chat.ts`
+- [x] 1.4 Export all new symbols from `libs/chat-shared/src/index.ts`
+- [x] 1.5 Verify: `pnpm nx typecheck chat-shared`
+
+## 2. File-type icon utility (`libs/conversation-input`)
+
+- [x] 2.1 Create `libs/conversation-input/src/utils/getAttachmentIcon.ts` — maps `contentType` string to the appropriate `@tabler/icons-react` icon component (csv → `IconCsv`, text → `IconTxt`, pdf → `IconPdf`, image/\* → `IconPhoto`, fallback → `IconFile`)
+- [x] 2.2 Export `getAttachmentIcon` from the lib's barrel (`libs/conversation-input/src/index.ts` if applicable, or keep internal)
+
+## 3. `AttachmentCard` component (`libs/conversation-input`)
+
+- [x] 3.1 Create folder `libs/conversation-input/src/components/AttachmentCard/`
+- [x] 3.2 Create `AttachmentCardProps` interface in `libs/conversation-input/src/models/AttachmentCard.ts` — props: `attachment: Attachment`, `onRemove: (id: string) => void`, `onRetry?: (id: string) => void`, `className?: string`
+- [x] 3.3 Implement `AttachmentCard.tsx` — renders title, format label, type icon; applies hover/selected/focus/loading/error states per Figma design
+- [x] 3.4 For `type: 'image'` render `<img>` thumbnail using `attachment.previewUrl`; for all other types render the icon from `getAttachmentIcon`
+- [x] 3.5 Show remove (×) button (`IconX`) on hover and focus; hide it during `loading` state
+- [x] 3.6 Show retry (↺) button (`IconRefresh`) alongside remove button in `error` state
+- [x] 3.7 Apply `aria-label` for remove button using i18n key `conversationInput.attachment.remove`
+- [x] 3.8 Apply `aria-label` for retry button using i18n key `conversationInput.attachment.retry`
+- [x] 3.9 Add i18n keys `conversationInput.attachment.remove` and `conversationInput.attachment.retry` to `apps/chat/src/i18n/locales/en.json`
+- [x] 3.10 Create `AttachmentCard.module.scss` for any states not expressible with Tailwind alone (hover show/hide of button overlay)
+- [x] 3.11 Write unit tests in `AttachmentCard/tests/AttachmentCard.spec.tsx` covering: default render, image thumbnail, loading state hides remove, error state shows retry, remove callback, keyboard remove
+- [x] 3.12 Verify: `pnpm nx test conversation-input`
+
+## 4. `AttachmentTray` component (`libs/conversation-input`)
+
+- [x] 4.1 Create folder `libs/conversation-input/src/components/AttachmentTray/`
+- [x] 4.2 Create `AttachmentTrayProps` interface in `libs/conversation-input/src/models/AttachmentTray.ts` — props: `attachments: Attachment[]`, `onRemove: (id: string) => void`, `onRetry?: (id: string) => void`, `className?: string`
+- [x] 4.3 Implement `AttachmentTray.tsx` — renders `role="list"` horizontal scrollable container; maps `attachments` to `AttachmentCard`s; returns `null` when list is empty
+- [x] 4.4 Add i18n key `conversationInput.attachmentTray.label` to `apps/chat/src/i18n/locales/en.json`
+- [x] 4.5 Apply `aria-label` from i18n key `conversationInput.attachmentTray.label` to the tray container
+- [x] 4.6 Write unit tests in `AttachmentTray/tests/AttachmentTray.spec.tsx` covering: renders cards, returns null when empty, remove callback forwarded, last card removal hides tray
+- [x] 4.7 Verify: `pnpm nx test conversation-input`
+
+## 5. Attach button & pending state in `Input` (`libs/conversation-input`)
+
+- [x] 5.1 Add `onAttachmentsChange?: (attachments: Attachment[]) => void` prop to `InputProps` in `libs/conversation-input/src/models/Input.ts`
+- [x] 5.2 Add `useState<Attachment[]>([])` for the attachment list inside `Input.tsx`
+- [x] 5.3 Add a visually-hidden `<input type="file" multiple ref={fileInputRef}>` element to `Input.tsx`
+- [x] 5.4 Add a `+` button (`DialGhostIconButton` with `IconPlus`, 40×40, icon 18px `BASE_ICON_SIZE`) wrapped in `DialDropdown` with a single "Attach file" item; clicking the item calls `fileInputRef.current?.click()`. Trigger button aria-label from `conversationInput.addMenu.ariaLabel`; item label from `conversationInput.attach.label`.
+- [x] 5.5 Add i18n keys `conversationInput.addMenu.ariaLabel` and `conversationInput.attach.label` to `apps/chat/src/i18n/locales/en.json`
+- [x] 5.6 Implement `handleFileChange` — converts selected `File[]` to `Attachment[]` (generate uuid id, set `type` from MIME, `status: RequestStatus.Idle`, `previewUrl` for images via `URL.createObjectURL`)
+- [x] 5.7 Merge new attachments into state; call `onAttachmentsChange` with updated list
+- [x] 5.8 Implement `handleRemove(id)` — filter out the attachment, call `URL.revokeObjectURL` if it had a `previewUrl`, call `onAttachmentsChange`
+- [x] 5.9 Add `useEffect` cleanup that calls `URL.revokeObjectURL` for all image `previewUrl`s on unmount
+- [x] 5.10 Render `<AttachmentTray>` above the textarea when list is non-empty
+- [x] 5.11 Extend existing `Input` unit tests in `Input/tests/` to cover: attach button present, file picked adds card, remove removes card, object URL revoked on remove
+- [x] 5.12 Verify: `pnpm nx test conversation-input`
+
+## 6. Propagate prop through `ConversationInput` (`libs/conversation-input`)
+
+- [x] 6.1 Add `onAttachmentsChange?: (attachments: Attachment[]) => void` to `ConversationInputProps` in `libs/conversation-input/src/models/ConversationInput.ts`
+- [x] 6.2 Forward `onAttachmentsChange` from `ConversationInput.tsx` down to `<Input>`
+- [x] 6.3 Verify: `pnpm nx typecheck conversation-input`
+
+## 7. Wire-up in `apps/chat` (optional observation)
+
+- [x] 7.1 In `ConversationView`, add `onAttachmentsChange` prop to `Props` (optional, `(attachments: Attachment[]) => void`)
+- [x] 7.2 Pass it through to `<ConversationInput onAttachmentsChange={onAttachmentsChange}>` (no-op if not provided)
+- [x] 7.3 Verify: `pnpm nx typecheck chat` and `pnpm nx build chat`
+
+## 8. Final verification
+
+- [ ] 8.1 Run `pnpm nx test conversation-input` — all tests pass
+- [ ] 8.2 Run `pnpm nx lint conversation-input` — no lint errors
+- [ ] 8.3 Run `pnpm nx typecheck chat-shared conversation-input chat` — no type errors
+- [ ] 8.4 Smoke-test in the browser: pick files, confirm cards render, hover shows ×, clicking × removes the card, tray disappears when last card is removed

--- a/openspec/changes/auth-frontend-integration/tasks.md
+++ b/openspec/changes/auth-frontend-integration/tasks.md
@@ -17,7 +17,7 @@ Implementation is split into six thin vertical slices on the SPA. Each slice is 
   - 1.6.c A `401` response causes `request()` to throw an instance of `UnauthorizedError` whose `status === 401` and whose `url` matches the call.
   - 1.6.d A `500` response throws a plain `Error` (not `UnauthorizedError`).
   - 1.6.e Listeners registered via `onUnauthorized` are invoked exactly once per `401` and not at all for non-401 errors; the cleanup callback unregisters the listener.
-- [x] 1.7 Verify the slice in isolation: `pnpm nx test chat` and `pnpm nx lint chat`.
+- [x] 1.7 Verify the slice in isolation: `npm exec nx test chat` and `npm exec nx lint chat`.
 
 ## 2. Slice 2 — UserContext provider and useUser hook
 
@@ -43,7 +43,7 @@ Implementation is split into six thin vertical slices on the SPA. Each slice is 
   - 2.5.e `refresh()` re-runs the fetch and updates state on a previously failed bootstrap.
   - 2.5.f `useUser()` outside `<UserProvider>` throws a descriptive `Error`.
   - 2.5.g A `401` from any subsequent call (simulated by manually firing a registered `onUnauthorized` listener) resets the context.
-- [x] 2.6 Verify the slice: `pnpm nx test chat` and `pnpm nx lint chat`.
+- [x] 2.6 Verify the slice: `npm exec nx test chat` and `npm exec nx lint chat`.
 
 ## 3. Slice 3 — i18n keys batch
 
@@ -56,7 +56,7 @@ Implementation is split into six thin vertical slices on the SPA. Each slice is 
   - `auth.providerButtonLabel`: "Sign in with {{provider}}"
   - `auth.providersError`: "Could not load identity providers. Please retry."
   - `auth.userMenuLabel`: "User menu"
-- [x] 3.2 Run `pnpm nx lint chat` to confirm no ESLint key-format rule is violated.
+- [x] 3.2 Run `npm exec nx lint chat` to confirm no ESLint key-format rule is violated.
 
 ## 4. Slice 4 — useAuthRedirect hook and <RequireAuth> gate with routing
 
@@ -88,7 +88,7 @@ Implementation is split into six thin vertical slices on the SPA. Each slice is 
   - 4.6.a Renders `null` when `status='loading'`.
   - 4.6.b Renders `null` when `status='unauthenticated'` (and `useAuthRedirect` is invoked — assert via a spy on its module export, or by asserting the side-effect from 4.5.a).
   - 4.6.c Renders children (resolved by role/text) when `status='authenticated'`.
-- [x] 4.7 Verify the slice: `pnpm nx test chat` and `pnpm nx lint chat`.
+- [x] 4.7 Verify the slice: `npm exec nx test chat` and `npm exec nx lint chat`.
 
 ## 5. Slice 5 — LoginPage route
 
@@ -107,7 +107,7 @@ Implementation is split into six thin vertical slices on the SPA. Each slice is 
   - 5.3.c Failed providers fetch renders the `auth.providersError` text and logs an error.
   - 5.3.d Anchors are real `<a>` elements (assert `anchor.tagName === 'A'`) — guards against the regression "someone replaced with `<Link>`".
   - 5.3.e Direct visits to `/login` without `callbackUrl` use `window.location.origin + '/'` as the default callback URL.
-- [x] 5.4 Verify the slice: `pnpm nx test chat` and `pnpm nx lint chat`.
+- [x] 5.4 Verify the slice: `npm exec nx test chat` and `npm exec nx lint chat`.
 
 ## 6. Slice 6 — UserMenu widget in Header
 
@@ -127,15 +127,15 @@ Implementation is split into six thin vertical slices on the SPA. Each slice is 
   - 6.3.e The submit button is resolvable by `getByRole('button', { name: /sign out/i })`.
   - 6.3.f No assertion uses `data-testid`.
 - [x] 6.4 Update `apps/chat/src/components/Header/tests/Header.spec.tsx` minimally: add a single test verifying the `<UserMenu />` mount point exists when `<UserProvider>` is mocked with an authenticated user. Existing logo assertions stay intact.
-- [x] 6.5 Verify the slice: `pnpm nx test chat` and `pnpm nx lint chat`.
+- [x] 6.5 Verify the slice: `npm exec nx test chat` and `npm exec nx lint chat`.
 
 ## 7. Final cross-slice verification
 
-- [x] 7.1 Run `pnpm nx test chat` and confirm green.
-- [x] 7.2 Run `pnpm nx lint chat` and confirm green.
-- [x] 7.3 Run `pnpm nx build chat` to confirm the bundle builds (validates the new lazy chunk for `LoginPage`).
-- [x] 7.4 Run `pnpm nx affected --target=lint --base=origin/development` from the workspace root to catch any cross-project regressions in `libs/chat-shared` (the only shared lib touched, via the new `ProviderInfo` type).
-- [x] 7.5 Run `pnpm nx affected --target=test --base=origin/development` from the workspace root.
+- [x] 7.1 Run `npm exec nx test chat` and confirm green.
+- [x] 7.2 Run `npm exec nx lint chat` and confirm green.
+- [x] 7.3 Run `npm exec nx build chat` to confirm the bundle builds (validates the new lazy chunk for `LoginPage`).
+- [x] 7.4 Run `npm exec nx affected --target=lint --base=origin/development` from the workspace root to catch any cross-project regressions in `libs/chat-shared` (the only shared lib touched, via the new `ProviderInfo` type).
+- [x] 7.5 Run `npm exec nx affected --target=test --base=origin/development` from the workspace root.
 - [x] 7.6 Open `apps/chat-api/AGENTS.md` and confirm that no rule in §1–§13 is violated by this change (sanity check — this change touches `apps/chat` only, but `libs/chat-shared` is shared with the API).
 
 ## 8. Out-of-scope notes (record only, no implementation here)

--- a/openspec/specs/conversation-input-attachments/spec.md
+++ b/openspec/specs/conversation-input-attachments/spec.md
@@ -1,0 +1,166 @@
+## ADDED Requirements
+
+---
+
+### Requirement: Add menu button
+
+The `Input` component SHALL include a `+` button (`DialGhostIconButton`, 40×40, icon 18px `BASE_ICON_SIZE`) that opens a `DialDropdown` positioned below the trigger (`placement="bottom-start"`). The menu lists available content sources; in phase 1 it contains a single item: "Attach file". Items are extensible — future phases add more sources without changing the trigger or surrounding layout.
+
+#### Scenario: Plus button opens dropdown
+
+- **WHEN** the user clicks the `+` button
+- **THEN** a dropdown menu appears below it
+
+#### Scenario: Dropdown closes on outside click
+
+- **WHEN** the dropdown is open and the user clicks outside it
+- **THEN** the dropdown closes
+
+#### Scenario: Plus button aria-label
+
+- **WHEN** the `+` button is rendered
+- **THEN** it has `aria-label` sourced from i18n key `conversationInput.addMenu.ariaLabel`
+
+#### Scenario: Plus button keyboard activation
+
+- **WHEN** the `+` button has focus and the user presses Enter or Space
+- **THEN** the dropdown menu opens
+
+#### Scenario: Attach file item
+
+- **WHEN** the dropdown is open
+- **THEN** an "Attach file" item is present, labelled from i18n key `conversationInput.attach.label`, with a paperclip icon
+
+#### Scenario: Attach file item triggers file picker
+
+- **WHEN** the user clicks the "Attach file" item
+- **THEN** the native file picker opens
+
+---
+
+### Requirement: File picking and Attachment creation
+
+The `Input` component SHALL include a visually-hidden `<input type="file" multiple>` triggered programmatically by the "Attach file" menu item. Each selected file SHALL be converted to an `Attachment` (`id`, `name`, `contentType`, `file`, `status: RequestStatus.Idle`). Image files additionally receive a `previewUrl` via `URL.createObjectURL`.
+
+#### Scenario: Multiple files selectable
+
+- **WHEN** the file picker opens
+- **THEN** the user can select one or more files simultaneously
+
+#### Scenario: Non-image file added
+
+- **WHEN** the user selects a non-image file (e.g. `.csv`)
+- **THEN** an `Attachment` with `type: AttachmentType.File` and no `previewUrl` is added to the list
+
+#### Scenario: Image file added with preview
+
+- **WHEN** the user selects an image file (MIME type starts with `image/`)
+- **THEN** an `Attachment` with `type: AttachmentType.Image` and a valid `previewUrl` is added
+
+#### Scenario: Object URL revoked on removal
+
+- **WHEN** an `Attachment` with a `previewUrl` is removed
+- **THEN** `URL.revokeObjectURL` is called with that URL
+
+#### Scenario: Object URLs revoked on unmount
+
+- **WHEN** the `Input` component unmounts while image attachments are present
+- **THEN** `URL.revokeObjectURL` is called for every `previewUrl` in the list
+
+---
+
+### Requirement: `onAttachmentsChange` callback
+
+`Input` and `ConversationInput` SHALL accept an optional `onAttachmentsChange?: (attachments: Attachment[]) => void` called whenever the attachment list changes.
+
+#### Scenario: Callback fired on add
+
+- **WHEN** files are selected and converted to `Attachment`s
+- **THEN** `onAttachmentsChange` is called with the full updated list
+
+#### Scenario: Callback fired on remove
+
+- **WHEN** the user removes an attachment from the tray
+- **THEN** `onAttachmentsChange` is called with the remaining list
+
+#### Scenario: No callback — no error
+
+- **WHEN** `onAttachmentsChange` is not provided
+- **THEN** the component operates normally without throwing
+
+---
+
+### Requirement: AttachmentCard renders pending attachments
+
+The system SHALL render a card component for each pending attachment, displaying the file name, format label, and a type-appropriate icon. `type: image` shows a thumbnail; all other types show a file-type icon from `getAttachmentIcon`.
+
+#### Scenario: File card default state
+
+- **WHEN** an attachment of type `file` with status `idle` is rendered
+- **THEN** the card displays the file name, format extension, and the matching `@tabler/icons-react` file icon
+
+#### Scenario: Image card shows thumbnail
+
+- **WHEN** an attachment of type `image` with a valid `previewUrl` is rendered
+- **THEN** the card displays the image thumbnail instead of an icon
+
+#### Scenario: Card in loading state
+
+- **WHEN** an attachment has status `loading`
+- **THEN** the card displays a spinner overlay and the remove button is hidden
+
+#### Scenario: Card in error state
+
+- **WHEN** an attachment has status `error`
+- **THEN** the card displays a red border, a retry button (↺), and the remove button (×)
+
+#### Scenario: Remove button on hover
+
+- **WHEN** the user hovers over a card with status `idle` or `error`
+- **THEN** a remove button (×) becomes visible
+
+#### Scenario: Remove via keyboard
+
+- **WHEN** the remove button has focus and the user presses Enter or Space
+- **THEN** the attachment is removed
+
+#### Scenario: Remove button aria-label
+
+- **WHEN** the card is rendered
+- **THEN** the remove button has `aria-label` sourced from i18n key `conversationInput.attachment.remove`
+
+#### Scenario: Retry button aria-label
+
+- **WHEN** a card in error state is rendered
+- **THEN** the retry button has `aria-label` sourced from i18n key `conversationInput.attachment.retry`
+
+---
+
+### Requirement: AttachmentTray renders the pending list
+
+The system SHALL render a horizontally scrollable row of `AttachmentCard` components above the textarea when the list is non-empty. The tray returns `null` when the list is empty.
+
+#### Scenario: Tray visible with attachments
+
+- **WHEN** one or more attachments are pending
+- **THEN** the `AttachmentTray` is rendered with one card per attachment
+
+#### Scenario: Tray hidden when empty
+
+- **WHEN** the pending list is empty
+- **THEN** the tray is not rendered
+
+#### Scenario: Tray scrolls horizontally
+
+- **WHEN** cards exceed the available width
+- **THEN** the tray scrolls horizontally
+
+#### Scenario: Last card removed hides tray
+
+- **WHEN** the user removes the last remaining card
+- **THEN** the tray is no longer rendered
+
+#### Scenario: Tray ARIA label
+
+- **WHEN** the tray is rendered
+- **THEN** it has `role="list"` and `aria-label` sourced from i18n key `conversationInput.attachmentTray.label`

--- a/openspec/specs/generated-api-client-integration/spec.md
+++ b/openspec/specs/generated-api-client-integration/spec.md
@@ -135,5 +135,5 @@ The telemetry middleware SHALL record the HTTP method, URL, response status, and
 `apps/chat/package.json` (or the workspace root `package.json` with appropriate Nx project boundary configuration) SHALL declare `@epam/chat-api-client` as a dependency so `nx graph` shows the correct lib → app edge.
 
 #### Scenario: Dependency graph edge
-- **WHEN** `pnpm nx graph` is run after the migration
+- **WHEN** `npm exec nx graph` is run after the migration
 - **THEN** `apps/chat` SHALL show an explicit dependency on `libs/chat-api-client`

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.8.0",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "@nestjs/schematics": "^11.0.0",
         "@nestjs/testing": "^11.0.0",
         "@nx/eslint": "22.7.2",
@@ -203,7 +204,8 @@
         "@epam/ai-dial-chat-shared": "0.0.1",
         "@epam/ai-dial-ui-kit": "0.10.0-dev.50",
         "@tabler/icons-react": "^3.44.0",
-        "react": "^19.0.0"
+        "react": "^19.0.0",
+        "react-i18next": "^17.0.0"
       }
     },
     "libs/conversation-messages": {
@@ -2845,6 +2847,19 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.2",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
@@ -4038,6 +4053,57 @@
         "ajv": "~8.18.0",
         "jju": "~1.4.0",
         "resolve": "~1.22.2"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "devOptional": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/@module-federation/bridge-react-webpack-plugin": {
@@ -12070,7 +12136,7 @@
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -12102,7 +12168,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
       "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.0.0"
@@ -14317,7 +14383,7 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -16544,6 +16610,29 @@
         "bare-events": "^2.7.0"
       }
     },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
+      "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/execa": {
       "version": "9.6.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.1.tgz",
@@ -16750,6 +16839,25 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "node_modules/exsolve": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.8.tgz",
@@ -16865,7 +16973,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
       "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -18503,6 +18611,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/hono": {
+      "version": "4.12.22",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.22.tgz",
+      "integrity": "sha512-7fvVPbB92zNRsQke+uiRGwtTuef0tB2Dg4hWxYfFNvkQhIltWoyi0ONReM5LWA+jJWS3nfT5lTq+qbsIpX0IQw==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
     "node_modules/hookified": {
       "version": "1.15.1",
       "resolved": "https://registry.npmjs.org/hookified/-/hookified-1.15.1.tgz",
@@ -19049,7 +19167,7 @@
       "version": "10.2.0",
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
       "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -19773,7 +19891,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/isobject": {
@@ -20614,8 +20732,15 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "devOptional": true,
+      "license": "BSD-2-Clause"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -24071,7 +24196,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -24190,6 +24315,16 @@
       "license": "MIT",
       "optionalDependencies": {
         "@napi-rs/nice": "^1.0.1"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/pkg-dir": {
@@ -26266,7 +26401,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -27635,7 +27770,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -27648,7 +27783,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -31384,7 +31519,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -31773,10 +31908,20 @@
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "devOptional": true,
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
       }
     },
     "node_modules/zod-validation-error": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.8.0",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "@nestjs/schematics": "^11.0.0",
     "@nestjs/testing": "^11.0.0",
     "@nx/eslint": "22.7.2",


### PR DESCRIPTION
## Description of changes

Added common component for Attachment, used it on Conversation Input

## Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #<ISSUE_ID>

## UI changes

<Please, provide Screenshots or Figma links>

## Checklist

- [ ] the pull request name ends with `(Issue #<ISSUE_ID>)` (comma-separated list of issues)
- [X] I confirm that I don't share any confidential information like API keys or any other secrets and private URLs

<details>
  <summary>PR title cheatsheet</summary>

`<type>[optional scope]: <description>`

1. type (required)
    - `feat` - A new feature
    - `fix` - A bug fix
    - `docs` - Documentation only changes
    - `test` - Adding missing tests or correcting existing tests
    - `ci` - Changes to our CI configuration files and scripts
    - `chore` - Other changes that are minor and/or not user-facing
2. scope (optional, current repo suggestions below)
    - `chat`
    - `overlay`
    - `shared`
    - `sandbox-overlay`
    - `visualizer-connector`

</details>
