### PR TITLE
fix(chat): fix quick app 2 starters autosave (Issue #6510)

### DIFF
--- a/apps/chat/src/components/AppsEditor/EditorForm/QuickApp2Form/ConversationStartersField.tsx
+++ b/apps/chat/src/components/AppsEditor/EditorForm/QuickApp2Form/ConversationStartersField.tsx
@@ -1,5 +1,5 @@
 import { IconTrashX } from '@tabler/icons-react';
-import { FC } from 'react';
+import { FC, FocusEvent } from 'react';
 
 import { useTranslation } from 'next-i18next';
 
@@ -52,8 +52,15 @@ export const ConversationStartersList: FC<ConversationStartersListProps> = ({
     }
   };
 
+  const handleContainerBlur = (e: FocusEvent<HTMLDivElement>) => {
+    if (!onBlur) return;
+    if (!e.currentTarget.contains(e.relatedTarget as Node | null)) {
+      onBlur();
+    }
+  };
+
   return (
-    <div className="flex flex-col gap-2">
+    <div className="flex flex-col gap-2" onBlur={handleContainerBlur}>
       {value.map((item, index) => {
         const isLastRow = index === value.length - 1;
 
@@ -62,7 +69,6 @@ export const ConversationStartersList: FC<ConversationStartersListProps> = ({
             <DialInput
               value={item.title}
               onChange={(value) => handleChange(index, 'title', value ?? '')}
-              onBlur={onBlur}
               containerClassName="flex-1"
               placeholder={t(MarketplaceI18nKeys.ButtonTitleTravelTips) ?? ''}
               disabled={disabled}
@@ -70,7 +76,6 @@ export const ConversationStartersList: FC<ConversationStartersListProps> = ({
             <DialInput
               value={item.text}
               onChange={(value) => handleChange(index, 'text', value ?? '')}
-              onBlur={onBlur}
               containerClassName="flex-[2]"
               placeholder={t(MarketplaceI18nKeys.PromptToSendInChat) ?? ''}
               disabled={disabled}


### PR DESCRIPTION
## Description of changes

Now the changes in 'Conversation starters' section are autosaved each time user changes the position of the cursor. Autosave looks better, but after the autosave the cursor is automatically set into input field in Preview -> bug
Steps to reproduce:

Type starter button name
Set the cursor to the starter prompt (or instruction, or intro text)
Autosave is done automatically -> ok
But the cursor is moved to the input field -> bug
Expected: the cursor should not change it's position while user updates the fields in Conversation Starters

## Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #6510

## Checklist

- [x] the pull request name ends with `(Issue #<ISSUE_ID>)` (comma-separated list of issues)
- [x] I confirm that I don't share any confidential information like API keys or any other secrets and private URLs

<details>
  <summary>PR title cheatsheet</summary>

`<type>[optional scope]: <description>`

1. type (required)
    - `feat` - A new feature
    - `fix` - A bug fix
    - `docs` - Documentation only changes
    - `test` - Adding missing tests or correcting existing tests
    - `ci` - Changes to our CI configuration files and scripts
    - `chore` - Other changes that are minor and/or not user-facing
2. scope (optional, current repo suggestions below)
    - `chat`
    - `overlay`
    - `shared`
    - `sandbox-overlay`
    - `visualizer-connector`

</details>
