### PR TITLE
fix(chat): fix creating applications with not nullable properties (Issue #7002)

### DIFF
--- a/apps/chat/src/components/AppsEditor/form.ts
+++ b/apps/chat/src/components/AppsEditor/form.ts
@@ -54,6 +54,7 @@ import {
 import { Translation } from '@/src/types/translation';
 
 import {
+  ApplicationPropertiesLocalFields,
   CODEAPPS_REQUIRED_FILES,
   FEATURES_ENDPOINTS,
   FEATURES_ENDPOINTS_DEFAULT_VALUES,
@@ -952,12 +953,10 @@ export const getApplicationPayload = ({
     case AppsEditorSchemaTypes.ExternalApp:
       return {
         ...generalData,
-        applicationProperties:
-          data.externalUrl === MANDATORY_FIELD_PLACEHOLDER || !data.externalUrl
-            ? undefined
-            : {
-                external_url: data.externalUrl,
-              },
+        applicationProperties: {
+          external_url: data.externalUrl ?? MANDATORY_FIELD_PLACEHOLDER,
+          [ApplicationPropertiesLocalFields.isExternalApp]: true,
+        },
       };
     case AppsEditorSchemaTypes.QuickApp:
       return {
@@ -1047,9 +1046,10 @@ export const getApplicationPayload = ({
     case AppsEditorSchemaTypes.SchemaDriven:
       return {
         ...generalData,
-        applicationProperties: omit(data.properties, [
-          MANDATORY_FIELD_PLACEHOLDER,
-        ]),
+        applicationProperties: {
+          ...omit(data.properties, [MANDATORY_FIELD_PLACEHOLDER]),
+          [ApplicationPropertiesLocalFields.isSchemaDrivenApp]: true,
+        },
       };
     case AppsEditorSchemaTypes.CustomApp:
     default:

--- a/apps/chat/src/constants/applications.ts
+++ b/apps/chat/src/constants/applications.ts
@@ -60,3 +60,8 @@ export const PUBLIC_APP_TOOLTIP = translate(
     ns: Translation.Common,
   },
 );
+
+export enum ApplicationPropertiesLocalFields {
+  isExternalApp = 'isExternalApp',
+  isSchemaDrivenApp = 'isSchemaDrivenApp',
+}

--- a/apps/chat/src/utils/app/application.ts
+++ b/apps/chat/src/utils/app/application.ts
@@ -35,6 +35,7 @@ import {
 import { ToolsetModel } from '@/src/types/toolsets';
 import { Translation } from '@/src/types/translation';
 
+import { ApplicationPropertiesLocalFields } from '@/src/constants/applications';
 import { DESCRIPTION_DELIMITER_REGEX } from '@/src/constants/chat';
 import {
   DEFAULT_APPLICATION_NAME,
@@ -49,7 +50,10 @@ import {
   DEFAULT_QUICK_APPS_SCHEMA_ID,
 } from '@/src/constants/quick-apps';
 
-import { AppsEditorSchemaTypes } from '@/src/components/AppsEditor/form';
+import {
+  AppsEditorSchemaTypes,
+  MANDATORY_FIELD_PLACEHOLDER,
+} from '@/src/components/AppsEditor/form';
 
 import {
   EntityStorageLimits,
@@ -197,6 +201,7 @@ export const mapApplicationPropertiesToApi = (
     | QuickAppConfig['document_relative_url'];
   const propertiesQA = properties as QuickAppConfig;
   const propertiesQA2 = properties as QuickApp2Config;
+  const unknownProperties = properties as Record<string, unknown>;
   const result = {
     ...properties,
   };
@@ -207,7 +212,10 @@ export const mapApplicationPropertiesToApi = (
       url: ApiUtils.encodeApiUrl(context.url),
     }));
     (result as QuickApp2Config).contexts = documentsRelativeUrls;
-  } else {
+  } else if (
+    !unknownProperties[ApplicationPropertiesLocalFields.isSchemaDrivenApp] &&
+    !unknownProperties[ApplicationPropertiesLocalFields.isExternalApp]
+  ) {
     if (!propertiesQA.document_relative_url) {
       (result as QuickAppConfig).document_relative_url = [];
     } else {
@@ -218,7 +226,7 @@ export const mapApplicationPropertiesToApi = (
     }
   }
 
-  return result;
+  return omit(result, Object.keys(ApplicationPropertiesLocalFields));
 };
 
 export const convertApplicationToApi = (
@@ -236,16 +244,21 @@ export const convertApplicationToApi = (
     reference: applicationData.reference || undefined,
     description_keywords: applicationData.topics,
   };
-
+  const unknownProperties = applicationData.applicationProperties as
+    | Record<string, unknown>
+    | undefined;
   if (schema) {
     return {
       ...commonData,
       application_properties:
-        (applicationData.applicationProperties &&
-          mapApplicationPropertiesToApi(
-            applicationData.applicationProperties,
-          )) ||
-        null,
+        unknownProperties?.[ApplicationPropertiesLocalFields.isExternalApp] &&
+        unknownProperties?.external_url === MANDATORY_FIELD_PLACEHOLDER
+          ? null
+          : (applicationData.applicationProperties &&
+              mapApplicationPropertiesToApi(
+                applicationData.applicationProperties,
+              )) ||
+            {},
       application_type_schema_id:
         applicationData.applicationTypeSchemaId ?? schema['$id'],
     };


### PR DESCRIPTION
## Description of changes

- add ***ApplicationPropertiesLocalFields*** enum to track app type across app mappers
- send empty ***{}*** when there is no properties by default

## Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #7002

## Checklist

- [x] the pull request name ends with `(Issue #<ISSUE_ID>)` (comma-separated list of issues)
- [x] I confirm that I don't share any confidential information like API keys or any other secrets and private URLs