### PR TITLE
fix: Fix renaming pinned conversations

### DIFF
--- a/apps/chat-api/src/conversations/conversation.service.ts
+++ b/apps/chat-api/src/conversations/conversation.service.ts
@@ -26,6 +26,7 @@ import type {
   SharedResourcesResult,
 } from './types/conversation.types';
 import {
+  buildConversationUrl,
   buildRenamedConversationPath,
   decodeNextToken,
   encodeCompoundToken,
@@ -33,6 +34,7 @@ import {
   getConversationName,
   getConversationTitleFromName,
   prepareEntityName,
+  safeDecodeURIComponent,
 } from './utils/conversation.utils';
 import { resolveUniqueConversationName } from './utils/resolve-unique-conversation-name';
 
@@ -224,9 +226,13 @@ export class ConversationService extends AppService {
     }
 
     // Remove from pins if present — fire-and-forget, non-fatal
-    const conversationId = `conversations/${bucket}/${conversationPath}`;
-    void this.pinConversation(conversationId, false, token, bucket).catch(
-      (err) => this.logger.error('Failed to clean up pin on delete', err),
+    void this.pinConversation(
+      buildConversationUrl(bucket, conversationPath),
+      false,
+      token,
+      bucket,
+    ).catch((err) =>
+      this.logger.error('Failed to clean up pin on delete', err),
     );
   }
 
@@ -242,8 +248,8 @@ export class ConversationService extends AppService {
       sanitisedTitle,
     );
 
-    const sourceUrl = `conversations/${bucket}/${encodeDialResourcePath(conversationPath)}`;
-    const destinationUrl = `conversations/${bucket}/${encodeDialResourcePath(renamedPath)}`;
+    const sourceUrl = `${buildConversationUrl(bucket, encodeDialResourcePath(conversationPath))}`;
+    const destinationUrl = `${buildConversationUrl(bucket, encodeDialResourcePath(renamedPath))}`;
 
     try {
       const { error } = (await this.client.moveResource({
@@ -259,7 +265,17 @@ export class ConversationService extends AppService {
       return handleDialError(error);
     }
 
-    return { newPath: `conversations/${bucket}/${renamedPath}` };
+    // Migrate pin state: if the old conversation was pinned, point the pin at
+    // the new path. Fire-and-forget, non-fatal (mirrors deleteConversation cleanup).
+    const oldPinId = buildConversationUrl(bucket, conversationPath);
+    const newPinId = buildConversationUrl(bucket, renamedPath);
+    void this.userConfigService
+      .migratePin(oldPinId, newPinId, token, bucket)
+      .catch((err) =>
+        this.logger.error('Failed to migrate pin on rename', err),
+      );
+
+    return { newPath: buildConversationUrl(bucket, renamedPath) };
   }
 
   async duplicateConversation(
@@ -282,8 +298,14 @@ export class ConversationService extends AppService {
     );
     const destFilename = buildRenamedConversationPath(filename, uniqueTitle);
 
-    const sourceUrl = `conversations/${sourceBucket}/${encodeDialResourcePath(subPath)}`;
-    const destinationUrl = `conversations/${sessionBucket}/${encodeURIComponent(destFilename)}`;
+    const sourceUrl = buildConversationUrl(
+      sourceBucket,
+      encodeDialResourcePath(subPath),
+    );
+    const destinationUrl = buildConversationUrl(
+      sessionBucket,
+      encodeURIComponent(destFilename),
+    );
 
     try {
       const { error } = (await this.client.copyResource({
@@ -299,7 +321,7 @@ export class ConversationService extends AppService {
       return handleDialError(error);
     }
 
-    return { newPath: `conversations/${sessionBucket}/${destFilename}` };
+    return { newPath: buildConversationUrl(sessionBucket, destFilename) };
   }
 
   async listConversations(
@@ -387,7 +409,7 @@ export class ConversationService extends AppService {
         );
       }
 
-      const pinnedSet = new Set(pinnedIds);
+      const pinnedSet = new Set(pinnedIds.map(safeDecodeURIComponent));
 
       const mapItems = (
         items: MetadataItem[],
@@ -398,6 +420,7 @@ export class ConversationService extends AppService {
           .map((item) => {
             const id =
               item.url ?? `${item.parentPath ?? ''}/${item.name ?? ''}`;
+            const decodedId = safeDecodeURIComponent(id);
             return {
               id,
               title: getConversationTitleFromName(item.name ?? ''),
@@ -406,7 +429,7 @@ export class ConversationService extends AppService {
                 overrides.sharedWithMe ?? item.sharedWithMe ?? false,
               publishedWithMe:
                 overrides.publishedWithMe ?? item.publishedWithMe ?? false,
-              isPinned: pinnedSet.has(id),
+              isPinned: pinnedSet.has(decodedId),
             };
           });
 
@@ -479,13 +502,14 @@ export class ConversationService extends AppService {
               .filter((r) => r.nodeType !== 'FOLDER')
               .map((r) => {
                 const id = r.url ?? `${r.parentPath ?? ''}/${r.name ?? ''}`;
+                const decodedId = safeDecodeURIComponent(id);
                 return {
                   id,
                   title: getConversationTitleFromName(r.name ?? ''),
                   updatedAt: 0,
                   sharedWithMe: true,
                   publishedWithMe: false,
-                  isPinned: pinnedSet.has(id),
+                  isPinned: pinnedSet.has(decodedId),
                 };
               })
           : [];

--- a/apps/chat-api/src/conversations/utils/conversation.utils.ts
+++ b/apps/chat-api/src/conversations/utils/conversation.utils.ts
@@ -66,6 +66,21 @@ export const buildRenamedConversationPath = (
 export const encodeDialResourcePath = (path: string): string =>
   path.split('/').map(encodeURIComponent).join('/');
 
+/** Decodes a URI component, returning the original string if decoding fails. */
+export const safeDecodeURIComponent = (value: string): string => {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+};
+
+/** Builds the full DIAL Core resource URL for a conversation: `conversations/<bucket>/<path>` */
+export const buildConversationUrl = (
+  bucket: string,
+  conversationPath: string,
+): string => `conversations/${bucket}/${conversationPath}`;
+
 export const encodeCompoundToken = (
   userToken?: string,
   publicToken?: string,

--- a/apps/chat-api/src/user-config/user-config.service.ts
+++ b/apps/chat-api/src/user-config/user-config.service.ts
@@ -107,4 +107,26 @@ export class UserConfigService extends AppService {
       bucket,
     );
   }
+
+  /**
+   * If `oldId` is currently pinned, replace it with `newId` in a single
+   * read-modify-write. No-ops silently when `oldId` is not pinned.
+   */
+  async migratePin(
+    oldId: string,
+    newId: string,
+    token: string,
+    bucket: string,
+  ): Promise<void> {
+    const config = await this.readConfig(token, bucket);
+    const ids = config.pinnedConversationIds;
+    const index = ids.indexOf(oldId);
+    if (index === -1) return;
+    ids[index] = newId;
+    await this.writeConfig(
+      { ...config, version: CURRENT_CONFIG_VERSION },
+      token,
+      bucket,
+    );
+  }
 }

--- a/openspec/specs/conversation-rename/spec.md
+++ b/openspec/specs/conversation-rename/spec.md
@@ -97,12 +97,18 @@ i18n keys:
 
 ### Requirement: ConversationsContext exposes renameConversation with optimistic update
 
-`ConversationsContext` SHALL expose a `renameConversation(id: string, newTitle: string): Promise<void>` operation. Implementation:
+`ConversationsContext` SHALL expose a `renameConversation(id: string, newTitle: string): Promise<string>` operation. Implementation:
 
-1. Optimistically update the matching item's `title` in local state.
-2. Call `PATCH /api/v1/conversations` via the server-api wrapper.
-3. On success, update the item's `id` in local state to the `newPath` returned by the API.
-4. On failure, revert the optimistic title update and re-throw the error.
+1. Capture whether the conversation is currently pinned (`wasPinned`).
+2. Optimistically update the matching item's `title` in local state.
+3. Call `PATCH /api/v1/conversations/:path/rename` via the server-api wrapper.
+4. On success:
+   a. Update the item's `id` in local state to the `newPath` returned by the API.
+   b. If `wasPinned` is true, call `PATCH /api/v1/user-config/pins` twice: first to unpin the old ID, then to pin the new `newPath`. Failures in this step are caught and logged without failing the rename.
+5. On failure, revert the optimistic title update and re-throw the error.
+6. Return `newPath`.
+
+Background: DIAL Core renames a conversation by **moving** it to a new path derived from the new title. The old ID ceases to exist after a rename, so the pinned-conversation list must be updated atomically or the pin state will be lost on page refresh.
 
 State ownership: `ConversationsContext` — no new context state needed beyond the function exposed on the interface.
 
@@ -120,6 +126,17 @@ State ownership: `ConversationsContext` — no new context state needed beyond t
 
 - **WHEN** the API returns `{ newPath: "conversations/bucket/model__New Name__uuid" }`
 - **THEN** the item's `id` in the list is updated to match the returned path
+
+#### Scenario: Pinned state is preserved after rename
+
+- **WHEN** a pinned conversation is renamed successfully
+- **THEN** `updatePin` is called to unpin the old ID and then pin the new ID
+- **AND** the conversation remains pinned after page refresh
+
+#### Scenario: Rename succeeds even when pin update fails
+
+- **WHEN** a pinned conversation is renamed and the `updatePin` API calls throw
+- **THEN** the rename itself still resolves (no error is re-thrown for the pin failure)
 
 ---
 


### PR DESCRIPTION
## Description of changes
Fix for pinned conversation loses pin state after rename + page refresh

## Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #<ISSUE_ID>

## UI changes

<Please, provide Screenshots or Figma links>

## Checklist

- [ ] the pull request name ends with `(Issue #<ISSUE_ID>)` (comma-separated list of issues)
- [ ] I confirm that I don't share any confidential information like API keys or any other secrets and private URLs

<details>
  <summary>PR title cheatsheet</summary>

`<type>[optional scope]: <description>`

1. type (required)
    - `feat` - A new feature
    - `fix` - A bug fix
    - `docs` - Documentation only changes
    - `test` - Adding missing tests or correcting existing tests
    - `ci` - Changes to our CI configuration files and scripts
    - `chore` - Other changes that are minor and/or not user-facing
2. scope (optional, current repo suggestions below)
    - `chat`
    - `overlay`
    - `shared`
    - `sandbox-overlay`
    - `visualizer-connector`

</details>
