### PR TITLE
fix(chat): fix quick app 2 not available orchestroator color (Issue #7152)

### DIFF
--- a/apps/chat/src/components/Common/ModelsSelector.tsx
+++ b/apps/chat/src/components/Common/ModelsSelector.tsx
@@ -24,12 +24,14 @@ import { Tooltip } from '@/src/components/Common/Tooltip';
 interface ModelSelectRowProps {
   item: DialAIEntityModel;
   isNotAllowed: boolean;
+  showInlineError?: boolean;
   truncate?: boolean;
 }
 
 const ModelSelectRow = ({
   item,
   isNotAllowed,
+  showInlineError,
   truncate = true,
 }: ModelSelectRowProps) => {
   const { t } = useTranslation(Translation.Chat);
@@ -51,7 +53,10 @@ const ModelSelectRow = ({
         data-qa="agent-attributes"
       >
         <span
-          className={classNames(truncate && 'min-w-0 flex-1 truncate')}
+          className={classNames(
+            truncate && 'min-w-0 flex-1 truncate',
+            isNotAllowed && 'text-secondary',
+          )}
           data-qa="agent-name"
         >
           {getOpenAIEntityFullName(item)}
@@ -67,7 +72,7 @@ const ModelSelectRow = ({
             {item.version}
           </span>
         )}
-        {isNotAllowed && (
+        {showInlineError && (
           <span className="text-error" data-qa="talk-to-entity-descr">
             <EntityMarkdownDescription isShortDescription>
               {t(ChatI18nKeys.IncorrectSelectedModel)}
@@ -142,7 +147,8 @@ export const ModelsSelector = memo(function ModelsSelector({
           itemRow={({ item, truncate }) => (
             <ModelSelectRow
               item={item}
-              isNotAllowed={!hideInlineError && item.id === value && !model}
+              isNotAllowed={item.id === value && !model}
+              showInlineError={!hideInlineError && item.id === value && !model}
               truncate={truncate}
             />
           )}


### PR DESCRIPTION
## Description of changes

[Regression][Quick App 2.0] Incorrect UI for the model in orchestrator if it was deleted from DIAL

## Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #7152

## Checklist

- [x] the pull request name ends with `(Issue #<ISSUE_ID>)` (comma-separated list of issues)
- [x] I confirm that I don't share any confidential information like API keys or any other secrets and private URLs

<details>
  <summary>PR title cheatsheet</summary>

`<type>[optional scope]: <description>`

1. type (required)
    - `feat` - A new feature
    - `fix` - A bug fix
    - `docs` - Documentation only changes
    - `test` - Adding missing tests or correcting existing tests
    - `ci` - Changes to our CI configuration files and scripts
    - `chore` - Other changes that are minor and/or not user-facing
2. scope (optional, current repo suggestions below)
    - `chat`
    - `overlay`
    - `shared`
    - `sandbox-overlay`
    - `visualizer-connector`

</details>
