### PR TITLE
fix(chat): RTL layout fixes for toggle switch and editor header avatar spacing

### DIFF
--- a/apps/chat/src/components/Common/ToggleSwitch/ToggleSwitch.tsx
+++ b/apps/chat/src/components/Common/ToggleSwitch/ToggleSwitch.tsx
@@ -19,7 +19,7 @@ const SwitchStateText = ({
 }: SwitchStateTextProps) => (
   <span
     className={classNames(
-      'h-4 text-xs',
+      'h-4 min-w-0 shrink text-xs leading-4',
       isOn && 'px-1',
       isOn && !disabled ? 'text-controls-permanent' : 'text-primary',
       disabled && '!text-controls-accent-disable',
@@ -43,7 +43,7 @@ export function ToggleSwitch({
   const id = useId();
   const switchText = isOn ? switchOnText : switchOFFText;
   const switchClassName = classNames(
-    'flex h-[22px] w-[50px] min-w-[50px] shrink-0 items-center justify-between rounded-full px-[5px] py-1 transition-all duration-200',
+    'flex h-[22px] w-[56px] min-w-[56px] shrink-0 items-center justify-between overflow-hidden rounded-full px-[5px] py-1 transition-all duration-200',
     isOn ? 'flex-row bg-accent-primary' : 'flex-row-reverse bg-layer-4',
     disabled ? 'cursor-not-allowed' : 'cursor-pointer',
     disabled && '!bg-controls-disable-accent',
@@ -70,7 +70,7 @@ export function ToggleSwitch({
           )}
           <span
             className={classNames(
-              'size-3 rounded-full',
+              'size-3 shrink-0 rounded-full',
               disabled ? 'bg-layer-4' : 'bg-controls-enable-primary',
             )}
           ></span>

--- a/apps/chat/src/components/Header/EditorHeader.tsx
+++ b/apps/chat/src/components/Header/EditorHeader.tsx
@@ -135,7 +135,7 @@ export const EditorHeader = <T extends string>({
         </div>
       }
       RightItems={
-        <div className="flex h-full items-center xl:mr-2 xl:border-r xl:border-secondary">
+        <div className="flex h-full items-center xl:me-2 xl:border-e xl:border-secondary">
           <DialLinkButton
             onClick={onSave}
             data-qa="save-and-exit"

--- a/apps/chat/src/components/Header/User/User.tsx
+++ b/apps/chat/src/components/Header/User/User.tsx
@@ -27,7 +27,7 @@ const view = withRenderWhen(
         <ProfileButton />
       </div>
 
-      <div className="hidden size-full border-r border-secondary md:block">
+      <div className="hidden size-full border-e border-secondary md:block">
         <UserDesktop />
       </div>
     </div>

--- a/apps/chat/src/components/Header/User/UserDesktop.tsx
+++ b/apps/chat/src/components/Header/User/UserDesktop.tsx
@@ -39,7 +39,7 @@ export const UserDesktop = Inversify.register('UserDesktop', () => {
         placement="bottom-end"
         trigger={
           <div
-            className="flex w-full cursor-pointer items-center justify-between gap-2 pe-3"
+            className="flex w-full cursor-pointer items-center justify-start gap-2 pe-3 rtl:justify-end"
             data-qa="account-settings"
           >
             <div className="flex items-center gap-3 overflow-hidden">


### PR DESCRIPTION
## Description of changes

- Fixes toggle knob squashing when Arabic ON/OFF labels are wider than English.
- Fixes missing avatar-to-divider gap in the Arabic apps editor header without reverting the mirrored RTL layout.

## Applicable issues

- fixes #7371 

## UI changes

<img width="643" height="206" alt="Screenshot 2026-06-22 at 14 41 27" src="https://github.com/user-attachments/assets/3b43f345-724d-4d2f-88ac-107057db38db" />

## Checklist

- [x] the pull request name ends with `(Issue #<ISSUE_ID>)` (comma-separated list of issues)
- [x] I confirm that I don't share any confidential information like API keys or any other secrets and private URLs

<details>
  <summary>PR title cheatsheet</summary>

`<type>[optional scope]: <description>`

1. type (required)
    - `feat` - A new feature
    - `fix` - A bug fix
    - `docs` - Documentation only changes
    - `test` - Adding missing tests or correcting existing tests
    - `ci` - Changes to our CI configuration files and scripts
    - `chore` - Other changes that are minor and/or not user-facing
2. scope (optional, current repo suggestions below)
    - `chat`
    - `overlay`
    - `shared`
    - `sandbox-overlay`
    - `visualizer-connector`

</details>
