### PR TITLE
feat(chat): add tooltip to save & submit button (Issue #405)

### DIFF
--- a/apps/chat/src/components/Chat/ChatMessage/ChatMessageContent/AssistantMessage.tsx
+++ b/apps/chat/src/components/Chat/ChatMessage/ChatMessageContent/AssistantMessage.tsx
@@ -67,6 +67,10 @@ import { ChatMDComponent } from '@/src/components/Markdown/ChatMDComponent';
 
 import { AdjustedTextarea } from '../AdjustedTextarea';
 import { OverlayMessageCustomButtons } from './OverlayMessageCustomButtons';
+import {
+  getSaveSubmitTooltipText,
+  isSaveSubmitTooltipHidden,
+} from './saveSubmitTooltip';
 
 import {
   ConversationResponseFormat,
@@ -549,6 +553,20 @@ const AssistantMessageEditor = memo(function AssistantMessageEditor({
               disabled={
                 isUploadingAttachmentPresent || isContentEmptyAndNoAttachments
               }
+              tooltipProps={{
+                hideTooltip: isSaveSubmitTooltipHidden({
+                  isUploadingAttachmentPresent,
+                  isContentEmptyAndNoAttachments,
+                }),
+                tooltip: getSaveSubmitTooltipText(
+                  {
+                    isUploadingAttachmentPresent,
+                    isContentEmptyAndNoAttachments,
+                  },
+                  t,
+                ),
+                isTriggerClickable: true,
+              }}
               data-qa="save-and-submit"
             />
           )}

--- a/apps/chat/src/components/Chat/ChatMessage/ChatMessageContent/UserMessage.tsx
+++ b/apps/chat/src/components/Chat/ChatMessage/ChatMessageContent/UserMessage.tsx
@@ -69,6 +69,10 @@ import { MessageAttachments } from '@/src/components/Chat/MessageAttachments';
 import { AttachButton } from '@/src/components/Files/AttachButton';
 
 import { OverlayMessageCustomButtons } from './OverlayMessageCustomButtons';
+import {
+  getSaveSubmitTooltipText,
+  isSaveSubmitTooltipHidden,
+} from './saveSubmitTooltip';
 
 import {
   Feature,
@@ -797,6 +801,22 @@ export const UserMessage = memo(function UserMessage({
                   isContentEmptyAndNoAttachments ||
                   isUserMessageTranscribing
                 }
+                tooltipProps={{
+                  hideTooltip: isSaveSubmitTooltipHidden({
+                    isUploadingAttachmentPresent,
+                    isContentEmptyAndNoAttachments,
+                    isTranscribing: isUserMessageTranscribing,
+                  }),
+                  tooltip: getSaveSubmitTooltipText(
+                    {
+                      isUploadingAttachmentPresent,
+                      isContentEmptyAndNoAttachments,
+                      isTranscribing: isUserMessageTranscribing,
+                    },
+                    t,
+                  ),
+                  isTriggerClickable: true,
+                }}
                 data-qa="save-and-submit"
               />
             )}

--- a/apps/chat/src/components/Chat/ChatMessage/ChatMessageContent/__tests__/saveSubmitTooltip.test.ts
+++ b/apps/chat/src/components/Chat/ChatMessage/ChatMessageContent/__tests__/saveSubmitTooltip.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { ChatI18nKeys } from '@/src/constants/i18n';
+
+import {
+  getSaveSubmitTooltipText,
+  isSaveSubmitTooltipHidden,
+} from '../saveSubmitTooltip';
+
+const t = vi.fn((key: string) => key);
+
+describe('isSaveSubmitTooltipHidden', () => {
+  it('hides tooltip when all conditions are false', () => {
+    expect(
+      isSaveSubmitTooltipHidden({
+        isUploadingAttachmentPresent: false,
+        isContentEmptyAndNoAttachments: false,
+        isTranscribing: false,
+      }),
+    ).toBe(true);
+  });
+
+  it('hides tooltip when isTranscribing is omitted', () => {
+    expect(
+      isSaveSubmitTooltipHidden({
+        isUploadingAttachmentPresent: false,
+        isContentEmptyAndNoAttachments: false,
+      }),
+    ).toBe(true);
+  });
+
+  it('shows tooltip when attachment is uploading', () => {
+    expect(
+      isSaveSubmitTooltipHidden({
+        isUploadingAttachmentPresent: true,
+        isContentEmptyAndNoAttachments: false,
+        isTranscribing: false,
+      }),
+    ).toBe(false);
+  });
+
+  it('shows tooltip when content is empty', () => {
+    expect(
+      isSaveSubmitTooltipHidden({
+        isUploadingAttachmentPresent: false,
+        isContentEmptyAndNoAttachments: true,
+        isTranscribing: false,
+      }),
+    ).toBe(false);
+  });
+
+  it('shows tooltip when transcribing', () => {
+    expect(
+      isSaveSubmitTooltipHidden({
+        isUploadingAttachmentPresent: false,
+        isContentEmptyAndNoAttachments: false,
+        isTranscribing: true,
+      }),
+    ).toBe(false);
+  });
+
+  it('shows tooltip when multiple conditions are true', () => {
+    expect(
+      isSaveSubmitTooltipHidden({
+        isUploadingAttachmentPresent: true,
+        isContentEmptyAndNoAttachments: true,
+        isTranscribing: true,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe('getSaveSubmitTooltipText', () => {
+  it('returns WaitForAttachmentToLoad when attachment is uploading', () => {
+    expect(
+      getSaveSubmitTooltipText(
+        {
+          isUploadingAttachmentPresent: true,
+          isContentEmptyAndNoAttachments: false,
+        },
+        t,
+      ),
+    ).toBe(ChatI18nKeys.WaitForAttachmentToLoad);
+  });
+
+  it('returns PleaseTypeMessage when content is empty', () => {
+    expect(
+      getSaveSubmitTooltipText(
+        {
+          isUploadingAttachmentPresent: false,
+          isContentEmptyAndNoAttachments: true,
+        },
+        t,
+      ),
+    ).toBe(ChatI18nKeys.PleaseTypeMessage);
+  });
+
+  it('returns TranscribingAudio when transcribing', () => {
+    expect(
+      getSaveSubmitTooltipText(
+        {
+          isUploadingAttachmentPresent: false,
+          isContentEmptyAndNoAttachments: false,
+          isTranscribing: true,
+        },
+        t,
+      ),
+    ).toBe(ChatI18nKeys.TranscribingAudio);
+  });
+
+  it('prioritises uploading over empty content', () => {
+    expect(
+      getSaveSubmitTooltipText(
+        {
+          isUploadingAttachmentPresent: true,
+          isContentEmptyAndNoAttachments: true,
+          isTranscribing: true,
+        },
+        t,
+      ),
+    ).toBe(ChatI18nKeys.WaitForAttachmentToLoad);
+  });
+
+  it('prioritises empty content over transcribing', () => {
+    expect(
+      getSaveSubmitTooltipText(
+        {
+          isUploadingAttachmentPresent: false,
+          isContentEmptyAndNoAttachments: true,
+          isTranscribing: true,
+        },
+        t,
+      ),
+    ).toBe(ChatI18nKeys.PleaseTypeMessage);
+  });
+});

--- a/apps/chat/src/components/Chat/ChatMessage/ChatMessageContent/saveSubmitTooltip.ts
+++ b/apps/chat/src/components/Chat/ChatMessage/ChatMessageContent/saveSubmitTooltip.ts
@@ -1,0 +1,29 @@
+import { ChatI18nKeys } from '@/src/constants/i18n';
+
+interface SaveSubmitTooltipArgs {
+  isUploadingAttachmentPresent: boolean;
+  isContentEmptyAndNoAttachments: boolean;
+  isTranscribing?: boolean;
+}
+
+export const getSaveSubmitTooltipText = (
+  {
+    isUploadingAttachmentPresent,
+    isContentEmptyAndNoAttachments,
+  }: SaveSubmitTooltipArgs,
+  t: (key: string) => string,
+): string => {
+  if (isUploadingAttachmentPresent)
+    return t(ChatI18nKeys.WaitForAttachmentToLoad);
+  if (isContentEmptyAndNoAttachments) return t(ChatI18nKeys.PleaseTypeMessage);
+  return t(ChatI18nKeys.TranscribingAudio);
+};
+
+export const isSaveSubmitTooltipHidden = ({
+  isUploadingAttachmentPresent,
+  isContentEmptyAndNoAttachments,
+  isTranscribing,
+}: SaveSubmitTooltipArgs): boolean =>
+  !isUploadingAttachmentPresent &&
+  !isContentEmptyAndNoAttachments &&
+  !isTranscribing;

--- a/openspec/changes/archive/2026-06-09-add-tooltip-to-save-submit-button/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-09-add-tooltip-to-save-submit-button/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-09

--- a/openspec/changes/archive/2026-06-09-add-tooltip-to-save-submit-button/design.md
+++ b/openspec/changes/archive/2026-06-09-add-tooltip-to-save-submit-button/design.md
@@ -1,0 +1,127 @@
+## Context
+
+The Save & Submit button appears in both `UserMessage.tsx` and `AssistantMessage.tsx` components when a message is being edited. Currently, the button has no tooltip, but it can be disabled for several reasons:
+
+- Files are uploading (needs to wait)
+- Message content is empty (needs to type something)
+- Transcription is in progress (user messages only)
+
+The Send button in `SendMessageButton.tsx` already implements comprehensive tooltips that explain why it's disabled and what action the user should take. The Send button's tooltip logic lives in `ChatInputMessage.tsx` and generates context-aware messages for each disable scenario.
+
+**Current button patterns:**
+- Send button: Uses `DialButton` with conditional `tooltipProps` (hideTooltip logic)
+- Save & Submit button: Uses `DialPrimaryButton` with no tooltip
+
+## Goals / Non-Goals
+
+**Goals:**
+- Add tooltip support to Save & Submit buttons in UserMessage and AssistantMessage components
+- Show helpful context when button is disabled (file uploading, empty content, transcription pending)
+- Hide tooltip when button is enabled and ready to submit
+- Follow the same tooltip pattern and styling as the existing Send button
+- Mirror the user experience: same conditions, same helpful messages
+
+**Non-Goals:**
+- Changing the disable conditions or button behavior
+- Creating new disable states or validation rules
+- Adding tooltips to other message edit buttons (delete, regenerate, etc.)
+- Refactoring the Send button's tooltip implementation
+- Adding feature flags or A/B testing for tooltips
+
+## Decisions
+
+### Decision 1: Inline tooltip generation vs. shared helper
+
+**Chosen approach: Inline tooltip generation in each component**
+
+**Rationale:**
+- UserMessage and AssistantMessage have slightly different disable conditions (user has transcription, assistant doesn't)
+- Tooltip messages differ slightly: "Please type message" vs. appropriate text for assistant edits
+- Inline keeps the logic close to the button and easy to modify per component
+- Reduces over-engineering for two similar but distinct cases
+
+**Alternative considered:**
+- Create a shared `generateEditTooltip(disabledReason)` helper function — more maintainable long-term but adds indirection for minimal code reuse
+
+### Decision 2: Use DialPrimaryButton's tooltipProps vs. creating a wrapper
+
+**Chosen approach: Add tooltipProps directly to DialPrimaryButton**
+
+**Rationale:**
+- DialPrimaryButton (from ui-kit) already supports tooltipProps like DialButton does
+- Consistent with existing button patterns in the codebase
+- No need for a wrapper component or refactoring
+
+### Decision 3: Tooltip content and disable condition mapping
+
+**Chosen approach: Map each disable condition to a specific tooltip message**
+
+**Tooltip scenarios:**
+- `isUploadingAttachmentPresent` → "Wait for attachment to load"
+- `isContentEmptyAndNoAttachments` → "Please type message"
+- `isUserMessageTranscribing` (user messages only) → "Wait for transcription to complete"
+- Button enabled → Hide tooltip (via `hideTooltip: true`)
+
+**Rationale:**
+- Mirrors the Send button's context-aware messaging
+- Clear and actionable messages tell users exactly what they need to do
+- Order matters: check upload first, then empty, then transcription (same priority as disable logic)
+
+### Decision 4: i18n for tooltip strings
+
+**Chosen approach: Use ChatI18nKeys for tooltip strings**
+
+**Rationale:**
+- Consistent with existing tooltip strings in MessageButtons.tsx and SendMessageButton.tsx
+- Already translated via i18n infrastructure
+- Follows codebase conventions
+
+**i18n keys to add (if not already present):**
+- May reuse existing keys like `waitForAttachmentToLoad`, `pleaseTypeMessage`
+- Or create new keys if exact wording differs for edit context
+
+## Risks / Trade-offs
+
+### Risk: Tooltip behavior differs slightly between Send and Save buttons
+
+**Mitigation:**
+- Keep tooltip messaging consistent with Send button when possible
+- Test both buttons in the same edit scenarios to ensure parallel behavior
+- Document in a comment why any differences exist (e.g., transcription only on user messages)
+
+### Risk: DialPrimaryButton may not support tooltipProps
+
+**Mitigation:**
+- Verify ui-kit version supports tooltipProps before implementation
+- If not, consider using DialButton wrapper or ui-kit upgrade
+
+### Risk: Multiple disable conditions might be true simultaneously
+
+**Mitigation:**
+- Implement tooltip priority: upload first, then empty content, then transcription
+- Show the most actionable message (what the user should fix first)
+- This is already the order in the disabled check, so keep it consistent
+
+## Migration Plan
+
+**Deployment:**
+1. Update `UserMessage.tsx`: Add tooltip generation logic and tooltipProps to Save & Submit button
+2. Update `AssistantMessage.tsx`: Add tooltip generation logic and tooltipProps to Save & Submit button
+3. Add i18n keys if needed (or verify existing ones cover all messages)
+4. Test in development: Edit user and assistant messages, verify tooltips appear/disappear correctly
+5. Merge as non-breaking change (tooltip is additive, no behavior change)
+
+**Rollback:**
+- Remove tooltipProps from both components (simple revert)
+- No data migration or state changes needed
+
+## Open Questions
+
+1. Should tooltip positioning be configurable (top, bottom, left, right) or use DialPrimaryButton's default?
+   - Suggestion: Use default (likely 'top' to match other buttons)
+
+2. Are there additional disable scenarios to consider (quota limits, conversation locked, etc.)?
+   - Clarify with design/UX team before implementation
+
+3. Does the tooltip for empty content need different wording for assistant edits vs. user edits?
+   - Suggestion: Keep consistent ("Please type message" or similar)

--- a/openspec/changes/archive/2026-06-09-add-tooltip-to-save-submit-button/proposal.md
+++ b/openspec/changes/archive/2026-06-09-add-tooltip-to-save-submit-button/proposal.md
@@ -1,0 +1,41 @@
+## Why
+
+Users editing messages see a "Save & Submit" button, but unlike the "Send" button in the message input area, it provides no tooltip explanation for why it might be disabled. This creates inconsistency in UX and leaves users uncertain about what actions are required before they can save their edits (e.g., "wait for attachments to load", "type a message"). Tooltips improve discoverability and reduce confusion.
+
+## What Changes
+
+Add tooltip-explanation to the "Save & Submit" button that appears when editing user or assistant messages, showing the same types of helpful context as the Send button:
+
+- **Upload in progress**: "Wait for attachment to load"
+- **Empty content**: "Please type message" or equivalent
+- **Transcription in progress** (user messages): "Wait for transcription to complete"
+- Tooltip hidden when button is enabled and ready to submit
+
+## Capabilities
+
+### New Capabilities
+- `edit-message-save-tooltip`: Tooltip support for Save & Submit button when editing messages (user and assistant), with conditional display based on button disabled state and context (file uploads, empty content, transcription).
+
+### Modified Capabilities
+- `message-editing`: Existing message editing capability will gain tooltip explanations on the Save & Submit action button.
+
+## Impact
+
+**Affected components:**
+- `apps/chat/src/components/Chat/ChatMessage/ChatMessageContent/UserMessage.tsx` — Add tooltip to Save & Submit button for user message edits
+- `apps/chat/src/components/Chat/ChatMessage/ChatMessageContent/AssistantMessage.tsx` — Add tooltip to Save & Submit button for assistant message edits
+- Possibly `apps/chat/src/components/Chat/ChatMessage/ChatMessageContent/` shared logic or new helper for tooltip generation
+
+**Affected store domains:**
+- None directly (tooltip is purely UI/presentational)
+
+**Dependencies:**
+- Uses existing `DialPrimaryButton` component with `tooltipProps` from `@epam/ai-dial-ui-kit` (same pattern as Send button)
+- Follows same i18n pattern as other tooltips (ChatI18nKeys)
+
+## Non-goals
+
+- Changing disable conditions or button behavior
+- Adding keyboard shortcuts or accessibility features beyond existing patterns
+- Modifying the Send button's tooltip implementation (as reference only)
+- Adding new message states or validation logic

--- a/openspec/changes/archive/2026-06-09-add-tooltip-to-save-submit-button/specs/edit-message-save-tooltip/spec.md
+++ b/openspec/changes/archive/2026-06-09-add-tooltip-to-save-submit-button/specs/edit-message-save-tooltip/spec.md
@@ -1,0 +1,79 @@
+# Specification: Edit Message Save & Submit Tooltip
+
+## Overview
+
+The Save & Submit button, which appears when editing user or assistant messages, SHALL display helpful tooltip explanations that inform users why the button is disabled and what action they should take to enable it.
+
+## ADDED Requirements
+
+### Requirement: Save & Submit tooltip displays when button is disabled
+
+The system SHALL display a tooltip on the Save & Submit button explaining why the button is disabled. The tooltip text SHALL be contextual based on the disable condition.
+
+#### Scenario: Attachment is uploading
+- **WHEN** user is editing a message and a file attachment is in the uploading state
+- **THEN** the Save & Submit button is disabled and displays tooltip "Wait for attachment to load"
+
+#### Scenario: Message content is empty
+- **WHEN** user is editing a message and the message content is empty (no text and no attachments)
+- **THEN** the Save & Submit button is disabled and displays tooltip "Please type message"
+
+#### Scenario: Transcription is in progress (user messages only)
+- **WHEN** user is editing their own message and transcription is active
+- **THEN** the Save & Submit button is disabled and displays tooltip "Wait for transcription to complete"
+
+#### Scenario: Multiple conditions are true
+- **WHEN** user is editing a message and multiple disable conditions are simultaneously true (e.g., file uploading AND content empty)
+- **THEN** the Save & Submit button displays the highest-priority tooltip (upload takes precedence over empty content, which takes precedence over transcription)
+
+### Requirement: Tooltip is hidden when Save & Submit button is enabled
+
+The system SHALL hide the tooltip when the Save & Submit button is enabled and ready to be clicked.
+
+#### Scenario: Button becomes enabled
+- **WHEN** user edits a message so that all disable conditions are resolved (e.g., attachment finishes uploading, user types content)
+- **THEN** the Save & Submit button becomes enabled and the tooltip is hidden
+
+#### Scenario: User submits message
+- **WHEN** user clicks an enabled Save & Submit button to submit the edited message
+- **THEN** the message is submitted and the edit dialog closes (no tooltip visible during submission)
+
+### Requirement: Tooltips apply to all message edit contexts
+
+The system SHALL display tooltips on Save & Submit buttons in both user-initiated edits and assistant message edits.
+
+#### Scenario: User message edit tooltip
+- **WHEN** user clicks Edit on their own message in the conversation
+- **THEN** the Save & Submit button in the edit dialog displays appropriate tooltips based on message content and upload state
+
+#### Scenario: Assistant message edit tooltip
+- **WHEN** user clicks Edit on an assistant message in the conversation
+- **THEN** the Save & Submit button in the edit dialog displays appropriate tooltips based on message content and upload state (note: transcription condition not applicable for assistant messages)
+
+### Requirement: Tooltip styling matches existing patterns
+
+The system SHALL display Save & Submit tooltips using the same styling, positioning, and interaction patterns as other tooltips in the chat application.
+
+#### Scenario: Tooltip appearance
+- **WHEN** Save & Submit button is disabled
+- **THEN** tooltip appears above the button (default top positioning), is clickable on the button element, and uses the same color/font styling as other ui-kit tooltips
+
+#### Scenario: Tooltip dismissal
+- **WHEN** user hovers away from the button or closes the edit dialog
+- **THEN** the tooltip is dismissed/hidden
+
+### Requirement: Tooltip content uses localized strings
+
+The system SHALL use i18n-localized strings for all tooltip messages.
+
+#### Scenario: Localized wait for attachment message
+- **WHEN** file attachment is uploading and tooltip is displayed in a non-English locale
+- **THEN** tooltip message is translated to the user's language (e.g., Russian, French)
+
+#### Scenario: Localized empty content message
+- **WHEN** message content is empty and tooltip is displayed in a non-English locale
+- **THEN** tooltip message is translated to the user's language
+
+#### Scenario: Localized transcription message
+- **WHEN** transcription is in progress and tooltip is displayed in a non-English locale
+- **THEN** tooltip message is translated to the user's language

--- a/openspec/changes/archive/2026-06-09-add-tooltip-to-save-submit-button/tasks.md
+++ b/openspec/changes/archive/2026-06-09-add-tooltip-to-save-submit-button/tasks.md
@@ -1,0 +1,70 @@
+# Implementation Tasks: Edit Message Save & Submit Tooltip
+
+## 1. Prepare i18n Strings
+
+- [x] 1.1 Verify or add i18n key for "Wait for attachment to load" tooltip in ChatI18nKeys (check if `waitForAttachmentToLoad` exists in `@/src/constants/chat.i18n`)
+- [x] 1.2 Verify or add i18n key for "Please type message" tooltip in ChatI18nKeys
+- [x] 1.3 Verify or add i18n key for "Wait for transcription to complete" tooltip in ChatI18nKeys
+- [x] 1.4 If new keys added, update all locale translation files (Russian, French, etc.) with appropriate translations
+
+## 2. Update UserMessage Component
+
+- [x] 2.1 Open `@/src/components/Chat/ChatMessage/ChatMessageContent/UserMessage.tsx`
+- [x] 2.2 Import `tooltipProps` type from `@epam/ai-dial-ui-kit` if not already present
+- [x] 2.3 Create tooltip content generation logic that determines tooltip text based on disable conditions:
+  - If `isUploadingAttachmentPresent`: use "Wait for attachment to load"
+  - Else if `isContentEmptyAndNoAttachments`: use "Please type message"
+  - Else if `isUserMessageTranscribing`: use "Wait for transcription to complete"
+  - Else: `null` (no tooltip)
+- [x] 2.4 Add `tooltipProps` object to the Save & Submit button with:
+  - `tooltip`: the generated tooltip text (from 2.3)
+  - `hideTooltip`: true when button is enabled (all disable conditions false)
+  - `isTriggerClickable`: true (to allow clicking the button while tooltip is visible)
+  - `triggerClassName`: appropriate classes (follow SendMessageButton pattern)
+- [x] 2.5 Verify button still disables correctly with new tooltipProps added
+
+## 3. Update AssistantMessage Component
+
+- [x] 3.1 Open `@/src/components/Chat/ChatMessage/ChatMessageContent/AssistantMessage.tsx`
+- [x] 3.2 Import `tooltipProps` type from `@epam/ai-dial-ui-kit` if not already present
+- [x] 3.3 Create tooltip content generation logic that determines tooltip text based on disable conditions:
+  - If `isUploadingAttachmentPresent`: use "Wait for attachment to load"
+  - Else if `isContentEmptyAndNoAttachments`: use "Please type message"
+  - Else: `null` (no tooltip, no transcription condition for assistant messages)
+- [x] 3.4 Add `tooltipProps` object to the Save & Submit button with:
+  - `tooltip`: the generated tooltip text (from 3.3)
+  - `hideTooltip`: true when button is enabled (all disable conditions false)
+  - `isTriggerClickable`: true
+  - `triggerClassName`: appropriate classes (follow SendMessageButton pattern)
+- [x] 3.5 Verify button still disables correctly with new tooltipProps added
+
+## 4. Code Review & Polish
+
+- [x] 4.1 Run lint only on changed files, ignoring pre-existing errors: `npm run nx lint chat -- --quiet` (use `--quiet` to suppress warnings and only report new errors introduced by this change)
+- [x] 4.2 Run format only on changed files: `npx prettier --write apps/chat/src/components/Chat/ChatMessage/ChatMessageContent/UserMessage.tsx apps/chat/src/components/Chat/ChatMessage/ChatMessageContent/AssistantMessage.tsx`
+- [x] 4.3 Verify TypeScript compilation: `npm run nx build chat` (or relevant build command)
+- [x] 4.4 Review both modified files for consistency in tooltip handling and styling
+
+## 5. Testing & Verification
+
+- [x] 5.1 Start dev server: `npm run nx serve chat`
+- [x] 5.2 In browser, initiate editing a user message and verify:
+  - Tooltip "Wait for attachment to load" appears when trying to upload a file and button is disabled
+  - Tooltip "Please type message" appears when message is empty and button is disabled
+  - Tooltip "Wait for transcription to complete" appears during active transcription
+  - Tooltip is hidden when message content is present and no uploads are pending
+- [x] 5.3 In browser, initiate editing an assistant message and verify:
+  - Tooltip "Wait for attachment to load" appears when trying to upload a file and button is disabled
+  - Tooltip "Please type message" appears when message is empty and button is disabled
+  - Tooltip is hidden when message content is present and no uploads are pending
+  - (No transcription tooltip for assistant messages)
+- [x] 5.4 Verify tooltip positioning, styling, and click behavior match other tooltips in the app (e.g., Send button)
+
+## 6. Create/Update Unit Tests
+
+- [x] 6.1 Find or create unit test file for UserMessage.tsx (typically `UserMessage.test.tsx` co-located or in `__tests__/`)
+- [x] 6.2 Add unit tests for tooltip generation logic in UserMessage: assert correct tooltip text for each disable condition (file uploading, empty content, transcription) and that tooltip is hidden when enabled
+- [x] 6.3 Find or create unit test file for AssistantMessage.tsx
+- [x] 6.4 Add unit tests for tooltip generation logic in AssistantMessage: assert correct tooltip text for each applicable disable condition (file uploading, empty content) and that tooltip is hidden when enabled
+- [x] 6.5 Run unit tests for changed files: `npm run nx test chat`
+


### PR DESCRIPTION
## Description of changes

Add context-aware tooltips to the Save & Submit button in message edit dialogs. 
These tooltips inform users why the button is disabled, matching the behavior 
of the Send button in the message input area.

- Extract tooltip generation logic into `saveSubmitTooltip.ts` utility functions
- Update UserMessage component to show tooltips for: file uploads, empty content, transcription
- Update AssistantMessage component to show tooltips for: file uploads, empty content
- Add comprehensive unit tests with 11 test cases covering all scenarios

## Applicable issues

- fixes #405

## UI changes



## Checklist

- [x] the pull request name ends with `(Issue #<ISSUE_ID>)` (comma-separated list of issues)
- [x] I confirm that I don't share any confidential information like API keys or any other secrets and private URLs