### PR TITLE
fix: Show attachments consistently in edit message input

### DIFF
--- a/libs/conversation-input/src/components/EditMessageInput/EditMessageInput.tsx
+++ b/libs/conversation-input/src/components/EditMessageInput/EditMessageInput.tsx
@@ -4,7 +4,6 @@ import { DialNeutralButton, DialPrimaryButton } from '@epam/ai-dial-ui-kit';
 import { ChangeEvent, type FC, useCallback, useRef, useState } from 'react';
 import type { EditMessageInputProps } from '../../models/ConversationInput';
 import { AddAttachmentButton } from '../AddAttachmentButton/AddAttachmentButton';
-import { AttachmentTray } from '../AttachmentTray/AttachmentTray';
 import { Input } from '../Input/Input';
 
 export const EditMessageInput: FC<EditMessageInputProps> = ({
@@ -71,15 +70,7 @@ export const EditMessageInput: FC<EditMessageInputProps> = ({
 
   return (
     <div className={mergeClasses('flex w-full flex-col gap-2', className)}>
-      {keptAttachments.length > 0 && (
-        <AttachmentTray
-          attachments={keptAttachments}
-          onRemove={handleRemovePreExisting}
-          removeLabel={removeLabel}
-        />
-      )}
-
-      {/* Bordered box — contains only the textarea (and new attachment tray) */}
+      {/* Bordered box — contains kept attachments, new attachments, and the textarea */}
       <Input
         message={message}
         ariaLabel={ariaLabel}
@@ -94,6 +85,8 @@ export const EditMessageInput: FC<EditMessageInputProps> = ({
         removeLabel={removeLabel}
         retryLabel={retryLabel}
         className="max-w-full"
+        prefixAttachments={keptAttachments}
+        onRemovePrefixAttachment={handleRemovePreExisting}
       />
 
       {/* Action row — outside the bordered box */}

--- a/libs/conversation-input/src/components/Input/Input.tsx
+++ b/libs/conversation-input/src/components/Input/Input.tsx
@@ -71,6 +71,8 @@ export const Input: FC<InputProps> = ({
   onUploadAudio,
   onTranscribeAudio,
   sendOnEnter = SendOnEnter.Enter,
+  prefixAttachments = [],
+  onRemovePrefixAttachment,
 }) => {
   const isMobile = useIsMobile();
   const cssVars = useMemo(
@@ -377,10 +379,16 @@ export const Input: FC<InputProps> = ({
         className,
       )}
     >
-      {attachments.length > 0 && (
+      {(prefixAttachments.length > 0 || attachments.length > 0) && (
         <AttachmentTray
-          attachments={attachments}
-          onRemove={handleRemove}
+          attachments={[...prefixAttachments, ...attachments]}
+          onRemove={(id) => {
+            if (prefixAttachments.some((a) => a.id === id)) {
+              onRemovePrefixAttachment?.(id);
+            } else {
+              handleRemove(id);
+            }
+          }}
           onRetry={handleRetry}
           onExpand={handleExpand}
           removeLabel={removeLabel}

--- a/libs/conversation-input/src/models/Input.ts
+++ b/libs/conversation-input/src/models/Input.ts
@@ -1,4 +1,8 @@
-import type { Attachment, DeploymentItem } from '@epam/ai-dial-chat-shared';
+import type {
+  Attachment,
+  DeploymentItem,
+  DisplayAttachment,
+} from '@epam/ai-dial-chat-shared';
 import type { ReactNode } from 'react';
 
 /**
@@ -182,4 +186,8 @@ export interface InputProps {
    * - `SendOnEnter.MetaEnter`: ⌘+Enter (macOS) / Ctrl+Enter (Windows/Linux) submits; bare Enter inserts a newline.
    */
   sendOnEnter?: SendOnEnter;
+  /** Attachments managed externally (e.g. pre-existing kept attachments in edit mode) prepended to the tray alongside locally-added ones. */
+  prefixAttachments?: DisplayAttachment[];
+  /** Called when the user removes an attachment from `prefixAttachments`. */
+  onRemovePrefixAttachment?: (id: string) => void;
 }

--- a/libs/conversation-messages/src/components/MessageBubble/UserMessageBubble.tsx
+++ b/libs/conversation-messages/src/components/MessageBubble/UserMessageBubble.tsx
@@ -87,6 +87,7 @@ export const UserMessageBubble: FC<UserMessageBubbleProps> = ({
           attachments={attachments ?? []}
           onAttachmentClick={onAttachmentClick}
           clickLabel={attachmentClickLabel}
+          className="max-w-[640px] flex-wrap justify-end overflow-x-visible"
         />
         {text && (
           <div

--- a/openspec/specs/attachment-response-display/spec.md
+++ b/openspec/specs/attachment-response-display/spec.md
@@ -62,6 +62,8 @@
 
 `libs/conversation-messages/src/components/MessageBubble/UserMessageBubble.tsx` SHALL accept an optional `attachments?: DisplayAttachment[]` display prop. When non-empty, it SHALL render an `AttachmentTray` above the message text. The tray SHALL be read-only: no remove button, no retry button (`alwaysShowActions={false}`, no `onRemove`, no `onRetry`). API attachment DTOs SHALL be mapped to `DisplayAttachment[]` before reaching this component.
 
+The tray SHALL be right-aligned (cards packed to the right edge), wrap to multiple rows when there are more than 6 cards, and show at most 6 cards per row (capped at `640px` = 6 × 100px cards + 5 × 8px gaps).
+
 #### Scenario: User bubble with attachments shows tray above text
 
 - **WHEN** `UserMessageBubble` is rendered with two attachments and a text body
@@ -76,6 +78,17 @@
 
 - **WHEN** the tray is rendered in a user bubble
 - **THEN** no remove (×) or retry (↺) buttons are shown
+
+#### Scenario: User bubble tray is right-aligned
+
+- **WHEN** the text bubble is wider than the attachment cards
+- **THEN** the attachment cards are packed against the right edge of the tray
+
+#### Scenario: User bubble tray wraps beyond 6 cards
+
+- **WHEN** a user message has more than 6 attachments
+- **THEN** the tray wraps to a second row rather than scrolling horizontally
+- **THEN** each row contains at most 6 cards, right-aligned
 
 ---
 

--- a/openspec/specs/edit-message/spec.md
+++ b/openspec/specs/edit-message/spec.md
@@ -26,7 +26,7 @@ Clicking the edit button on a user message SHALL replace the static message bubb
 - **WHEN** the user clicks the edit button on a user message
 - **THEN** the message bubble is replaced by an inline editable input area
 - **THEN** the textarea contains the original message text
-- **THEN** existing attachments are displayed in an attachment tray above the bordered textarea box
+- **THEN** existing attachments are displayed inside the bordered textarea box, in the same attachment tray as any newly added attachments
 
 #### Scenario: Edit mode on mobile
 - **WHEN** the user taps the edit button on a mobile device
@@ -40,12 +40,12 @@ Clicking the edit button on a user message SHALL replace the static message bubb
 
 ### Requirement: Edit area layout
 The inline edit area consists of two parts stacked vertically:
-1. A bordered box containing only the textarea (new attachments added during editing appear in a tray inside this box, above the textarea; pre-existing attachments from the original message appear in a tray above the bordered box).
+1. A bordered box containing the attachment tray (pre-existing and newly added attachments shown together) and the textarea below it.
 2. An action row below the bordered box: the attach (+) button on the left, Cancel and Save & Submit buttons on the right.
 
 #### Scenario: Action bar layout
 - **WHEN** a message is in edit mode
-- **THEN** a bordered box is shown containing only the textarea
+- **THEN** a bordered box is shown containing the attachment tray (when attachments are present) and the textarea
 - **THEN** below the bordered box: an attach (+) button is shown on the left
 - **THEN** a Cancel button (neutral style) and a Save & Submit button (primary style) are shown on the right of the action row
 
@@ -66,7 +66,7 @@ While in edit mode, the user SHALL be able to remove existing attachments and ad
 - **WHEN** the user clicks the attach (+) button in the action row
 - **THEN** a file picker opens (desktop: dropdown menu; mobile: bottom sheet)
 - **WHEN** the user selects a file
-- **THEN** the new file is added to the attachment tray inside the bordered box
+- **THEN** the new file appears in the shared attachment tray inside the bordered box, alongside any pre-existing attachments
 
 ---
 


### PR DESCRIPTION
## Description of changes

<!-- Please explain the changes you made right below this line. -->

## Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #<ISSUE_ID>

## UI changes

RO
<img width="1315" height="514" alt="image" src="https://github.com/user-attachments/assets/bb4b5e10-9190-4a00-907e-b7af07420227" />
Edit
<img width="1054" height="293" alt="image" src="https://github.com/user-attachments/assets/b07356f6-1048-42ec-b429-00383e784c58" />
Edit with new attachment
<img width="1034" height="284" alt="image" src="https://github.com/user-attachments/assets/b801a1ee-2d41-418f-8b0d-fd71ca4d2aa7" />
Many attachments
<img width="1197" height="860" alt="image" src="https://github.com/user-attachments/assets/9286b52b-9829-4f45-82e3-88f5f21e0320" />


## Checklist

- [ ] the pull request name ends with `(Issue #<ISSUE_ID>)` (comma-separated list of issues)
- [ ] I confirm that I don't share any confidential information like API keys or any other secrets and private URLs

<details>
  <summary>PR title cheatsheet</summary>

`<type>[optional scope]: <description>`

1. type (required)
    - `feat` - A new feature
    - `fix` - A bug fix
    - `docs` - Documentation only changes
    - `test` - Adding missing tests or correcting existing tests
    - `ci` - Changes to our CI configuration files and scripts
    - `chore` - Other changes that are minor and/or not user-facing
2. scope (optional, current repo suggestions below)
    - `chat`
    - `overlay`
    - `shared`
    - `sandbox-overlay`
    - `visualizer-connector`

</details>
