### PR TITLE
fix: handle undefined contentType in attachment icon retrieval

### DIFF
--- a/libs/conversation-input/src/utils/getAttachmentCardState.ts
+++ b/libs/conversation-input/src/utils/getAttachmentCardState.ts
@@ -25,7 +25,7 @@ const getBottomIcon = (attachment: DisplayAttachment): Icon => {
   if (type === AttachmentType.Prompt) return IconTerminal2;
   if (type === AttachmentType.Pasted) return IconClipboard;
   if (type === AttachmentType.Image) return IconPhoto;
-  return getAttachmentIcon(contentType);
+  return getAttachmentIcon(contentType ?? '');
 };
 
 const getBottomLabel = (attachment: DisplayAttachment): string => {
@@ -37,7 +37,7 @@ const getBottomLabel = (attachment: DisplayAttachment): string => {
   if (name.includes('.')) {
     return `.${name.slice(name.lastIndexOf('.') + 1).toLowerCase()}`;
   }
-  const subtype = contentType.split('/')[1];
+  const subtype = contentType?.split('/')[1];
   return subtype ? `.${subtype.toLowerCase()}` : name;
 };
 

--- a/libs/conversation-input/src/utils/getAttachmentIcon.ts
+++ b/libs/conversation-input/src/utils/getAttachmentIcon.ts
@@ -35,6 +35,7 @@ import type { Icon } from '@tabler/icons-react';
  * covers as many known file types as possible. Falls back to `IconFile`.
  */
 export const getAttachmentIcon = (contentType: string): Icon => {
+  if (!contentType) return IconFile;
   // Broad category checks first
   if (contentType.startsWith('image/')) {
     switch (contentType) {


### PR DESCRIPTION
## Description of changes

<!-- Please explain the changes you made right below this line. -->

## Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #<ISSUE_ID>

## UI changes

<Please, provide Screenshots or Figma links>

## Checklist

- [ ] the pull request name ends with `(Issue #<ISSUE_ID>)` (comma-separated list of issues)
- [ ] I confirm that I don't share any confidential information like API keys or any other secrets and private URLs

<details>
  <summary>PR title cheatsheet</summary>

`<type>[optional scope]: <description>`

1. type (required)
    - `feat` - A new feature
    - `fix` - A bug fix
    - `docs` - Documentation only changes
    - `test` - Adding missing tests or correcting existing tests
    - `ci` - Changes to our CI configuration files and scripts
    - `chore` - Other changes that are minor and/or not user-facing
2. scope (optional, current repo suggestions below)
    - `chat`
    - `overlay`
    - `shared`
    - `sandbox-overlay`
    - `visualizer-connector`

</details>
