### PR TITLE
feat(chat): pass JWT to external application type editor iframe (Issue #7026)

### DIFF
--- a/apps/chat/src/components/AppsEditor/EditorForm/CustomViewerForm.tsx
+++ b/apps/chat/src/components/AppsEditor/EditorForm/CustomViewerForm.tsx
@@ -94,6 +94,8 @@ export const CustomViewerForm = () => {
         height="100%"
         containerClassName="w-full h-full border-none transition-all"
         onMessage={onMessage}
+        passAuthInfo
+        passExplicitToken
       />
     </div>
   );

--- a/apps/chat/src/components/IframeRenderer/index.tsx
+++ b/apps/chat/src/components/IframeRenderer/index.tsx
@@ -11,6 +11,12 @@ import React, {
 
 import { useRouter } from 'next/router';
 
+import { useVisualizerAuthLayoutFields } from '@/src/hooks/useVisualizerAuthLayoutFields';
+import { useVisualizerLocaleLayoutFields } from '@/src/hooks/useVisualizerLocaleLayoutFields';
+
+import { useAppSelector } from '@/src/store/hooks';
+import { UISelectors } from '@/src/store/selectors';
+
 import { Routes } from '@/src/constants/routes';
 
 import { Spinner } from '@/src/components/Common/Spinner';
@@ -18,6 +24,7 @@ import { Spinner } from '@/src/components/Common/Spinner';
 import {
   AttachmentData,
   CustomVisualizerData,
+  CustomVisualizerDataLayout,
   VisualizerConnectorEvents,
   VisualizerConnectorRequest,
   VisualizerConnectorRequests,
@@ -33,6 +40,8 @@ interface IframeRendererProps {
   containerStyle?: React.CSSProperties;
   containerClassName?: string;
   conversationId?: string;
+  passAuthInfo?: boolean;
+  passExplicitToken?: boolean;
 }
 
 export const IframeRenderer = forwardRef<HTMLDivElement, IframeRendererProps>(
@@ -46,11 +55,19 @@ export const IframeRenderer = forwardRef<HTMLDivElement, IframeRendererProps>(
       containerStyle = {},
       containerClassName = '',
       conversationId,
+      passAuthInfo,
+      passExplicitToken,
     },
     ref: Ref<HTMLDivElement>,
   ) => {
     const containerRef = useRef<HTMLDivElement>(null);
     const visualizer = useRef<VisualizerConnector | null>(null);
+    const localeLayoutFields = useVisualizerLocaleLayoutFields();
+    const authLayoutFields = useVisualizerAuthLayoutFields({
+      passAuthInfo,
+      passExplicitToken,
+    });
+    const themeId = useAppSelector(UISelectors.selectThemeState);
 
     const router = useRouter();
 
@@ -59,6 +76,17 @@ export const IframeRenderer = forwardRef<HTMLDivElement, IframeRendererProps>(
     }, [router.pathname]);
 
     const [loading, setLoading] = useState<boolean>(true);
+
+    const visualizerLayout = useMemo(
+      (): CustomVisualizerDataLayout => ({
+        width: 0,
+        height: 0,
+        themeId,
+        ...authLayoutFields,
+        ...localeLayoutFields,
+      }),
+      [themeId, authLayoutFields, localeLayoutFields],
+    );
 
     useImperativeHandle(ref, () => containerRef.current as HTMLDivElement);
 
@@ -107,7 +135,7 @@ export const IframeRenderer = forwardRef<HTMLDivElement, IframeRendererProps>(
           visualizerData: {
             isPreview: isPreviewConversation,
             conversationId: conversationId,
-            layout: { width: 0, height: 0 },
+            layout: visualizerLayout,
             // TODO: fix typing here
           } as CustomVisualizerData,
         };
@@ -118,7 +146,7 @@ export const IframeRenderer = forwardRef<HTMLDivElement, IframeRendererProps>(
           messagePayload,
         );
       },
-      [isPreviewConversation, conversationId],
+      [isPreviewConversation, conversationId, visualizerLayout],
     );
 
     useEffect(() => {

--- a/apps/chat/src/components/VisualalizerRenderer/GroupedVisualizerRenderer.tsx
+++ b/apps/chat/src/components/VisualalizerRenderer/GroupedVisualizerRenderer.tsx
@@ -3,12 +3,12 @@ import {
   IconArrowsMinimize,
   IconRefresh,
 } from '@tabler/icons-react';
-import { useSession } from 'next-auth/react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import classNames from 'classnames';
 
 import { useTranslation } from '@/src/hooks/useTranslation';
+import { useVisualizerAuthLayoutFields } from '@/src/hooks/useVisualizerAuthLayoutFields';
 import { useVisualizerLocaleLayoutFields } from '@/src/hooks/useVisualizerLocaleLayoutFields';
 import { useWindowResizeEvent } from '@/src/hooks/useWindowResizeEvent';
 
@@ -102,7 +102,6 @@ export const GroupedVisualizerRenderer = ({
   }, []);
   useWindowResizeEvent(handleResize);
 
-  const { data: session } = useSession();
   const {
     url: rendererUrl,
     title: visualizerTitle = 'Visualizer',
@@ -117,25 +116,10 @@ export const GroupedVisualizerRenderer = ({
   const themeId = useAppSelector(UISelectors.selectThemeState);
 
   const localeLayoutFields = useVisualizerLocaleLayoutFields();
-
-  const authLayoutFields = useMemo((): Partial<CustomVisualizerDataLayout> => {
-    const sessionAccessToken = session?.accessToken;
-    const tokenField =
-      passExplicitToken && sessionAccessToken != null
-        ? { accessToken: sessionAccessToken }
-        : {};
-
-    if (!passAuthInfo) return tokenField;
-    if (!session) return tokenField;
-
-    const email = session.user?.email ?? undefined;
-    const providerId = (session as { providerId?: string } | null)?.providerId;
-    return {
-      ...(email != null && { logInHint: email }),
-      ...(providerId != null && { providerId }),
-      ...tokenField,
-    };
-  }, [passAuthInfo, passExplicitToken, session]);
+  const authLayoutFields = useVisualizerAuthLayoutFields({
+    passAuthInfo,
+    passExplicitToken,
+  });
 
   const loadedCustomAttachmentsData = useAppSelector(
     ConversationsSelectors.selectLoadedCustomAttachments,

--- a/apps/chat/src/components/VisualalizerRenderer/VisualizerRenderer.tsx
+++ b/apps/chat/src/components/VisualalizerRenderer/VisualizerRenderer.tsx
@@ -3,12 +3,12 @@ import {
   IconArrowsMinimize,
   IconRefresh,
 } from '@tabler/icons-react';
-import { useSession } from 'next-auth/react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import classNames from 'classnames';
 
 import { useTranslation } from '@/src/hooks/useTranslation';
+import { useVisualizerAuthLayoutFields } from '@/src/hooks/useVisualizerAuthLayoutFields';
 import { useVisualizerLocaleLayoutFields } from '@/src/hooks/useVisualizerLocaleLayoutFields';
 
 import { CustomVisualizer } from '@/src/types/custom-visualizers';
@@ -63,7 +63,6 @@ export const VisualizerRenderer = ({
   const { t } = useTranslation(Translation.Chat);
 
   const [ready, setReady] = useState<boolean>();
-  const { data: session } = useSession();
   const {
     url: rendererUrl,
     title: visualizerTitle,
@@ -75,24 +74,10 @@ export const VisualizerRenderer = ({
   const dispatch = useAppDispatch();
 
   const localeLayoutFields = useVisualizerLocaleLayoutFields();
-
-  const authLayoutFields = useMemo((): Partial<CustomVisualizerDataLayout> => {
-    const sessionAccessToken = session?.accessToken;
-    const tokenField =
-      passExplicitToken && sessionAccessToken != null
-        ? { accessToken: sessionAccessToken }
-        : {};
-
-    if (!passAuthInfo || !session) return tokenField;
-
-    const email = session.user?.email ?? undefined;
-    const providerId = (session as { providerId?: string }).providerId;
-    return {
-      ...(email != null && { logInHint: email }),
-      ...(providerId != null && { providerId }),
-      ...tokenField,
-    };
-  }, [passAuthInfo, passExplicitToken, session]);
+  const authLayoutFields = useVisualizerAuthLayoutFields({
+    passAuthInfo,
+    passExplicitToken,
+  });
 
   const attachmentDataLoading = useAppSelector(
     ConversationsSelectors.selectCustomAttachmentLoading,

--- a/apps/chat/src/hooks/useVisualizerAuthLayoutFields.ts
+++ b/apps/chat/src/hooks/useVisualizerAuthLayoutFields.ts
@@ -1,0 +1,34 @@
+import { useSession } from 'next-auth/react';
+import { useMemo } from 'react';
+
+import { CustomVisualizerDataLayout } from '@epam/ai-dial-shared';
+
+interface UseVisualizerAuthLayoutFieldsOptions {
+  passAuthInfo?: boolean;
+  passExplicitToken?: boolean;
+}
+
+export const useVisualizerAuthLayoutFields = ({
+  passAuthInfo,
+  passExplicitToken,
+}: UseVisualizerAuthLayoutFieldsOptions): Partial<CustomVisualizerDataLayout> => {
+  const { data: session } = useSession();
+
+  return useMemo((): Partial<CustomVisualizerDataLayout> => {
+    const sessionAccessToken = session?.accessToken;
+    const tokenField =
+      passExplicitToken && sessionAccessToken != null
+        ? { accessToken: sessionAccessToken }
+        : {};
+
+    if (!passAuthInfo || !session) return tokenField;
+
+    const email = session.user?.email ?? undefined;
+    const providerId = (session as { providerId?: string }).providerId;
+    return {
+      ...(email != null && { logInHint: email }),
+      ...(providerId != null && { providerId }),
+      ...tokenField,
+    };
+  }, [passAuthInfo, passExplicitToken, session]);
+};


### PR DESCRIPTION
## Description of changes

External application-type editors (`applicationTypeEditorUrl`) open in `IframeRenderer` inside Apps Editor. Unlike custom visualizers, the iframe previously received only `{ width, height }` in `SEND_VISUALIZE_DATA` layout — no JWT or auth hints — so external App Settings UIs could not authenticate BFF/Core calls (401).
This PR:
- Adds shared hook `useVisualizerAuthLayoutFields` (same session/token logic as visualizers).
- Extends `IframeRenderer` with optional `passAuthInfo` / `passExplicitToken` and sends full auth layout (`accessToken`, `logInHint`, `providerId`, `themeId`, locale fields) in `SEND_VISUALIZE_DATA`.
- Enables both flags in `CustomViewerForm` for schema-based App Settings iframes.
- Refactors `VisualizerRenderer` and `GroupedVisualizerRenderer` to use the shared hook (no behavior change).
Token is passed only when `passExplicitToken` is set and `ALLOW_TOKEN_IN_SESSION=true` in Chat env (existing DIAL pattern).


## Applicable issues

- fixes #7026

## UI changes

No visible Chat UI changes. Behavior change is in the iframe protocol: external App Settings editors can receive auth layout from Chat and establish an authenticated session with their backend.
N/A — screenshots not required unless reviewers want Apps Editor iframe load confirmation.

## Checklist

- [x] the pull request name ends with `(Issue #<ISSUE_ID>)` (comma-separated list of issues)
- [x] I confirm that I don't share any confidential information like API keys or any other secrets and private URLs
