### PR TITLE
chore: add dial-docs skill to surface docs/ on demand

### DIFF
--- a/.claude/skills/dial-docs/SKILL.md
+++ b/.claude/skills/dial-docs/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: dial-docs
+description: On-demand index of the AI DIAL Chat design docs in docs/. Use when you need ground-truth on how the app works or is built — overall architecture, technical/product requirements, or the authentication subsystem (login, logout, OIDC, session cookies, encrypted session, transparent token refresh, BFF auth flow, SessionGuard). Resolves to the one relevant doc; do not preload all of them.
+---
+
+# DIAL Docs
+
+Ground-truth design docs live in `docs/`. This skill is the index. Open **only** the doc that matches your task — don't read all of them. When your change alters behavior a doc describes, update that doc (and any affected diagram) in the **same commit**.
+
+## Index
+
+| Doc                                                                                                             | Read it when                                                                                                                                                 |
+| --------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| [`docs/architecture.md`](../../../docs/architecture.md)                                                         | Orienting on the overall app: structure, layers, major decisions.                                                                                            |
+| [`docs/technical-requirements.md`](../../../docs/technical-requirements.md)                                     | You need the product/technical requirements behind a feature.                                                                                                |
+| [`docs/auth/auth-bff-encrypted-cookie.md`](../../../docs/auth/auth-bff-encrypted-cookie.md)                     | Changing the auth flow: stateless BFF, OIDC login/callback, encrypted session cookie, transparent refresh, federated logout, cross-pod stateless decryption. |
+| [`docs/auth/testing-current-auth-implementation.md`](../../../docs/auth/testing-current-auth-implementation.md) | Writing or running auth tests: what exists today (`GET /api/v1/auth/me`, global `SessionGuard`, refresh) and how to exercise it.                             |
+| [`docs/auth/auth-diagrams/`](../../../docs/auth/auth-diagrams/)                                                 | You need the picture: Mermaid `.mmd` + `.svg` for architecture, provider registry, login, refresh, logout, cross-pod, cookie structure.                      |
+
+## How to use
+
+1. Match your task to a row above and open that one doc.
+2. For auth work, start with `auth-bff-encrypted-cookie.md`; use the diagrams for flow detail.
+3. If your change alters documented behavior, edit the matching doc in the same commit.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,7 @@ Use these local skills directly:
 - `./.claude/skills/feature-research/SKILL.md` for broad feature research and trade-off analysis
 - `./.claude/skills/figma/SKILL.md` for translating Figma designs into React components
 - `./.claude/skills/responsive-design/SKILL.md` for any UI work that must support both mobile and desktop, or any review of mobile parity
+- `./.claude/skills/dial-docs/SKILL.md` to find the right design doc in `docs/` on demand — app architecture, technical/product requirements, or the auth subsystem (read before changing documented behavior; update the doc in the same commit)
 
 Default behavior:
 


### PR DESCRIPTION
## What

Adds a single on-demand index skill — `.claude/skills/dial-docs` — that resolves the right design doc in `docs/` instead of preloading them or leaving them orphaned.

Covered docs:
- `docs/architecture.md` — overall app orientation
- `docs/technical-requirements.md` — product/technical requirements
- `docs/auth/auth-bff-encrypted-cookie.md` — auth flow design
- `docs/auth/testing-current-auth-implementation.md` — auth testing
- `docs/auth/auth-diagrams/` — Mermaid/SVG auth diagrams

Also adds a one-line pointer to the skill in `AGENTS.md` skill routing.

## Why

These docs hold ground-truth on architecture, requirements, and auth, but nothing surfaced them — the root README doesn't link them, and the only references were inside `docs/` and archived OpenSpec changes. An agent never saw them unless it stumbled in. Copying their content into `CLAUDE.md` would bloat always-on context; this skill loads only when its description matches the task, then points to the single relevant doc.

The skill instructs: open only the matching doc, and update it in the same commit when documented behavior changes.

## Verification

- Skill passes the agent-config validator (prettier + frontmatter).
- `AGENTS.md` passes the validator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)