### PR TITLE
fix: Send button is disabled after conversation duplication

### DIFF
--- a/apps/chat/src/pages/Conversation/Conversation.tsx
+++ b/apps/chat/src/pages/Conversation/Conversation.tsx
@@ -188,7 +188,11 @@ export const ConversationPage: FC = () => {
         // Restore the last selected agent from the conversation's change history
         // so the deployment selector reflects what was active, not the default.
         const lastDeploymentId = getLastDeploymentId(result.messages);
-        setSelectedItemId(lastDeploymentId ?? result.assistantModelId);
+        const modelToSelect =
+          lastDeploymentId ?? (result.assistantModelId || result.model.id);
+        if (modelToSelect) {
+          setSelectedItemId(modelToSelect);
+        }
 
         const lastMsg = result.messages[result.messages.length - 1];
 


### PR DESCRIPTION
## Description of changes

Fix for the issue: Send button disabled in existing and duplicated conversations — cannot continue the chat

## Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #<ISSUE_ID>

## UI changes

<Please, provide Screenshots or Figma links>

## Checklist

- [ ] the pull request name ends with `(Issue #<ISSUE_ID>)` (comma-separated list of issues)
- [ ] I confirm that I don't share any confidential information like API keys or any other secrets and private URLs

<details>
  <summary>PR title cheatsheet</summary>

`<type>[optional scope]: <description>`

1. type (required)
    - `feat` - A new feature
    - `fix` - A bug fix
    - `docs` - Documentation only changes
    - `test` - Adding missing tests or correcting existing tests
    - `ci` - Changes to our CI configuration files and scripts
    - `chore` - Other changes that are minor and/or not user-facing
2. scope (optional, current repo suggestions below)
    - `chat`
    - `overlay`
    - `shared`
    - `sandbox-overlay`
    - `visualizer-connector`

</details>
