### PR TITLE
fix: Clear search in attachments sidebar on close, Issue #7151

### DIFF
--- a/apps/chat/src/context/SourcesSidebarContext.tsx
+++ b/apps/chat/src/context/SourcesSidebarContext.tsx
@@ -14,7 +14,7 @@ export interface SourcesSidebarContextValue {
   isOpen: boolean;
   /** Open the sidebar. */
   handleOpen: () => void;
-  /** Close the sidebar and clear the messages. */
+  /** Close the sidebar. */
   handleClose: () => void;
   /** Messages of the active conversation; used to derive uploaded and generated files. */
   messages: Message[];
@@ -38,7 +38,6 @@ export const SourcesSidebarProvider = ({
   const handleOpen = useCallback(() => setIsOpen(true), []);
   const handleClose = useCallback(() => {
     setIsOpen(false);
-    setMessages([]);
   }, []);
 
   return (

--- a/apps/chat/src/context/tests/SourcesSidebarContext.spec.tsx
+++ b/apps/chat/src/context/tests/SourcesSidebarContext.spec.tsx
@@ -58,13 +58,14 @@ describe('SourcesSidebarContext', () => {
     expect(result.current.isOpen).toBe(true);
   });
 
-  it('close() also clears messages', () => {
+  it('close() preserves messages', () => {
     const { result } = renderHook(() => useSourcesSidebar(), { wrapper });
     act(() => result.current.handleOpen());
-    act(() => result.current.setMessages(makeMessages()));
+    const messages = makeMessages();
+    act(() => result.current.setMessages(messages));
     act(() => result.current.handleClose());
     expect(result.current.isOpen).toBe(false);
-    expect(result.current.messages).toEqual([]);
+    expect(result.current.messages).toEqual(messages);
   });
 
   it('throws when used outside provider', () => {

--- a/apps/chat/src/pages/Conversation/Conversation.tsx
+++ b/apps/chat/src/pages/Conversation/Conversation.tsx
@@ -131,7 +131,10 @@ export const ConversationPage: FC = () => {
 
   useEffect(() => {
     setMessages(conversation?.messages ?? []);
-    return () => handleCloseSourcesSidebar();
+    return () => {
+      handleCloseSourcesSidebar();
+      setMessages([]);
+    };
   }, [handleCloseSourcesSidebar, conversation?.messages, setMessages]);
 
   const addStatusMessage = useCallback(


### PR DESCRIPTION
## Description of changes

Fixed problem on search message clean up

UI state (searchQuery) — should reset when panel closes.
Data state (messages used to build attachments) — should survive close/reopen.

Before the change, handleClose() cleared both by clearing messages. So reopen happened with searchQuery='' but no messages, and the panel showed “No data”.

After moving the clear to conversation page unmount cleanup, close/reopen only resets the query, while attachment data stays available. So reopen shows full list, and data is still cleaned when leaving the conversation.
## Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #7151

## UI changes

<Please, provide Screenshots or Figma links>

## Checklist

- [X] the pull request name ends with `(Issue #<ISSUE_ID>)` (comma-separated list of issues)
- [X] I confirm that I don't share any confidential information like API keys or any other secrets and private URLs

<details>
  <summary>PR title cheatsheet</summary>

`<type>[optional scope]: <description>`

1. type (required)
    - `feat` - A new feature
    - `fix` - A bug fix
    - `docs` - Documentation only changes
    - `test` - Adding missing tests or correcting existing tests
    - `ci` - Changes to our CI configuration files and scripts
    - `chore` - Other changes that are minor and/or not user-facing
2. scope (optional, current repo suggestions below)
    - `chat`
    - `overlay`
    - `shared`
    - `sandbox-overlay`
    - `visualizer-connector`

</details>
