### PR TITLE
feat: make My Chats filter work on Conversation Panel

### DIFF
--- a/apps/chat-api/src/conversations/conversation.service.ts
+++ b/apps/chat-api/src/conversations/conversation.service.ts
@@ -165,6 +165,8 @@ export class ConversationService extends AppService {
             parentPath?: string;
             updatedAt?: number;
             nodeType?: string;
+            sharedWithMe?: boolean;
+            publishedWithMe?: boolean;
           }[];
           nextToken?: string;
         };
@@ -182,6 +184,8 @@ export class ConversationService extends AppService {
           id: item.url ?? `${item.parentPath ?? ''}/${item.name ?? ''}`,
           title: getConversationTitleFromName(item.name ?? ''),
           updatedAt: item.updatedAt ?? 0,
+          sharedWithMe: item.sharedWithMe ?? false,
+          publishedWithMe: item.publishedWithMe ?? false,
         }));
 
       return { items, nextToken: data.nextToken };

--- a/apps/chat-api/src/conversations/dto/conversation-list.dto.ts
+++ b/apps/chat-api/src/conversations/dto/conversation-list.dto.ts
@@ -21,6 +21,20 @@ export class ConversationListItemDto {
     example: 1749600000000,
   })
   updatedAt!: number;
+
+  @ApiProperty({
+    description:
+      'True when this conversation was shared with the current user by another user.',
+    example: false,
+  })
+  sharedWithMe!: boolean;
+
+  @ApiProperty({
+    description:
+      'True when this conversation was published to the organisation and is visible to the current user.',
+    example: false,
+  })
+  publishedWithMe!: boolean;
 }
 
 export class ConversationListResponseDto {

--- a/apps/chat/src/components/ConversationPanel/ConversationPanelView.tsx
+++ b/apps/chat/src/components/ConversationPanel/ConversationPanelView.tsx
@@ -8,6 +8,7 @@ import { normalizeConversationId } from '../../constants/routes.js';
 import { ConversationHistoryI18nKeys } from '../../constants/translation-keys.js';
 import { useConversations } from '../../context/ConversationsContext.js';
 import { useIsMobile } from '../../hooks/breakpoint/useBreakpoint.js';
+import { getConversationSource } from './conversationSource.utils.js';
 
 interface Props {
   isOpen: boolean;
@@ -39,7 +40,7 @@ const ConversationPanelView: FC<Props> = ({
           console.error('Failed to decode conversation id:', rawId, e);
           id = rawId;
         }
-        return { id, title: item.title };
+        return { id, title: item.title, source: getConversationSource(item) };
       }),
     [items],
   );

--- a/apps/chat/src/components/ConversationPanel/conversationSource.utils.ts
+++ b/apps/chat/src/components/ConversationPanel/conversationSource.utils.ts
@@ -1,0 +1,10 @@
+import { ConversationSource } from '@epam/ai-dial-conversation-panel';
+import { type ConversationListItemDto } from '@epam/chat-api-client';
+
+export const getConversationSource = (
+  item: Pick<ConversationListItemDto, 'sharedWithMe' | 'publishedWithMe'>,
+): ConversationSource => {
+  if (item.sharedWithMe) return ConversationSource.Shared;
+  if (item.publishedWithMe) return ConversationSource.Organization;
+  return ConversationSource.MyChats;
+};

--- a/libs/chat-api-client/openapi.json
+++ b/libs/chat-api-client/openapi.json
@@ -1949,9 +1949,25 @@
             "type": "number",
             "description": "Unix epoch milliseconds of the last update.",
             "example": 1749600000000
+          },
+          "sharedWithMe": {
+            "type": "boolean",
+            "description": "True when this conversation was shared with the current user by another user.",
+            "example": false
+          },
+          "publishedWithMe": {
+            "type": "boolean",
+            "description": "True when this conversation was published to the organisation and is visible to the current user.",
+            "example": false
           }
         },
