### PR TITLE
fix: "Save & Submit" triggers unnecessary response regeneration when prompt text is unchanged

### DIFF
--- a/.claude/rules/libs.md
+++ b/.claude/rules/libs.md
@@ -26,24 +26,31 @@ Component folders under `src/components/` must use PascalCase and match the comp
 
 Every exported symbol (interfaces, enums, types, functions) must have a JSDoc comment. Each interface/type property must also have an inline `/** ... */` doc. Keep comments factual — describe what the value represents, not how it is used.
 
-## Typography utility classes as props
+## Typography and color utility classes as props
 
-**Never hardcode typography utility classes** (e.g. `dial-body-semi-bold-text`, `dial-small-text`, `text-sm`, `font-bold`) directly in lib component JSX. The consuming app decides which type scale to use. Instead, accept an optional prop and use a sensible default:
+**Never hardcode typography or color utility classes** (e.g. `dial-body-semi-bold-text`, `dial-small-text`, `text-sm`, `font-bold`, `text-primary`, `text-secondary`, `text-accent`) directly in lib component JSX. The consuming app decides which type scale and color tokens to use. Instead, accept an optional prop and use a sensible default:
 
 ```tsx
 // ✅ correct — configurable with a sensible default
 interface MyProps {
   /** Typography class applied to the title. Defaults to `'dial-body-semi-bold-text'`. */
   titleClassName?: string;
+  /** Color class applied to the placeholder icon. Defaults to `'text-secondary'`. */
+  placeholderIconClassName?: string;
 }
 export const MyComponent: FC<MyProps> = ({
   titleClassName = 'dial-body-semi-bold-text',
-}) => <span className={mergeClasses(styles.title, titleClassName)}>…</span>;
+  placeholderIconClassName = 'text-secondary',
+}) => (
+  <>
+    <span className={mergeClasses(styles.title, titleClassName)}>…</span>
+    <Icon className={placeholderIconClassName} />
+  </>
+);
 
 // ❌ wrong — hardcoded in JSX
-<span className={mergeClasses(styles.title, 'dial-body-semi-bold-text')}>
-  …
-</span>;
+<span className={mergeClasses(styles.title, 'dial-body-semi-bold-text')}>…</span>
+<Icon className="text-secondary" />
 ```
 
-Name the prop `<element>ClassName` (e.g. `titleClassName`, `labelClassName`, `itemLabelClassName`). Layout helpers (`truncate`, `min-w-0`, `flex-1`) that are structural rather than typographic may remain hardcoded.
+Name the prop `<element>ClassName` (e.g. `titleClassName`, `labelClassName`, `placeholderIconClassName`). Layout helpers (`truncate`, `min-w-0`, `flex-1`) and structural color-independent utilities that do not vary by theme may remain hardcoded.

--- a/apps/chat/src/hooks/conversation/useConversationHandlers.ts
+++ b/apps/chat/src/hooks/conversation/useConversationHandlers.ts
@@ -28,6 +28,7 @@ import { attachmentsToDtos } from '../../utils/attachment-to-dto';
 import { buildUploadPath } from '../../utils/build-upload-path';
 import { getConversationPath } from '../../utils/conversation-path';
 import { createMessagePair } from '../../utils/message-factory';
