### PR TITLE
fix(chat): improve voice-to-text limit error handling (Issue #6868)

### DIFF
--- a/apps/chat/public/locales/en/chat.json
+++ b/apps/chat/public/locales/en/chat.json
@@ -341,6 +341,7 @@
   "No compatible audio format available for this model.": "No compatible audio format available for this model.",
   "Transcribing audio...": "Transcribing audio...",
   "Audio transcription failed. Please try again.": "Audio transcription failed. Please try again.",
+  "Recording is too long. Please record a shorter message.": "Recording is too long. Please record a shorter message.",
   "This name will be displayed instead of the author's name for this publication.": "This name will be displayed instead of the author's name for this publication.",
   "Type publication request name...": "Type publication request name...",
   "Type unpublish request name...": "Type unpublish request name...",

--- a/apps/chat/src/constants/audio.ts
+++ b/apps/chat/src/constants/audio.ts
@@ -10,8 +10,6 @@ export enum AudioMimeType {
   WMA = 'audio/wma',
 }
 
-export const TRANSCRIBE_SIZE_LIMIT_MEGABYTES = 5;
-// Maximum size for audio transcription requests (in bytes)
-// Must match the sizeLimit in transcribe.ts API route config
-export const TRANSCRIBE_SIZE_LIMIT_BYTES =
-  TRANSCRIBE_SIZE_LIMIT_MEGABYTES * 1024 * 1024;
+// Maximum size for audio transcription requests in bytes (5 MB).
+// Must match the sizeLimit in transcribe.ts API route config.
+export const TRANSCRIBE_SIZE_LIMIT_BYTES = 5 * 1024 * 1024;

--- a/apps/chat/src/constants/audio.ts
+++ b/apps/chat/src/constants/audio.ts
@@ -9,3 +9,9 @@ export enum AudioMimeType {
   FLAC = 'audio/flac',
   WMA = 'audio/wma',
 }
+
+export const TRANSCRIBE_SIZE_LIMIT_MEGABYTES = 5;
+// Maximum size for audio transcription requests (in bytes)
+// Must match the sizeLimit in transcribe.ts API route config
+export const TRANSCRIBE_SIZE_LIMIT_BYTES =
+  TRANSCRIBE_SIZE_LIMIT_MEGABYTES * 1024 * 1024;

--- a/apps/chat/src/constants/errors.ts
+++ b/apps/chat/src/constants/errors.ts
@@ -91,5 +91,4 @@ export const errorsMessages = {
   toolsetDeleteFailed: 'Failed to delete toolset',
   toolsetSignInFailed: 'Failed to sign in toolset',
   toolsetSignOutFailed: 'Failed to sign out toolset',
-  transcriptionFailed: 'Audio transcription failed. Please try again.',
 };

--- a/apps/chat/src/constants/i18n.ts
+++ b/apps/chat/src/constants/i18n.ts
@@ -870,6 +870,7 @@ export enum ChatI18nKeys {
   AudioFormatNotSupported = 'No compatible audio format available for this model.',
   TranscribingAudio = 'Transcribing audio...',
   TranscriptionFailed = 'Audio transcription failed. Please try again.',
+  TranscriptionFailedTooLarge = 'Recording is too long. Please record a shorter message.',
   AuthorPublicNameTooltip = "This name will be displayed instead of the author's name for this publication.",
   TypePublicationRequestName = 'Type publication request name...',
   TypeUnpublishRequestName = 'Type unpublish request name...',

--- a/apps/chat/src/pages/api/transcribe.ts
+++ b/apps/chat/src/pages/api/transcribe.ts
@@ -10,7 +10,7 @@ import { getFullToken } from '@/src/utils/server/server';
 
 import { HTTPMethod } from '@/src/types/http';
 
-import { TRANSCRIBE_SIZE_LIMIT_MEGABYTES } from '@/src/constants/audio';
+import { TRANSCRIBE_SIZE_LIMIT_BYTES } from '@/src/constants/audio';
 import {
   DIAL_API_HOST,
   DIAL_API_VERSION,
@@ -106,11 +106,10 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
   }
 };
 
-// Must match TRANSCRIBE_SIZE_LIMIT_BYTES in src/constants/audio.ts
 export const config = {
   api: {
     bodyParser: {
-      sizeLimit: `${TRANSCRIBE_SIZE_LIMIT_MEGABYTES}mb`,
+      sizeLimit: TRANSCRIBE_SIZE_LIMIT_BYTES,
     },
   },
 };

--- a/apps/chat/src/pages/api/transcribe.ts
+++ b/apps/chat/src/pages/api/transcribe.ts
@@ -10,6 +10,7 @@ import { getFullToken } from '@/src/utils/server/server';
 
 import { HTTPMethod } from '@/src/types/http';
 
+import { TRANSCRIBE_SIZE_LIMIT_MEGABYTES } from '@/src/constants/audio';
 import {
   DIAL_API_HOST,
   DIAL_API_VERSION,
@@ -105,10 +106,11 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
   }
 };
 
