### PR TITLE
fix(chat): skip optimistic like update when message has no responseId (Issue #5207)

### DIFF
--- a/apps/chat/src/store/conversations/conversations.epics.ts
+++ b/apps/chat/src/store/conversations/conversations.epics.ts
@@ -1365,10 +1365,20 @@ const updateMessageEpic: AppEpic = (action$, state$) =>
     }),
   );
 
-const rateMessageSuccessEpic: AppEpic = (action$) =>
+const rateMessageSuccessEpic: AppEpic = (action$, state$) =>
   action$.pipe(
     ofType(ConversationsActions.rateMessage.type),
     switchMap(({ payload }) => {
+      const conversation = ConversationsSelectors.selectConversation(
+        state$.value,
+        payload.conversationId,
+      ) as Conversation;
+      const message = conversation?.messages[payload.messageIndex];
+
+      if (!conversation || !message?.responseId) {
+        return EMPTY;
+      }
+
       return of(
         ConversationsActions.updateMessage({
           conversationId: payload.conversationId,


### PR DESCRIPTION
## Description of changes

When a message had no `responseId` (e.g. an empty response or an error-only response that was later edited), clicking Like/Dislike showed a _"Message cannot be rated"_ error toast but still saved the like state on the UI — and the state persisted after a page refresh.

**Root cause — a race condition in the epics:**

`rateMessageEpic` is listed before `rateMessageSuccessEpic` in `combineEpics`. Both subscribe to `rateMessage`. For messages without a `responseId`, `rateMessageEpic` synchronously emits `rateMessageFail`, which `rateMessageFailEpic` handles by reverting the like state to `NoState`. However, because the epics are merged in order, `rateMessageSuccessEpic`'s optimistic update (`like → Liked/Disliked`) fired **after** the revert, winning the race and leaving the like state incorrectly saved.

**Fix:**

Mirror the same `responseId` guard inside `rateMessageSuccessEpic`. When the conversation is missing or the message has no `responseId`, the epic returns `EMPTY` — skipping the optimistic update entirely. The optimistic-update path for messages that **do** have a `responseId` is completely unchanged.

## Applicable issues

Closes #5207

## UI changes

None — visually the fix removes incorrect like/dislike highlighting after a failed rating attempt.

## Checklist

- [x] No new dependencies introduced
- [x] TypeScript compiles without new errors
- [x] Optimistic-update behaviour for valid messages is preserved