### PR TITLE
chore: share coding rules across agents via symlinks

### DIFF
--- a/.claude/rules/all-ts.md
+++ b/.claude/rules/all-ts.md
@@ -2,6 +2,9 @@
 paths:
   - '**/*.ts'
   - '**/*.tsx'
+globs: '**/*.ts,**/*.tsx'
+applyTo: '**/*.ts,**/*.tsx'
+alwaysApply: false
 ---
 
 # TypeScript conventions

--- a/.claude/rules/all-tsx.md
+++ b/.claude/rules/all-tsx.md
@@ -1,6 +1,9 @@
 ---
 paths:
   - '**/*.tsx'
+globs: '**/*.tsx'
+applyTo: '**/*.tsx'
+alwaysApply: false
 ---
 
 # JSX / TSX conventions

--- a/.claude/rules/apps.md
+++ b/.claude/rules/apps.md
@@ -2,6 +2,9 @@
 paths:
   - 'apps/**/*.tsx'
   - 'apps/**/*.ts'
+globs: 'apps/**/*.ts,apps/**/*.tsx'
+applyTo: 'apps/**/*.ts,apps/**/*.tsx'
+alwaysApply: false
 ---
 
 @.claude/rules/rtl.md

--- a/.claude/rules/lib-styling.md
+++ b/.claude/rules/lib-styling.md
@@ -3,6 +3,9 @@ paths:
   - 'libs/**/*.tsx'
   - 'libs/**/*.ts'
   - 'libs/**/*.scss'
+globs: 'libs/**/*.ts,libs/**/*.tsx,libs/**/*.scss'
+applyTo: 'libs/**/*.ts,libs/**/*.tsx,libs/**/*.scss'
+alwaysApply: false
 ---
 
 @openspec/lib-styling-guide.md

--- a/.claude/rules/libs.md
+++ b/.claude/rules/libs.md
@@ -2,6 +2,9 @@
 paths:
   - 'libs/**/*.ts'
   - 'libs/**/*.tsx'
+globs: 'libs/**/*.ts,libs/**/*.tsx'
+applyTo: 'libs/**/*.ts,libs/**/*.tsx'
+alwaysApply: false
 ---
 
 # Libs coding conventions
@@ -31,7 +34,7 @@ Every exported symbol (interfaces, enums, types, functions) must have a JSDoc co
 **Never hardcode typography or color utility classes** (e.g. `dial-body-semi-bold-text`, `dial-small-text`, `text-sm`, `font-bold`, `text-primary`, `text-secondary`, `text-accent`) directly in lib component JSX. The consuming app decides which type scale and color tokens to use. Instead, accept an optional prop and use a sensible default:
 
 ```tsx
-// ✅ correct — configurable with a sensible default
+// Correct — configurable with a sensible default
 interface MyProps {
   /** Typography class applied to the title. Defaults to `'dial-body-semi-bold-text'`. */
   titleClassName?: string;
@@ -48,7 +51,7 @@ export const MyComponent: FC<MyProps> = ({
   </>
 );
 
-// ❌ wrong — hardcoded in JSX
+// Wrong — hardcoded in JSX
 <span className={mergeClasses(styles.title, 'dial-body-semi-bold-text')}>…</span>
 <Icon className="text-secondary" />
 ```

--- a/.claude/rules/rtl.md
+++ b/.claude/rules/rtl.md
@@ -1,3 +1,8 @@
+---
+alwaysApply: true
+applyTo: '**'
+---
+
 # RTL and Arabic language support
 
 All apps and libs must support Arabic (`ar`) and any other right-to-left locale. The active language drives `document.documentElement.dir` — `rtl` or `ltr` — which Tailwind's `rtl:` / `ltr:` variants and CSS logical properties key off.

--- a/.claude/rules/utils.md
+++ b/.claude/rules/utils.md
@@ -2,6 +2,9 @@
 paths:
   - '**/utils/**/*.ts'
   - '**/utils/**/*.tsx'
+globs: '**/utils/**/*.ts,**/utils/**/*.tsx'
+applyTo: '**/utils/**/*.ts,**/utils/**/*.tsx'
+alwaysApply: false
 ---
 
 # Utils conventions
@@ -9,9 +12,9 @@ paths:
 Prefer arrow-function declarations over `function` declarations:
 
 ```ts
-// ✅
+// Correct
 const formatDate = (date: Date): string => { ... };
 
-// ❌
+// Wrong
 function formatDate(date: Date): string { ... }
 ```