-        "required": ["id", "title", "updatedAt"]
+        "required": [
+          "id",
+          "title",
+          "updatedAt",
+          "sharedWithMe",
+          "publishedWithMe"
+        ]
       },
       "ConversationListResponseDto": {
         "type": "object",

--- a/libs/chat-api-client/src/generated/src/models/index.ts
+++ b/libs/chat-api-client/src/generated/src/models/index.ts
@@ -310,6 +310,18 @@ export interface ConversationListItemDto {
    * @memberof ConversationListItemDto
    */
   updatedAt: number;
+  /**
+   * True when this conversation was shared with the current user by another user.
+   * @type {boolean}
+   * @memberof ConversationListItemDto
+   */
+  sharedWithMe: boolean;
+  /**
+   * True when this conversation was published to the organisation and is visible to the current user.
+   * @type {boolean}
+   * @memberof ConversationListItemDto
+   */
+  publishedWithMe: boolean;
 }
 /**
  *

--- a/libs/conversation-panel/src/index.ts
+++ b/libs/conversation-panel/src/index.ts
@@ -1,11 +1,11 @@
 export { ConversationPanel } from './components/ConversationPanel/ConversationPanel.js';
+export { ConversationSource } from './models/ConversationPanel.js';
 export type {
   ConversationPanelProps,
   ConversationPanelStyles,
   ConversationHistoryColors,
   ConversationHistoryTypography,
   ConversationHistoryItem,
-  ConversationSource,
   FilterTab,
   FilterLabels,
 } from './models/ConversationPanel.js';

--- a/openspec/changes/archive/2026-06-03-conversation-panel-source-filtering/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-03-conversation-panel-source-filtering/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-03

--- a/openspec/changes/archive/2026-06-03-conversation-panel-source-filtering/design.md
+++ b/openspec/changes/archive/2026-06-03-conversation-panel-source-filtering/design.md
@@ -1,0 +1,70 @@
+## Context
+
+The conversation panel displays conversations in three source-based tabs: **My chats**, **Shared**, and **Organization**. The panel library (`libs/conversation-panel`) already models this via `ConversationSource` enum and the `matchesTab` filter — it is fully implemented and correct.
+
+The gap is in the data pipeline: DIAL Core returns `sharedWithMe` and `publishedWithMe` boolean flags on each listing item, but the NestJS service casts the response to a narrow type that omits these fields, so they never reach the frontend.
+
+**Current flow:**
+```
+DIAL Core → [sharedWithMe/publishedWithMe dropped by type cast] → ConversationListItemDto (id, title, updatedAt) → ConversationPanelView (no source set) → all tabs empty except "All"
+```
+
+**Target flow:**
+```
+DIAL Core → [flags preserved] → ConversationListItemDto (+ sharedWithMe, publishedWithMe) → ConversationPanelView (maps to ConversationSource) → tabs filter correctly
+```
+
+Investigation reference: `docs/conversation-filtering-investigation.md` and `development` branch (`apps/chat/src/utils/app/search.ts`).
+
+## Goals / Non-Goals
+
+**Goals:**
+- Preserve `sharedWithMe` and `publishedWithMe` from the DIAL Core listing response
+- Expose them on the backend DTO and regenerated API client
+- Map them to `ConversationSource` in the frontend adapter
+- Enable "My chats", "Shared", and "Organization" tabs to filter correctly
+
+**Non-Goals:**
+- Changes to `libs/conversation-panel` (model and filter logic are already correct)
+- Pagination of the conversations list (separate concern)
+- Pinning / `isPinned` mapping (separate concern)
+- Any UI design changes to the filter tabs themselves
+
+## Decisions
+
+### Decision: Preserve flags via type cast extension, not SDK type change
+
+The DIAL Core SDK type for `getConversationMetadata` items does not include `sharedWithMe`/`publishedWithMe` in its TypeScript declaration, but DIAL Core does return them at runtime. Rather than patching the SDK, we widen the local type cast in `conversation.service.ts` to include the two optional boolean fields.
+
+**Why**: The SDK is an external dependency managed independently. A local cast extension is the minimal, reversible change and stays within our control. When the SDK type is eventually updated upstream, the cast can be narrowed back.
+
+**Alternative considered**: Add a custom runtime response interceptor to extract arbitrary fields — rejected as over-engineering for two simple flags.
+
+### Decision: Map to ConversationSource in the app adapter, not the backend DTO
+
+`ConversationSource` is a lib-level concept (`libs/conversation-panel`). The backend DTO remains framework-neutral (two raw booleans). The mapping from `{sharedWithMe, publishedWithMe}` → `ConversationSource` lives in `ConversationPanelView.tsx` (the app-level adapter).
+
+**Why**: Libs must not know about app/backend integration details. The backend DTO should be a clean data contract, not coupled to a frontend enum. The adapter layer is the correct place for this translation.
+
+### Decision: Default unmapped items to ConversationSource.MyChats
+
+An item where both flags are `false` (or absent) belongs to the current user — it is a "my chat". This mirrors the logic in the `development` branch: `!sharedWithMe && !publishedWithMe` → my item.
+
+## Risks / Trade-offs
+
+- **[Risk] DIAL Core does not return flags for all environments** → Flags default to `false` (absent = own item), which maps to `MyChats`. Worst case: shared/org conversations appear in "My chats" rather than disappearing. Mitigation: test against the target environment before shipping.
+
+- **[Risk] Client regeneration breaks other consumers** → The new fields are additive (optional booleans). Existing frontend code that destructures only `id`/`title`/`updatedAt` is unaffected. Mitigation: run typecheck and affected tests after regeneration.
+
+- **[Trade-off] sharedWithMe/publishedWithMe naming is specific to one DIAL Core version** → If DIAL Core renames these fields, the type cast and DTO must be updated. Acceptable given we own the backend and can track SDK changelogs.
+
+## Migration Plan
+
+1. Update `conversation.service.ts` (type cast + item mapping)
+2. Update `ConversationListItemDto` (add two `@ApiProperty` boolean fields)
+3. Regenerate `libs/chat-api-client` using existing repo OpenAPI scripts
+4. Update `ConversationPanelView.tsx` to set `source` on each item
+5. Verify filter tabs in browser against DIAL Core test environment
+6. Remove temporary debug `console.log` from `ConversationsContext.tsx` and `conversation.service.ts`
+
+Rollback: revert the four file changes; no database or infrastructure changes involved.

--- a/openspec/changes/archive/2026-06-03-conversation-panel-source-filtering/proposal.md
+++ b/openspec/changes/archive/2026-06-03-conversation-panel-source-filtering/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+The conversation panel has "My chats", "Shared", and "Organization" filter tabs, but all three always show empty because the backend strips `sharedWithMe` and `publishedWithMe` flags that DIAL Core already returns. Users cannot filter conversations by source.
+
+## What Changes
+
+- Extend the DIAL Core response type cast in `conversation.service.ts` to preserve `sharedWithMe` and `publishedWithMe` per-item flags
+- Add `sharedWithMe` and `publishedWithMe` boolean fields to `ConversationListItemDto`
+- Regenerate `libs/chat-api-client` from the updated OpenAPI/Swagger spec
+- Map the two flags to `ConversationSource` in `ConversationPanelView` so that each item is assigned to the correct tab
+
+## Capabilities
+
+### New Capabilities
+
+- `conversation-source-filtering`: Expose per-conversation ownership flags (`sharedWithMe`, `publishedWithMe`) from the backend listing endpoint and wire them through the frontend adapter so that the conversation panel's My chats / Shared / Organization tabs correctly filter the conversation list.
+
+### Modified Capabilities
+
+<!-- None — no existing specs are changing requirements -->
+
+## Impact
+
+- **Backend**: `apps/chat-api/src/conversations/conversation.service.ts` (type cast + mapping), `apps/chat-api/src/conversations/dto/conversation-list.dto.ts` (two new fields)
+- **Generated client**: `libs/chat-api-client` — must be regenerated after DTO change
+- **Frontend adapter**: `apps/chat/src/components/ConversationPanel/ConversationPanelView.tsx`
+- **No lib changes**: `libs/conversation-panel` model and filter logic are already correct; only the app-level adapter is updated
+- **No breaking changes**: new fields are additive; existing consumers that don't read them are unaffected

--- a/openspec/changes/archive/2026-06-03-conversation-panel-source-filtering/specs/conversation-source-filtering/spec.md
+++ b/openspec/changes/archive/2026-06-03-conversation-panel-source-filtering/specs/conversation-source-filtering/spec.md
@@ -1,0 +1,63 @@
+## ADDED Requirements
+
+### Requirement: Backend preserves ownership flags from DIAL Core
+The conversations listing service SHALL extract `sharedWithMe` and `publishedWithMe` boolean fields from the DIAL Core `getConversationMetadata` response and include them in each `ConversationListItemDto` item.
+
+#### Scenario: Own conversation has no flags set
+- **WHEN** DIAL Core returns an item with `sharedWithMe` absent or `false` and `publishedWithMe` absent or `false`
+- **THEN** the API response item SHALL have `sharedWithMe: false` and `publishedWithMe: false`
+
+#### Scenario: Shared conversation carries sharedWithMe flag
+- **WHEN** DIAL Core returns an item with `sharedWithMe: true`
+- **THEN** the API response item SHALL have `sharedWithMe: true`
+
+#### Scenario: Published conversation carries publishedWithMe flag
+- **WHEN** DIAL Core returns an item with `publishedWithMe: true`
+- **THEN** the API response item SHALL have `publishedWithMe: true`
+
+---
+
+### Requirement: ConversationListItemDto exposes ownership fields
+The `ConversationListItemDto` SHALL include `sharedWithMe: boolean` and `publishedWithMe: boolean` fields, both documented in the OpenAPI/Swagger spec.
+
+#### Scenario: DTO fields appear in Swagger
+- **WHEN** the Swagger docs endpoint is requested
+- **THEN** the `ConversationListItemDto` schema SHALL list `sharedWithMe` and `publishedWithMe` as boolean fields
+
+---
+
+### Requirement: Frontend adapter maps ownership flags to ConversationSource
+`ConversationPanelView` SHALL derive a `ConversationSource` value from each item's `sharedWithMe` and `publishedWithMe` fields and pass it as the `source` property on `ConversationHistoryItem`.
+
+#### Scenario: Own item maps to MyChats
+- **WHEN** an item has `sharedWithMe: false` and `publishedWithMe: false`
+- **THEN** its `source` SHALL be `ConversationSource.MyChats`
+
+#### Scenario: Shared item maps to Shared
+- **WHEN** an item has `sharedWithMe: true`
+- **THEN** its `source` SHALL be `ConversationSource.Shared`
+
+#### Scenario: Published item maps to Organization
+- **WHEN** an item has `publishedWithMe: true`
+- **THEN** its `source` SHALL be `ConversationSource.Organization`
+
+---
+
+### Requirement: Conversation panel tabs filter by source
+The conversation panel SHALL display only items whose `source` matches the active filter tab.
+
+#### Scenario: All tab shows every conversation
+- **WHEN** the active tab is "All"
+- **THEN** all conversations SHALL be visible regardless of source
+
+#### Scenario: My chats tab shows only own conversations
+- **WHEN** the active tab is "My chats"
+- **THEN** only items with `source === ConversationSource.MyChats` SHALL be visible
+
+#### Scenario: Shared tab shows only shared conversations
+- **WHEN** the active tab is "Shared"
+- **THEN** only items with `source === ConversationSource.Shared` SHALL be visible
+
+#### Scenario: Organization tab shows only published conversations
+- **WHEN** the active tab is "Organization"
+- **THEN** only items with `source === ConversationSource.Organization` SHALL be visible

--- a/openspec/changes/archive/2026-06-03-conversation-panel-source-filtering/tasks.md
+++ b/openspec/changes/archive/2026-06-03-conversation-panel-source-filtering/tasks.md
@@ -1,0 +1,29 @@
+## 1. Backend — Preserve DIAL Core flags
+
+- [x] 1.1 In `apps/chat-api/src/conversations/conversation.service.ts`, extend the `getConversationMetadata` response type cast to include `sharedWithMe?: boolean` and `publishedWithMe?: boolean` on each item
+- [x] 1.2 In the same service, map the two flags in the `.map()` transform: `sharedWithMe: item.sharedWithMe ?? false` and `publishedWithMe: item.publishedWithMe ?? false`
+- [x] 1.3 Remove the temporary debug `this.logger.log('DIAL Core listConversations raw items: ...')` added during investigation
+
+## 2. Backend — DTO and Swagger
+
+- [x] 2.1 In `apps/chat-api/src/conversations/dto/conversation-list.dto.ts`, add `sharedWithMe: boolean` and `publishedWithMe: boolean` fields with `@ApiProperty` decorators
+- [x] 2.2 Run `npm exec nx lint chat-api` and `npm exec nx build chat-api` to verify no type errors
+
+## 3. Generated API Client
+
+- [x] 3.1 Regenerate `libs/chat-api-client` using the repo OpenAPI script so the generated `ConversationListItemDto` includes the two new fields
+- [x] 3.2 Verify the generated model in `libs/chat-api-client/src/generated/src/models/index.ts` contains `sharedWithMe` and `publishedWithMe`
+
+## 4. Frontend Adapter
+
+- [x] 4.1 In `apps/chat/src/components/ConversationPanel/ConversationPanelView.tsx`, import `ConversationSource` from `@epam/ai-dial-conversation-panel`
+- [x] 4.2 Add a `getSource` helper that maps `{sharedWithMe, publishedWithMe}` → `ConversationSource` (Shared / Organization / MyChats)
+- [x] 4.3 Pass `source: getSource(item)` in the `conversations` useMemo mapping alongside `id` and `title`
+- [x] 4.4 Remove the temporary debug `console.log('[ConversationsContext] raw response:...')` from `apps/chat/src/context/ConversationsContext.tsx`
+
+## 5. Verification
+
+- [x] 5.1 Run `npm exec nx typecheck chat` and `npm exec nx lint chat` — no errors
+- [x] 5.2 Start the app (`npm run start:all`) and open the conversation panel
+- [x] 5.3 Verify "My chats" tab shows own conversations, "Shared" shows shared-with-me, "Organization" shows published — or confirm tabs show empty when no such conversations exist in the test environment
+- [x] 5.4 Verify the "All" tab still shows all conversations

--- a/openspec/specs/conversation-source-filtering/spec.md
+++ b/openspec/specs/conversation-source-filtering/spec.md
@@ -1,0 +1,67 @@
+# conversation-source-filtering Specification
+
+## Purpose
+TBD - created by archiving change conversation-panel-source-filtering. Update Purpose after archive.
+## Requirements
+### Requirement: Backend preserves ownership flags from DIAL Core
+The conversations listing service SHALL extract `sharedWithMe` and `publishedWithMe` boolean fields from the DIAL Core `getConversationMetadata` response and include them in each `ConversationListItemDto` item.
+
+#### Scenario: Own conversation has no flags set
+- **WHEN** DIAL Core returns an item with `sharedWithMe` absent or `false` and `publishedWithMe` absent or `false`
+- **THEN** the API response item SHALL have `sharedWithMe: false` and `publishedWithMe: false`
+
+#### Scenario: Shared conversation carries sharedWithMe flag
+- **WHEN** DIAL Core returns an item with `sharedWithMe: true`
+- **THEN** the API response item SHALL have `sharedWithMe: true`
+
+#### Scenario: Published conversation carries publishedWithMe flag
+- **WHEN** DIAL Core returns an item with `publishedWithMe: true`
+- **THEN** the API response item SHALL have `publishedWithMe: true`
+
+---
+
+### Requirement: ConversationListItemDto exposes ownership fields
+The `ConversationListItemDto` SHALL include `sharedWithMe: boolean` and `publishedWithMe: boolean` fields, both documented in the OpenAPI/Swagger spec.
+
+#### Scenario: DTO fields appear in Swagger
+- **WHEN** the Swagger docs endpoint is requested
+- **THEN** the `ConversationListItemDto` schema SHALL list `sharedWithMe` and `publishedWithMe` as boolean fields
+
+---
+
+### Requirement: Frontend adapter maps ownership flags to ConversationSource
+`ConversationPanelView` SHALL derive a `ConversationSource` value from each item's `sharedWithMe` and `publishedWithMe` fields and pass it as the `source` property on `ConversationHistoryItem`.
+
+#### Scenario: Own item maps to MyChats
+- **WHEN** an item has `sharedWithMe: false` and `publishedWithMe: false`
+- **THEN** its `source` SHALL be `ConversationSource.MyChats`
+
+#### Scenario: Shared item maps to Shared
+- **WHEN** an item has `sharedWithMe: true`
+- **THEN** its `source` SHALL be `ConversationSource.Shared`
+
+#### Scenario: Published item maps to Organization
+- **WHEN** an item has `publishedWithMe: true`
+- **THEN** its `source` SHALL be `ConversationSource.Organization`
+
+---
+
+### Requirement: Conversation panel tabs filter by source
+The conversation panel SHALL display only items whose `source` matches the active filter tab.
+
+#### Scenario: All tab shows every conversation
+- **WHEN** the active tab is "All"
+- **THEN** all conversations SHALL be visible regardless of source
+
+#### Scenario: My chats tab shows only own conversations
+- **WHEN** the active tab is "My chats"
+- **THEN** only items with `source === ConversationSource.MyChats` SHALL be visible
+
+#### Scenario: Shared tab shows only shared conversations
+- **WHEN** the active tab is "Shared"
+- **THEN** only items with `source === ConversationSource.Shared` SHALL be visible
+
+#### Scenario: Organization tab shows only published conversations
+- **WHEN** the active tab is "Organization"
+- **THEN** only items with `source === ConversationSource.Organization` SHALL be visible
+


### PR DESCRIPTION

## Description of changes
feat: make My Chats filter work on Conversation Panel

My Chats - it's those where sharedWithMe and publishedWithMe boolean flags are false. 

Logic to get listing for Shared and Organization will be done in future commits

## Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #<ISSUE_ID>

## UI changes

<Please, provide Screenshots or Figma links>

## Checklist

- [ ] the pull request name ends with `(Issue #<ISSUE_ID>)` (comma-separated list of issues)
- [X] I confirm that I don't share any confidential information like API keys or any other secrets and private URLs

<details>
  <summary>PR title cheatsheet</summary>

`<type>[optional scope]: <description>`

1. type (required)
    - `feat` - A new feature
    - `fix` - A bug fix
    - `docs` - Documentation only changes
    - `test` - Adding missing tests or correcting existing tests
    - `ci` - Changes to our CI configuration files and scripts
    - `chore` - Other changes that are minor and/or not user-facing
2. scope (optional, current repo suggestions below)
    - `chat`
    - `overlay`
    - `shared`
    - `sandbox-overlay`
    - `visualizer-connector`

</details>