+// Must match TRANSCRIBE_SIZE_LIMIT_BYTES in src/constants/audio.ts
 export const config = {
   api: {
     bodyParser: {
-      sizeLimit: '5mb',
+      sizeLimit: `${TRANSCRIBE_SIZE_LIMIT_MEGABYTES}mb`,
     },
   },
 };

--- a/apps/chat/src/pages/api/transcribe.ts
+++ b/apps/chat/src/pages/api/transcribe.ts
@@ -10,7 +10,6 @@ import { getFullToken } from '@/src/utils/server/server';
 
 import { HTTPMethod } from '@/src/types/http';
 
-import { TRANSCRIBE_SIZE_LIMIT_BYTES } from '@/src/constants/audio';
 import {
   DIAL_API_HOST,
   DIAL_API_VERSION,
@@ -106,10 +105,13 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
   }
 };
 
+// sizeLimit must be a static literal — Next.js does not resolve imported
+// identifiers in `config`. Keep in sync with TRANSCRIBE_SIZE_LIMIT_BYTES
+// in src/constants/audio.ts (currently 5 MB = 5 * 1024 * 1024).
 export const config = {
   api: {
     bodyParser: {
-      sizeLimit: TRANSCRIBE_SIZE_LIMIT_BYTES,
+      sizeLimit: '5mb',
     },
   },
 };

--- a/apps/chat/src/store/chat/chat.epics.ts
+++ b/apps/chat/src/store/chat/chat.epics.ts
@@ -44,7 +44,6 @@ import {
   ModelsSelectors,
 } from '@/src/store/selectors';
 
-import { errorsMessages } from '@/src/constants/errors';
 import { ChatI18nKeys } from '@/src/constants/i18n';
 
 import { Message, Role } from '@epam/ai-dial-shared';