--- a/.cursor/rules/all-ts.mdc
+++ b/.cursor/rules/all-ts.mdc
@@ -1,0 +1,1 @@
+../../.claude/rules/all-ts.md

--- a/.cursor/rules/all-tsx.mdc
+++ b/.cursor/rules/all-tsx.mdc
@@ -1,0 +1,1 @@
+../../.claude/rules/all-tsx.md

--- a/.cursor/rules/apps.mdc
+++ b/.cursor/rules/apps.mdc
@@ -1,0 +1,1 @@
+../../.claude/rules/apps.md

--- a/.cursor/rules/lib-styling.mdc
+++ b/.cursor/rules/lib-styling.mdc
@@ -1,0 +1,1 @@
+../../.claude/rules/lib-styling.md

--- a/.cursor/rules/libs.mdc
+++ b/.cursor/rules/libs.mdc
@@ -1,0 +1,1 @@
+../../.claude/rules/libs.md

--- a/.cursor/rules/rtl.mdc
+++ b/.cursor/rules/rtl.mdc
@@ -1,0 +1,1 @@
+../../.claude/rules/rtl.md

--- a/.cursor/rules/utils.mdc
+++ b/.cursor/rules/utils.mdc
@@ -1,0 +1,1 @@
+../../.claude/rules/utils.md

--- a/.github/instructions/all-ts.instructions.md
+++ b/.github/instructions/all-ts.instructions.md
@@ -1,0 +1,1 @@
+../../.claude/rules/all-ts.md

--- a/.github/instructions/all-tsx.instructions.md
+++ b/.github/instructions/all-tsx.instructions.md
@@ -1,0 +1,1 @@
+../../.claude/rules/all-tsx.md

--- a/.github/instructions/apps.instructions.md
+++ b/.github/instructions/apps.instructions.md
@@ -1,0 +1,1 @@
+../../.claude/rules/apps.md

--- a/.github/instructions/lib-styling.instructions.md
+++ b/.github/instructions/lib-styling.instructions.md
@@ -1,0 +1,1 @@
+../../.claude/rules/lib-styling.md

--- a/.github/instructions/libs.instructions.md
+++ b/.github/instructions/libs.instructions.md
@@ -1,0 +1,1 @@
+../../.claude/rules/libs.md

--- a/.github/instructions/rtl.instructions.md
+++ b/.github/instructions/rtl.instructions.md
@@ -1,0 +1,1 @@
+../../.claude/rules/rtl.md

--- a/.github/instructions/utils.instructions.md
+++ b/.github/instructions/utils.instructions.md
@@ -1,0 +1,1 @@
+../../.claude/rules/utils.md


### PR DESCRIPTION
## Context

The repo drives four AI coding agents (Claude, Cursor, GitHub Copilot, opencode) from per-agent config dirs. Skills, commands, and prompts are already mirrored — but the **path-scoped coding rules** in `.claude/rules/*.md` were Claude-only. Cursor and Copilot never saw them.

## What this does

Exposes those rules to Cursor and Copilot through **symlinks** to a single source of truth (`.claude/rules/`). Edit a source file once → every agent updates.

The one obstacle is that each agent keys its glob differently (`paths:` Claude, `globs:` Cursor, `applyTo:` Copilot). Fix: put **all keys in the one source file** — each agent reads its own and ignores the rest, so one physical file can be symlinked everywhere.

## Changes

- **Modified (7):** `.claude/rules/*.md` — added `globs`/`applyTo`/`alwaysApply` frontmatter; bodies unchanged (plus emoji→text in two code samples)
- **New symlinks (7):** `.cursor/rules/*.mdc` → `../../.claude/rules/*.md`
- **New symlinks (7):** `.github/instructions/*.instructions.md` → `../../.claude/rules/*.md`
- opencode reads `AGENTS.md` natively (no path-scoped rule mechanism) → no files added

## Notes / risk

Relies on Cursor/Copilot **ignoring unknown frontmatter keys** — standard YAML-parser behavior, but not contractually documented. Verify once: open a `.ts` file in Cursor and confirm a rule (e.g. `all-ts`) auto-attaches and isn't silently skipped. Fallback if not: a per-agent copy with only that agent's key.

Symlinks commit as git mode `120000` (resolve on macOS/Linux; Windows needs `core.symlinks=true`, the default).

🤖 Generated with [Claude Code](https://claude.com/claude-code)