### PR TITLE
fix: Fix selection lost after conversation rename

### DIFF
--- a/apps/chat/src/components/ConversationPanel/ConversationPanelView.tsx
+++ b/apps/chat/src/components/ConversationPanel/ConversationPanelView.tsx
@@ -284,8 +284,9 @@ const ConversationPanelView: FC<Props> = ({
 
       setIsRenaming(true);
       setRenameError(null);
+      let newPath: string;
       try {
-        await renameConversation(id, newTitle);
+        newPath = await renameConversation(id, newTitle);
       } catch {
         setRenameError(t(ConversationHistoryI18nKeys.RenameError));
         setIsRenaming(false);
@@ -293,8 +294,20 @@ const ConversationPanelView: FC<Props> = ({
       }
       setIsRenaming(false);
       setPendingRenameItem(null);
+
+      const activeContextId = activeConversationId
+        ? panelToContextId.get(activeConversationId)
+        : undefined;
+      if (activeContextId === id) navigate(getConversationRoute(newPath));
     },
-    [pendingRenameItem, renameConversation, t],
+    [
+      pendingRenameItem,
+      renameConversation,
+      activeConversationId,
+      panelToContextId,
+      navigate,
+      t,
+    ],
   );
 
   const handleCloseRenameDialog = useCallback(() => {

--- a/apps/chat/src/context/ConversationsContext.tsx
+++ b/apps/chat/src/context/ConversationsContext.tsx
@@ -29,8 +29,8 @@ interface ConversationsContextType {
   pinConversation: (id: string, isPinned: boolean) => Promise<void>;
   /** Delete a conversation by id, removing it from the local list on success. */
   deleteConversation: (id: string) => Promise<void>;
-  /** Rename a conversation; optimistically updates title, reverts on failure. */
-  renameConversation: (id: string, newTitle: string) => Promise<void>;
+  /** Rename a conversation; optimistically updates title, reverts on failure. Returns the new conversation id. */
+  renameConversation: (id: string, newTitle: string) => Promise<string>;
   /** Duplicate a conversation into the user's own bucket; returns the new conversation id. */
   duplicateConversation: (id: string) => Promise<string>;
   /** Re-fetch the full conversation list from the server. */
@@ -138,6 +138,7 @@ export const ConversationsProvider = ({
         setConversations((prev) =>
           prev.map((c) => (c.id === id ? { ...c, id: newPath } : c)),
         );
+        return newPath;
       } catch (err) {
         if (originalTitle != null) {
           setConversations((prev) =>


### PR DESCRIPTION
## Description of changes

Fix for renaming conversation leading to selected conversation lost in conversation panel

## Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #<ISSUE_ID>

## UI changes

<Please, provide Screenshots or Figma links>

## Checklist

- [ ] the pull request name ends with `(Issue #<ISSUE_ID>)` (comma-separated list of issues)
- [X] I confirm that I don't share any confidential information like API keys or any other secrets and private URLs

<details>
  <summary>PR title cheatsheet</summary>

`<type>[optional scope]: <description>`

1. type (required)
    - `feat` - A new feature
    - `fix` - A bug fix
    - `docs` - Documentation only changes
    - `test` - Adding missing tests or correcting existing tests
    - `ci` - Changes to our CI configuration files and scripts
    - `chore` - Other changes that are minor and/or not user-facing
2. scope (optional, current repo suggestions below)
    - `chat`
    - `overlay`
    - `shared`
    - `sandbox-overlay`
    - `visualizer-connector`

</details>
