### PR TITLE
fix(chat): fix overlay header indents and padding (Issue #6850)

### DIFF
--- a/apps/chat/src/components/Chat/ChatHeader/Header.tsx
+++ b/apps/chat/src/components/Chat/ChatHeader/Header.tsx
@@ -109,7 +109,10 @@ export const ChatHeader = Inversify.register(
     const enabledFeatures = useAppSelector(
       SettingsSelectors.selectEnabledFeatures,
     );
-    const floatingPanelTogglePadding = useFloatingPanelTogglePadding();
+    const {
+      hasFloatingPanelToggles,
+      headerClassNames: headerClassNamesWithFloatingPanelToggles,
+    } = useFloatingPanelTogglePadding();
     const selectedConversations = useAppSelector(
       ConversationsSelectors.selectSelectedConversations,
     );
@@ -194,10 +197,13 @@ export const ChatHeader = Inversify.register(
       <>
         <div
           className={classNames(
-            'sticky top-0 z-10 flex w-full min-w-0 items-center justify-center gap-2 bg-layer-2 px-3 py-2 text-sm md:flex-wrap md:px-0 lg:flex-row',
+            'sticky top-0 z-10 flex w-full min-w-0 items-center justify-center gap-2 bg-layer-2 text-sm md:flex-wrap md:px-0 lg:flex-row',
             isChatHeaderBorderEnabled && 'border-b border-secondary',
-            isChatFullWidth && 'px-3 md:px-5 lg:flex-nowrap',
-            floatingPanelTogglePadding,
+            isChatFullWidth && !hasFloatingPanelToggles && 'px-3 md:px-5',
+            isChatFullWidth && 'lg:flex-nowrap',
+            hasFloatingPanelToggles && headerClassNamesWithFloatingPanelToggles
+              ? headerClassNamesWithFloatingPanelToggles
+              : 'px-3 py-2',
           )}
           data-qa="chat-header"
         >

--- a/apps/chat/src/hooks/useFloatingPanelTogglePadding.ts
+++ b/apps/chat/src/hooks/useFloatingPanelTogglePadding.ts
@@ -4,9 +4,7 @@ import { useAppSelector } from '@/src/store/hooks';
 import { SettingsSelectors } from '@/src/store/selectors';
 
 import { Feature } from '@epam/ai-dial-shared';
-
-/** 40px toggle + 8px container padding (p-2) on each side */
-export const FLOATING_PANEL_TOGGLE_SIDE_OFFSET_PX = 48;
+import uniq from 'lodash-es/uniq';
 
 export const useFloatingPanelTogglePadding = () => {
   const enabledFeatures = useAppSelector(
@@ -15,7 +13,10 @@ export const useFloatingPanelTogglePadding = () => {
 
   return useMemo(() => {
     if (enabledFeatures.has(Feature.Header)) {
-      return '';
+      return {
+        hasFloatingPanelToggles: false,
+        headerClassNames: '',
+      };
     }
 
     const classes: string[] = [];
@@ -25,17 +26,16 @@ export const useFloatingPanelTogglePadding = () => {
       enabledFeatures.has(Feature.PromptsPanelToggle);
 
     if (hasFloatingPanelToggles) {
-      classes.push('!py-4');
+      classes.push('py-4');
     }
 
-    if (enabledFeatures.has(Feature.ConversationsPanelToggle)) {
-      classes.push('!pl-12', 'md:!pl-12');
+    if (hasFloatingPanelToggles) {
+      classes.push('px-14', 'md:px-14');
     }
 
-    if (enabledFeatures.has(Feature.PromptsPanelToggle)) {
-      classes.push('!pr-12', 'md:!pr-12');
-    }
-
-    return classes.join(' ');
+    return {
+      hasFloatingPanelToggles,
+      headerClassNames: uniq(classes).join(' '),
+    };
   }, [enabledFeatures]);
 };


### PR DESCRIPTION
## Description of changes

Refactored floating panel toggle padding logic to correctly apply header indents when floating panels are enabled:

- Modified `useFloatingPanelTogglePadding` hook to return an object with `hasFloatingPanelToggles` flag and corresponding class names
- Updated padding classes: changed from `!py-4`, `!pl-12`/`!pr-12` to `py-4` and `px-14` for consistent spacing
- Updated Header component to destructure and conditionally apply the new padding classes
- Removed unused `FLOATING_PANEL_TOGGLE_SIDE_OFFSET_PX` constant

## Applicable issues

- fixes #6850

## UI changes

Shows corrected floating panel toggle padding in the chat header.
<img width="681" height="204" alt="image" src="https://github.com/user-attachments/assets/f53ea91a-b1f0-4885-93f6-f6de84e37ee2" />


## Checklist

- [x] the pull request name ends with `(Issue #6850)`
- [x] I confirm that I don't share any confidential information like API keys or any other secrets and private URLs
