### PR TITLE
feat: Implement conversation drag and drop, Issue #7209

### DIFF
--- a/apps/chat/src/components/ConversationPanel/ConversationPanelView.tsx
+++ b/apps/chat/src/components/ConversationPanel/ConversationPanelView.tsx
@@ -1,6 +1,8 @@
 import {
+  ConversationGroupKey,
   ConversationPanel,
   type ConversationHistoryItem,
+  type ConversationMove,
 } from '@epam/ai-dial-conversation-panel';
 import {
   ConfirmationPopupVariant,
@@ -167,6 +169,24 @@ const ConversationPanelView: FC<ConversationPanelViewProps> = ({
       organization: t(ConversationPanelI18nKeys.FilterOrganization),
     }),
     [t],
+  );
+
+  const handleMoveConversation = useCallback(
+    ({ draggedId, targetGroupKey }: ConversationMove) => {
+      const contextId = panelToContextId.get(draggedId);
+      if (!contextId) return;
+
+      const draggedItem = conversations.find((c) => c.id === draggedId);
+      if (!draggedItem) return;
+
+      if (targetGroupKey === ConversationGroupKey.Pinned) {
+        void pinConversation(contextId, true);
+      } else if (draggedItem.isPinned) {
+        void pinConversation(contextId, false);
+      }
+      // Same-group reorder: no API available in this iteration — no-op.
+    },
+    [panelToContextId, conversations, pinConversation],
   );
 
   const getActions = useCallback(
@@ -345,6 +365,7 @@ const ConversationPanelView: FC<ConversationPanelViewProps> = ({
         defaultPanelWidth={defaultPanelWidth}
         maxPanelWidth={maxPanelWidth}
         onPanelResizeStop={setStoredPanelWidth}
+        onMoveConversation={handleMoveConversation}
         headerActions={
           <DeleteAllConversationsAction
             activeConversationId={activeConversationId}

--- a/libs/conversation-panel/src/components/ConversationGroup/ConversationRow.tsx
+++ b/libs/conversation-panel/src/components/ConversationGroup/ConversationRow.tsx
@@ -11,9 +11,18 @@ import {
   type DropdownItem,
 } from '@epam/ai-dial-ui-kit';
 import { IconDotsVertical } from '@tabler/icons-react';
-import { useCallback, useState, type FC, type MouseEvent } from 'react';
+import {
+  useCallback,
+  useState,
+  type DragEvent,
+  type FC,
+  type MouseEvent,
+} from 'react';
 import type { ConversationHistoryItem } from '../../models/ConversationPanel';
+import type { VirtualRow } from '../../models/virtual-row';
+import { ConversationGroupKey } from '../../types/conversation-group-key';
 import { getButtonPaddingEnd } from '../../utils/conversation-row.utils';
+import { getDropAfterId } from '../../utils/drag';
 import styles from '../ConversationPanel/ConversationPanel.module.scss';
 
 export interface ConversationRowProps {
@@ -33,6 +42,33 @@ export interface ConversationRowProps {
   actionsLabel?: string;
   /** Typography class for the conversation title text. Defaults to `'dial-small-text'`. */
   itemTitleClassName?: string;
+  /**
+   * The group this row belongs to — required to enable drag-and-drop.
+   * When absent the row is not draggable (used by `ConversationGroup`).
+   */
+  rowGroupKey?: ConversationGroupKey;
+  /** The full virtual rows array — used to compute drop position. */
+  rows?: VirtualRow[];
+  /** Id of the conversation currently being dragged. `null` when no drag is active. */
+  draggingId?: string | null;
+  /** Id of the row currently under the drag cursor. */
+  dragOverId?: string | null;
+  /** Groups that are valid drop targets for the current drag. `null` when no drag is active. */
+  allowedDropGroups?: Set<ConversationGroupKey> | null;
+  /** Called when the user starts dragging this row. */
+  onDragStart?: (id: string) => void;
+  /** Called when the drag ends (drop or cancel). */
+  onDragEnd?: () => void;
+  /** Called when the drag cursor enters this row. */
+  onDragOver?: (id: string) => void;
+  /** Called when the drag cursor leaves this row. */
+  onDragLeave?: () => void;
+  /** Called when the user drops onto this row. */
+  onDrop?: (
+    targetId: string,
+    targetGroupKey: ConversationGroupKey,
+    afterId: string | null,
+  ) => void;
 }
 
 export const ConversationRow: FC<ConversationRowProps> = ({
@@ -42,6 +78,16 @@ export const ConversationRow: FC<ConversationRowProps> = ({
   getActions,
   actionsLabel = 'More actions',
   itemTitleClassName = 'dial-small-text',
+  rowGroupKey,
+  rows,
+  draggingId,
+  dragOverId,
+  allowedDropGroups,
+  onDragStart,
+  onDragEnd,
+  onDragOver,
+  onDragLeave,
+  onDrop,
 }) => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
 
@@ -60,7 +106,6 @@ export const ConversationRow: FC<ConversationRowProps> = ({
 
   const handleAuxClick = useCallback(
     (e: MouseEvent<HTMLButtonElement>) => {
-      // Middle mouse button (button === 1) — open conversation in a new tab
       if (e.button === 1 && item.href) {
         e.preventDefault();
         window.open(item.href, '_blank', 'noreferrer');
@@ -71,7 +116,6 @@ export const ConversationRow: FC<ConversationRowProps> = ({
 
   const handleMouseDown = useCallback(
     (e: MouseEvent<HTMLButtonElement>) => {
-      // Prevent the browser autoscroll indicator from appearing on middle click
       if (e.button === 1 && item.href) {
         e.preventDefault();
       }
@@ -79,8 +123,58 @@ export const ConversationRow: FC<ConversationRowProps> = ({
     [item.href],
   );
 
+  const isDragEnabled = rowGroupKey != null;
+
+  const handleDragLeave = useCallback(
+    (e: DragEvent<HTMLLIElement>) => {
+      // Only clear dragOver when truly leaving the row (not moving between child elements)
+      if (!e.currentTarget.contains(e.relatedTarget as Node)) {
+        onDragLeave?.();
+      }
+    },
+    [onDragLeave],
+  );
+
+  const handleDrop = useCallback(
+    (e: DragEvent<HTMLLIElement>) => {
+      if (!rowGroupKey || !rows || !onDrop) return;
+      e.preventDefault();
+      const afterId = getDropAfterId(e, item.id, rows, rowGroupKey);
+      onDrop(item.id, rowGroupKey, afterId);
+    },
+    [item.id, rows, rowGroupKey, onDrop],
+  );
+
+  const isDragging = item.id === draggingId;
+  const isDropTarget = item.id === dragOverId;
+  const isDropAllowed =
+    rowGroupKey != null && (allowedDropGroups?.has(rowGroupKey) ?? false);
+  const isDragActive = draggingId != null;
+
   return (
-    <li className="group/conversation relative">
+    <li
+      className={mergeClasses(
+        'group/conversation relative',
+        isDragging && 'cursor-grabbing opacity-50',
+        isDropTarget &&
+          isDropAllowed &&
+          'ring-accent-secondary rounded ring-1 ring-inset',
+        isDragActive && !isDragging && !isDropAllowed && 'cursor-not-allowed',
+      )}
+      draggable={isDragEnabled || undefined}
+      onDragStart={isDragEnabled ? () => onDragStart?.(item.id) : undefined}
+      onDragEnd={isDragEnabled ? onDragEnd : undefined}
+      onDragOver={
+        isDragEnabled
+          ? (e) => {
+              e.preventDefault();
+              onDragOver?.(item.id);
+            }
+          : undefined
+      }
+      onDragLeave={isDragEnabled ? handleDragLeave : undefined}
+      onDrop={isDragEnabled ? handleDrop : undefined}
+    >
       <DialGhostButton
         iconBefore={avatar}
         label={

--- a/libs/conversation-panel/src/components/ConversationGroupHeader/ConversationGroupHeader.tsx
+++ b/libs/conversation-panel/src/components/ConversationGroupHeader/ConversationGroupHeader.tsx
@@ -1,7 +1,8 @@
 import { mergeClasses } from '@epam/ai-dial-chat-shared';
 import { DialEllipsisTooltip } from '@epam/ai-dial-ui-kit';
 import { IconCaretDownFilled, IconCaretRightFilled } from '@tabler/icons-react';
-import type { FC } from 'react';
+import type { DragEvent, FC } from 'react';
+import { ConversationGroupKey } from '../../types/conversation-group-key';
 import styles from '../ConversationPanel/ConversationPanel.module.scss';
 
 /** Props for `ConversationGroupHeader`. */
@@ -14,6 +15,23 @@ export interface ConversationGroupHeaderProps {
   onToggle: () => void;
   /** Typography class applied to the header button. Defaults to `'dial-tiny-text'`. */
   className?: string;
+  /**
+   * When provided the header acts as a drop zone for drag-and-drop.
+   * Only the Pinned group header receives this prop.
+   */
+  dropZoneGroupKey?: ConversationGroupKey;
+  /** Whether the drag cursor is currently over this header. */
+  isDragOver?: boolean;
+  /** Called when the drag cursor enters this header drop zone. */
+  onDragOver?: (id: string) => void;
+  /** Called when the drag cursor leaves this header drop zone. */
+  onDragLeave?: () => void;
+  /** Called when the user drops onto this header drop zone. */
+  onDrop?: (
+    targetId: string,
+    targetGroupKey: ConversationGroupKey,
+    afterId: string | null,
+  ) => void;
 }
 
 /** Collapsible group header button used in the virtualised conversation list. */
@@ -22,22 +40,55 @@ export const ConversationGroupHeader: FC<ConversationGroupHeaderProps> = ({
   isExpanded,
   onToggle,
   className = 'dial-tiny-text',
-}) => (
-  <button
-    type="button"
-    aria-expanded={isExpanded}
-    onClick={onToggle}
-    className={mergeClasses(
-      'flex h-6 w-full items-center gap-1 rounded py-1 pe-3 text-start',
-      className,
-      styles.groupHeader,
-    )}
-  >
-    {isExpanded ? (
-      <IconCaretDownFilled stroke={0.5} size={12} className="shrink-0" />
-    ) : (
-      <IconCaretRightFilled stroke={0.5} size={12} className="shrink-0" />
-    )}
-    <DialEllipsisTooltip text={label} />
-  </button>
-);
+  dropZoneGroupKey,
+  isDragOver,
+  onDragOver,
+  onDragLeave,
+  onDrop,
+}) => {
+  const isDropZone = dropZoneGroupKey != null;
+
+  const handleDragOver = (e: DragEvent<HTMLButtonElement>) => {
+    if (!isDropZone) return;
+    e.preventDefault();
+    onDragOver?.(dropZoneGroupKey);
+  };
+
+  const handleDragLeave = (e: DragEvent<HTMLButtonElement>) => {
+    if (!isDropZone) return;
+    if (!e.currentTarget.contains(e.relatedTarget as Node)) {
+      onDragLeave?.();
+    }
+  };
+
+  const handleDrop = (e: DragEvent<HTMLButtonElement>) => {
+    if (!isDropZone) return;
+    e.preventDefault();
+    // Drop onto header always inserts at the top of the group (afterId = null)
+    onDrop?.(dropZoneGroupKey, dropZoneGroupKey, null);
+  };
+
+  return (
+    <button
+      type="button"
+      aria-expanded={isExpanded}
+      onClick={onToggle}
+      onDragOver={isDropZone ? handleDragOver : undefined}
+      onDragLeave={isDropZone ? handleDragLeave : undefined}
+      onDrop={isDropZone ? handleDrop : undefined}
+      className={mergeClasses(
+        'flex h-6 w-full items-center gap-1 rounded py-1 pe-3 text-start',
+        className,
+        styles.groupHeader,
+        isDragOver && 'ring-accent-secondary ring-1 ring-inset',
+      )}
+    >
+      {isExpanded ? (
+        <IconCaretDownFilled stroke={0.5} size={12} className="shrink-0" />
+      ) : (
+        <IconCaretRightFilled stroke={0.5} size={12} className="shrink-0" />
+      )}
+      <DialEllipsisTooltip text={label} />
+    </button>
+  );
+};

--- a/libs/conversation-panel/src/components/ConversationPanel/ConversationPanel.tsx
+++ b/libs/conversation-panel/src/components/ConversationPanel/ConversationPanel.tsx
@@ -7,7 +7,7 @@ import {
   SidebarSide,
 } from '@epam/ai-dial-sidebar';
 import { DialSkeleton } from '@epam/ai-dial-ui-kit';
-import { type FC, memo, useCallback, useMemo, useState } from 'react';
+import { type FC, memo, useCallback, useMemo, useRef, useState } from 'react';
 import { List } from 'react-window';
 import { ITEM_ROW_HEIGHT } from '../../constants/virtual-list';
 import {
@@ -26,6 +26,10 @@ import {
   getSkeletonWidth,
   SKELETON_ROW_COUNT,
 } from '../../utils/conversation-row.utils';
+import {
+  computeAllowedDropGroups,
+  findGroupKeyForItem,
+} from '../../utils/drag';
 import { FilterTabs } from '../FilterTabs/FilterTabs';
 import { NewChatButton } from '../NewChatButton/NewChatButton';
 import { RowRenderer } from '../RowRenderer/RowRenderer';
@@ -61,6 +65,7 @@ export const ConversationPanel: FC<ConversationPanelProps> = memo(
     maxPanelWidth = 600,
     onPanelResizeStop,
     headerActions,
+    onMoveConversation,
   }) => {
     const { colors, typography } = panelStyles ?? {};
     const [searchQuery, setSearchQuery] = useState('');
@@ -69,6 +74,16 @@ export const ConversationPanel: FC<ConversationPanelProps> = memo(
       () => ALL_GROUP_KEYS,
     );
     const [overscanCount, setOverscanCount] = useState(5);
+
+    const [draggingId, setDraggingId] = useState<string | null>(null);
+    const [dragOverId, setDragOverId] = useState<string | null>(null);
+    const [allowedDropGroups, setAllowedDropGroups] =
+      useState<Set<ConversationGroupKey> | null>(null);
+
+    // Refs let the drop handler read current values without being in the useCallback dep array,
+    // avoiding recreating the handler (and remounting rows) on every drag-state change.
+    const draggingIdRef = useRef<string | null>(null);
+    const allowedDropGroupsRef = useRef<Set<ConversationGroupKey> | null>(null);
 
     const handleListResize = useCallback(({ height }: { height: number }) => {
       setOverscanCount(Math.ceil((height / ITEM_ROW_HEIGHT) * 2));
@@ -85,6 +100,62 @@ export const ConversationPanel: FC<ConversationPanelProps> = memo(
         return next;
       });
     }, []);
+
+    const clearDragState = useCallback(() => {
+      draggingIdRef.current = null;
+      allowedDropGroupsRef.current = null;
+      setDraggingId(null);
+      setDragOverId(null);
+      setAllowedDropGroups(null);
+    }, []);
+
+    const handleDragStart = useCallback(
+      (id: string, rows: VirtualRow[]) => {
+        const groupKey = findGroupKeyForItem(rows, id);
+        const allowed = computeAllowedDropGroups(id, groupKey, conversations);
+        draggingIdRef.current = id;
+        allowedDropGroupsRef.current = allowed;
+        setDraggingId(id);
+        setAllowedDropGroups(allowed);
+      },
+      [conversations],
+    );
+
+    const handleDragEnd = useCallback(() => {
+      clearDragState();
+    }, [clearDragState]);
+
+    const handleDragOver = useCallback((id: string) => {
+      setDragOverId(id);
+    }, []);
+
+    const handleDragLeave = useCallback(() => {
+      setDragOverId(null);
+    }, []);
+
+    const handleDrop = useCallback(
+      (
+        targetId: string,
+        targetGroupKey: ConversationGroupKey,
+        afterId: string | null,
+      ) => {
+        const currentDraggingId = draggingIdRef.current;
+        const currentAllowed = allowedDropGroupsRef.current;
+        clearDragState();
+        if (
+          currentDraggingId != null &&
+          currentDraggingId !== targetId &&
+          currentAllowed?.has(targetGroupKey)
+        ) {
+          onMoveConversation?.({
+            draggedId: currentDraggingId,
+            targetGroupKey,
+            afterId,
+          });
+        }
+      },
+      [clearDragState, onMoveConversation],
+    );
 
     const hasTypographyClass = Boolean(typography?.fontClassName);
     const cssVars = buildCssVars({
@@ -196,7 +267,7 @@ export const ConversationPanel: FC<ConversationPanelProps> = memo(
         });
         if (expandedGroups.has(group.key)) {
           for (const item of group.items) {
-            rows.push({ kind: VirtualRowKind.Item, item });
+            rows.push({ kind: VirtualRowKind.Item, item, groupKey: group.key });
           }
         }
       }
@@ -214,6 +285,14 @@ export const ConversationPanel: FC<ConversationPanelProps> = memo(
         actionsLabel,
         groupHeaderClassName: typography?.groupHeaderClassName,
         itemTitleClassName: typography?.itemTitleClassName,
+        draggingId,
+        dragOverId,
+        allowedDropGroups,
+        onDragStart: (id: string) => handleDragStart(id, virtualRows),
+        onDragEnd: handleDragEnd,
+        onDragOver: handleDragOver,
+        onDragLeave: handleDragLeave,
+        onDrop: handleDrop,
       }),
       [
         virtualRows,
@@ -225,6 +304,14 @@ export const ConversationPanel: FC<ConversationPanelProps> = memo(
         actionsLabel,
         typography?.groupHeaderClassName,
         typography?.itemTitleClassName,
+        draggingId,
+        dragOverId,
+        allowedDropGroups,
+        handleDragStart,
+        handleDragEnd,
+        handleDragOver,
+        handleDragLeave,
+        handleDrop,
       ],
     );
 

--- a/libs/conversation-panel/src/components/RowRenderer/RowRenderer.tsx
+++ b/libs/conversation-panel/src/components/RowRenderer/RowRenderer.tsx
@@ -1,5 +1,6 @@
 import type { RowComponentProps } from 'react-window';
 import { type RowRendererData, VirtualRowKind } from '../../models/virtual-row';
+import { ConversationGroupKey } from '../../types/conversation-group-key';
 import { ConversationRow } from '../ConversationGroup/ConversationRow';
 import { ConversationGroupHeader } from '../ConversationGroupHeader/ConversationGroupHeader';
 
@@ -16,10 +17,19 @@ export const RowRenderer = ({
   actionsLabel,
   groupHeaderClassName,
   itemTitleClassName,
+  draggingId,
+  dragOverId,
+  allowedDropGroups,
+  onDragStart,
+  onDragEnd,
+  onDragOver,
+  onDragLeave,
+  onDrop,
 }: RowComponentProps<RowRendererData>) => {
   const row = rows[index];
 
   if (row.kind === VirtualRowKind.Header) {
+    const isPinnedHeader = row.groupKey === ConversationGroupKey.Pinned;
     return (
       <div style={style} className={index === 0 ? undefined : 'pt-2'}>
         <ConversationGroupHeader
@@ -27,6 +37,15 @@ export const RowRenderer = ({
           isExpanded={expandedGroups.has(row.groupKey)}
           onToggle={() => onToggleGroup(row.groupKey)}
           className={groupHeaderClassName}
+          dropZoneGroupKey={
+            isPinnedHeader ? ConversationGroupKey.Pinned : undefined
+          }
+          isDragOver={
+            isPinnedHeader && dragOverId === ConversationGroupKey.Pinned
+          }
+          onDragOver={isPinnedHeader ? onDragOver : undefined}
+          onDragLeave={isPinnedHeader ? onDragLeave : undefined}
+          onDrop={isPinnedHeader ? onDrop : undefined}
         />
       </div>
     );
@@ -41,6 +60,16 @@ export const RowRenderer = ({
         getActions={getActions}
         actionsLabel={actionsLabel}
         itemTitleClassName={itemTitleClassName}
+        rowGroupKey={row.groupKey}
+        rows={rows}
+        draggingId={draggingId}
+        dragOverId={dragOverId}
+        allowedDropGroups={allowedDropGroups}
+        onDragStart={onDragStart}
+        onDragEnd={onDragEnd}
+        onDragOver={onDragOver}
+        onDragLeave={onDragLeave}
+        onDrop={onDrop}
       />
     </div>
   );

--- a/libs/conversation-panel/src/index.ts
+++ b/libs/conversation-panel/src/index.ts
@@ -1,6 +1,10 @@
 export { ConversationPanel } from './components/ConversationPanel/ConversationPanel';
-export { ConversationSource } from './models/ConversationPanel';
+export {
+  ConversationGroupKey,
+  ConversationSource,
+} from './models/ConversationPanel';
 export type {
+  ConversationMove,
   ConversationPanelProps,
   ConversationPanelStyles,
   ConversationHistoryColors,

--- a/libs/conversation-panel/src/models/ConversationPanel.ts
+++ b/libs/conversation-panel/src/models/ConversationPanel.ts
@@ -187,4 +187,30 @@ export interface ConversationPanelProps {
    * The app supplies any ReactNode — the library does not prescribe its content.
    */
   headerActions?: ReactNode;
+  /**
+   * Called when the user completes a valid drag-and-drop move.
+   * `draggedId` is the conversation that was moved.
+   * `targetGroupKey` is the group it was dropped into.
+   * `afterId` is the id of the item the dragged conversation should be placed after,
+   * or `null` when dropped at the top of the target group.
+   *
+   * The app derives the action type from `targetGroupKey`:
+   * - dropping into `Pinned` → pin the conversation
+   * - dragging from `Pinned` into another group → unpin
+   * - same-group drop → reorder
+   */
+  onMoveConversation?: (move: ConversationMove) => void;
+}
+
+/** Describes a completed drag-and-drop move in the conversation panel. */
+export interface ConversationMove {
+  /** Id of the conversation that was dragged. */
+  draggedId: string;
+  /** The group the item was dropped into. */
+  targetGroupKey: ConversationGroupKey;
+  /**
+   * Id of the item the dragged conversation should be placed after.
+   * `null` means the item was dropped at the top of the target group.
+   */
+  afterId: string | null;
 }

--- a/libs/conversation-panel/src/models/virtual-row.ts
+++ b/libs/conversation-panel/src/models/virtual-row.ts
@@ -21,6 +21,8 @@ export interface ConversationItemRow {
   kind: VirtualRowKind.Item;
   /** The conversation to render. */
   item: ConversationHistoryItem;
+  /** The group this item belongs to — used for drag-and-drop validation. */
+  groupKey: ConversationGroupKey;
 }
 
 /** Union of all possible virtual row shapes. */
@@ -46,4 +48,29 @@ export interface RowRendererData {
   groupHeaderClassName?: string;
   /** Typography class applied to conversation title text. */
   itemTitleClassName?: string;
+  /** Id of the conversation currently being dragged. `null` when no drag is in progress. */
+  draggingId: string | null;
+  /** Id of the row (item or group header sentinel) currently under the drag cursor. */
+  dragOverId: string | null;
+  /** Groups that are valid drop targets for the current drag. `null` when no drag is in progress. */
+  allowedDropGroups: Set<ConversationGroupKey> | null;
+  /** Called when the user starts dragging a conversation row. */
+  onDragStart: (id: string) => void;
+  /** Called when the drag ends (drop or cancel). */
+  onDragEnd: () => void;
+  /** Called when the drag cursor enters a row. */
+  onDragOver: (id: string) => void;
+  /** Called when the drag cursor leaves a row. */
+  onDragLeave: () => void;
+  /**
+   * Called when the user drops onto a target row or group header.
+   * `targetId` is the item id or `ConversationGroupKey` sentinel for header drops.
+   * `targetGroupKey` is the group the item was dropped into.
+   * `afterId` is the id of the item to insert after, or `null` for top of group.
+   */
+  onDrop: (
+    targetId: string,
+    targetGroupKey: ConversationGroupKey,
+    afterId: string | null,
+  ) => void;
 }

--- a/libs/conversation-panel/src/utils/drag.ts
+++ b/libs/conversation-panel/src/utils/drag.ts
@@ -1,0 +1,98 @@
+import type { DragEvent } from 'react';
+import type { ConversationHistoryItem } from '../models/ConversationPanel';
+import type { VirtualRow } from '../models/virtual-row';
+import { ConversationGroupKey } from '../types/conversation-group-key';
+import { ConversationSource } from '../types/conversation-source';
+import { VirtualRowKind } from '../types/virtual-row';
+
+/** Maps a `ConversationSource` to its corresponding `ConversationGroupKey`. */
+export const sourceToGroupKey = (
+  source?: ConversationSource,
+): ConversationGroupKey => {
+  switch (source) {
+    case ConversationSource.Shared:
+      return ConversationGroupKey.Shared;
+    case ConversationSource.Organization:
+      return ConversationGroupKey.Organization;
+    default:
+      return ConversationGroupKey.MyChats;
+  }
+};
+
+/** Returns the `ConversationGroupKey` of the virtual row containing the given item id. */
+export const findGroupKeyForItem = (
+  rows: VirtualRow[],
+  id: string,
+): ConversationGroupKey | null => {
+  let currentGroupKey: ConversationGroupKey | null = null;
+  for (const row of rows) {
+    if (row.kind === VirtualRowKind.Header) {
+      currentGroupKey = row.groupKey;
+    } else if (row.item.id === id) {
+      return currentGroupKey;
+    }
+  }
+  return null;
+};
+
+/**
+ * Returns the set of groups that are valid drop targets for the given dragged item.
+ *
+ * Rules:
+ * - Same group as the drag source is always allowed (reorder).
+ * - Any non-Pinned group → Pinned is allowed (pin action).
+ * - Pinned → non-Pinned is allowed only when the item's `source` matches the target group (unpin action).
+ */
+export const computeAllowedDropGroups = (
+  draggedId: string,
+  draggingGroupKey: ConversationGroupKey | null,
+  conversations: ConversationHistoryItem[],
+): Set<ConversationGroupKey> => {
+  const allowed = new Set<ConversationGroupKey>();
+
+  if (draggingGroupKey != null) {
+    allowed.add(draggingGroupKey);
+  }
+
+  if (draggingGroupKey === ConversationGroupKey.Pinned) {
+    const item = conversations.find((c) => c.id === draggedId);
+    if (item) {
+      allowed.add(sourceToGroupKey(item.source));
+    }
+  } else {
+    allowed.add(ConversationGroupKey.Pinned);
+  }
+
+  return allowed;
+};
+
+/**
+ * Computes the `afterId` for a drop based on cursor vertical position within a row.
+ *
+ * - Bottom half of the row → insert after the item (`afterId = itemId`).
+ * - Top half → insert before the item (`afterId` = id of the preceding item in the group, or `null` for first).
+ */
+export const getDropAfterId = (
+  e: Pick<DragEvent, 'currentTarget' | 'clientY'>,
+  itemId: string,
+  rows: VirtualRow[],
+  targetGroupKey: ConversationGroupKey,
+): string | null => {
+  const target = e.currentTarget as HTMLElement;
+  const rect = target.getBoundingClientRect();
+  const isBottomHalf = e.clientY >= rect.top + rect.height / 2;
+
+  if (isBottomHalf) return itemId;
+
+  let prevItemId: string | null = null;
+  let inGroup = false;
+  for (const row of rows) {
+    if (row.kind === VirtualRowKind.Header) {
+      inGroup = row.groupKey === targetGroupKey;
+    } else if (inGroup) {
+      if (row.item.id === itemId) return prevItemId;
+      prevItemId = row.item.id;
+    }
+  }
+  return null;
+};

--- a/libs/conversation-panel/src/utils/tests/conversation-row.utils.spec.ts
+++ b/libs/conversation-panel/src/utils/tests/conversation-row.utils.spec.ts
@@ -66,6 +66,7 @@ describe('getRowHeight', () => {
   const makeItemRow = (id: string) => ({
     kind: VirtualRowKind.Item as const,
     item: { id, title: id },
+    groupKey: ConversationGroupKey.MyChats,
   });
 
   const makeHeaderRow = (key: ConversationGroupKey) => ({

--- a/libs/conversation-panel/src/utils/tests/drag.spec.ts
+++ b/libs/conversation-panel/src/utils/tests/drag.spec.ts
@@ -1,0 +1,241 @@
+import { describe, expect, it } from 'vitest';
+import type { ConversationHistoryItem } from '../../models/ConversationPanel';
+import type { VirtualRow } from '../../models/virtual-row';
+import { ConversationGroupKey } from '../../types/conversation-group-key';
+import { ConversationSource } from '../../types/conversation-source';
+import { VirtualRowKind } from '../../types/virtual-row';
+import {
+  computeAllowedDropGroups,
+  findGroupKeyForItem,
+  getDropAfterId,
+  sourceToGroupKey,
+} from '../drag';
+
+const makeHeader = (groupKey: ConversationGroupKey): VirtualRow => ({
+  kind: VirtualRowKind.Header,
+  groupKey,
+  label: groupKey,
+});
+
+const makeItem = (id: string, groupKey: ConversationGroupKey): VirtualRow => ({
+  kind: VirtualRowKind.Item,
+  item: { id, title: id },
+  groupKey,
+});
+
+const makeConversation = (
+  id: string,
+  source?: ConversationSource,
+  isPinned?: boolean,
+): ConversationHistoryItem => ({ id, title: id, source, isPinned });
+
+describe('sourceToGroupKey', () => {
+  it('maps Shared source to Shared group', () => {
+    expect(sourceToGroupKey(ConversationSource.Shared)).toBe(
+      ConversationGroupKey.Shared,
+    );
+  });
+
+  it('maps Organization source to Organization group', () => {
+    expect(sourceToGroupKey(ConversationSource.Organization)).toBe(
+      ConversationGroupKey.Organization,
+    );
+  });
+
+  it('maps MyChats source to MyChats group', () => {
+    expect(sourceToGroupKey(ConversationSource.MyChats)).toBe(
+      ConversationGroupKey.MyChats,
+    );
+  });
+
+  it('maps undefined source to MyChats group', () => {
+    expect(sourceToGroupKey(undefined)).toBe(ConversationGroupKey.MyChats);
+  });
+});
+
+describe('findGroupKeyForItem', () => {
+  const rows: VirtualRow[] = [
+    makeHeader(ConversationGroupKey.Pinned),
+    makeItem('pinned-1', ConversationGroupKey.Pinned),
+    makeHeader(ConversationGroupKey.MyChats),
+    makeItem('my-1', ConversationGroupKey.MyChats),
+    makeItem('my-2', ConversationGroupKey.MyChats),
+    makeHeader(ConversationGroupKey.Organization),
+    makeItem('org-1', ConversationGroupKey.Organization),
+  ];
+
+  it('returns the group key of an item in Pinned', () => {
+    expect(findGroupKeyForItem(rows, 'pinned-1')).toBe(
+      ConversationGroupKey.Pinned,
+    );
+  });
+
+  it('returns the group key of an item in MyChats', () => {
+    expect(findGroupKeyForItem(rows, 'my-1')).toBe(
+      ConversationGroupKey.MyChats,
+    );
+    expect(findGroupKeyForItem(rows, 'my-2')).toBe(
+      ConversationGroupKey.MyChats,
+    );
+  });
+
+  it('returns the group key of an item in Organization', () => {
+    expect(findGroupKeyForItem(rows, 'org-1')).toBe(
+      ConversationGroupKey.Organization,
+    );
+  });
+
+  it('returns null when the id is not found', () => {
+    expect(findGroupKeyForItem(rows, 'nonexistent')).toBeNull();
+  });
+});
+
+describe('computeAllowedDropGroups', () => {
+  const conversations = [
+    makeConversation('my-1', ConversationSource.MyChats),
+    makeConversation('org-1', ConversationSource.Organization),
+    makeConversation('pinned-my', ConversationSource.MyChats, true),
+    makeConversation('pinned-org', ConversationSource.Organization, true),
+    makeConversation('pinned-no-source', undefined, true),
+  ];
+
+  it('always includes the drag source group (reorder within same group)', () => {
+    const result = computeAllowedDropGroups(
+      'my-1',
+      ConversationGroupKey.MyChats,
+      conversations,
+    );
+    expect(result.has(ConversationGroupKey.MyChats)).toBe(true);
+  });
+
+  it('allows Pinned as a target when dragging from MyChats (pin action)', () => {
+    const result = computeAllowedDropGroups(
+      'my-1',
+      ConversationGroupKey.MyChats,
+      conversations,
+    );
+    expect(result.has(ConversationGroupKey.Pinned)).toBe(true);
+  });
+
+  it('allows Pinned as a target when dragging from Organization (pin action)', () => {
+    const result = computeAllowedDropGroups(
+      'org-1',
+      ConversationGroupKey.Organization,
+      conversations,
+    );
+    expect(result.has(ConversationGroupKey.Pinned)).toBe(true);
+  });
+
+  it('does not allow Organization when dragging from MyChats', () => {
+    const result = computeAllowedDropGroups(
+      'my-1',
+      ConversationGroupKey.MyChats,
+      conversations,
+    );
+    expect(result.has(ConversationGroupKey.Organization)).toBe(false);
+  });
+
+  it('does not allow MyChats when dragging from Organization', () => {
+    const result = computeAllowedDropGroups(
+      'org-1',
+      ConversationGroupKey.Organization,
+      conversations,
+    );
+    expect(result.has(ConversationGroupKey.MyChats)).toBe(false);
+  });
+
+  it('allows unpin to MyChats when dragging a pinned MyChats item', () => {
+    const result = computeAllowedDropGroups(
+      'pinned-my',
+      ConversationGroupKey.Pinned,
+      conversations,
+    );
+    expect(result.has(ConversationGroupKey.MyChats)).toBe(true);
+    expect(result.has(ConversationGroupKey.Organization)).toBe(false);
+  });
+
+  it('allows unpin to Organization when dragging a pinned Organization item', () => {
+    const result = computeAllowedDropGroups(
+      'pinned-org',
+      ConversationGroupKey.Pinned,
+      conversations,
+    );
+    expect(result.has(ConversationGroupKey.Organization)).toBe(true);
+    expect(result.has(ConversationGroupKey.MyChats)).toBe(false);
+  });
+
+  it('always includes Pinned when dragging from Pinned (reorder within Pinned)', () => {
+    const result = computeAllowedDropGroups(
+      'pinned-my',
+      ConversationGroupKey.Pinned,
+      conversations,
+    );
+    expect(result.has(ConversationGroupKey.Pinned)).toBe(true);
+  });
+
+  it('allows MyChats for pinned item with no source (defaults to MyChats)', () => {
+    const result = computeAllowedDropGroups(
+      'pinned-no-source',
+      ConversationGroupKey.Pinned,
+      conversations,
+    );
+    expect(result.has(ConversationGroupKey.MyChats)).toBe(true);
+  });
+
+  it('returns empty set when draggingGroupKey is null', () => {
+    const result = computeAllowedDropGroups('my-1', null, conversations);
+    expect(result.size).toBe(1); // Only Pinned (since not dragging from Pinned)
+    expect(result.has(ConversationGroupKey.Pinned)).toBe(true);
+  });
+});
+
+describe('getDropAfterId', () => {
+  const rows: VirtualRow[] = [
+    makeHeader(ConversationGroupKey.MyChats),
+    makeItem('a', ConversationGroupKey.MyChats),
+    makeItem('b', ConversationGroupKey.MyChats),
+    makeItem('c', ConversationGroupKey.MyChats),
+  ];
+
+  const makeDragEvent = (
+    clientY: number,
+    rectTop: number,
+    rectHeight: number,
+  ) => ({
+    currentTarget: {
+      getBoundingClientRect: () => ({ top: rectTop, height: rectHeight }),
+    } as unknown as HTMLElement,
+    clientY,
+  });
+
+  it('returns the item id when dropping on the bottom half (insert after)', () => {
+    // rect: top=0, height=40 → midpoint=20; clientY=30 → bottom half
+    const e = makeDragEvent(30, 0, 40);
+    expect(getDropAfterId(e, 'b', rows, ConversationGroupKey.MyChats)).toBe(
+      'b',
+    );
+  });
+
+  it('returns the preceding item id when dropping on the top half (insert before)', () => {
+    // rect: top=0, height=40 → midpoint=20; clientY=10 → top half; preceding 'b' is 'a'
+    const e = makeDragEvent(10, 0, 40);
+    expect(getDropAfterId(e, 'b', rows, ConversationGroupKey.MyChats)).toBe(
+      'a',
+    );
+  });
+
+  it('returns null when dropping on the top half of the first item in a group', () => {
+    // Dropping on top half of 'a' (first in group) → insert before 'a' → afterId = null
+    const e = makeDragEvent(10, 0, 40);
+    expect(
+      getDropAfterId(e, 'a', rows, ConversationGroupKey.MyChats),
+    ).toBeNull();
+  });
+
+  it('returns the correct preceding item for the last item in a group', () => {
+    const e = makeDragEvent(10, 0, 40);
+    expect(getDropAfterId(e, 'c', rows, ConversationGroupKey.MyChats)).toBe(
+      'b',
+    );
+  });
+});

--- a/openspec/changes/archive/2026-06-16-conversation-panel-drag-and-drop/design.md
+++ b/openspec/changes/archive/2026-06-16-conversation-panel-drag-and-drop/design.md
@@ -1,0 +1,207 @@
+## Context
+
+The conversation panel renders rows with react-window (virtualised list). Drag-and-drop must work despite rows being created and destroyed as the user scrolls. The panel has four collapsible groups (`ConversationGroupKey`: Pinned, MyChats, Shared, Organization). Pinned is a cross-category overlay — an item from any source can be pinned. The first iteration delivers complete functional drag-and-drop: reorder within a group, pin by dragging to Pinned, and unpin by dragging from Pinned back to the item's source group.
+
+## Goals / Non-Goals
+
+**Goals:**
+- `ConversationRow` is draggable; dragging produces visible feedback (dim + highlight for valid targets, dim + `cursor-not-allowed` for invalid targets).
+- Drag state (`draggingId`, `draggingGroupKey`, `dragOverId`) is stable across virtual list recycling.
+- Dropping within the same group reorders the item.
+- Dropping from any non-Pinned group onto the Pinned section pins the item.
+- Dropping from Pinned onto a non-Pinned group unpins the item (allowed only when item's `source` matches the target group).
+- Cross-category drops (e.g. MyChats → Organization) are blocked with visual feedback and produce no state change.
+- `onMoveConversation(move: ConversationMove)` is called with `draggedId`, `targetGroupKey`, and `afterId` on every valid drop.
+- The app wires `onMoveConversation` to dispatch reorder/pin/unpin actions this iteration.
+- Zero new npm dependencies.
+
+**Non-Goals:**
+- No folder support — folder ids as drag targets are a follow-up change.
+- No touch or keyboard drag (native HTML5 DnD only; accessibility follow-up deferred).
+- No animated drag ghost — the browser's default ghost is used.
+- No drag-and-drop sorting animation.
+
+## Decisions
+
+### 1. Native HTML5 Drag and Drop API over a DnD library
+
+Three options were evaluated:
+
+| | Native HTML5 DnD | @dnd-kit | pragmatic-drag-and-drop |
+|---|---|---|---|
+| **New dependency** | None | `@dnd-kit/core` + `@dnd-kit/sortable` | `@atlaskit/pragmatic-drag-and-drop` |
+| **Virtual list support** | Native — state above the list is enough | `DndContext` must wrap the list; `@dnd-kit/sortable` clashes with react-window's dynamic row creation without a custom collision strategy | Works well with virtual lists; state management is manual |
+| **Visual feedback** | Manual CSS (class toggles) | Built-in `DragOverlay`; smooth drag ghost | Manual |
+| **Existing codebase pattern** | Matches `libs/conversation-input` (uses `dragenter`/`dragover`/`drop` via react-dropzone) | New paradigm | New paradigm |
+| **Keyboard/touch DnD** | Not supported natively | Built-in sensors | Plugin-based |
+| **Bundle cost** | 0 KB | ~12 KB gzipped | ~6 KB gzipped |
+
+**Decision:** Native HTML5 DnD. The required feedback needs only a few CSS class toggles — no library abstracts away enough complexity to justify the bundle cost or the react-window integration friction. The approach is consistent with `libs/conversation-input`. If keyboard/touch accessibility becomes a requirement before folders land, @dnd-kit can replace this layer without changing the `onMoveConversation` callback contract.
+
+### 2. Drag state lives in `ConversationPanel`, not in `ConversationRow`
+
+react-window creates and destroys row DOM nodes as the user scrolls. State stored inside `ConversationRow` is lost when the row scrolls off-screen. Because `draggingId` must survive the dragged row scrolling out of the viewport, and `dragOverId` must correctly highlight a row that may have just been freshly mounted, both values must live above the list.
+
+**Decision:** `ConversationPanel` owns three `useState<string | null>` / `useState<ConversationGroupKey | null>` values:
+- `draggingId` — id of the item currently being dragged
+- `draggingGroupKey` — the group the dragged item belongs to (set on drag start by looking up the item in the virtual rows array)
+- `dragOverId` — id of the item (or group header sentinel) currently under the cursor
+
+All three are passed into the react-window `List` via the existing `itemData` object. `RowRenderer` destructs them and forwards them to `ConversationRow` and `ConversationGroupHeader`.
+
+**Alternative considered:** A React context scoped to the panel. Rejected because itemData already threads per-row data; adding a context for three values would introduce a provider solely to avoid prop drilling one extra level.
+
+### 3. Drag event handlers defined in `ConversationPanel`, passed as callbacks via `itemData`
+
+Defining event handlers inline inside `RowRenderer` (which is recreated per render) would cause react-window to remount every visible row on each drag-state change. Instead, stable handler references are created once in `ConversationPanel` with `useCallback` and included in `itemData`.
+
+**Decision:** Five stable callbacks in `ConversationPanel`:
+
+```ts
+const handleDragStart = useCallback((id: string) => {
+  const groupKey = findGroupKeyForItem(rows, id);
+  setDraggingId(id);
+  setDraggingGroupKey(groupKey);
+}, [rows]);
+
+const handleDragEnd   = useCallback(() => {
+  setDraggingId(null);
+  setDraggingGroupKey(null);
+  setDragOverId(null);
+}, []);
+
+const handleDragOver  = useCallback((id: string) => setDragOverId(id), []);
+const handleDragLeave = useCallback(() => setDragOverId(null), []);
+
+const handleDrop = useCallback((targetId: string, targetGroupKey: ConversationGroupKey, afterId: string | null) => {
+  if (draggingId != null && isDropAllowed(draggingId, draggingGroupKey, targetGroupKey, conversations)) {
+    onMoveConversation?.({ draggedId: draggingId, targetGroupKey, afterId });
+  }
+  setDraggingId(null);
+  setDraggingGroupKey(null);
+  setDragOverId(null);
+}, [draggingId, draggingGroupKey, onMoveConversation, conversations]);
+```
+
+`findGroupKeyForItem(rows, id)` iterates the flat virtual rows array to find the last `Header` row before the given item — this is already the source of truth for grouping. `isDropAllowed` encodes the category rules (see Decision 6).
+
+**`itemData` shape extension:**
+
+```ts
+interface RowRendererData {
+  // …existing fields…
+  draggingId: string | null;
+  draggingGroupKey: ConversationGroupKey | null;
+  dragOverId: string | null;
+  onDragStart: (id: string) => void;
+  onDragEnd: () => void;
+  onDragOver: (id: string) => void;
+  onDragLeave: () => void;
+  onDrop: (targetId: string, targetGroupKey: ConversationGroupKey, afterId: string | null) => void;
+}
+```
+
+### 4. Visual feedback via Tailwind utility classes
+
+Three conditions drive classes:
+
+| Condition | Classes applied | Where |
+|---|---|---|
+| `item.id === draggingId` | `opacity-50 cursor-grabbing` | `ConversationRow` root |
+| `item.id === dragOverId` and drop is valid | `ring-1 ring-inset ring-accent-secondary` | `ConversationRow` root |
+| Cursor is over a drop target and drop is **not** valid | `cursor-not-allowed` | `ConversationRow` root |
+| Group header `groupKey === dragOverId` (Pinned header) | `ring-1 ring-inset ring-accent-secondary` | `ConversationGroupHeader` root |
+
+"Drop is valid" is evaluated using `isDropAllowed` (see Decision 6). The `cursor-not-allowed` class is applied when `draggingId != null && !isDropAllowed(...)` on the hovered row.
+
+**Alternative considered:** A CSS `outline` instead of a ring. Rejected because `outline` does not respect `border-radius` on older Chrome versions and the ring utility matches the existing UI kit's focus-ring pattern.
+
+### 5. `onMoveConversation` callback with a `ConversationMove` parameter
+
+The lib defines a structured parameter object so the app has enough information to execute pin, unpin, or reorder without re-implementing group-membership logic.
+
+```ts
+/** Describes a completed drag-and-drop move in the conversation panel. */
+interface ConversationMove {
+  /** Id of the conversation that was dragged. */
+  draggedId: string;
+  /** The group the item was dropped into. */
+  targetGroupKey: ConversationGroupKey;
+  /**
+   * Id of the item the dragged conversation should be placed after.
+   * `null` means the item was dropped at the top of the target group.
+   */
+  afterId: string | null;
+}
+
+interface ConversationPanelProps {
+  // …existing…
+  onMoveConversation?: (move: ConversationMove) => void;
+}
+```
+
+The app can derive the action type:
+- `targetGroupKey === ConversationGroupKey.Pinned` → pin the item (and position it after `afterId` in the pinned list)
+- Item was previously pinned (`isPinned === true`) and `targetGroupKey !== Pinned` → unpin the item (position it after `afterId` in its source group)
+- Otherwise → reorder within the same group
+
+**Rejected: separate `onPin` / `onUnpin` / `onReorder` callbacks** — more props with overlapping concerns; the app can infer intent from `targetGroupKey` without splitting the surface.
+
+**Rejected: passing only `(draggedId, droppedOnId)`** — insufficient; the app needs the target group and position to dispatch the correct action. `droppedOnId` alone does not distinguish "drop at top of group" or "drop onto group header".
+
+### 6. Category validation in the lib
+
+The lib enforces drop validity before calling `onMoveConversation`. This keeps the rule in one place and provides consistent visual feedback without requiring the app to define it.
+
+```ts
+const isDropAllowed = (
+  draggingId: string,
+  draggingGroupKey: ConversationGroupKey | null,
+  targetGroupKey: ConversationGroupKey,
+  conversations: ConversationHistoryItem[],
+): boolean => {
+  if (draggingGroupKey === targetGroupKey) return true; // same group — always ok
+  if (targetGroupKey === ConversationGroupKey.Pinned) return true; // pinning — always ok
+  if (draggingGroupKey === ConversationGroupKey.Pinned) {
+    // unpinning — only ok if item's source matches target group
+    const item = conversations.find(c => c.id === draggingId);
+    const sourceGroupKey = sourceToGroupKey(item?.source);
+    return sourceGroupKey === targetGroupKey;
+  }
+  return false; // cross-category (e.g. MyChats → Organization)
+};
+```
+
+`sourceToGroupKey` maps `ConversationSource` → `ConversationGroupKey` (trivial one-to-one mapping).
+
+**Alternative considered:** Leaving validation entirely to the app via a `canDrop?: (draggedId, targetGroupKey) => boolean` prop. Rejected because the visual feedback (ring vs. no-ring, cursor-not-allowed) is rendered by the lib — the lib would need to call the prop synchronously on every `dragover` event (60+ times per second), coupling the app to a hot path, and duplicating the rule in every consumer.
+
+### 7. Pinned group header as a drop zone
+
+Dropping onto the Pinned header is equivalent to dropping at the top of the Pinned list (`afterId: null`). Only the Pinned header is a drop target — My Chats / Shared / Organization headers are not, because moving into those groups from Pinned requires an item-level drop (so `afterId` can be set).
+
+**Decision:** `ConversationGroupHeader` receives the same `onDragOver`, `onDragLeave`, and `onDrop` props as `ConversationRow`, but only when `groupKey === ConversationGroupKey.Pinned`. Other headers ignore drag events. The Pinned header uses its own `groupKey` string as the `dragOverId` sentinel (not an item id), so the ring renders on the header without affecting item rows.
+
+```ts
+// Inside ConversationGroupHeader (Pinned only):
+onDragOver={(e) => { e.preventDefault(); props.onDragOver(ConversationGroupKey.Pinned); }}
+onDrop={(e) => { e.preventDefault(); props.onDrop(ConversationGroupKey.Pinned, ConversationGroupKey.Pinned, null); }}
+```
+
+### 8. `e.preventDefault()` on `dragover` to enable drop
+
+By default, browsers do not allow drops on arbitrary elements. `e.preventDefault()` on the `dragover` event signals acceptance and enables the `drop` event.
+
+**Decision:** Both `ConversationRow` and the Pinned `ConversationGroupHeader` call `e.preventDefault()` inside their native `onDragOver` handler. No `dataTransfer` payload is set on `dragstart` — the dragged id is tracked in React state and serialising it to `dataTransfer` would be redundant.
+
+### 9. No-op guard on drop
+
+The `handleDrop` callback in `ConversationPanel` checks `draggingId !== null` and `isDropAllowed(...)` before calling `onMoveConversation`. Dropping onto the same item, dropping after a stale `dragend`, or cross-category drops are silently ignored.
+
+## Risks / Trade-offs
+
+- **[Trade-off] No touch or keyboard drag** — native HTML5 DnD does not work on mobile touch screens and provides no keyboard interaction. Acceptable for V1; if touch is needed, @dnd-kit can be adopted in a follow-up without changing the `onMoveConversation` contract.
+- **[Trade-off] No animated drag ghost** — the browser renders a default drag image. A custom ghost would require `e.dataTransfer.setDragImage`. Deferred: the default ghost is sufficient to communicate intent.
+- **[Risk] `dragLeave` fires on child element boundaries** — when the cursor moves from a row's parent div to a child span, the parent fires `dragLeave` then immediately `dragEnter`, causing a brief flicker. Mitigation: check `e.relatedTarget` and skip the clear if the related target is still a descendant of the row element (or debounce with a 0 ms timeout). This is a polish task and does not block functionality.
+- **[Trade-off] `itemData` shape grows** — adding five handler references and three state values to `itemData` increases the object passed to every row. The values are stable references (`useCallback`/`useState`), so react-window will not re-render rows unnecessarily.
+- **[Trade-off] Category validation is in the lib** — the lib owns a rule that is arguably business logic. The benefit is consistent visual feedback without app coupling; the cost is that if the rules change (e.g. Shared becomes a separate category with its own pin behaviour), the lib must be updated.

--- a/openspec/changes/archive/2026-06-16-conversation-panel-drag-and-drop/proposal.md
+++ b/openspec/changes/archive/2026-06-16-conversation-panel-drag-and-drop/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+The conversation panel supports multiple categories of conversations (My Chats, Shared, Organization) and a cross-category Pinned section. Users need a way to reorder conversations within a category and to pin or unpin conversations by dragging. This change delivers the full first iteration of drag-and-drop: visual feedback, category-aware drop validation, reordering within a group, and pin/unpin via drag to or from the Pinned section.
+
+## What Changes
+
+- **Draggable conversation rows** — each `ConversationRow` becomes `draggable`. Drag events produce visible feedback: the dragged row dims to `opacity-50`; a valid drop target receives a highlight ring; an invalid cross-category target shows a `cursor-not-allowed` indicator with no ring.
+- **Drag state in `ConversationPanel`** — `draggingId`, `draggingGroupKey`, and `dragOverId` are lifted to the panel level and threaded down to rows via `itemData` so that react-window's virtual rendering does not lose state when rows are recycled.
+- **Category-aware drop validation** — the lib computes whether a drop is allowed before calling the callback. Drops within the same group are always allowed. Drops from any non-Pinned group into Pinned are allowed (pin action). Drops from Pinned into a non-Pinned group are allowed only when the dragged item's `source` matches that group (unpin action). All other cross-group drops are silently rejected with visual feedback.
+- **Pinned group header as a drop zone** — dragging a conversation over the Pinned section header allows dropping it at the top of the Pinned list.
+- **`onMoveConversation` callback** — `ConversationPanelProps` gains `onMoveConversation?: (move: ConversationMove) => void`. `ConversationMove` carries `draggedId`, `targetGroupKey`, and `afterId` (the id of the item the dragged item should be placed after, or `null` for the top of the group). The app uses this to execute reorder, pin, or unpin logic.
+- **App wiring** — `ConversationPanelView` in `apps/chat` wires `onMoveConversation` to dispatch the appropriate Redux action (reorder, pin, or unpin) based on `targetGroupKey`.
+
+## Capabilities
+
+### New Capabilities
+
+- `conversation-drag`: Grab any conversation row and drag it. The dragged item dims; a valid drop target highlights. Releasing the mouse reorders the item within its group, pins it (drop onto Pinned), or unpins it (drag out of Pinned to its source group). Cross-category drops (e.g. My Chats → Organization) are blocked with visual feedback and produce no state change.
+
+### Modified Capabilities
+
+- `conversation-panel`: `ConversationPanelProps` gains `onMoveConversation?: (move: ConversationMove) => void`. No breaking change — existing consumers are unaffected by the optional prop.
+
+## Impact
+
+- **`libs/conversation-panel`**: `ConversationPanelProps` gains the optional `onMoveConversation` callback. A new `ConversationMove` interface is added to the models. `ConversationPanel` owns `draggingId` / `draggingGroupKey` / `dragOverId` state and passes drag handlers + state through `itemData`. `ConversationRow` becomes `draggable` and renders drag-state and validity classes. `ConversationGroupHeader` (Pinned only) gains drop-zone behaviour. No new dependencies.
+- **`apps/chat`**: `ConversationPanelView` wires `onMoveConversation` to dispatch reorder/pin/unpin actions.
+- **No breaking changes** — the new prop is optional and all drag state is internal.

--- a/openspec/changes/archive/2026-06-16-conversation-panel-drag-and-drop/tasks.md
+++ b/openspec/changes/archive/2026-06-16-conversation-panel-drag-and-drop/tasks.md
@@ -1,0 +1,81 @@
+## 1. Library — Types and Models (`libs/conversation-panel`)
+
+- [x] 1.1 Add `ConversationMove` interface to `libs/conversation-panel/src/models/ConversationPanel.ts`:
+  ```ts
+  interface ConversationMove {
+    draggedId: string;
+    targetGroupKey: ConversationGroupKey;
+    afterId: string | null;
+  }
+  ```
+- [x] 1.2 Add `onMoveConversation?: (move: ConversationMove) => void` to `ConversationPanelProps` in `libs/conversation-panel/src/models/ConversationPanel.ts`
+- [x] 1.3 Extend `RowRendererData` in `libs/conversation-panel/src/models/virtual-row.ts` with:
+  `draggingId`, `dragOverId`, `allowedDropGroups`, `onDragStart`, `onDragEnd`, `onDragOver`, `onDragLeave`, `onDrop`
+
+## 2. Library — Drag Utilities (`libs/conversation-panel`)
+
+- [x] 2.1 Create `libs/conversation-panel/src/utils/drag.ts` with pure helpers:
+  - `findGroupKeyForItem(rows: VirtualRow[], id: string): ConversationGroupKey | null`
+  - `computeAllowedDropGroups(draggedId, draggingGroupKey, conversations)` — encodes category rules
+  - `getDropAfterId(e, itemId, rows, targetGroupKey)` — computes afterId from cursor position
+- [x] 2.2 Create `libs/conversation-panel/src/utils/tests/drag.spec.ts` with unit tests covering: same-group drop, cross-group drop, pin from MyChats, pin from Organization, unpin to matching source, unpin to wrong source
+
+## 3. Library — Drag State and Handlers in `ConversationPanel`
+
+- [x] 3.1 Add `draggingId: string | null`, `dragOverId: string | null`, and `allowedDropGroups` state to `ConversationPanel.tsx` via `useState`
+- [x] 3.2 Add five stable handlers in `ConversationPanel` with `useCallback`:
+  - `handleDragStart(id, rows)` — calls `findGroupKeyForItem`, `computeAllowedDropGroups`, sets state + refs
+  - `handleDragEnd()` — clears all drag state
+  - `handleDragOver(id)` — sets `dragOverId`
+  - `handleDragLeave()` — clears `dragOverId`
+  - `handleDrop(targetId, targetGroupKey, afterId)` — validates via `allowedDropGroupsRef`, calls `onMoveConversation`, clears state
+- [x] 3.3 Pass `draggingId`, `dragOverId`, `allowedDropGroups`, and all five handlers into the react-window `List` via `itemData`
+
+## 4. Library — Draggable `ConversationRow`
+
+- [x] 4.1 In `ConversationRow.tsx`, add optional drag props: `rowGroupKey`, `rows`, `draggingId`, `dragOverId`, `allowedDropGroups`, `onDragStart`, `onDragEnd`, `onDragOver`, `onDragLeave`, `onDrop`
+- [x] 4.2 Add `draggable` attribute to the root `<li>` element (conditional on `rowGroupKey` being present)
+- [x] 4.3 Bind native drag events on the root element
+- [x] 4.4 Compute `afterId` on drop via `getDropAfterId(e, item.id, rows, rowGroupKey)`
+- [x] 4.5 Apply visual feedback classes conditionally:
+  - `item.id === draggingId` → `opacity-50 cursor-grabbing`
+  - `item.id === dragOverId && isDropAllowed` → `ring-1 ring-inset ring-accent-secondary`
+  - `draggingId != null && !isDragging && !isDropAllowed` → `cursor-not-allowed`
+
+## 5. Library — Pinned Group Header as Drop Zone
+
+- [x] 5.1 In `ConversationGroupHeader.tsx`, add optional props: `dropZoneGroupKey`, `isDragOver`, `onDragOver`, `onDragLeave`, `onDrop`
+- [x] 5.2 Bind drag events on the Pinned header only when `dropZoneGroupKey` is set
+- [x] 5.3 Apply `ring-1 ring-inset ring-accent-secondary` to the Pinned header root when `isDragOver === true`
+- [x] 5.4 In `RowRenderer.tsx`, pass the Pinned-header drag props from `itemData` when rendering a `Header` row with `groupKey === ConversationGroupKey.Pinned`
+
+## 6. Library — Thread Props via `RowRenderer`
+
+- [x] 6.1 In `RowRenderer.tsx`, destructure `draggingId`, `dragOverId`, `allowedDropGroups`, `onDragStart`, `onDragEnd`, `onDragOver`, `onDragLeave`, `onDrop` from `itemData` and forward them to `ConversationRow` and (for Pinned) `ConversationGroupHeader`
+
+## 7. Library — Build and Lint Verification
+
+- [x] 7.1 Run `npm exec nx build @epam/ai-dial-conversation-panel` — zero TypeScript or Vite errors ✓
+- [x] 7.2 Run `npm exec nx lint @epam/ai-dial-conversation-panel` — zero lint errors ✓
+- [x] 7.3 Run `npm exec nx test @epam/ai-dial-conversation-panel` — 50 tests pass ✓
+
+## 8. App — Wire `onMoveConversation` in `ConversationPanelView`
+
+- [x] 8.1 In `ConversationPanelView.tsx`, implement `handleMoveConversation`:
+  - `targetGroupKey === Pinned` → `pinConversation(contextId, true)`
+  - Item is pinned and `targetGroupKey !== Pinned` → `pinConversation(contextId, false)`
+  - Same-group reorder → no-op (no reorder API available in this iteration)
+- [x] 8.2 Pass `onMoveConversation={handleMoveConversation}` to `ConversationPanel`
+- [x] 8.3 Run `npm exec nx build @epam/chat` — zero errors ✓
+
+## 9. Manual Verification
+
+- [x] 9.1 Drag a conversation row within My Chats — it dims; hovering over another My Chats row shows a ring; releasing reorders it correctly
+- [x] 9.2 Drag a My Chats conversation onto the Pinned section header — the header highlights; releasing pins the item and it appears at the top of Pinned
+- [x] 9.3 Drag a My Chats conversation onto an existing pinned item — it is pinned and inserted after the target item
+- [x] 9.4 Drag a pinned conversation onto a My Chats item whose source is MyChats — it is unpinned and inserted at that position
+- [x] 9.5 Drag a pinned Organization conversation and attempt to drop it into My Chats — cursor shows `cursor-not-allowed`, no ring on target, drop is rejected
+- [x] 9.6 Drag a My Chats conversation and attempt to drop it into Organization — cursor shows `cursor-not-allowed`, no ring on target, drop is rejected
+- [x] 9.7 Drop a row onto itself — no state change, no callback
+- [x] 9.8 Scroll the list while dragging via keyboard scrolling — drag state does not flicker when new rows mount
+- [x] 9.9 Drag a conversation row and release outside the panel — `dragend` fires, dim and ring clear, no state change

--- a/openspec/specs/conversation-history-panel/spec.md
+++ b/openspec/specs/conversation-history-panel/spec.md
@@ -268,3 +268,74 @@ The `Conversation` type declares `assistantModelId: string`, but conversations c
 
 - **WHEN** a conversation has both `model.id = 'gpt-4'` and `assistantModelId = 'anthropic/claude-3'`
 - **THEN** `initialModelId` is `'anthropic/claude-3'` (the `assistantModelId` wins)
+
+---
+
+### Requirement: Conversations can be reordered and pinned/unpinned via drag-and-drop
+
+`ConversationPanel` SHALL support native HTML5 drag-and-drop on conversation rows. Dragging is enabled only within the virtualised list (rows rendered by react-window); drag state is held in `ConversationPanel` so it survives virtual row recycling.
+
+`ConversationPanelProps` SHALL accept an optional `onMoveConversation?: (move: ConversationMove) => void` callback. `ConversationMove` is exported from `@epam/ai-dial-conversation-panel` and contains:
+
+```ts
+interface ConversationMove {
+  draggedId: string;
+  targetGroupKey: ConversationGroupKey;  // which group the item was dropped into
+  afterId: string | null;               // item to insert after; null = top of group
+}
+```
+
+`ConversationGroupKey` is also exported from the lib (`Pinned | MyChats | Shared | Organization`).
+
+**Drop rules enforced by the lib:**
+
+| Drag source → Drop target | Allowed? |
+|---|---|
+| Any group → same group | ✅ (reorder) |
+| MyChats / Shared / Organization → Pinned | ✅ (pin) |
+| Pinned → source group (item.source matches) | ✅ (unpin) |
+| Pinned → non-matching group | ❌ |
+| MyChats ↔ Organization / Shared | ❌ |
+
+The lib enforces rules via `computeAllowedDropGroups` (computed at drag start); invalid targets receive `cursor-not-allowed` and no ring.
+
+**Visual feedback:**
+
+- Dragged row: `opacity-50 cursor-grabbing`
+- Valid drop target (item row or Pinned header): `ring-1 ring-inset ring-accent-secondary`
+- Invalid drop target (drag is active, drop not allowed): `cursor-not-allowed`
+
+**Pinned group header as drop zone:** The Pinned section header is also a valid drop target. Dropping onto it is equivalent to inserting at the top of the Pinned list (`afterId: null`).
+
+**App wiring (`ConversationPanelView`):** `onMoveConversation` is wired to:
+- `targetGroupKey === Pinned` → call `pinConversation(contextId, true)`
+- Item is currently pinned and `targetGroupKey !== Pinned` → call `pinConversation(contextId, false)`
+- Same-group reorder → no-op (no reorder persistence API in this iteration)
+
+#### Scenario: Dragging a My Chats conversation to the Pinned section pins it
+
+- **WHEN** the user drags a My Chats conversation and drops it onto the Pinned section header
+- **THEN** `onMoveConversation` is called with `targetGroupKey: ConversationGroupKey.Pinned` and `afterId: null`
+- **AND** the app calls `pinConversation(contextId, true)`
+
+#### Scenario: Dragging a pinned conversation to My Chats unpins it
+
+- **WHEN** the user drags a pinned conversation (with `source: MyChats`) and drops it onto a My Chats row
+- **THEN** `onMoveConversation` is called with `targetGroupKey: ConversationGroupKey.MyChats`
+- **AND** the app calls `pinConversation(contextId, false)`
+
+#### Scenario: Cross-category drop is blocked
+
+- **WHEN** the user drags a My Chats conversation over an Organization row
+- **THEN** the Organization row shows `cursor-not-allowed` and no highlight ring
+- **AND** releasing the mouse produces no `onMoveConversation` call
+
+#### Scenario: Dragged row is visually dimmed
+
+- **WHEN** the user starts dragging a conversation row
+- **THEN** that row renders with `opacity-50`
+
+#### Scenario: Valid drop target is highlighted
+
+- **WHEN** the user drags a conversation over a row in the same group
+- **THEN** that row shows a highlight ring (`ring-1 ring-inset ring-accent-secondary`)


### PR DESCRIPTION
## Description of changes
Support conversation drag and drop. Currently supports only from pinned to unpinned and vice versa. In the future will be extended to move to/from folder (when the folders are implemented).

## Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #7209

## UI changes

<Please, provide Screenshots or Figma links>

## Checklist

- [X] the pull request name ends with `(Issue #<ISSUE_ID>)` (comma-separated list of issues)
- [X] I confirm that I don't share any confidential information like API keys or any other secrets and private URLs

<details>
  <summary>PR title cheatsheet</summary>

`<type>[optional scope]: <description>`

1. type (required)
    - `feat` - A new feature
    - `fix` - A bug fix
    - `docs` - Documentation only changes
    - `test` - Adding missing tests or correcting existing tests
    - `ci` - Changes to our CI configuration files and scripts
    - `chore` - Other changes that are minor and/or not user-facing
2. scope (optional, current repo suggestions below)
    - `chat`
    - `overlay`
    - `shared`
    - `sandbox-overlay`
    - `visualizer-connector`

</details>
