### PR TITLE
fix: Fix input lose focus and settings not applied, Issues  #7170, #7171

### DIFF
--- a/apps/chat/src/hooks/keyboard-shortcut/useKeyboardShortcutPreference.ts
+++ b/apps/chat/src/hooks/keyboard-shortcut/useKeyboardShortcutPreference.ts
@@ -1,5 +1,5 @@
 import { SendOnEnter } from '@epam/ai-dial-conversation-input';
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { StorageKey } from '../../constants/storage';
 import {
   getFromLocalStorage,
@@ -12,6 +12,8 @@ export const isMac =
 
 export const metaKey = isMac ? '⌘' : 'Ctrl';
 
+const PREFERENCE_CHANGE_EVENT = 'keyboard-shortcut-preference-change';
+
 const readStoredPreference = (): SendOnEnter => {
   const stored = getFromLocalStorage(StorageKey.KeyboardShortcut);
   return stored === SendOnEnter.MetaEnter
@@ -23,9 +25,21 @@ export const useKeyboardShortcutPreference = () => {
   const [preference, setPreferenceState] =
     useState<SendOnEnter>(readStoredPreference);
 
+  useEffect(() => {
+    const handleChange = (e: Event) => {
+      setPreferenceState((e as CustomEvent<SendOnEnter>).detail);
+    };
+    window.addEventListener(PREFERENCE_CHANGE_EVENT, handleChange);
+    return () =>
+      window.removeEventListener(PREFERENCE_CHANGE_EVENT, handleChange);
+  }, []);
+
   const setPreference = useCallback((value: SendOnEnter) => {
     setToLocalStorage(StorageKey.KeyboardShortcut, value);
     setPreferenceState(value);
+    window.dispatchEvent(
+      new CustomEvent<SendOnEnter>(PREFERENCE_CHANGE_EVENT, { detail: value }),
+    );
   }, []);
 
   return { preference, setPreference };

--- a/libs/conversation-input/src/components/Input/Input.tsx
+++ b/libs/conversation-input/src/components/Input/Input.tsx
@@ -129,6 +129,7 @@ export const Input: FC<InputProps> = ({
   const fileInputRef = useRef<HTMLInputElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const singleRowHeightRef = useRef<number>(0);
+  const restoreCursorPosRef = useRef<number | null>(null);
   const [isMultiLine, setIsMultiLine] = useState(false);
 
   useEffect(() => {
@@ -274,6 +275,15 @@ export const Input: FC<InputProps> = ({
     }
   };
 
+  useLayoutEffect(() => {
+    const pos = restoreCursorPosRef.current;
+    if (pos != null && isStackedLayout && textareaRef.current) {
+      restoreCursorPosRef.current = null;
+      textareaRef.current.focus();
+      textareaRef.current.setSelectionRange(pos, pos);
+    }
+  }, [isStackedLayout]);
+
   const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
     const isEnterKey = e.key === 'Enter';
     if (!isEnterKey) return;
@@ -288,6 +298,13 @@ export const Input: FC<InputProps> = ({
       if (!isStreaming && canSend && hasModelSelected) {
         handleSend();
       }
+    } else if (!isStackedLayout) {
+      // A newline will be inserted and the layout will transition from
+      // non-stacked to stacked, remounting the textarea and losing focus.
+      // Capture the position after the inserted '\n' so the layout-effect
+      // can restore both focus and the cursor to the correct location.
+      const pos = e.currentTarget.selectionStart ?? 0;
+      restoreCursorPosRef.current = pos + 1;
     }
   };
 

--- a/openspec/specs/keyboard-shortcut-preference/spec.md
+++ b/openspec/specs/keyboard-shortcut-preference/spec.md
@@ -26,6 +26,11 @@ A hook `useKeyboardShortcutPreference` SHALL expose `{ preference, setPreference
 - **WHEN** `setPreference('meta-enter')` is called
 - **THEN** `localStorage` is updated to `'meta-enter'` AND subsequent reads of `preference` return `'meta-enter'`
 
+### Scenario: Preference change is reflected in all hook instances immediately
+- **GIVEN** multiple components each call `useKeyboardShortcutPreference()` (e.g. settings menu and the chat input)
+- **WHEN** `setPreference` is called in one instance (e.g. the user selects a new option in settings)
+- **THEN** all other mounted instances update their `preference` value on the same render cycle — no page reload or navigation is required
+
 ---
 
 ## Requirement: Chat input respects the keyboard shortcut preference
@@ -50,3 +55,24 @@ The chat input send handler SHALL read `useKeyboardShortcutPreference` and apply
 ### Scenario: Bare Enter inserts newline when preference is meta-enter
 - **WHEN** `preference = 'meta-enter'` AND the user presses Enter without modifier keys
 - **THEN** a newline is inserted and the message is NOT submitted
+
+---
+
+## Requirement: Focus and cursor position retained after newline insertion
+
+When a newline-inserting key combination (Shift+Enter with `preference = 'enter'`, or bare Enter with `preference = 'meta-enter'`) is pressed and the textarea layout transitions from single-line (non-stacked) to multi-line (stacked), the `Input` component SHALL:
+
+1. Keep keyboard focus in the textarea — the user MUST NOT need to click the input again.
+2. Place the cursor on the new line, immediately after the inserted `\n` — NOT at the start of the text.
+
+This applies to the **first** such key press in a session (when the textarea moves from the inline row into the stacked position) as well as all subsequent presses.
+
+### Scenario: First Shift+Enter retains focus on new line
+- **GIVEN** `preference = 'enter'` AND the textarea is in single-line (non-stacked) layout
+- **WHEN** the user presses Shift+Enter for the first time
+- **THEN** the textarea retains keyboard focus AND the cursor is positioned at the start of the newly inserted line
+
+### Scenario: Subsequent Shift+Enter presses retain focus
+- **GIVEN** `preference = 'enter'` AND the textarea is already in stacked layout
+- **WHEN** the user presses Shift+Enter
+- **THEN** the textarea retains keyboard focus AND the cursor is positioned after the inserted newline


### PR DESCRIPTION
## Description of changes

Fix for two issues related to conversation input - it lose focus on first new line, and send settings are not applied immediately

## Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #7171
- fixes #7170 

## UI changes

<Please, provide Screenshots or Figma links>

## Checklist

- [X] the pull request name ends with `(Issue #<ISSUE_ID>)` (comma-separated list of issues)
- [X] I confirm that I don't share any confidential information like API keys or any other secrets and private URLs

<details>
  <summary>PR title cheatsheet</summary>

`<type>[optional scope]: <description>`

1. type (required)
    - `feat` - A new feature
    - `fix` - A bug fix
    - `docs` - Documentation only changes
    - `test` - Adding missing tests or correcting existing tests
    - `ci` - Changes to our CI configuration files and scripts
    - `chore` - Other changes that are minor and/or not user-facing
2. scope (optional, current repo suggestions below)
    - `chat`
    - `overlay`
    - `shared`
    - `sandbox-overlay`
    - `visualizer-connector`

</details>
