### PR TITLE
fix: "System" theme option does nothing when selected, Issue #7169

### DIFF
--- a/apps/chat/src/utils/apply-theme-colors.ts
+++ b/apps/chat/src/utils/apply-theme-colors.ts
@@ -1,6 +1,5 @@
 import { Theme } from '@epam/ai-dial-chat-shared';
-import { StorageKey, ThemeId } from '../constants/storage';
-import { setToLocalStorage } from './local-storage';
+import { ThemeId } from '../constants/storage';
 
 export const getOsPreferredTheme = (): string =>
   window.matchMedia('(prefers-color-scheme: dark)').matches
@@ -14,7 +13,5 @@ export const applyThemeColors = (div: HTMLElement, theme?: Theme) => {
     Object.entries(themeColors).forEach(([key, value]) => {
       div.style.setProperty(`--${key}`, value);
     });
-
-    setToLocalStorage(StorageKey.Theme, theme.id); // Persist the theme
   }
 };


### PR DESCRIPTION


## Description of changes
Fix removes the setToLocalStorage(StorageKey.Theme, theme.id) side-effect from applyThemeColors.

Root cause: When the user clicked System, setTheme('system') correctly wrote 'system' to localStorage, but then applyThemeColors immediately overwrote it with the resolved value ('dark' or 'light'). So storedTheme read back from localStorage was never 'system', causing the checkmark to never land on System and the stored preference to be lost on page reload too.

## Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #7169

## UI changes

<Please, provide Screenshots or Figma links>

## Checklist

- [X] the pull request name ends with `(Issue #<ISSUE_ID>)` (comma-separated list of issues)
- [X] I confirm that I don't share any confidential information like API keys or any other secrets and private URLs

<details>
  <summary>PR title cheatsheet</summary>

`<type>[optional scope]: <description>`

1. type (required)
    - `feat` - A new feature
    - `fix` - A bug fix
    - `docs` - Documentation only changes
    - `test` - Adding missing tests or correcting existing tests
    - `ci` - Changes to our CI configuration files and scripts
    - `chore` - Other changes that are minor and/or not user-facing
2. scope (optional, current repo suggestions below)
    - `chat`
    - `overlay`
    - `shared`
    - `sandbox-overlay`
    - `visualizer-connector`

</details>
