### PR TITLE
feat(chat): add a feature flag for the file upload auto-rename flow (Issue #7134)

### DIFF
--- a/apps/chat/src/hooks/useUploadFilesHandler.ts
+++ b/apps/chat/src/hooks/useUploadFilesHandler.ts
@@ -7,20 +7,22 @@ import { getRelativePath } from '@/src/utils/app/file';
 import { isRootId } from '@/src/utils/app/id';
 import {
   ResolvedUploadFile,
+  applyUploadReplaceActions,
   detectUploadFileConflicts,
   dispatchPreparedFileUploads,
 } from '@/src/utils/app/prepare-files-for-upload';
 import { splitEntityId } from '@/src/utils/app/shared-utils';
 
+import { ReplaceOptions } from '@/src/types/common';
 import { Translation } from '@/src/types/translation';
 
 import { FilesActions, UIActions } from '@/src/store/actions';
 import { useAppDispatch, useAppSelector } from '@/src/store/hooks';
-import { FilesSelectors } from '@/src/store/selectors';
+import { FilesSelectors, SettingsSelectors } from '@/src/store/selectors';
 
 import { ChatI18nKeys } from '@/src/constants/i18n';
 
-import { UploadStatus } from '@epam/ai-dial-shared';
+import { Feature, UploadStatus } from '@epam/ai-dial-shared';
 
 export interface DispatchPreparedFilesOptions {
   bucket?: string;
@@ -40,6 +42,9 @@ export const useUploadFilesHandler = (
   const dispatch = useAppDispatch();
 
   const allFiles = useAppSelector(FilesSelectors.selectFiles);
+  const isConflictDialogEnabled = useAppSelector((state) =>
+    SettingsSelectors.isFeatureEnabled(state, Feature.ConflictDialogDragDrop),
+  );
 
   const { bucket } = useMemo(
     () =>
@@ -114,6 +119,24 @@ export const useUploadFilesHandler = (
       if (!duplicatedFiles.length && !nonDuplicatedFiles.length) return;
 
       if (duplicatedFiles.length) {
+        if (!isConflictDialogEnabled) {
+          const mappedActions = Object.fromEntries(
+            duplicatedFiles.map((f) => [f.id, ReplaceOptions.Postfix]),
+          );
+          const resolvedFiles = applyUploadReplaceActions({
+            duplicatedFiles,
+            nonDuplicatedFiles,
+            mappedActions,
+            existingFiles: allFiles,
+            folderId,
+            bucket,
+          });
+          dispatchPreparedFiles(resolvedFiles, folderPath, {
+            showSuccessMessage: true,
+          });
+          return Promise.resolve(resolvedFiles);
+        }
+
         dispatch(
           FilesActions.showUploadReplaceDialog({
             duplicatedFiles,
@@ -141,6 +164,7 @@ export const useUploadFilesHandler = (
       dispatch,
       allFiles,
       dispatchPreparedFiles,
+      isConflictDialogEnabled,
       t,
       folderId,
       bucket,

--- a/libs/shared/src/types/features.ts
+++ b/libs/shared/src/types/features.ts
@@ -31,6 +31,7 @@ export enum Feature {
   DislikeComment = 'dislike-comment', // Enable adding comment when disliking a message
   InputFiles = 'input-files', // Allow attach files to conversation
   InputLinks = 'input-links', // Allow attach links to conversation
+  ConflictDialogDragDrop = 'conflict-dialog-drag-drop', // Show conflict resolution dialog for drag-and-drop and paste uploads; auto-postfix when disabled
   MessageTemplates = 'message-templates', // message templates
   LiveChatInteraction = 'live-chat-interaction', // Enable interactive tool login flow during chat completion when agent tools are logged out
 


### PR DESCRIPTION
## Description of changes

<!-- Please explain the changes you made right below this line. -->
- Add a feature flag for the file upload auto-rename flow for the drag & drop and copy/paste.

## Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #7134 

## UI changes

<Please, provide Screenshots or Figma links>

## Checklist

- [x] the pull request name ends with `(Issue #<ISSUE_ID>)` (comma-separated list of issues)
- [x] I confirm that I don't share any confidential information like API keys or any other secrets and private URLs

<details>
  <summary>PR title cheatsheet</summary>

`<type>[optional scope]: <description>`

1. type (required)
    - `feat` - A new feature
    - `fix` - A bug fix
    - `docs` - Documentation only changes
    - `test` - Adding missing tests or correcting existing tests
    - `ci` - Changes to our CI configuration files and scripts
    - `chore` - Other changes that are minor and/or not user-facing
2. scope (optional, current repo suggestions below)
    - `chat`
    - `overlay`
    - `shared`
    - `sandbox-overlay`
    - `visualizer-connector`

</details>
