### PR TITLE
fix: Fix style of retry button in attachment card

### DIFF
--- a/libs/conversation-input/src/components/AttachmentCard/AttachmentCard.tsx
+++ b/libs/conversation-input/src/components/AttachmentCard/AttachmentCard.tsx
@@ -1,6 +1,6 @@
 import {
-  buildCssVars,
   AttachmentType,
+  buildCssVars,
   mergeClasses,
 } from '@epam/ai-dial-chat-shared';
 import {
@@ -10,7 +10,7 @@ import {
   DialLoader,
   ElementSize,
 } from '@epam/ai-dial-ui-kit';
-import { IconRefresh, IconX } from '@tabler/icons-react';
+import { IconReload, IconX } from '@tabler/icons-react';
 import { type FC, type KeyboardEvent, type MouseEvent, useMemo } from 'react';
 import type { AttachmentCardProps } from '../../models/AttachmentCard.js';
 import { getAttachmentCardState } from '../../utils/getAttachmentCardState.js';
@@ -159,12 +159,9 @@ export const AttachmentCard: FC<AttachmentCardProps> = ({
         >
           {isError && onRetry && (
             <DialGhostIconButton
-              icon={<IconRefresh size={DIAL_ICON_SIZE.SM} aria-hidden />}
+              icon={<IconReload size={DIAL_ICON_SIZE.SM} aria-hidden />}
               size={ElementSize.Small}
-              className={mergeClasses(
-                'h-6 w-6 rounded bg-transparent',
-                styles.actionBtn,
-              )}
+              className={mergeClasses('h-6 w-6 rounded', removeBtnClass)}
               aria-label={retryLabel}
               onClick={(e: MouseEvent) => {
                 e.stopPropagation();


### PR DESCRIPTION
## Description of changes

Fixed the button look for now, and asked designers to see if we can show error text somewhere as well (in the future commits)

## Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #<ISSUE_ID>

## UI changes

<img width="800" height="572" alt="image" src="https://github.com/user-attachments/assets/e2876396-e579-495f-8663-008e1ab8992f" />


## Checklist

- [ ] the pull request name ends with `(Issue #<ISSUE_ID>)` (comma-separated list of issues)
- [x] I confirm that I don't share any confidential information like API keys or any other secrets and private URLs

<details>
  <summary>PR title cheatsheet</summary>

`<type>[optional scope]: <description>`

1. type (required)
    - `feat` - A new feature
    - `fix` - A bug fix
    - `docs` - Documentation only changes
    - `test` - Adding missing tests or correcting existing tests
    - `ci` - Changes to our CI configuration files and scripts
    - `chore` - Other changes that are minor and/or not user-facing
2. scope (optional, current repo suggestions below)
    - `chat`
    - `overlay`
    - `shared`
    - `sandbox-overlay`
    - `visualizer-connector`

</details>
