### PR TITLE
feat: Add 'thinking' label and shimmer animation for streaming messages

### DIFF
--- a/apps/chat-api/src/conversations/dto/max-utf8-byte-length.validator.ts
+++ b/apps/chat-api/src/conversations/dto/max-utf8-byte-length.validator.ts
@@ -1,4 +1,8 @@
-import { registerDecorator, type ValidationArguments, type ValidationOptions } from 'class-validator';
+import {
+  registerDecorator,
+  type ValidationArguments,
+  type ValidationOptions,
+} from 'class-validator';
 import { StringUtils } from '../../common/utils/string-utils';
 
 export const MaxUtf8ByteLength = (

--- a/apps/chat-api/src/conversations/dto/max-utf8-byte-length.validator.ts
+++ b/apps/chat-api/src/conversations/dto/max-utf8-byte-length.validator.ts
@@ -1,5 +1,5 @@
-import { registerDecorator, type ValidationOptions } from 'class-validator';
-import { StringUtils } from '../../common/utils/string-utils.js';
+import { registerDecorator, type ValidationArguments, type ValidationOptions } from 'class-validator';
+import { StringUtils } from '../../common/utils/string-utils';
 
 export const MaxUtf8ByteLength = (
   max: number,
@@ -19,7 +19,7 @@ export const MaxUtf8ByteLength = (
             StringUtils.getUtf8ByteLength(value) <= max
           );
         },
-        defaultMessage({ constraints, property }) {
+        defaultMessage({ constraints, property }: ValidationArguments) {
           return `${property} must be at most ${constraints[0]} bytes in UTF-8 encoding`;
         },
       },

--- a/apps/chat-api/src/conversations/dto/rename-conversation.dto.ts
+++ b/apps/chat-api/src/conversations/dto/rename-conversation.dto.ts
@@ -1,6 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsString, MinLength } from 'class-validator';
-import { MaxUtf8ByteLength } from './max-utf8-byte-length.validator.js';
+import { MaxUtf8ByteLength } from './max-utf8-byte-length.validator';
 
 export class RenameConversationBodyDto {
   @ApiProperty({

--- a/apps/chat-api/src/conversations/prepare-entity-name.ts
+++ b/apps/chat-api/src/conversations/prepare-entity-name.ts
@@ -1,4 +1,4 @@
-import { StringUtils } from '../common/utils/string-utils.js';
+import { StringUtils } from '../common/utils/string-utils';
 
 const notAllowedSymbolsRegex = /[:;,=/{}%&"]/g;
 const MAX_ENTITY_BYTES = 255;

--- a/apps/chat/src/components/ConversationView/ConversationMessageItem.tsx
+++ b/apps/chat/src/components/ConversationView/ConversationMessageItem.tsx
@@ -68,6 +68,7 @@ interface Props {
   statusModelChangedTitle: string;
   formatStatusModelChangedBody: (from: string, to: string) => string;
   streamErrorText: string;
+  thinkingLabel: string;
 }
 
 const ConversationMessageItem: FC<Props> = ({
@@ -95,6 +96,7 @@ const ConversationMessageItem: FC<Props> = ({
   statusModelChangedTitle,
   formatStatusModelChangedBody,
   streamErrorText,
+  thinkingLabel,
 }) => {
   const isStreaming = isStreamingMessage(
     msg.role,
@@ -213,6 +215,7 @@ const ConversationMessageItem: FC<Props> = ({
       startersAriaLabel={quickReplyButtonsAriaLabel}
       deploymentIconUrl={deploymentEntry?.iconUrl}
       deploymentDisplayName={deploymentEntry?.displayName}
+      thinkingLabel={thinkingLabel}
       {...statusProps}
     />
   );

--- a/apps/chat/src/components/ConversationView/ConversationView.tsx
+++ b/apps/chat/src/components/ConversationView/ConversationView.tsx
@@ -331,6 +331,7 @@ const ConversationView: FC<Props> = ({
                   )}
                   formatStatusModelChangedBody={formatStatusModelChangedBody}
                   streamErrorText={streamErrorText}
+                  thinkingLabel={t(ChatI18nKeys.Thinking)}
                 />
               );
             })}

--- a/apps/chat/src/constants/translation-keys.ts
+++ b/apps/chat/src/constants/translation-keys.ts
@@ -15,6 +15,7 @@ export enum ChatI18nKeys {
   StopStreaming = 'chat.stopStreaming',
   QuickReplyButtons = 'chat.quickReplyButtons',
   StoppedGenerating = 'chat.stoppedGenerating',
+  Thinking = 'chat.thinking',
 }
 
 export enum ActionsI18nKeys {

--- a/apps/chat/src/i18n/locales/en.json
+++ b/apps/chat/src/i18n/locales/en.json
@@ -15,7 +15,8 @@
     "sendMessage": "Send message",
     "stopStreaming": "Stop streaming",
     "quickReplyButtons": "Quick reply buttons",
-    "stoppedGenerating": "You stopped generating the response"
+    "stoppedGenerating": "You stopped generating the response",
+    "thinking": "Thinking"
   },
   "navigation": {
     "ariaLabel": "Main navigation",

--- a/libs/conversation-messages/src/components/Markdown/MDMessageViewer.tsx
+++ b/libs/conversation-messages/src/components/Markdown/MDMessageViewer.tsx
@@ -7,30 +7,38 @@ interface Props {
   content: string;
   /** Enables gradual reveal for appended streaming content. */
   isStreaming?: boolean;
+  /**
+   * Label shown while `isStreaming` is true and no content has arrived yet.
+   * Forwarded to {@link MarkdownRenderer}. Defaults to `'Thinking'`.
+   */
+  thinkingLabel?: string;
 }
 
 /** Renders assistant message content as formatted markdown. */
-export const MDMessageViewer: FC<Props> = memo(({ content, isStreaming }) => (
-  <MarkdownRenderer
-    content={content}
-    isStreaming={isStreaming}
-    classNames={{
-      h1: 'dial-h1-text mb-2',
-      h2: 'dial-h2-text mb-2',
-      h3: 'dial-h3-text mb-1',
-      p: 'mb-2 break-words [overflow-wrap:anywhere] last:mb-0',
-      ul: 'mb-2',
-      ol: 'mb-2',
-      codeBlock:
-        'bg-black/20 my-2 max-w-full whitespace-pre-wrap break-words [overflow-wrap:anywhere]',
-      codeFont:
-        'font-mono whitespace-pre-wrap break-words [overflow-wrap:anywhere]',
-      codeInline: 'bg-black/20 break-words [overflow-wrap:anywhere]',
-      blockquote: 'border-current/30 my-2',
-      link: 'break-words [overflow-wrap:anywhere]',
-      tableWrapper: 'my-2',
-      tableCell: 'border-white/20',
-      tableHeader: 'bg-white/10',
-    }}
-  />
-));
+export const MDMessageViewer: FC<Props> = memo(
+  ({ content, isStreaming, thinkingLabel }) => (
+    <MarkdownRenderer
+      content={content}
+      isStreaming={isStreaming}
+      thinkingLabel={thinkingLabel}
+      classNames={{
+        h1: 'dial-h1-text mb-2',
+        h2: 'dial-h2-text mb-2',
+        h3: 'dial-h3-text mb-1',
+        p: 'mb-2 break-words [overflow-wrap:anywhere] last:mb-0',
+        ul: 'mb-2',
+        ol: 'mb-2',
+        codeBlock:
+          'bg-black/20 my-2 max-w-full whitespace-pre-wrap break-words [overflow-wrap:anywhere]',
+        codeFont:
+          'font-mono whitespace-pre-wrap break-words [overflow-wrap:anywhere]',
+        codeInline: 'bg-black/20 break-words [overflow-wrap:anywhere]',
+        blockquote: 'border-current/30 my-2',
+        link: 'break-words [overflow-wrap:anywhere]',
+        tableWrapper: 'my-2',
+        tableCell: 'border-white/20',
+        tableHeader: 'bg-white/10',
+      }}
+    />
+  ),
+);

--- a/libs/conversation-messages/src/components/Markdown/MarkdownRenderer.module.scss
+++ b/libs/conversation-messages/src/components/Markdown/MarkdownRenderer.module.scss
@@ -1,0 +1,28 @@
+@keyframes cm-shimmer {
+  0% {
+    background-position: 200% center;
+  }
+  100% {
+    background-position: -200% center;
+  }
+}
+
+/*
+ * Gradient matches Figma "Thinking" node:
+ *   to-l (270deg), from Text&Icon/Inverted (#161b2d) → Text&Icon/Secondary (#9fa6bd)
+ * For the sweep animation the gradient is extended with a symmetric tail so the
+ * secondary "beam" visibly travels across the word.
+ */
+.thinking {
+  background: linear-gradient(
+    270deg,
+    var(--cm-thinking-inverted, #161b2d) 0%,
+    var(--cm-thinking-secondary, var(--text-secondary, #9fa6bd)) 40%,
+    var(--cm-thinking-inverted, #161b2d) 80%
+  );
+  background-size: 200% auto;
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  animation: cm-shimmer 2s linear infinite;
+}

--- a/libs/conversation-messages/src/components/Markdown/MarkdownRenderer.tsx
+++ b/libs/conversation-messages/src/components/Markdown/MarkdownRenderer.tsx
@@ -3,6 +3,7 @@ import { type FC, memo } from 'react';
 import ReactMarkdown, { type Components } from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { useStreamedMarkdownContent } from '../../hooks/useStreamedMarkdownContent.js';
+import styles from './MarkdownRenderer.module.scss';
 
 /** Per-element className overrides passed to {@link MarkdownRenderer}. */
 export interface MarkdownRendererClassNames {
@@ -63,6 +64,11 @@ export interface MarkdownRendererProps {
    * Use for elements not covered by `classNames`.
    */
   components?: Components;
+  /**
+   * Label shown with a shimmer animation while `isStreaming` is true and no content has arrived yet.
+   * Defaults to `'Thinking'`. Pass a translated string from the consuming app.
+   */
+  thinkingLabel?: string;
 }
 
 /** GFM remark plugins list, shared across all markdown instances. */
@@ -183,12 +189,17 @@ export const MarkdownRenderer: FC<MarkdownRendererProps> = memo(
     streamCharactersPerSecond,
     classNames = {},
     components,
+    thinkingLabel = 'Thinking',
   }) => {
     const displayedContent = useStreamedMarkdownContent(
       content,
       isStreaming,
       streamCharactersPerSecond,
     );
+
+    if (isStreaming && !displayedContent) {
+      return <span className={styles.thinking}>{thinkingLabel}</span>;
+    }
 
     return (
       <ReactMarkdown

--- a/libs/conversation-messages/src/components/MessageBubble/AssistantMessageBubble.tsx
+++ b/libs/conversation-messages/src/components/MessageBubble/AssistantMessageBubble.tsx
@@ -28,6 +28,7 @@ export const AssistantMessageBubble: FC<AssistantMessageBubbleProps> = ({
   startersAriaLabel = 'Quick reply buttons',
   deploymentIconUrl,
   deploymentDisplayName,
+  thinkingLabel,
 }) => {
   const [isIconFailed, setIsIconFailed] = useState(false);
   const iconImgRef = useRef<HTMLImageElement>(null);
@@ -104,14 +105,18 @@ export const AssistantMessageBubble: FC<AssistantMessageBubbleProps> = ({
             bubbleClassName,
           )}
         >
-          {text && (
+          {(text || isStreaming) && (
             <div
               className={mergeClasses(
                 textClass,
                 'min-w-0 max-w-full text-left',
               )}
             >
-              <MDMessageViewer content={text} isStreaming={isStreaming} />
+              <MDMessageViewer
+                content={text}
+                isStreaming={isStreaming}
+                thinkingLabel={thinkingLabel}
+              />
             </div>
           )}
           <AttachmentTray attachments={attachments ?? []} />

--- a/libs/conversation-messages/src/components/MessageBubble/MessageBubble.tsx
+++ b/libs/conversation-messages/src/components/MessageBubble/MessageBubble.tsx
@@ -25,6 +25,7 @@ export const MessageBubble: FC<MessageBubbleProps> = ({ role, ...props }) => {
       {...props}
       deploymentIconUrl={props.deploymentIconUrl}
       deploymentDisplayName={props.deploymentDisplayName}
+      thinkingLabel={props.thinkingLabel}
     />
   );
 };

--- a/libs/conversation-messages/src/models/MessageBubble.ts
+++ b/libs/conversation-messages/src/models/MessageBubble.ts
@@ -85,6 +85,11 @@ export interface AssistantMessageBubbleProps extends BaseMessageBubbleProps {
   deploymentIconUrl?: string;
   /** Human-readable deployment name shown as the icon's accessible label. */
   deploymentDisplayName?: string;
+  /**
+   * Label shown with a shimmer animation while `isStreaming` is true and the message text is still empty.
+   * Pass a translated string from the consuming app. Defaults to `'Thinking'`.
+   */
+  thinkingLabel?: string;
 }
 
 /** Props accepted by the `MessageBubble` role-switching wrapper. */
@@ -122,4 +127,9 @@ export interface MessageBubbleProps extends BaseMessageBubbleProps {
    * Required when `role === MessageRole.Status`.
    */
   statusBodyText?: string;
+  /**
+   * Label shown with a shimmer animation while `isStreaming` is true and the message text is still empty.
+   * Forwarded to `AssistantMessageBubble`. Defaults to `'Thinking'`.
+   */
+  thinkingLabel?: string;
 }


### PR DESCRIPTION
## Description of changes

<!-- Please explain the changes you made right below this line. -->

## Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #<ISSUE_ID>

## UI changes

<Please, provide Screenshots or Figma links>

## Checklist

- [ ] the pull request name ends with `(Issue #<ISSUE_ID>)` (comma-separated list of issues)
- [ ] I confirm that I don't share any confidential information like API keys or any other secrets and private URLs

<details>
  <summary>PR title cheatsheet</summary>

`<type>[optional scope]: <description>`

1. type (required)
    - `feat` - A new feature
    - `fix` - A bug fix
    - `docs` - Documentation only changes
    - `test` - Adding missing tests or correcting existing tests
    - `ci` - Changes to our CI configuration files and scripts
    - `chore` - Other changes that are minor and/or not user-facing
2. scope (optional, current repo suggestions below)
    - `chat`
    - `overlay`
    - `shared`
    - `sandbox-overlay`
    - `visualizer-connector`

</details>
