### PR TITLE
fix: correct ConversationView layout — scrollbar position and vertical padding

### DIFF
--- a/apps/chat/src/components/ConversationView/ConversationView.tsx
+++ b/apps/chat/src/components/ConversationView/ConversationView.tsx
@@ -191,16 +191,16 @@ const ConversationView: FC<Props> = ({
 
   return (
     <>
-      <div className="relative flex w-full max-w-[748px] flex-1 flex-col overflow-hidden">
+      <div className="relative flex w-full flex-1 flex-col overflow-hidden">
         <div
           ref={containerRef}
           role="log"
           aria-label={t(ChatI18nKeys.ConversationMessages)}
           aria-live="polite"
           aria-relevant="additions"
-          className="flex flex-1 flex-col overflow-y-auto px-4 py-8"
+          className="flex flex-1 flex-col overflow-y-auto"
         >
-          <div className="flex flex-1 flex-col gap-6">
+          <div className="mx-auto flex w-full max-w-[748px] flex-1 flex-col gap-6 px-4 pt-2">
             {messages.map((msg, index) => {
               const isStreaming = isStreamingMessage(
                 msg.role,


### PR DESCRIPTION
fix: correct ConversationView layout — scrollbar position and vertical padding

Move vertical scrollbar to the viewport's right edge by making the scroll container full-width and centering message content (max-w-[748px]) inside it. Remove vertical padding that was consuming conversation space; add 8px top padding only. Also apply nx sync tsconfig.app.json project references update.

## Description of changes

<!-- Please explain the changes you made right below this line. -->

## Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #<ISSUE_ID>

## UI changes

<Please, provide Screenshots or Figma links>

## Checklist

- [ ] the pull request name ends with `(Issue #<ISSUE_ID>)` (comma-separated list of issues)
- [ ] I confirm that I don't share any confidential information like API keys or any other secrets and private URLs

<details>
  <summary>PR title cheatsheet</summary>

`<type>[optional scope]: <description>`

1. type (required)
    - `feat` - A new feature
    - `fix` - A bug fix
    - `docs` - Documentation only changes
    - `test` - Adding missing tests or correcting existing tests
    - `ci` - Changes to our CI configuration files and scripts
    - `chore` - Other changes that are minor and/or not user-facing
2. scope (optional, current repo suggestions below)
    - `chat`
    - `overlay`
    - `shared`
    - `sandbox-overlay`
    - `visualizer-connector`

</details>