+import { isMessageChanged } from '../../utils/message-utils';
 import { getStarterSubmitText } from '../../utils/starter-option';
 
 interface Params {
@@ -396,14 +397,14 @@ export const useConversationHandlers = ({
       const originalMessage = conversation.messages[idx];
       const conversationPath = getConversationPath(conversationId);
 
-      const originalAttachmentCount =
-        originalMessage.custom_content?.attachments?.length ?? 0;
-      const isTextUnchanged = text === originalMessage.content;
-      const hasNoNewAttachments = newAttachments.length === 0;
-      const hasNoRemovedAttachments =
-        keptDisplayAttachments.length === originalAttachmentCount;
-
-      if (isTextUnchanged && hasNoNewAttachments && hasNoRemovedAttachments) {
+      if (
+        !isMessageChanged(
+          originalMessage,
+          text,
+          keptDisplayAttachments,
+          newAttachments,
+        )
+      ) {
         setEditingMessageIndexes((prev) => {
           const next = new Set(prev);
           next.delete(idx);

--- a/apps/chat/src/hooks/conversation/useConversationHandlers.ts
+++ b/apps/chat/src/hooks/conversation/useConversationHandlers.ts
@@ -396,6 +396,22 @@ export const useConversationHandlers = ({
       const originalMessage = conversation.messages[idx];
       const conversationPath = getConversationPath(conversationId);
 
+      const originalAttachmentCount =
+        originalMessage.custom_content?.attachments?.length ?? 0;
+      const isTextUnchanged = text === originalMessage.content;
+      const hasNoNewAttachments = newAttachments.length === 0;
+      const hasNoRemovedAttachments =
+        keptDisplayAttachments.length === originalAttachmentCount;
+
+      if (isTextUnchanged && hasNoNewAttachments && hasNoRemovedAttachments) {
+        setEditingMessageIndexes((prev) => {
+          const next = new Set(prev);
+          next.delete(idx);
+          return next;
+        });
+        return;
+      }
+
       const newDtos = attachmentsToDtos(newAttachments);
 
       const keptIds = new Set(keptDisplayAttachments.map((a) => a.id));

--- a/apps/chat/src/utils/message-utils.ts
+++ b/apps/chat/src/utils/message-utils.ts
@@ -1,4 +1,6 @@
 import {
+  type Attachment,
+  type DisplayAttachment,
   Message,
   MessageRole,
   StatusEvent,
@@ -34,6 +36,28 @@ export const getLastDeploymentId = (messages: Message[]): string | null => {
     }
   }
   return null;
+};
+
+/**
+ * Returns `true` when the edited text or attachment list differs from the
+ * original message, meaning a regeneration is needed.
+ *
+ * @param originalMessage - The unmodified message stored in the conversation.
+ * @param newText - The text the user submitted from the edit area.
+ * @param keptDisplayAttachments - Attachments the user kept (not removed).
+ * @param newAttachments - Brand-new attachments the user added during editing.
+ */
+export const isMessageChanged = (
+  originalMessage: Message,
+  newText: string,
+  keptDisplayAttachments: DisplayAttachment[],
+  newAttachments: Attachment[],
+): boolean => {
+  if (newText !== originalMessage.content) return true;
+  if (newAttachments.length > 0) return true;
+  const originalAttachmentCount =
+    originalMessage.custom_content?.attachments?.length ?? 0;
+  return keptDisplayAttachments.length !== originalAttachmentCount;
 };
 
 export const messageHasStages = (message: Message): boolean =>

--- a/apps/chat/src/utils/tests/message-utils.spec.ts
+++ b/apps/chat/src/utils/tests/message-utils.spec.ts
@@ -1,0 +1,245 @@
+import {
+  type Attachment,
+  AttachmentType,
+  type DisplayAttachment,
+  type Message,
+  MessageRole,
+  RequestStatus,
+  StageStatus,
+  StatusEvent,
+} from '@epam/ai-dial-chat-shared';
+import { describe, expect, it } from 'vitest';
+import {
+  getLastDeploymentId,
+  isMessageChanged,
+  isMessageStreaming,
+  messageHasStages,
+} from '../message-utils';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const userMessage = (content = 'hello'): Message => ({
+  role: MessageRole.User,
+  content,
+  timestamp: '2024-01-01T00:00:00.000Z',
+});
+
+const assistantMessage = (content = 'hi'): Message => ({
+  role: MessageRole.Assistant,
+  content,
+  timestamp: '2024-01-01T00:00:00.000Z',
+});
+
+const statusModelChanged = (newId: string): Message =>
+  ({
+    role: MessageRole.Status,
+    content: '',
+    custom_content: {
+      event_type: StatusEvent.ModelChanged,
+      new_deployment_id: newId,
+    },
+  }) as unknown as Message;
+
+const displayAttachment = (id: string): DisplayAttachment => ({
+  id,
+  name: id,
+  contentType: 'application/octet-stream',
+  type: AttachmentType.File,
+  status: RequestStatus.Idle,
+  url: id,
+});
+
+const attachment = (url: string): Attachment => ({
+  id: url,
+  name: url,
+  contentType: 'application/octet-stream',
+  type: AttachmentType.File,
+  status: RequestStatus.Idle,
+  url,
+  file: new File([], url),
+});
+
+// ---------------------------------------------------------------------------
+// isMessageStreaming
+// ---------------------------------------------------------------------------
+
+describe('isMessageStreaming', () => {
+  it('returns true for the last assistant message while streaming', () => {
+    const msg = assistantMessage();
+    expect(isMessageStreaming(msg, 2, 3, true)).toBe(true);
+  });
+
+  it('returns false when isAssistantTyping is false', () => {
+    const msg = assistantMessage();
+    expect(isMessageStreaming(msg, 2, 3, false)).toBe(false);
+  });
+
+  it('returns false when the message is not the last one', () => {
+    const msg = assistantMessage();
+    expect(isMessageStreaming(msg, 1, 3, true)).toBe(false);
+  });
+
+  it('returns false for a user message even if it is last and typing is true', () => {
+    const msg = userMessage();
+    expect(isMessageStreaming(msg, 2, 3, true)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getLastDeploymentId
+// ---------------------------------------------------------------------------
+
+describe('getLastDeploymentId', () => {
+  it('returns null for an empty list', () => {
+    expect(getLastDeploymentId([])).toBeNull();
+  });
+
+  it('returns null when there are no model_changed status messages', () => {
+    expect(getLastDeploymentId([userMessage(), assistantMessage()])).toBeNull();
+  });
+
+  it('returns the deployment id from the last model_changed event', () => {
+    const messages: Message[] = [
+      userMessage(),
+      statusModelChanged('model-a'),
+      userMessage(),
+      statusModelChanged('model-b'),
+      assistantMessage(),
+    ];
+    expect(getLastDeploymentId(messages)).toBe('model-b');
+  });
+
+  it('returns the only deployment id when there is one model_changed event', () => {
+    expect(
+      getLastDeploymentId([userMessage(), statusModelChanged('model-x')]),
+    ).toBe('model-x');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isMessageChanged
+// ---------------------------------------------------------------------------
+
+describe('isMessageChanged', () => {
+  describe('text only (no attachments)', () => {
+    it('returns false when text is the same and no attachments exist', () => {
+      const original = userMessage('hello');
+      expect(isMessageChanged(original, 'hello', [], [])).toBe(false);
+    });
+
+    it('returns true when text differs', () => {
+      const original = userMessage('hello');
+      expect(isMessageChanged(original, 'world', [], [])).toBe(true);
+    });
+  });
+
+  describe('with existing attachments', () => {
+    const originalWithAttachments: Message = {
+      role: MessageRole.User,
+      content: 'hello',
+      timestamp: '2024-01-01T00:00:00.000Z',
+      custom_content: {
+        attachments: [
+          { type: 'application/octet-stream', title: 'a1', url: 'a1' },
+          { type: 'application/octet-stream', title: 'a2', url: 'a2' },
+        ],
+      },
+    };
+
+    it('returns false when text unchanged and all attachments kept', () => {
+      const kept = [displayAttachment('a1'), displayAttachment('a2')];
+      expect(isMessageChanged(originalWithAttachments, 'hello', kept, [])).toBe(
+        false,
+      );
+    });
+
+    it('returns true when one attachment is removed', () => {
+      const kept = [displayAttachment('a1')];
+      expect(isMessageChanged(originalWithAttachments, 'hello', kept, [])).toBe(
+        true,
+      );
+    });
+
+    it('returns true when a new attachment is added', () => {
+      const kept = [displayAttachment('a1'), displayAttachment('a2')];
+      const added = [attachment('a3')];
+      expect(
+        isMessageChanged(originalWithAttachments, 'hello', kept, added),
+      ).toBe(true);
+    });
+
+    it('returns true when an attachment is removed and a new one added', () => {
+      const kept = [displayAttachment('a1')];
+      const added = [attachment('a3')];
+      expect(
+        isMessageChanged(originalWithAttachments, 'hello', kept, added),
+      ).toBe(true);
+    });
+
+    it('returns true when text also changed alongside attachment changes', () => {
+      const kept = [displayAttachment('a1'), displayAttachment('a2')];
+      expect(
+        isMessageChanged(originalWithAttachments, 'changed', kept, []),
+      ).toBe(true);
+    });
+  });
+
+  describe('original message has no attachments', () => {
+    it('returns true when a new attachment is added to a message without attachments', () => {
+      const original = userMessage('hello');
+      expect(isMessageChanged(original, 'hello', [], [attachment('a1')])).toBe(
+        true,
+      );
+    });
+
+    it('returns false when kept list is empty matching original zero attachments', () => {
+      const original = userMessage('hello');
+      expect(isMessageChanged(original, 'hello', [], [])).toBe(false);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// messageHasStages
+// ---------------------------------------------------------------------------
+
+describe('messageHasStages', () => {
+  it('returns false for a user message', () => {
+    expect(messageHasStages(userMessage())).toBe(false);
+  });
+
+  it('returns false for an assistant message with no stages', () => {
+    expect(messageHasStages(assistantMessage())).toBe(false);
+  });
+
+  it('returns false for an assistant message with an empty stages array', () => {
+    const msg: Message = {
+      role: MessageRole.Assistant,
+      content: '',
+      timestamp: '2024-01-01T00:00:00.000Z',
+      custom_content: { stages: [] },
+    };
+    expect(messageHasStages(msg)).toBe(false);
+  });
+
+  it('returns true for an assistant message with at least one stage', () => {
+    const msg: Message = {
+      role: MessageRole.Assistant,
+      content: '',
+      timestamp: '2024-01-01T00:00:00.000Z',
+      custom_content: {
+        stages: [
+          {
+            index: 0,
+            name: 'step-1',
+            status: StageStatus.Completed,
+            content: '',
+          },
+        ],
+      },
+    };
+    expect(messageHasStages(msg)).toBe(true);
+  });
+});

--- a/libs/conversation-input/src/components/AttachmentCard/AttachmentCard.tsx
+++ b/libs/conversation-input/src/components/AttachmentCard/AttachmentCard.tsx
@@ -118,7 +118,7 @@ export const AttachmentCard: FC<AttachmentCardProps> = ({
               overlay={
                 <IconPhoto
                   size={DIAL_ICON_SIZE.LG}
-                  className="text-secondary"
+                  className={typography?.placeholderIconClassName ?? 'text-secondary'}
                   aria-hidden
                 />
               }

--- a/libs/conversation-input/src/models/AttachmentCard.ts
+++ b/libs/conversation-input/src/models/AttachmentCard.ts
@@ -18,6 +18,8 @@ export interface AttachmentCardTypography {
   fontClassName?: string;
   /** Utility class applied to the bottom meta label (file type / status). Defaults to `'dial-tiny-text'`. */
   metaClassName?: string;
+  /** Utility class applied to the placeholder icon shown while the image is loading. Defaults to `'text-secondary'`. */
+  placeholderIconClassName?: string;
 }
 
 /** Props accepted by the `AttachmentCard` component. */

--- a/openspec/changes/archive/2026-06-02-edit-message/specs/edit-message/spec.md
+++ b/openspec/changes/archive/2026-06-02-edit-message/specs/edit-message/spec.md
@@ -65,7 +65,7 @@ Clicking Cancel SHALL exit edit mode and restore the original message bubble wit
 - **THEN** the original message text and attachments are displayed unchanged
 
 ### Requirement: Submitting an edit
-Clicking Save & Submit (or pressing Enter in the textarea) SHALL update the message content, discard all subsequent messages, silently cancel any other active edits, and re-run the AI from that message.
+Clicking Save & Submit (or pressing Enter in the textarea) SHALL update the message content, discard all subsequent messages, silently cancel any other active edits, and re-run the AI from that message. If the text and attachments are identical to the original, the edit is silently discarded and no regeneration occurs.
 
 #### Scenario: Successful edit submission
 - **WHEN** the user modifies the text in the edit area and clicks Save & Submit
@@ -73,6 +73,12 @@ Clicking Save & Submit (or pressing Enter in the textarea) SHALL update the mess
 - **THEN** all messages after the edited message are removed from the conversation
 - **THEN** the AI is re-triggered with the updated message and attachments
 - **THEN** a new streaming assistant response begins
+
+#### Scenario: Save & Submit with no changes discards the edit silently
+- **WHEN** the user opens edit mode on a message and clicks Save & Submit without changing the text or attachments
+- **THEN** the edit area is closed
+- **THEN** the original message bubble is restored unchanged
+- **THEN** no new AI response is generated
 
 #### Scenario: Other edits silently cancelled on submit
 - **WHEN** the user submits an edit while other messages are also in edit mode


### PR DESCRIPTION
## Description of changes
Fix for issue that  "Save & Submit" triggers unnecessary response regeneration when prompt text is unchanged
## Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #<ISSUE_ID>

## UI changes

<Please, provide Screenshots or Figma links>

## Checklist

- [X] the pull request name ends with `(Issue #<ISSUE_ID>)` (comma-separated list of issues)
- [ ] I confirm that I don't share any confidential information like API keys or any other secrets and private URLs

<details>
  <summary>PR title cheatsheet</summary>

`<type>[optional scope]: <description>`

1. type (required)
    - `feat` - A new feature
    - `fix` - A bug fix
    - `docs` - Documentation only changes
    - `test` - Adding missing tests or correcting existing tests
    - `ci` - Changes to our CI configuration files and scripts
    - `chore` - Other changes that are minor and/or not user-facing
2. scope (optional, current repo suggestions below)
    - `chat`
    - `overlay`
    - `shared`
    - `sandbox-overlay`
    - `visualizer-connector`

</details>
