### PR TITLE
feat(chat): add possibility to create prompt inside skills select modal (Issue #6772)

### DIFF
--- a/apps/chat/src/components/Common/AgentSkillsSelector/AgentSkillsModal.tsx
+++ b/apps/chat/src/components/Common/AgentSkillsSelector/AgentSkillsModal.tsx
@@ -1,4 +1,5 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { IconPlus } from '@tabler/icons-react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { useTranslation } from '@/src/hooks/useTranslation';
 
@@ -18,7 +19,7 @@ import { useAppDispatch, useAppSelector } from '@/src/store/hooks';
 import { PromptsSelectors } from '@/src/store/prompts/prompts.selectors';
 import { SettingsSelectors } from '@/src/store/settings/settings.selectors';
 
-import { MarketplaceI18nKeys } from '@/src/constants/i18n';
+import { MarketplaceI18nKeys, PromptBarI18nKeys } from '@/src/constants/i18n';
 import {
   ORGANIZATION_SECTION_NAME,
   PINNED_PROMPTS_SECTION_NAME,
@@ -33,7 +34,7 @@ import { PromptRow } from '@/src/components/Common/PromptRow';
 
 import { NoData } from '../NoData';
 
-import { DialPrimaryButton, DialSearch } from '@epam/ai-dial-ui-kit';
+import { DialLinkButton, DialPrimaryButton, DialSearch } from '@epam/ai-dial-ui-kit';
 
 interface SkillsSectionProps {
   sectionName: string;
@@ -45,9 +46,11 @@ interface SkillsSectionProps {
   openByDefault?: boolean;
   skipFolders?: boolean;
   skipRootPrompts?: boolean;
+  scrollToId?: string | null;
   onToggle: (id: string) => void;
   onToggleFolder: (descendantIds: string[]) => void;
   onClickFolder: (folderId: string) => void;
+  onScrollRef: (id: string, el: HTMLDivElement | null) => void;
 }
 
 const SkillsSection = ({
@@ -60,9 +63,11 @@ const SkillsSection = ({
   skipFolders = false,
   openByDefault = true,
   skipRootPrompts = false,
+  scrollToId,
   onToggle,
   onToggleFolder,
   onClickFolder,
+  onScrollRef,
 }: SkillsSectionProps) => {
   const rootFoldersSelector = useMemo(
     () => PromptsSelectors.selectFilteredFolders(filters, searchTerm),
@@ -120,6 +125,11 @@ const SkillsSection = ({
           {rootPrompts.map((p) => (
             <PromptRow
               key={p.id}
+              ref={
+                scrollToId === p.id
+                  ? (el: HTMLDivElement | null) => onScrollRef(p.id, el)
+                  : null
+              }
               item={p}
               level={0}
               isSelected={selectedIds.includes(p.id)}
@@ -147,9 +157,12 @@ export const AgentSkillsModal = ({
 
   const dispatch = useAppDispatch();
 
+  const preCreateSnapshotRef = useRef<Set<string> | null>(null);
+
   const [searchTerm, setSearchTerm] = useState('');
   const [selectedIds, setSelectedIds] = useState<string[]>(initialSelectedIds);
   const [openedFoldersIds, setOpenedFoldersIds] = useState<string[]>([]);
+  const [scrollToId, setScrollToId] = useState<string | null>(null);
 
   const myItemsFilters = useAppSelector(PromptsSelectors.selectMyItemsFilters);
   const allFolders = useAppSelector(PromptsSelectors.selectFolders);
@@ -167,6 +180,26 @@ export const AgentSkillsModal = ({
   const rootFolders = useAppSelector(rootFoldersSelector);
 
   const isEmpty = rootFolders.length === 0 && allPrompts.length === 0;
+
+  useEffect(() => {
+    if (!preCreateSnapshotRef.current) return;
+
+    const newId = allPrompts.find((p) => !preCreateSnapshotRef.current!.has(p.id))?.id;
+    if (!newId) return;
+
+    preCreateSnapshotRef.current = null;
+    setSelectedIds((prev) => (prev.includes(newId) ? prev : [...prev, newId]));
+    setScrollToId(newId);
+  }, [allPrompts]);
+
+  const handleScrollRef = useCallback(
+    (_id: string, el: HTMLDivElement | null) => {
+      if (!el) return;
+      el.scrollIntoView({ block: 'center', behavior: 'smooth' });
+      setScrollToId(null);
+    },
+    [],
+  );
 
   useEffect(() => {
     dispatch(PromptsActions.uploadPromptsWithFoldersRecursive());
@@ -203,6 +236,14 @@ export const AgentSkillsModal = ({
         : [...prev, folderId],
     );
   }, []);
+
+  const handleCreatePrompt = useCallback(() => {
+    preCreateSnapshotRef.current = new Set(allPrompts.map((p) => p.id));
+    dispatch(PromptsActions.setIsNewPromptCreating(true));
+    dispatch(
+      PromptsActions.setIsPromptModalOpen({ isOpen: true, isInitModeEdit: true, isQuickAppEditPrompt: true }),
+    );
+  }, [dispatch, allPrompts]);
 
   const handleConfirm = useCallback(() => {
     onConfirm(selectedIds);
@@ -273,17 +314,24 @@ export const AgentSkillsModal = ({
                 searchTerm={searchTerm}
                 allFolders={allFolders}
                 selectedIds={selectedIds}
+                scrollToId={scrollToId}
                 onToggle={handleTogglePrompt}
                 onToggleFolder={handleToggleFolder}
                 openedFoldersIds={openedFoldersIds}
                 onClickFolder={handleClickFolder}
+                onScrollRef={handleScrollRef}
               />
             ))}
           </div>
         )}
       </div>
 
-      <div className="absolute bottom-0 flex w-full justify-end border-t border-tertiary bg-layer-2 px-6 py-[14px]">
+      <div className="absolute bottom-0 flex w-full justify-between border-t border-tertiary bg-layer-2 px-6 py-[14px]">
+        <DialLinkButton
+          iconBefore={<IconPlus size={18} />}
+          label={t(PromptBarI18nKeys.CreatePrompt)}
+          onClick={handleCreatePrompt}
+        />
         <DialPrimaryButton
           label={t(MarketplaceI18nKeys.SelectAgentSkills)}
           onClick={handleConfirm}

--- a/apps/chat/src/components/Common/AgentSkillsSelector/AgentSkillsModal.tsx
+++ b/apps/chat/src/components/Common/AgentSkillsSelector/AgentSkillsModal.tsx
@@ -34,7 +34,11 @@ import { PromptRow } from '@/src/components/Common/PromptRow';
 
 import { NoData } from '../NoData';
 
-import { DialLinkButton, DialPrimaryButton, DialSearch } from '@epam/ai-dial-ui-kit';
+import {
+  DialLinkButton,
+  DialPrimaryButton,
+  DialSearch,
+} from '@epam/ai-dial-ui-kit';
 
 interface SkillsSectionProps {
   sectionName: string;
@@ -184,7 +188,9 @@ export const AgentSkillsModal = ({
   useEffect(() => {
     if (!preCreateSnapshotRef.current) return;
 
-    const newId = allPrompts.find((p) => !preCreateSnapshotRef.current!.has(p.id))?.id;
+    const newId = allPrompts.find(
+      (p) => !preCreateSnapshotRef.current!.has(p.id),
+    )?.id;
     if (!newId) return;
 
     preCreateSnapshotRef.current = null;
@@ -241,7 +247,11 @@ export const AgentSkillsModal = ({
     preCreateSnapshotRef.current = new Set(allPrompts.map((p) => p.id));
     dispatch(PromptsActions.setIsNewPromptCreating(true));
     dispatch(
-      PromptsActions.setIsPromptModalOpen({ isOpen: true, isInitModeEdit: true, isQuickAppEditPrompt: true }),
+      PromptsActions.setIsPromptModalOpen({
+        isOpen: true,
+        isInitModeEdit: true,
+        isQuickAppEditPrompt: true,
+      }),
     );
   }, [dispatch, allPrompts]);
 

--- a/apps/chat/src/components/Common/PromptRow.tsx
+++ b/apps/chat/src/components/Common/PromptRow.tsx
@@ -1,5 +1,5 @@
 import { IconBulb } from '@tabler/icons-react';
-import { FC } from 'react';
+import { forwardRef } from 'react';
 
 import classNames from 'classnames';
 
@@ -14,21 +14,20 @@ interface PromptRowProps {
   onToggle: (id: string) => void;
 }
 
-export const PromptRow: FC<PromptRowProps> = ({
-  item: prompt,
-  level = 0,
-  isSelected,
-  onToggle,
-}) => {
+export const PromptRow = forwardRef<
+  HTMLDivElement,
+  PromptRowProps
+>(({ item: prompt, level = 0, isSelected, onToggle }, ref) => {
   return (
     <div
+      ref={ref}
       className={classNames(
         'group relative flex h-[32px] w-full shrink-0 cursor-pointer select-none items-center rounded border-l-2 border-l-transparent pr-3 hover:bg-accent-primary-alpha',
         isSelected && 'bg-accent-primary-alpha',
       )}
       style={{ paddingLeft: `${level * 24 + 16}px` }}
       onClick={() => onToggle(prompt.id)}
-      data-qa="skill"
+      data-qa="prompt-row"
     >
       <div className="flex size-full items-center gap-2">
         <div className="relative flex size-[18px] shrink-0 items-center justify-center">
@@ -60,4 +59,6 @@ export const PromptRow: FC<PromptRowProps> = ({
       </div>
     </div>
   );
-};
+});
+
+PromptRow.displayName = 'PromptRow';

--- a/apps/chat/src/components/Common/PromptRow.tsx
+++ b/apps/chat/src/components/Common/PromptRow.tsx
@@ -14,51 +14,50 @@ interface PromptRowProps {
   onToggle: (id: string) => void;
 }
 
-export const PromptRow = forwardRef<
-  HTMLDivElement,
-  PromptRowProps
->(({ item: prompt, level = 0, isSelected, onToggle }, ref) => {
-  return (
-    <div
-      ref={ref}
-      className={classNames(
-        'group relative flex h-[32px] w-full shrink-0 cursor-pointer select-none items-center rounded border-l-2 border-l-transparent pr-3 hover:bg-accent-primary-alpha',
-        isSelected && 'bg-accent-primary-alpha',
-      )}
-      style={{ paddingLeft: `${level * 24 + 16}px` }}
-      onClick={() => onToggle(prompt.id)}
-      data-qa="prompt-row"
-    >
-      <div className="flex size-full items-center gap-2">
-        <div className="relative flex size-[18px] shrink-0 items-center justify-center">
-          <IconBulb
-            size={18}
-            strokeWidth={1.5}
-            className={classNames(
-              'shrink-0 text-secondary',
-              isSelected ? 'opacity-0' : 'group-hover:opacity-0',
-            )}
-          />
-          <div
-            className={classNames(
-              'absolute inset-0 flex items-center justify-center',
-              !isSelected && 'opacity-0 group-hover:opacity-100',
-            )}
-            onClick={(e) => e.stopPropagation()}
-          >
-            <Checkbox
-              checked={isSelected}
-              onChange={() => onToggle(prompt.id)}
-              className="mr-0"
+export const PromptRow = forwardRef<HTMLDivElement, PromptRowProps>(
+  ({ item: prompt, level = 0, isSelected, onToggle }, ref) => {
+    return (
+      <div
+        ref={ref}
+        className={classNames(
+          'group relative flex h-[32px] w-full shrink-0 cursor-pointer select-none items-center rounded border-l-2 border-l-transparent pr-3 hover:bg-accent-primary-alpha',
+          isSelected && 'bg-accent-primary-alpha',
+        )}
+        style={{ paddingLeft: `${level * 24 + 16}px` }}
+        onClick={() => onToggle(prompt.id)}
+        data-qa="prompt-row"
+      >
+        <div className="flex size-full items-center gap-2">
+          <div className="relative flex size-[18px] shrink-0 items-center justify-center">
+            <IconBulb
+              size={18}
+              strokeWidth={1.5}
+              className={classNames(
+                'shrink-0 text-secondary',
+                isSelected ? 'opacity-0' : 'group-hover:opacity-0',
+              )}
             />
+            <div
+              className={classNames(
+                'absolute inset-0 flex items-center justify-center',
+                !isSelected && 'opacity-0 group-hover:opacity-100',
+              )}
+              onClick={(e) => e.stopPropagation()}
+            >
+              <Checkbox
+                checked={isSelected}
+                onChange={() => onToggle(prompt.id)}
+                className="mr-0"
+              />
+            </div>
           </div>
+          <span className="relative truncate text-left text-sm text-primary">
+            {prompt.name}
+          </span>
         </div>
-        <span className="relative truncate text-left text-sm text-primary">
-          {prompt.name}
-        </span>
       </div>
-    </div>
-  );
-});
+    );
+  },
+);
 
 PromptRow.displayName = 'PromptRow';

--- a/apps/chat/src/store/prompts/prompts.reducers.ts
+++ b/apps/chat/src/store/prompts/prompts.reducers.ts
@@ -305,7 +305,13 @@ export const promptsSlice = createSlice({
     },
     setIsPromptModalOpen: (
       state,
-      { payload }: PayloadAction<{ isOpen: boolean; isInitModeEdit?: boolean; isQuickAppEditPrompt?: boolean }>,
+      {
+        payload,
+      }: PayloadAction<{
+        isOpen: boolean;
+        isInitModeEdit?: boolean;
+        isQuickAppEditPrompt?: boolean;
+      }>,
     ) => {
       state.isPromptModalOpen = payload.isOpen;
       state.isPromptModalInitModeEdit = !!payload.isInitModeEdit;

--- a/apps/chat/src/store/prompts/prompts.reducers.ts
+++ b/apps/chat/src/store/prompts/prompts.reducers.ts
@@ -305,10 +305,11 @@ export const promptsSlice = createSlice({
     },
     setIsPromptModalOpen: (
       state,
-      { payload }: PayloadAction<{ isOpen: boolean; isInitModeEdit?: boolean }>,
+      { payload }: PayloadAction<{ isOpen: boolean; isInitModeEdit?: boolean; isQuickAppEditPrompt?: boolean }>,
     ) => {
       state.isPromptModalOpen = payload.isOpen;
       state.isPromptModalInitModeEdit = !!payload.isInitModeEdit;
+      state.isQuickAppEditPrompt = !!payload.isQuickAppEditPrompt;
 
       if (!payload.isOpen) {
         state.isNewPromptCreating = false;


### PR DESCRIPTION
## Description of changes

add possibility to create prompt inside skills select modal

## Applicable issues

#6772 

## Checklist

- [x] the pull request name ends with `(Issue #<ISSUE_ID>)` (comma-separated list of issues)
- [x] I confirm that I don't share any confidential information like API keys or any other secrets and private URLs

<details>
  <summary>PR title cheatsheet</summary>

`<type>[optional scope]: <description>`

1. type (required)
    - `feat` - A new feature
    - `fix` - A bug fix
    - `docs` - Documentation only changes
    - `test` - Adding missing tests or correcting existing tests
    - `ci` - Changes to our CI configuration files and scripts
    - `chore` - Other changes that are minor and/or not user-facing
2. scope (optional, current repo suggestions below)
    - `chat`
    - `overlay`
    - `shared`
    - `sandbox-overlay`
    - `visualizer-connector`

</details>
