### PR TITLE
feat: align Conversation Panel to Figma design specs

### DIFF
--- a/apps/chat/src/components/ConversationPanel/ConversationPanelView.tsx
+++ b/apps/chat/src/components/ConversationPanel/ConversationPanelView.tsx
@@ -30,10 +30,17 @@ const ConversationPanelView: FC<Props> = ({
 
   const conversations: ConversationHistoryItem[] = useMemo(
     () =>
-      items.map((item) => ({
-        id: normalizeConversationId(item.id),
-        title: item.title,
-      })),
+      items.map((item) => {
+        const rawId = normalizeConversationId(item.id);
+        let id: string;
+        try {
+          id = decodeURIComponent(rawId);
+        } catch (e) {
+          console.error('Failed to decode conversation id:', rawId, e);
+          id = rawId;
+        }
+        return { id, title: item.title };
+      }),
     [items],
   );
 

--- a/libs/conversation-panel/src/components/ConversationGroup/ConversationGroup.tsx
+++ b/libs/conversation-panel/src/components/ConversationGroup/ConversationGroup.tsx
@@ -1,5 +1,8 @@
 import { mergeClasses } from '@epam/ai-dial-chat-shared';
-import { IconChevronDown, IconChevronRight } from '@tabler/icons-react';
+import {
+  IconCaretDownFilled,
+  IconCaretRightFilled,
+} from '@tabler/icons-react';
 import { type FC, memo, useState } from 'react';
 import type { ConversationHistoryItem } from '../../models/ConversationPanel.js';
 import styles from '../ConversationPanel/ConversationPanel.module.scss';
@@ -14,11 +17,11 @@ export interface ConversationGroupProps {
   activeConversationId?: string;
   /** Called when the user selects a conversation row. */
   onSelectConversation: (id: string) => void;
-  /** Typography class applied to the group header button. Defaults to `'text-xs font-semibold'`. */
+  /** Typography class applied to the group header button. Defaults to `'dial-tiny-text'`. */
   groupHeaderClassName?: string;
   /** Typography class applied to the initial-letter icon fallback. Defaults to `'text-xs font-bold'`. */
   itemIconClassName?: string;
-  /** Typography class applied to the conversation title text. Defaults to `'text-sm'`. */
+  /** Typography class applied to the conversation title text. Defaults to `'dial-small-text'`. */
   itemTitleClassName?: string;
 }
 // TODO: review all styles ((!!!!))
@@ -29,9 +32,9 @@ export const ConversationGroup: FC<ConversationGroupProps> = memo(
     items,
     activeConversationId,
     onSelectConversation,
-    groupHeaderClassName = 'text-xs font-semibold',
+    groupHeaderClassName = 'dial-tiny-text',
     itemIconClassName = 'text-xs font-bold',
-    itemTitleClassName = 'text-sm',
+    itemTitleClassName = 'dial-small-text',
   }) => {
     const [isExpanded, setIsExpanded] = useState(true);
 
@@ -44,21 +47,21 @@ export const ConversationGroup: FC<ConversationGroupProps> = memo(
           aria-expanded={isExpanded}
           onClick={() => setIsExpanded((prev) => !prev)}
           className={mergeClasses(
-            'flex w-full items-center gap-1 px-3 py-1 text-left',
+            'flex h-6 w-full items-center gap-1 rounded py-1 pr-3 text-left',
             groupHeaderClassName,
             styles.groupHeader,
           )}
         >
           {isExpanded ? (
-            <IconChevronDown size={14} className="shrink-0" />
+            <IconCaretDownFilled size={12} className="shrink-0" />
           ) : (
-            <IconChevronRight size={14} className="shrink-0" />
+            <IconCaretRightFilled size={12} className="shrink-0" />
           )}
           <span className="truncate">{label}</span>
         </button>
 
         {isExpanded && (
-          <ul role="list" className="flex flex-col">
+          <ul role="list" className="flex flex-col gap-0.5">
             {items.map((item) => {
               const isActive = item.id === activeConversationId;
               return (
@@ -68,7 +71,7 @@ export const ConversationGroup: FC<ConversationGroupProps> = memo(
                     aria-current={isActive ? 'page' : undefined}
                     onClick={() => onSelectConversation(item.id)}
                     className={mergeClasses(
-                      'flex w-full items-center gap-2 px-3 py-2 text-left',
+                      'flex h-8 w-full items-center gap-2 rounded py-1 pl-3 pr-3 text-left',
                       styles.item,
                       isActive && styles.itemActive,
                     )}

--- a/libs/conversation-panel/src/components/ConversationGroup/ConversationGroup.tsx
+++ b/libs/conversation-panel/src/components/ConversationGroup/ConversationGroup.tsx
@@ -1,8 +1,5 @@
 import { mergeClasses } from '@epam/ai-dial-chat-shared';
-import {
-  IconCaretDownFilled,
-  IconCaretRightFilled,
-} from '@tabler/icons-react';
+import { IconCaretDownFilled, IconCaretRightFilled } from '@tabler/icons-react';
 import { type FC, memo, useState } from 'react';
 import type { ConversationHistoryItem } from '../../models/ConversationPanel.js';
 import styles from '../ConversationPanel/ConversationPanel.module.scss';

--- a/libs/conversation-panel/src/components/ConversationPanel/ConversationPanel.module.scss
+++ b/libs/conversation-panel/src/components/ConversationPanel/ConversationPanel.module.scss
@@ -26,7 +26,7 @@
   }
 
   &.itemActive {
-    background: var(--cp-item-active, var(--bg-accent, #335cad));
+    background: var(--cp-item-active, var(--bg-accent-secondary-alpha, #37babc2e));
   }
 }
 

--- a/libs/conversation-panel/src/components/ConversationPanel/ConversationPanel.tsx
+++ b/libs/conversation-panel/src/components/ConversationPanel/ConversationPanel.tsx
@@ -130,6 +130,8 @@ export const ConversationPanel: FC<ConversationPanelProps> = memo(
             activeTab={activeTab}
             labels={filterLabels}
             onChange={setActiveTab}
+            tabClassName={typography?.tabClassName}
+            tabColorClassName={typography?.tabColorClassName}
           />
 
           {/* Conversation list */}

--- a/libs/conversation-panel/src/components/ConversationPanel/Header/Header.tsx
+++ b/libs/conversation-panel/src/components/ConversationPanel/Header/Header.tsx
@@ -14,13 +14,13 @@ export interface HeaderProps {
 export const Header: FC<HeaderProps> = memo(({ title, titleClassName }) => (
   <div
     className={mergeClasses(
-      'flex h-12 shrink-0 items-center justify-between border-b px-2',
+      'flex h-12 shrink-0 items-center justify-between border-b px-5',
       styles.header,
     )}
   >
     <span
       className={mergeClasses(
-        'truncate px-2',
+        'truncate',
         styles.headerTitle,
         titleClassName,
       )}

--- a/libs/conversation-panel/src/components/ConversationPanel/tests/ConversationPanel.spec.tsx
+++ b/libs/conversation-panel/src/components/ConversationPanel/tests/ConversationPanel.spec.tsx
@@ -63,6 +63,8 @@ vi.mock('@tabler/icons-react', () => ({
   IconPlus: () => <span>plus-icon</span>,
   IconChevronDown: () => <span>chevron-down</span>,
   IconChevronRight: () => <span>chevron-right</span>,
+  IconCaretDownFilled: () => <span>caret-down-filled</span>,
+  IconCaretRightFilled: () => <span>caret-right-filled</span>,
 }));
 
 const FILTER_LABELS = {

--- a/libs/conversation-panel/src/components/FilterTabs/FilterTabs.tsx
+++ b/libs/conversation-panel/src/components/FilterTabs/FilterTabs.tsx
@@ -15,6 +15,10 @@ export interface FilterTabsProps {
   labels: FilterLabels;
   /** Called when the user selects a different tab. */
   onChange: (tab: FilterTab) => void;
+  /** Typography class applied to each tab label. Defaults to `'dial-tiny-semi-text'`. */
+  tabClassName?: string;
+  /** Text color class applied to each tab label. Defaults to `'text-primary'`. */
+  tabColorClassName?: string;
 }
 
 const TABS: { value: FilterTab; labelKey: keyof FilterLabels }[] = [
@@ -26,7 +30,13 @@ const TABS: { value: FilterTab; labelKey: keyof FilterLabels }[] = [
 
 /** Segmented pill-tab control for filtering conversations by source. */
 export const FilterTabs: FC<FilterTabsProps> = memo(
-  ({ activeTab, labels, onChange }) => (
+  ({
+    activeTab,
+    labels,
+    onChange,
+    tabClassName = 'dial-tiny-semi-text',
+    tabColorClassName = 'text-primary',
+  }) => (
     <div
       className={mergeClasses(
         'flex flex-wrap gap-2 border-b px-5 py-3',
@@ -40,8 +50,11 @@ export const FilterTabs: FC<FilterTabsProps> = memo(
           selected={activeTab === value}
           onClick={() => onChange(value)}
           className={mergeClasses(
-            'dial-tiny-semi-text border py-1 px-2 text-primary border-primary',
-            activeTab === value && 'border-accent-secondary bg-accent-secondary-alpha',
+            'border border-primary px-2 py-1',
+            tabClassName,
+            tabColorClassName,
+            activeTab === value &&
+              'border-accent-secondary bg-accent-secondary-alpha',
           )}
         />
       ))}

--- a/libs/conversation-panel/src/components/FilterTabs/FilterTabs.tsx
+++ b/libs/conversation-panel/src/components/FilterTabs/FilterTabs.tsx
@@ -39,6 +39,10 @@ export const FilterTabs: FC<FilterTabsProps> = memo(
           label={labels[labelKey]}
           selected={activeTab === value}
           onClick={() => onChange(value)}
+          className={mergeClasses(
+            'dial-tiny-semi-text border py-1 px-2 text-primary border-primary',
+            activeTab === value && 'border-accent-secondary bg-accent-secondary-alpha',
+          )}
         />
       ))}
     </div>

--- a/libs/conversation-panel/src/components/NewChatButton/NewChatButton.tsx
+++ b/libs/conversation-panel/src/components/NewChatButton/NewChatButton.tsx
@@ -23,7 +23,7 @@ export const NewChatButton: FC<NewChatButtonProps> = memo(
         onClick={onClick}
         type="button"
         className={mergeClasses(
-          'flex h-[40px] w-full cursor-pointer items-center gap-2 px-3 py-1',
+          'flex h-[40px] w-full cursor-pointer items-center gap-2 px-5 py-1',
           styles.button,
         )}
       >

--- a/libs/conversation-panel/src/components/SearchInput/SearchInput.tsx
+++ b/libs/conversation-panel/src/components/SearchInput/SearchInput.tsx
@@ -21,7 +21,7 @@ export const SearchInput: FC<SearchInputProps> = memo(
         value={value}
         placeholder={placeholder}
         onChange={onChange}
-        wrapperClassName="border-0"
+        wrapperClassName="border-0 px-5"
       />
     </div>
   ),

--- a/libs/conversation-panel/src/models/ConversationPanel.ts
+++ b/libs/conversation-panel/src/models/ConversationPanel.ts
@@ -64,6 +64,10 @@ export interface ConversationHistoryTypography {
   emptyLabelClassName?: string;
   /** Typography class applied to the New chat button label. Defaults to `'dial-small-text'`. */
   newChatLabelClassName?: string;
+  /** Typography class applied to each filter tab label. Defaults to `'dial-tiny-semi-text'`. */
+  tabClassName?: string;
+  /** Text color class applied to each filter tab label. Defaults to `'text-primary'`. */
+  tabColorClassName?: string;
 }
 
 /** CSS custom-property overrides for `ConversationPanel`. */


### PR DESCRIPTION

## Description of changes

  - FilterTabs: apply dial-tiny-semi-text font, py-1/px-2 padding, text-primary color, border-primary inactive border, border-accent-secondary + bg-accent-secondary-alpha active state; section container uses plain border-b only (no active bg/border)

  - Header: increase horizontal padding from px-2 to px-5 (20px)

  - NewChatButton: increase horizontal padding from px-3 to px-5 (20px)

  - SearchInput: move px-5 from wrapper div into DialSearch wrapperClassName to avoid double padding

  - ConversationGroup:
    - Group header: switch to filled caret icons (IconCaretDownFilled / IconCaretRightFilled) at size 12, dial-tiny-text font, h-6 rounded py-1 pr-3 layout
    - Chat item: h-8 rounded py-1 pl-3 pr-3 layout, dial-small-text title font, 24px icon
    - Default itemTitleClassName changed from text-sm to dial-small-text

  - ConversationPanel.module.scss: replace primary (blue) accent colors with secondary (green) equivalents throughout — itemActive background now uses bg-accent-secondary-alpha (#37babc2e)


## Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #<ISSUE_ID>

## UI changes

<img width="1882" height="1016" alt="image" src="https://github.com/user-attachments/assets/c3e18cd6-d952-482d-862d-004d22ad75a7" />


## Checklist

- [ ] the pull request name ends with `(Issue #<ISSUE_ID>)` (comma-separated list of issues)
- [ ] I confirm that I don't share any confidential information like API keys or any other secrets and private URLs

<details>
  <summary>PR title cheatsheet</summary>

`<type>[optional scope]: <description>`

1. type (required)
    - `feat` - A new feature
    - `fix` - A bug fix
    - `docs` - Documentation only changes
    - `test` - Adding missing tests or correcting existing tests
    - `ci` - Changes to our CI configuration files and scripts
    - `chore` - Other changes that are minor and/or not user-facing
2. scope (optional, current repo suggestions below)
    - `chat`
    - `overlay`
    - `shared`
    - `sandbox-overlay`
    - `visualizer-connector`

</details>
