### PR TITLE
fix: Don't allow entering forbidden symbols to chat name, Issue #7303

### DIFF
--- a/apps/chat/src/components/RenameConversationPopup/RenameConversationPopup.tsx
+++ b/apps/chat/src/components/RenameConversationPopup/RenameConversationPopup.tsx
@@ -5,7 +5,11 @@ import {
   ButtonsI18nKeys,
   ConversationPanelI18nKeys,
 } from '../../constants/translation-keys';
-import { getUtf8ByteLength } from '../../utils/string-utils';
+import {
+  getUtf8ByteLength,
+  sanitizeConversationName,
+  stripTrailingDots,
+} from '../../utils/string-utils';
 
 interface Props {
   isOpen: boolean;
@@ -36,7 +40,7 @@ const RenameConversationPopup: FC<Props> = ({
     }
   }, [isOpen, currentTitle]);
 
-  const trimmed = value.trim();
+  const trimmed = stripTrailingDots(value.trim());
   const isTooLong = getUtf8ByteLength(trimmed) > 255;
   const isSaveDisabled =
     isSaving || trimmed === '' || trimmed === currentTitle.trim() || isTooLong;
@@ -75,7 +79,7 @@ const RenameConversationPopup: FC<Props> = ({
               ? t(ConversationPanelI18nKeys.RenameTitleTooLong)
               : (error ?? undefined)
           }
-          onChange={(v) => setValue(v ?? '')}
+          onChange={(v) => setValue(sanitizeConversationName(v ?? ''))}
           onKeyDown={handleKeyDown}
         />
       </div>

--- a/apps/chat/src/utils/string-utils.ts
+++ b/apps/chat/src/utils/string-utils.ts
@@ -1,3 +1,12 @@
+// Characters prohibited in conversation names: tab, ", :, ;, /, \, ,, =, {, }, %, &
+export const PROHIBITED_CONVERSATION_NAME_CHARS_RE = /[\t":;/\\,={}%&]/g;
+
+export const sanitizeConversationName = (name: string): string =>
+  name.replace(PROHIBITED_CONVERSATION_NAME_CHARS_RE, '');
+
+export const stripTrailingDots = (name: string): string =>
+  name.replace(/\.+$/, '');
+
 export const getUtf8ByteLength = (str: string): number =>
   new TextEncoder().encode(str).byteLength;
 

--- a/apps/chat/src/utils/tests/string-utils.spec.ts
+++ b/apps/chat/src/utils/tests/string-utils.spec.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getUtf8ByteLength,
+  PROHIBITED_CONVERSATION_NAME_CHARS_RE,
+  sanitizeConversationName,
+  stripTrailingDots,
+} from '../string-utils';
+
+describe('PROHIBITED_CONVERSATION_NAME_CHARS_RE', () => {
+  const prohibited = [
+    '\t',
+    '"',
+    ':',
+    ';',
+    '/',
+    '\\',
+    ',',
+    '=',
+    '{',
+    '}',
+    '%',
+    '&',
+  ];
+
+  it.each(prohibited)('matches prohibited character %j', (char) => {
+    PROHIBITED_CONVERSATION_NAME_CHARS_RE.lastIndex = 0;
+    expect(PROHIBITED_CONVERSATION_NAME_CHARS_RE.test(char)).toBe(true);
+  });
+
+  it('does not match allowed characters', () => {
+    PROHIBITED_CONVERSATION_NAME_CHARS_RE.lastIndex = 0;
+    expect(
+      PROHIBITED_CONVERSATION_NAME_CHARS_RE.test(
+        'Hello World 123 !@#$^*()-_+[]|',
+      ),
+    ).toBe(false);
+  });
+});
+
+describe('sanitizeConversationName', () => {
+  it('removes all prohibited characters from a mixed string', () => {
+    expect(sanitizeConversationName('a"b:c;d/e\\f,g=h{i}j%k&l')).toBe(
+      'abcdefghijkl',
+    );
+  });
+
+  it('removes tab characters', () => {
+    expect(sanitizeConversationName('a\tb')).toBe('ab');
+  });
+
+  it('returns an empty string when input contains only prohibited characters', () => {
+    expect(sanitizeConversationName('":;/\\,={}%&\t')).toBe('');
+  });
+
+  it('leaves allowed characters unchanged', () => {
+    expect(sanitizeConversationName('Hello World')).toBe('Hello World');
+  });
+
+  it('preserves other special symbols that are not prohibited', () => {
+    const allowed = "!@#$^*()-_+[]|~' 123";
+    expect(sanitizeConversationName(allowed)).toBe(allowed);
+  });
+
+  it('preserves dots inside the name', () => {
+    expect(sanitizeConversationName('my.conversation.name')).toBe(
+      'my.conversation.name',
+    );
+  });
+
+  it('returns an empty string for an empty input', () => {
+    expect(sanitizeConversationName('')).toBe('');
+  });
+
+  it('removes multiple occurrences of the same prohibited character', () => {
+    expect(sanitizeConversationName('a::b;;c')).toBe('abc');
+  });
+});
+
+describe('stripTrailingDots', () => {
+  it('removes a single trailing dot', () => {
+    expect(stripTrailingDots('name.')).toBe('name');
+  });
+
+  it('removes multiple trailing dots', () => {
+    expect(stripTrailingDots('name...')).toBe('name');
+  });
+
+  it('preserves a dot at the start of the name', () => {
+    expect(stripTrailingDots('.hiddenfile')).toBe('.hiddenfile');
+  });
+
+  it('preserves dots inside the name', () => {
+    expect(stripTrailingDots('my.conv.name')).toBe('my.conv.name');
+  });
+
+  it('returns an empty string when input is only dots', () => {
+    expect(stripTrailingDots('...')).toBe('');
+  });
+
+  it('returns an empty string for an empty input', () => {
+    expect(stripTrailingDots('')).toBe('');
+  });
+
+  it('leaves a name without trailing dots unchanged', () => {
+    expect(stripTrailingDots('hello')).toBe('hello');
+  });
+});
+
+describe('getUtf8ByteLength', () => {
+  it('returns the byte length of an ASCII string', () => {
+    expect(getUtf8ByteLength('hello')).toBe(5);
+  });
+
+  it('returns 0 for an empty string', () => {
+    expect(getUtf8ByteLength('')).toBe(0);
+  });
+
+  it('counts multi-byte characters correctly', () => {
+    // '€' is 3 bytes in UTF-8
+    expect(getUtf8ByteLength('€')).toBe(3);
+  });
+
+  it('counts emoji (4-byte) characters correctly', () => {
+    // '😀' is 4 bytes in UTF-8
+    expect(getUtf8ByteLength('😀')).toBe(4);
+  });
+});

--- a/openspec/specs/conversation-rename/spec.md
+++ b/openspec/specs/conversation-rename/spec.md
@@ -64,6 +64,16 @@ i18n keys:
 - **WHEN** the user types "  New Title  " and clicks Save
 - **THEN** `onSave` is called with `"New Title"` (trimmed)
 
+#### Scenario: Trailing dot is stripped before save
+
+- **WHEN** the user types "My Chat..." and clicks Save
+- **THEN** `onSave` is called with `"My Chat"` (trailing dots removed after trimming)
+
+#### Scenario: Dot at start or inside name is preserved
+
+- **WHEN** the user types ".hidden" or "v1.2.chat"
+- **THEN** the value is accepted as-is and `onSave` receives the value unchanged
+
 #### Scenario: onCancel is called on Cancel click
 
 - **WHEN** the user clicks Cancel
@@ -148,3 +158,43 @@ Unit tests SHALL be written at `apps/chat/src/components/RenameConversationPopup
 
 - **WHEN** the unit test suite runs
 - **THEN** it covers: pre-fill, Save disabled (unchanged), Save disabled (empty), Save disabled (saving), trimmed onSave, onCancel, error display
+
+---
+
+### Requirement: Conversation name input filters prohibited characters and strips trailing dots
+
+The conversation name input SHALL enforce the following naming conventions at the point of input, with no error message shown — invalid content is silently excluded:
+
+- The following characters are **prohibited** and must be stripped as the user types: tab (`\t`), `"`, `:`, `;`, `/`, `\`, `,`, `=`, `{`, `}`, `%`, `&`.
+- Trailing dots (`.`) are **automatically removed** from the value before it is passed to `onSave`. Dots at the start of or inside the name are preserved.
+
+Implementation:
+- `sanitizeConversationName(name: string): string` in `apps/chat/src/utils/string-utils.ts` strips all prohibited characters using `PROHIBITED_CONVERSATION_NAME_CHARS_RE`.
+- `stripTrailingDots(name: string): string` in the same file strips one or more trailing dots.
+- The `onChange` handler of the input calls `sanitizeConversationName` so prohibited characters never appear in the field.
+- Before calling `onSave`, the value is trimmed and then passed through `stripTrailingDots`.
+
+#### Scenario: Prohibited characters are stripped while typing
+
+- **WHEN** the user types any of `"`, `:`, `;`, `/`, `\`, `,`, `=`, `{`, `}`, `%`, `&` or a tab
+- **THEN** those characters are not reflected in the input value
+
+#### Scenario: Other special symbols are allowed
+
+- **WHEN** the user types characters such as `!`, `@`, `#`, `$`, `^`, `*`, `(`, `)`, `-`, `_`, `+`, `[`, `]`, `|`, `~`, `'`
+- **THEN** those characters appear in the input and are passed to `onSave` unchanged
+
+#### Scenario: Trailing dots are removed before save
+
+- **WHEN** the input value is `"My Chat..."` and Save is clicked
+- **THEN** `onSave` receives `"My Chat"`
+
+#### Scenario: Dot at the start is preserved
+
+- **WHEN** the input value is `".hidden"`
+- **THEN** `onSave` receives `".hidden"`
+
+#### Scenario: Dot inside the name is preserved
+
+- **WHEN** the input value is `"v1.2.release"`
+- **THEN** `onSave` receives `"v1.2.release"`


### PR DESCRIPTION
## Description of changes

<!-- Please explain the changes you made right below this line. -->

## Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #7303

## UI changes

<Please, provide Screenshots or Figma links>

## Checklist

- [ ] the pull request name ends with `(Issue #<ISSUE_ID>)` (comma-separated list of issues)
- [ ] I confirm that I don't share any confidential information like API keys or any other secrets and private URLs

<details>
  <summary>PR title cheatsheet</summary>

`<type>[optional scope]: <description>`

1. type (required)
    - `feat` - A new feature
    - `fix` - A bug fix
    - `docs` - Documentation only changes
    - `test` - Adding missing tests or correcting existing tests
    - `ci` - Changes to our CI configuration files and scripts
    - `chore` - Other changes that are minor and/or not user-facing
2. scope (optional, current repo suggestions below)
    - `chat`
    - `overlay`
    - `shared`
    - `sandbox-overlay`
    - `visualizer-connector`

</details>
