### PR TITLE
fix: Fix 429 on many files upload, Issue #7273

### DIFF
--- a/apps/chat-api/src/files/files.controller.ts
+++ b/apps/chat-api/src/files/files.controller.ts
@@ -39,7 +39,7 @@ export class FilesController {
 
   @Post()
   @HttpCode(201)
-  @Throttle({ default: { limit: 20, ttl: 60000 } })
+  @Throttle({ default: { limit: 100, ttl: 60000 } })
   @UseInterceptors(FileInterceptor('file'))
   @ApiConsumes('multipart/form-data')
   @ApiBody({

--- a/libs/conversation-input/src/components/Input/Input.tsx
+++ b/libs/conversation-input/src/components/Input/Input.tsx
@@ -23,12 +23,14 @@ import {
   useRef,
   useState,
 } from 'react';
+import { MAX_UPLOADS_PER_MINUTE } from '../../constants/upload';
 import { useClipboardPaste } from '../../hooks/useClipboardPaste';
 import { useInputHistoryNavigation } from '../../hooks/useInputHistoryNavigation';
 import { useIsMobile } from '../../hooks/useIsMobile';
 import { useVoiceRecorder } from '../../hooks/useVoiceRecorder';
 import { SendOnEnter } from '../../models/Input';
 import type { InputProps } from '../../models/Input';
+import { runAtRate } from '../../utils/concurrency';
 import { generateAttachmentId } from '../../utils/generateAttachmentId';
 import { AddAttachmentButton } from '../AddAttachmentButton/AddAttachmentButton';
 import { AttachmentTray } from '../AttachmentTray/AttachmentTray';
@@ -274,6 +276,7 @@ export const Input: FC<InputProps> = ({
         return [...prev, ...toAdd];
       });
       if (upload) {
+        const validToUpload: Attachment[] = [];
         toAdd.forEach((attachment) => {
           const errorReason = validateAttachment?.(attachment);
           if (errorReason != null) {
@@ -285,9 +288,10 @@ export const Input: FC<InputProps> = ({
               ),
             );
           } else {
-            void uploadAttachment(attachment);
+            validToUpload.push(attachment);
           }
         });
+        void runAtRate(validToUpload, MAX_UPLOADS_PER_MINUTE, uploadAttachment);
       }
     },
     [updateAttachments, uploadAttachment, validateAttachment],

--- a/libs/conversation-input/src/constants/upload.ts
+++ b/libs/conversation-input/src/constants/upload.ts
@@ -1,0 +1,1 @@
+export const MAX_UPLOADS_PER_MINUTE = 100;

--- a/libs/conversation-input/src/utils/concurrency.ts
+++ b/libs/conversation-input/src/utils/concurrency.ts
@@ -1,0 +1,49 @@
+/**
+ * Runs `fn` over every item in `items` with at most `concurrency` calls in flight
+ * at a time. Items are consumed from a shared queue by N concurrent workers, so
+ * faster tasks don't leave workers idle waiting for a slow sibling.
+ */
+export const runConcurrent = async <T>(
+  items: T[],
+  concurrency: number,
+  fn: (item: T) => Promise<void>,
+): Promise<void> => {
+  const queue = [...items];
+  const workers = Array.from(
+    { length: Math.min(concurrency, items.length) },
+    async () => {
+      while (queue.length > 0) {
+        const item = queue.shift();
+        if (item != null) await fn(item);
+      }
+    },
+  );
+  await Promise.all(workers);
+};
+
+/**
+ * Runs `fn` over every item in `items` at a steady rate of `maxPerMinute` calls
+ * per minute. All calls run concurrently — the rate limit controls when each
+ * call starts, not how many are in flight. This prevents bursting past a
+ * server-side throttle window while still parallelising the work.
+ *
+ * Example: 200 items at 100/min → one call every 600 ms, all overlapping,
+ * never more than 100 starts within any 60-second window.
+ */
+export const runAtRate = async <T>(
+  items: T[],
+  maxPerMinute: number,
+  fn: (item: T) => Promise<void>,
+): Promise<void> => {
+  const intervalMs = 60000 / maxPerMinute;
+  const promises: Promise<void>[] = [];
+
+  for (let i = 0; i < items.length; i++) {
+    if (i > 0) {
+      await new Promise<void>((resolve) => setTimeout(resolve, intervalMs));
+    }
+    promises.push(fn(items[i]));
+  }
+
+  await Promise.allSettled(promises);
+};

--- a/openspec/changes/wire-attachment-upload-to-dial/specs/conversation-input-attachments/spec.md
+++ b/openspec/changes/wire-attachment-upload-to-dial/specs/conversation-input-attachments/spec.md
@@ -1,0 +1,38 @@
+## MODIFIED Requirements
+
+---
+
+### Requirement: Rate-limited upload dispatching
+
+When `addAttachments` is called with multiple files, the `Input` component SHALL dispatch uploads at a steady rate of `MAX_UPLOADS_PER_MINUTE` (100) starts per minute rather than firing all requests simultaneously. Uploads run concurrently — the rate limit controls when each upload **starts**, not how many are in flight at once.
+
+The dispatcher fires one upload every `60000 / MAX_UPLOADS_PER_MINUTE` ms (600 ms). All started uploads run in parallel; the next dispatch slot opens after each interval regardless of whether prior uploads have completed.
+
+The rate limiter is implemented via `runAtRate` from `libs/conversation-input/src/utils/concurrency.ts`. The constant `MAX_UPLOADS_PER_MINUTE` is defined in `libs/conversation-input/src/constants/upload.ts`.
+
+Attachments that fail `validateAttachment` are marked `RequestStatus.Error` synchronously before the dispatcher starts.
+
+#### Scenario: Uploads are dispatched at a steady rate
+
+- **WHEN** more than 100 files are added at once
+- **THEN** uploads start one every 600 ms; at most 100 upload requests are started within any 60-second window
+
+#### Scenario: Small batches are unaffected
+
+- **WHEN** 100 or fewer files are added at once
+- **THEN** all uploads start within 60 seconds with 600 ms spacing between each dispatch
+
+#### Scenario: Uploads run concurrently
+
+- **WHEN** multiple uploads are in flight
+- **THEN** each upload proceeds independently without waiting for others to complete
+
+#### Scenario: Invalid attachments are marked immediately
+
+- **WHEN** a batch contains files that fail `validateAttachment` alongside valid files
+- **THEN** invalid ones are immediately set to `RequestStatus.Error` and valid ones enter the rate-limited dispatch queue
+
+#### Scenario: All uploads complete after the last dispatch
+
+- **WHEN** the dispatcher has started all items
+- **THEN** the process waits for all in-flight uploads to settle before resolving

--- a/openspec/changes/wire-attachment-upload-to-dial/specs/file-upload-api/spec.md
+++ b/openspec/changes/wire-attachment-upload-to-dial/specs/file-upload-api/spec.md
@@ -1,0 +1,19 @@
+## MODIFIED Requirements
+
+---
+
+### Requirement: Frontend respects backend throttle via rate-limited dispatch
+
+The frontend SHALL NOT fire unbounded parallel upload requests. The backend `POST /api/v1/files` endpoint is rate-limited to 100 requests per 60 seconds (`@Throttle({ default: { limit: 100, ttl: 60000 } })`). To stay within this limit, the `Input` component dispatches uploads through `runAtRate` at `MAX_UPLOADS_PER_MINUTE = 100`, firing one upload every 600 ms. This ensures at most 100 upload starts occur within any 60-second window, matching the backend throttle exactly.
+
+A 429 response from the backend SHALL be surfaced as `RequestStatus.Error` on the affected attachment card, consistent with other upload failures.
+
+#### Scenario: No 429 when uploading many files
+
+- **WHEN** a user attaches any number of files simultaneously
+- **THEN** the rate-limited dispatcher keeps starts within 100 per minute and no 429 errors occur under normal backend load
+
+#### Scenario: 429 from backend sets attachment to error state
+
+- **WHEN** the backend returns `429 Too Many Requests` for an upload request
+- **THEN** the corresponding `AttachmentCard` transitions to `RequestStatus.Error` and the user can retry


### PR DESCRIPTION
## Description of changes

Increased nest throttle to 100 file upload per minute, add logic on FE side to portion file upload requests to 100 per minute as well.

## Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #7273

## UI changes

<Please, provide Screenshots or Figma links>

## Checklist

- [X] the pull request name ends with `(Issue #<ISSUE_ID>)` (comma-separated list of issues)
- [X] I confirm that I don't share any confidential information like API keys or any other secrets and private URLs

<details>
  <summary>PR title cheatsheet</summary>

`<type>[optional scope]: <description>`

1. type (required)
    - `feat` - A new feature
    - `fix` - A bug fix
    - `docs` - Documentation only changes
    - `test` - Adding missing tests or correcting existing tests
    - `ci` - Changes to our CI configuration files and scripts
    - `chore` - Other changes that are minor and/or not user-facing
2. scope (optional, current repo suggestions below)
    - `chat`
    - `overlay`
    - `shared`
    - `sandbox-overlay`
    - `visualizer-connector`

</details>