@@ -308,12 +307,16 @@ const handleUserMessageVoiceRecordingEpic: AppEpic = (action$, state$) =>
               return from(
                 requestAudioTranscription(base64Data, audioBlob.type),
               ).pipe(
-                switchMap((transcript) =>
+                switchMap(({ transcript, isTooLarge }) =>
                   transcript?.trim()
                     ? of(
                         ChatActions.setUserMessageTranscript(transcript.trim()),
                       )
-                    : of(ChatActions.userMessageTranscriptionFailed()),
+                    : of(
+                        ChatActions.userMessageTranscriptionFailed({
+                          isTooLarge,
+                        }),
+                      ),
                 ),
                 catchError(() =>
                   of(ChatActions.userMessageTranscriptionFailed()),
@@ -349,9 +352,9 @@ const startTranscriptionEpic: AppEpic = (action$) =>
       const { audioData, mimeType } = payload;
 
       return from(requestAudioTranscription(audioData, mimeType)).pipe(
-        switchMap((transcript) => {
+        switchMap(({ transcript, isTooLarge }) => {
           if (!transcript) {
-            return of(ChatActions.transcriptionFailed());
+            return of(ChatActions.transcriptionFailed({ isTooLarge }));
           }
 
           return of(
@@ -375,7 +378,7 @@ const transcriptionSuccessEpic: AppEpic = (action$, state$) =>
           of(ChatActions.clearAsrInsertionContext()),
           of(
             UIActions.showErrorToast({
-              message: translate(errorsMessages.transcriptionFailed),
+              message: translate(ChatI18nKeys.TranscriptionFailed),
             }),
           ),
         );
@@ -423,9 +426,13 @@ const transcriptionSuccessEpic: AppEpic = (action$, state$) =>
 const transcriptionFailedEpic: AppEpic = (action$) =>
   action$.pipe(
     ofType(ChatActions.transcriptionFailed.type),
-    map(() =>
+    map(({ payload }) =>
       UIActions.showErrorToast({
-        message: translate(errorsMessages.transcriptionFailed),
+        message: translate(
+          payload?.isTooLarge
+            ? ChatI18nKeys.TranscriptionFailedTooLarge
+            : ChatI18nKeys.TranscriptionFailed,
+        ),
       }),
     ),
   );
@@ -433,9 +440,13 @@ const transcriptionFailedEpic: AppEpic = (action$) =>
 const userMessageTranscriptionFailedEpic: AppEpic = (action$) =>
   action$.pipe(
     ofType(ChatActions.userMessageTranscriptionFailed.type),
-    map(() =>
+    map(({ payload }) =>
       UIActions.showErrorToast({
-        message: translate(errorsMessages.transcriptionFailed),
+        message: translate(
+          payload?.isTooLarge
+            ? ChatI18nKeys.TranscriptionFailedTooLarge
+            : ChatI18nKeys.TranscriptionFailed,
+        ),
       }),
     ),
   );

--- a/apps/chat/src/store/chat/chat.reducer.ts
+++ b/apps/chat/src/store/chat/chat.reducer.ts
@@ -208,7 +208,10 @@ export const chatSlice = createSlice({
     clearUserMessageVoiceAttachmentId: (state) => {
       state.userMessageVoiceAttachmentId = undefined;
     },
-    userMessageTranscriptionFailed: (state) => {
+    userMessageTranscriptionFailed: (
+      state,
+      _action: PayloadAction<{ isTooLarge?: boolean } | undefined>,
+    ) => {
       state.isUserMessageTranscribing = false;
     },
     startTranscription: (
@@ -224,7 +227,10 @@ export const chatSlice = createSlice({
     ) => {
       state.isTranscribing = false;
     },
-    transcriptionFailed: (state) => {
+    transcriptionFailed: (
+      state,
+      _action: PayloadAction<{ isTooLarge?: boolean } | undefined>,
+    ) => {
       state.isTranscribing = false;
       state.isAsrFlowActive = false;
       state.asrInsertionContext = undefined;

--- a/apps/chat/src/utils/app/epics-helpers/chat.epic-helpers.ts
+++ b/apps/chat/src/utils/app/epics-helpers/chat.epic-helpers.ts
@@ -7,13 +7,13 @@ import { getFileRootId } from '@/src/utils/app/id';
 import { Conversation } from '@/src/types/chat';
 import { HTTPMethod } from '@/src/types/http';
 
-import { TRANSCRIBE_SIZE_LIMIT_BYTES } from '@/src/constants/audio';
-
 import {
   ChatActions,
   ConversationsActions,
   FilesActions,
 } from '@/src/store/actions';
+
+import { TRANSCRIBE_SIZE_LIMIT_BYTES } from '@/src/constants/audio';
 
 import { Message } from '@epam/ai-dial-shared';
 

--- a/apps/chat/src/utils/app/epics-helpers/chat.epic-helpers.ts
+++ b/apps/chat/src/utils/app/epics-helpers/chat.epic-helpers.ts
@@ -7,6 +7,8 @@ import { getFileRootId } from '@/src/utils/app/id';
 import { Conversation } from '@/src/types/chat';
 import { HTTPMethod } from '@/src/types/http';
 
+import { TRANSCRIBE_SIZE_LIMIT_BYTES } from '@/src/constants/audio';
+
 import {
   ChatActions,
   ConversationsActions,
@@ -67,20 +69,42 @@ export const createVoiceQuickAttachment = (
   return { file, fileId, relativePath, fileName };
 };
 
+export interface TranscriptionResult {
+  transcript: string | null;
+  isTooLarge?: boolean;
+}
+
 export const requestAudioTranscription = async (
   audioData: string,
   mimeType: string,
-): Promise<string | null> => {
+): Promise<TranscriptionResult> => {
+  const body = JSON.stringify({ audioData, mimeType });
+
+  // Check actual UTF-8 byte size of the request body (what gets sent over HTTP)
+  // In browser: new Blob([body]).size; In Node: Buffer.byteLength(body, 'utf8')
+  const bodyByteLength =
+    typeof Buffer !== 'undefined'
+      ? Buffer.byteLength(body, 'utf8')
+      : new Blob([body]).size;
+
+  if (bodyByteLength > TRANSCRIBE_SIZE_LIMIT_BYTES) {
+    return { transcript: null, isTooLarge: true };
+  }
+
   const response = await fetch('/api/transcribe', {
     method: HTTPMethod.POST,
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ audioData, mimeType }),
+    body,
   });
 
+  if (response.status === 413) {
+    return { transcript: null, isTooLarge: true };
+  }
+
   if (!response.ok) {
-    return null;
+    return { transcript: null };
   }
 
   const data = (await response.json()) as { transcript?: string };
-  return data.transcript ?? null;
+  return { transcript: data.transcript ?? null };
 };


### PR DESCRIPTION
## Description of changes

Replaces the generic "Audio transcription failed. Please try again." toast with a specific "Recording is too long. Please record a shorter message." when the recorded audio exceeds the server's size limit.

Key changes:
- Add `TranscriptionFailedTooLarge` i18n key and `en` locale entry
- Add `TRANSCRIBE_SIZE_LIMIT_MEGABYTES` / `TRANSCRIBE_SIZE_LIMIT_BYTES` to `audio.ts` as a single source of truth shared by the API route config and the client-side pre-flight guard
- Guard `requestAudioTranscription` with a pre-flight byte-length check (`Blob.size` / `Buffer.byteLength` for correct UTF-8 sizing) to avoid silent `ERR_CONNECTION_RESET` failures on very large recordings
- Keep the 413 HTTP response fallback for server-enforced limits
- Pass `isTooLarge` flag through `transcriptionFailed` / `userMessageTranscriptionFailed` actions so epics pick the right toast
- Switch epics from `errorsMessages` string literals to typed `ChatI18nKeys` enum values; remove now-unused `transcriptionFailed` entry from `errorsMessages`

## Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #6868

## UI changes

N/A

## Checklist

- [x] the pull request name ends with `(Issue #6868)`
- [x] I confirm that I don't share any confidential information like API keys or any other secrets and private URLs

<details>
  <summary>PR title cheatsheet</summary>

`<type>[optional scope]: <description>`

1. type (required)
    - `feat` - A new feature
    - `fix` - A bug fix
    - `docs` - Documentation only changes
    - `test` - Adding missing tests or correcting existing tests
    - `ci` - Changes to our CI configuration files and scripts
    - `chore` - Other changes that are minor and/or not user-facing
2. scope (optional, current repo suggestions below)
    - `chat`
    - `overlay`
    - `shared`
    - `sandbox-overlay`
    - `visualizer-connector`

</details>