### PR TITLE
fix: Fix duplicate name and metadata, Issue #7086

### DIFF
--- a/apps/chat-api/src/conversations/conversation.service.ts
+++ b/apps/chat-api/src/conversations/conversation.service.ts
@@ -40,6 +40,7 @@ import type {
 import {
   buildConversationUrl,
   buildRenamedConversationPath,
+  buildRenamedFilename,
   decodeNextToken,
   encodeCompoundToken,
   encodeDialResourcePath,
@@ -307,14 +308,39 @@ export class ConversationService extends AppService {
     const subPath =
       slashIndex === -1 ? sourcePath : sourcePath.slice(slashIndex + 1);
 
-    const filename = subPath.split('/').at(-1) ?? subPath;
-    const sourceTitle = getConversationTitleFromName(filename);
+    // `subPath` arrives percent-encoded (it comes from a resource URL). Each
+    // `/`-separated segment is one path component; a literal slash inside a
+    // component (e.g. a deployment name "Team/App One") is encoded as %2F.
+    const segments = subPath.split('/');
+    const encodedFilename = segments.at(-1) ?? subPath;
+    const decodedFilename = safeDecodeURIComponent(encodedFilename);
+    const decodedFolderSegments = segments
+      .slice(0, -1)
+      .map(safeDecodeURIComponent);
+
+    const sourceTitle = getConversationTitleFromName(decodedFilename);
+    const baseTitle = prepareEntityName(sourceTitle);
     const existingTitles = await this.fetchAllUserTitles(token, sessionBucket);
+    // A duplicate must never reuse the source's exact name+path
+    const reservedTitles = new Set(existingTitles);
+    reservedTitles.add(baseTitle);
     const uniqueTitle = resolveUniqueConversationName(
-      prepareEntityName(sourceTitle),
-      existingTitles,
+      baseTitle,
+      reservedTitles,
     );
-    const destinationPath = buildRenamedConversationPath(subPath, uniqueTitle);
+
+    const decodedRenamedFilename = buildRenamedFilename(
+      decodedFilename,
+      uniqueTitle,
+    );
+    const decodedDestinationSubPath = [
+      ...decodedFolderSegments,
+      decodedRenamedFilename,
+    ].join('/');
+    const encodedDestinationSubPath = [
+      ...decodedFolderSegments.map(encodeURIComponent),
+      encodeURIComponent(decodedRenamedFilename),
+    ].join('/');
 
     const sourceUrl = buildConversationUrl(
       sourceBucket,
@@ -322,7 +348,7 @@ export class ConversationService extends AppService {
     );
     const destinationUrl = buildConversationUrl(
       sessionBucket,
-      encodeDialResourcePath(destinationPath),
+      encodedDestinationSubPath,
     );
 
     try {
@@ -339,7 +365,69 @@ export class ConversationService extends AppService {
       return handleDialError(error);
     }
 
-    return { newPath: buildConversationUrl(sessionBucket, destinationPath) };
+    const folderId = decodedFolderSegments.length
+      ? `${sessionBucket}/${decodedFolderSegments.join('/')}`
+      : sessionBucket;
+    await this.rewriteDuplicatedConversationMetadata(
+      sessionBucket,
+      encodedDestinationSubPath,
+      {
+        id: `${sessionBucket}/${decodedDestinationSubPath}`,
+        folderId,
+        name: uniqueTitle,
+      },
+      token,
+    );
+
+    return { newPath: destinationUrl };
+  }
+
+  /**
+   * Repoints a freshly-copied conversation's identity fields (id/folderId/name)
+   * at the destination bucket/path. Reads from the user's own bucket and
+   * re-saves; all failures are logged and swallowed so the duplicate still
+   * succeeds.
+   */
+  private async rewriteDuplicatedConversationMetadata(
+    bucket: string,
+    encodedSubPath: string,
+    identity: Pick<ConversationResponseDto, 'id' | 'folderId' | 'name'>,
+    token: string,
+  ): Promise<void> {
+    try {
+      const { data, error } = (await this.client.getConversation(
+        bucket,
+        encodedSubPath,
+        { headers: getBearerAuthHeaders(token) },
+      )) as { data?: ConversationResponseDto; error?: unknown };
+      if (error != null || !data) {
+        this.logger.warn(
+          'Could not read duplicated conversation to fix its metadata',
+          error,
+        );
+        return;
+      }
+
+      const { error: saveError } = (await this.client.saveConversation(
+        bucket,
+        encodedSubPath,
+        {
+          headers: getBearerAuthHeaders(token),
+          body: { ...data, ...identity },
+        },
+      )) as { error?: unknown };
+      if (saveError != null) {
+        this.logger.warn(
+          'Could not re-save duplicated conversation metadata',
+          saveError,
+        );
+      }
+    } catch (error) {
+      this.logger.warn(
+        'Failed to rewrite duplicated conversation metadata',
+        error,
+      );
+    }
   }
 
   async listConversations(
@@ -365,7 +453,9 @@ export class ConversationService extends AppService {
             encodeDialResourcePath(path ?? ''),
             {
               headers: getBearerAuthHeaders(token),
-              params: { query: buildQuery(userNextToken) },
+              params: {
+                query: { ...buildQuery(userNextToken), permissions: true },
+              },
             },
           ) as Promise<MetadataResult>,
           (
@@ -431,7 +521,11 @@ export class ConversationService extends AppService {
 
       const mapItems = (
         items: MetadataItem[],
-        overrides: { sharedWithMe?: boolean; publishedWithMe?: boolean } = {},
+        overrides: {
+          sharedWithMe?: boolean;
+          publishedWithMe?: boolean;
+          isReadonly?: boolean;
+        } = {},
       ): ConversationListItemDto[] =>
         items
           .filter((item) => item.nodeType !== 'FOLDER')
@@ -439,6 +533,9 @@ export class ConversationService extends AppService {
             const id =
               item.url ?? `${item.parentPath ?? ''}/${item.name ?? ''}`;
             const decodedId = safeDecodeURIComponent(id);
+            const isReadonly =
+              overrides.isReadonly ??
+              !(item.permissions?.includes('WRITE') ?? false);
             return {
               id,
               title: getConversationTitleFromName(item.name ?? ''),
@@ -448,6 +545,7 @@ export class ConversationService extends AppService {
               publishedWithMe:
                 overrides.publishedWithMe ?? item.publishedWithMe ?? false,
               isPinned: pinnedSet.has(decodedId),
+              isReadonly,
             };
           });
 
@@ -511,7 +609,7 @@ export class ConversationService extends AppService {
               (publicData.items ?? []).filter(
                 (item) => !userItemPaths.has(getBucketRelativePath(item)),
               ),
-              { publishedWithMe: true },
+              { publishedWithMe: true, isReadonly: true },
             )
           : [];
       const sharedItems =
@@ -528,6 +626,7 @@ export class ConversationService extends AppService {
                   sharedWithMe: true,
                   publishedWithMe: false,
                   isPinned: pinnedSet.has(decodedId),
+                  isReadonly: true,
                 };
               })
           : [];

--- a/apps/chat-api/src/conversations/dto/conversation-list.dto.ts
+++ b/apps/chat-api/src/conversations/dto/conversation-list.dto.ts
@@ -41,6 +41,13 @@ export class ConversationListItemDto {
     example: false,
   })
   isPinned!: boolean;
+
+  @ApiProperty({
+    description:
+      'True when the current user does not have WRITE permission on this conversation.',
+    example: false,
+  })
+  isReadonly!: boolean;
 }
 
 export class ConversationListResponseDto {

--- a/apps/chat-api/src/conversations/tests/conversation.service.spec.ts
+++ b/apps/chat-api/src/conversations/tests/conversation.service.spec.ts
@@ -492,6 +492,12 @@ describe('ConversationService', () => {
       const copySpy = vi
         .spyOn(service['client'], 'copyResource')
         .mockResolvedValue({ data: {} } as never);
+      vi.spyOn(service['client'], 'getConversation').mockResolvedValue({
+        data: { ...TEST_CONVERSATION },
+      } as never);
+      vi.spyOn(service['client'], 'saveConversation').mockResolvedValue({
+        data: {},
+      } as never);
 
       const result = await service.duplicateConversation(
         `source-bucket/${conversationPath}`,
@@ -504,13 +510,13 @@ describe('ConversationService', () => {
           body: {
             sourceUrl: `conversations/source-bucket/${conversationPath}`,
             destinationUrl:
-              'conversations/test-bucket/applications/catalog/Team%2FApp%20One__0.0.1__hello',
+              'conversations/test-bucket/applications/catalog/Team%2FApp%20One__0.0.1__hello%201',
             overwrite: false,
           },
         }),
       );
       expect(result.newPath).toBe(
-        'conversations/test-bucket/applications/catalog/Team%2FApp%20One__0.0.1__hello',
+        'conversations/test-bucket/applications/catalog/Team%2FApp%20One__0.0.1__hello%201',
       );
     });
 
@@ -546,6 +552,146 @@ describe('ConversationService', () => {
         'test-bucket',
         conversationPath,
         expect.any(Object),
+      );
+    });
+  });
+
+  describe('duplicateConversation', () => {
+    const SHARED_CONVERSATION = {
+      ...TEST_CONVERSATION,
+      id: 'shared-bucket/gpt-4o__New chat',
+      folderId: 'shared-bucket',
+      name: 'New chat',
+    };
+
+    // The copy is performed by copyResource; the metadata fix then reads the
+    // copy back (getConversation) and re-saves it (saveConversation).
+    const mockGetConversation = (
+      conversation: typeof TEST_CONVERSATION = SHARED_CONVERSATION,
+    ) => {
+      vi.spyOn(service['client'], 'copyResource').mockResolvedValue({
+        data: {},
+      } as never);
+      return vi.spyOn(service['client'], 'getConversation').mockResolvedValue({
+        data: { ...conversation },
+      } as never);
+    };
+
+    it('decodes the encoded filename so the title is not mangled (no "New20 chat")', async () => {
+      mockGetConversation();
+      const saveSpy = vi
+        .spyOn(service['client'], 'saveConversation')
+        .mockResolvedValue({ data: {} } as never);
+
+      await service.duplicateConversation(
+        'shared-bucket/gpt-4o__New%20chat',
+        'test-token',
+        'test-bucket',
+      );
+
+      // The space stays a real space (encoded %20), never collapsed to "New20".
+      expect(saveSpy).toHaveBeenCalledWith(
+        'test-bucket',
+        'gpt-4o__New%20chat%201',
+        expect.objectContaining({
+          body: expect.objectContaining({ name: 'New chat 1' }),
+        }),
+      );
+    });
+
+    it('gives the copy a distinct name so it does not collide with the source path', async () => {
+      // Source is in another (shared/org) bucket and has no namesake in the user
+      // bucket, yet the copy must still be renamed so its relative path differs.
+      mockGetConversation();
+      const saveSpy = vi
+        .spyOn(service['client'], 'saveConversation')
+        .mockResolvedValue({ data: {} } as never);
+
+      await service.duplicateConversation(
+        'shared-bucket/gpt-4o__New%20chat',
+        'test-token',
+        'test-bucket',
+      );
+
+      expect(saveSpy).toHaveBeenCalledWith(
+        'test-bucket',
+        expect.not.stringMatching(/__New%20chat$/),
+        expect.objectContaining({
+          body: expect.objectContaining({ name: 'New chat 1' }),
+        }),
+      );
+    });
+
+    it('rewrites the duplicate id/folderId to the session bucket', async () => {
+      mockGetConversation();
+      const saveSpy = vi
+        .spyOn(service['client'], 'saveConversation')
+        .mockResolvedValue({ data: {} } as never);
+
+      await service.duplicateConversation(
+        'shared-bucket/gpt-4o__New%20chat',
+        'test-token',
+        'test-bucket',
+      );
+
+      expect(saveSpy).toHaveBeenCalledWith(
+        'test-bucket',
+        'gpt-4o__New%20chat%201',
+        expect.objectContaining({
+          body: expect.objectContaining({
+            id: 'test-bucket/gpt-4o__New chat 1',
+            folderId: 'test-bucket',
+          }),
+        }),
+      );
+    });
+
+    it('increments the suffix past existing copies in the bucket', async () => {
+      vi.spyOn(service['client'], 'getConversationMetadata').mockResolvedValue({
+        data: {
+          items: [
+            { name: 'gpt-4o__New chat', nodeType: 'CONVERSATION' },
+            { name: 'gpt-4o__New chat 1', nodeType: 'CONVERSATION' },
+          ],
+        },
+      } as never);
+      mockGetConversation();
+      const saveSpy = vi
+        .spyOn(service['client'], 'saveConversation')
+        .mockResolvedValue({ data: {} } as never);
+
+      await service.duplicateConversation(
+        'shared-bucket/gpt-4o__New%20chat',
+        'test-token',
+        'test-bucket',
+      );
+
+      expect(saveSpy).toHaveBeenCalledWith(
+        'test-bucket',
+        'gpt-4o__New%20chat%202',
+        expect.objectContaining({
+          body: expect.objectContaining({
+            name: 'New chat 2',
+            id: 'test-bucket/gpt-4o__New chat 2',
+          }),
+        }),
+      );
+    });
+
+    it('returns the encoded path of the new conversation', async () => {
+      mockGetConversation();
+      vi.spyOn(service['client'], 'saveConversation').mockResolvedValue({
+        data: {},
+      } as never);
+
+      const result = await service.duplicateConversation(
+        'shared-bucket/gpt-4o__New%20chat',
+        'test-token',
+        'test-bucket',
+      );
+
+      expect(result.newPath).toBe(
+        'conversations/test-bucket/gpt-4o__New%20chat%201',
       );
     });
   });

--- a/apps/chat-api/src/conversations/utils/conversation.utils.ts
+++ b/apps/chat-api/src/conversations/utils/conversation.utils.ts
@@ -79,6 +79,33 @@ export const getConversationTitleFromName = (name: string): string => {
 };
 
 /**
+ * Replaces the title segment inside a single conversation filename, preserving
+ * a versioned application deployment ID prefix and a legacy UUID suffix.
+ * Operates on a bare filename (no `/` path separators), so it is safe to use
+ * on a decoded filename whose deployment name contains a literal slash.
+ */
+export const buildRenamedFilename = (
+  filename: string,
+  sanitisedTitle: string,
+): string => {
+  const parts = filename.split(CONVERSATION_NAME_SEPARATOR);
+  if (parts.length < 2) return sanitisedTitle;
+
+  const deploymentNameParts = getDeploymentNameParts(parts);
+  const hasVersionedDeployment = deploymentNameParts.length > 1;
+  const hasLegacySuffix = hasVersionedDeployment
+    ? isUuid(parts[parts.length - 1])
+    : parts.length >= 3;
+  const legacySuffix = hasLegacySuffix ? parts[parts.length - 1] : undefined;
+
+  return [
+    ...deploymentNameParts,
+    sanitisedTitle,
+    ...(legacySuffix ? [legacySuffix] : []),
+  ].join(CONVERSATION_NAME_SEPARATOR);
+};
+
+/**
  * Builds the new conversation path by replacing the title segment in the filename.
  * Preserves versioned application deployment IDs and legacy UUID suffixes.
  */
@@ -88,24 +115,7 @@ export const buildRenamedConversationPath = (
 ): string => {
   const segments = conversationPath.split('/');
   const filename = segments[segments.length - 1];
-  const parts = filename.split(CONVERSATION_NAME_SEPARATOR);
-  if (parts.length < 2) {
-    return segments.length > 1
-      ? [...segments.slice(0, -1), sanitisedTitle].join('/')
-      : sanitisedTitle;
-  }
-
-  const deploymentNameParts = getDeploymentNameParts(parts);
-  const hasVersionedDeployment = deploymentNameParts.length > 1;
-  const hasLegacySuffix = hasVersionedDeployment
-    ? isUuid(parts[parts.length - 1])
-    : parts.length >= 3;
-  const legacySuffix = hasLegacySuffix ? parts[parts.length - 1] : undefined;
-  const renamedFilename = [
-    ...deploymentNameParts,
-    sanitisedTitle,
-    ...(legacySuffix ? [legacySuffix] : []),
-  ].join(CONVERSATION_NAME_SEPARATOR);
+  const renamedFilename = buildRenamedFilename(filename, sanitisedTitle);
 
   return segments.length > 1
     ? [...segments.slice(0, -1), renamedFilename].join('/')

--- a/apps/chat/src/app/app.tsx
+++ b/apps/chat/src/app/app.tsx
@@ -1,3 +1,4 @@
+import { FilterTab } from '@epam/ai-dial-conversation-panel';
 import {
   lazy,
   memo,
@@ -5,6 +6,7 @@ import {
   useCallback,
   useEffect,
   useMemo,
+  useRef,
   useState,
   type FC,
 } from 'react';
@@ -85,6 +87,21 @@ const App: FC = () => {
     }
   }, [pathname]);
 
+  const switchToMyChatsOnNavRef = useRef(false);
+  const [panelRequestedFilter, setPanelRequestedFilter] = useState<
+    FilterTab | undefined
+  >(undefined);
+
+  useEffect(() => {
+    if (!switchToMyChatsOnNavRef.current) return;
+    switchToMyChatsOnNavRef.current = false;
+    setPanelRequestedFilter(FilterTab.MyChats);
+  }, [activeConversationId]);
+
+  const handleDuplicateReadonly = useCallback(() => {
+    switchToMyChatsOnNavRef.current = true;
+  }, []);
+
   const handleSelectConversation = useCallback(
     (id: string) => {
       if (isMobile) {
@@ -107,6 +124,9 @@ const App: FC = () => {
         onClose={closeHistoryPanel}
         onSelectConversation={handleSelectConversation}
         onNewChat={() => navigate(ROUTES.Root)}
+        requestedFilter={panelRequestedFilter}
+        onRequestedFilterChange={() => setPanelRequestedFilter(undefined)}
+        onDuplicateReadonly={handleDuplicateReadonly}
       />
 
       <main
@@ -133,7 +153,9 @@ const App: FC = () => {
             path="/conversations/*"
             element={
               <Suspense fallback={<RouteFallback />}>
-                <ConversationPage />
+                <ConversationPage
+                  onDuplicateReadonly={handleDuplicateReadonly}
+                />
               </Suspense>
             }
           />

--- a/apps/chat/src/components/ConversationPanel/ConversationPanelView.tsx
+++ b/apps/chat/src/components/ConversationPanel/ConversationPanelView.tsx
@@ -2,6 +2,7 @@ import { mergeClasses } from '@epam/ai-dial-chat-shared';
 import {
   ConversationGroupKey,
   ConversationPanel,
+  FilterTab,
   type ConversationHistoryItem,
   type ConversationMove,
 } from '@epam/ai-dial-conversation-panel';
@@ -59,6 +60,9 @@ interface ConversationPanelViewProps {
   onClose: () => void;
   onSelectConversation: (id: string) => void;
   onNewChat: () => void;
+  requestedFilter?: FilterTab;
+  onRequestedFilterChange?: () => void;
+  onDuplicateReadonly?: () => void;
 }
 
 const ConversationPanelView: FC<ConversationPanelViewProps> = ({
@@ -67,6 +71,9 @@ const ConversationPanelView: FC<ConversationPanelViewProps> = ({
   onClose,
   onSelectConversation,
   onNewChat,
+  requestedFilter,
+  onRequestedFilterChange,
+  onDuplicateReadonly,
 }) => {
   const { t } = useTranslation();
   const isMobile = useIsMobile();
@@ -196,22 +203,54 @@ const ConversationPanelView: FC<ConversationPanelViewProps> = ({
       const contextId = panelToContextId.get(panelItem.id);
       if (!contextId) return [];
 
-      return [
-        {
-          key: 'pin',
-          label: panelItem.isPinned
-            ? t(ConversationPanelI18nKeys.UnpinLabel)
-            : t(ConversationPanelI18nKeys.PinLabel),
-          icon: panelItem.isPinned ? (
-            <IconPinnedFilled
-              size={DIAL_ICON_SIZE.SM}
-              className="text-secondary"
-            />
-          ) : (
-            <IconPin size={DIAL_ICON_SIZE.SM} className="text-secondary" />
-          ),
-          onClick: () => pinConversation(contextId, !panelItem.isPinned),
+      const rawItem = items.find((c) => c.id === contextId);
+      const isReadonlyItem =
+        rawItem?.isReadonly ||
+        rawItem?.sharedWithMe ||
+        rawItem?.publishedWithMe;
+
+      const pinAction: DropdownItem = {
+        key: 'pin',
+        label: panelItem.isPinned
+          ? t(ConversationPanelI18nKeys.UnpinLabel)
+          : t(ConversationPanelI18nKeys.PinLabel),
+        icon: panelItem.isPinned ? (
+          <IconPinnedFilled
+            size={DIAL_ICON_SIZE.SM}
+            className="text-secondary"
+          />
+        ) : (
+          <IconPin size={DIAL_ICON_SIZE.SM} className="text-secondary" />
+        ),
+        onClick: () => pinConversation(contextId, !panelItem.isPinned),
+      };
+
+      const duplicateAction: DropdownItem = {
+        key: 'duplicate',
+        label: t(ButtonsI18nKeys.Duplicate),
+        icon: <IconCopy size={DIAL_ICON_SIZE.SM} className="text-secondary" />,
+        onClick: async () => {
+          try {
+            const newPath = await duplicateConversation(contextId);
+            if (isReadonlyItem && panelItem.id === activeConversationId) {
+              onDuplicateReadonly?.();
+            }
+            navigate(getConversationRoute(newPath));
+          } catch {
+            showNotification({
+              variant: NotificationVariant.Error,
+              message: t(ConversationPanelI18nKeys.DuplicateError),
+            });
+          }
         },
+      };
+
+      if (isReadonlyItem) {
+        return [pinAction, duplicateAction];
+      }
+
+      return [
+        pinAction,
         {
           key: 'rename',
           label: t(ButtonsI18nKeys.Rename),
@@ -224,24 +263,7 @@ const ConversationPanelView: FC<ConversationPanelViewProps> = ({
           onClick: () =>
             setPendingRenameItem({ id: contextId, title: panelItem.title }),
         },
-        {
-          key: 'duplicate',
-          label: t(ButtonsI18nKeys.Duplicate),
-          icon: (
-            <IconCopy size={DIAL_ICON_SIZE.SM} className="text-secondary" />
-          ),
-          onClick: async () => {
-            try {
-              const newPath = await duplicateConversation(contextId);
-              navigate(getConversationRoute(newPath));
-            } catch {
-              showNotification({
-                variant: NotificationVariant.Error,
-                message: t(ConversationPanelI18nKeys.DuplicateError),
-              });
-            }
-          },
-        },
+        duplicateAction,
         {
           key: 'delete',
           label: t(ButtonsI18nKeys.Delete),
@@ -254,11 +276,14 @@ const ConversationPanelView: FC<ConversationPanelViewProps> = ({
     },
     [
       panelToContextId,
+      items,
+      t,
       pinConversation,
       duplicateConversation,
+      activeConversationId,
       navigate,
+      onDuplicateReadonly,
       showNotification,
-      t,
     ],
   );
 
@@ -346,6 +371,8 @@ const ConversationPanelView: FC<ConversationPanelViewProps> = ({
         isOpen={isOpen}
         onSelectConversation={onSelectConversation}
         activeConversationId={activeConversationId}
+        activeFilter={requestedFilter}
+        onActiveFilterChange={onRequestedFilterChange}
         title={t(ConversationPanelI18nKeys.Title)}
         emptyLabel={t(ConversationPanelI18nKeys.Empty)}
         noResultsLabel={t(BasicI18nKeys.NoResults)}

--- a/apps/chat/src/context/tests/ConversationsContext.spec.tsx
+++ b/apps/chat/src/context/tests/ConversationsContext.spec.tsx
@@ -35,6 +35,7 @@ const seedConversations = [
     updatedAt: 0,
     sharedWithMe: false,
     publishedWithMe: false,
+    isReadonly: false,
   },
   {
     id: 'conv2',
@@ -43,6 +44,7 @@ const seedConversations = [
     updatedAt: 0,
     sharedWithMe: false,
     publishedWithMe: false,
+    isReadonly: false,
   },
   {
     id: 'conv3',
@@ -51,6 +53,7 @@ const seedConversations = [
     updatedAt: 0,
     sharedWithMe: false,
     publishedWithMe: false,
+    isReadonly: false,
   },
 ];
 
@@ -82,6 +85,7 @@ describe('ConversationsContext — deleteAllConversations', () => {
         updatedAt: 0,
         sharedWithMe: true,
         publishedWithMe: false,
+        isReadonly: true,
       },
     ];
     mockListConversations.mockResolvedValueOnce({ items: afterDelete });
@@ -146,6 +150,7 @@ describe('ConversationsContext — deleteAllConversations', () => {
         updatedAt: 0,
         sharedWithMe: false,
         publishedWithMe: false,
+        isReadonly: false,
       },
     ];
     mockListConversations.mockResolvedValueOnce({ items: refreshedConvs });

--- a/apps/chat/src/hooks/conversation-sources/useConversationSources.ts
+++ b/apps/chat/src/hooks/conversation-sources/useConversationSources.ts
@@ -1,7 +1,7 @@
 import type { DisplayAttachment, Message } from '@epam/ai-dial-chat-shared';
 import { MessageRole } from '@epam/ai-dial-chat-shared';
-import { useMemo } from 'react';
 import type { QuotationSource } from '@epam/ai-dial-source-panel';
+import { useMemo } from 'react';
 import { attachmentDtosToDisplayAttachments } from '../../utils/attachment-dto-to-display';
 
 /**

--- a/apps/chat/src/pages/Conversation/Conversation.tsx
+++ b/apps/chat/src/pages/Conversation/Conversation.tsx
@@ -48,7 +48,11 @@ import { buildUploadPath } from '../../utils/build-upload-path';
 import { getConversationPath } from '../../utils/conversation-path';
 import { getLastDeploymentId } from '../../utils/message-utils';
 
-export const ConversationPage: FC = () => {
+interface Props {
+  onDuplicateReadonly?: () => void;
+}
+
+export const ConversationPage: FC<Props> = ({ onDuplicateReadonly }) => {
   const { '*': conversationId } = useParams<{ '*': string }>();
   const [conversation, setConversation] = useState<Conversation | null>(null);
   const [isFetching, setIsFetching] = useState(!!conversationId);
@@ -66,7 +70,7 @@ export const ConversationPage: FC = () => {
     useSourcesSidebar();
   const { user } = useUser();
   const bucket = user?.bucket ?? '';
-  const { duplicateConversation } = useConversations();
+  const { conversations, duplicateConversation } = useConversations();
   const [duplicateError, setDuplicateError] = useState<string | null>(null);
 
   const isTranscriptionSupported = useMemo(() => {
@@ -152,21 +156,37 @@ export const ConversationPage: FC = () => {
   >(null);
 
   const isReadOnly = useMemo(() => {
-    if (!conversationId || !bucket) return false;
+    if (!conversationId) return false;
+    const listItem = conversations.find((c) => c.id.includes(conversationId));
+    if (listItem) {
+      return (
+        listItem.isReadonly || listItem.sharedWithMe || listItem.publishedWithMe
+      );
+    }
+    // Fallback: bucket-prefix check when the conversation isn't in the list yet.
+    if (!bucket) return false;
     const slashIndex = conversationId.indexOf('/');
     return slashIndex !== -1 && conversationId.slice(0, slashIndex) !== bucket;
-  }, [conversationId, bucket]);
+  }, [conversationId, bucket, conversations]);
 
   const handleDuplicateConversation = useCallback(async () => {
     if (!conversationId) return;
     setDuplicateError(null);
     try {
       const newPath = await duplicateConversation(conversationId);
+      if (isReadOnly) onDuplicateReadonly?.();
       navigate(getConversationRoute(newPath));
     } catch {
       setDuplicateError(t(ConversationPanelI18nKeys.DuplicateError));
     }
-  }, [conversationId, duplicateConversation, navigate, t]);
+  }, [
+    conversationId,
+    isReadOnly,
+    onDuplicateReadonly,
+    duplicateConversation,
+    navigate,
+    t,
+  ]);
 
   useEffect(() => {
     setMessages(conversation?.messages ?? []);

--- a/apps/chat/src/pages/ConversationRoute/ConversationRoute.tsx
+++ b/apps/chat/src/pages/ConversationRoute/ConversationRoute.tsx
@@ -26,7 +26,6 @@ import RouteFallback from '../../components/RouteFallback/RouteFallback';
 import StarterButtons from '../../components/StarterButtons/StarterButtons';
 import { MAX_SELECTABLE_FILE_SIZE_BYTES } from '../../constants/files';
 import { getConversationRoute } from '../../constants/routes';
-import { NETWORK_ERROR_DEBOUNCE_MS } from '../../constants/upload';
 import {
   AttachmentsI18nKeys,
   BasicI18nKeys,
@@ -37,6 +36,7 @@ import {
   ButtonsI18nKeys,
   FileDndI18nKeys,
 } from '../../constants/translation-keys';
+import { NETWORK_ERROR_DEBOUNCE_MS } from '../../constants/upload';
 import { useAppConfig } from '../../context/AppConfigContext';
 import { useUser } from '../../context/auth/UserContext';
 import { useDeployments } from '../../context/DeploymentsContext';

--- a/libs/chat-api-client/src/generated/src/models/index.ts
+++ b/libs/chat-api-client/src/generated/src/models/index.ts
@@ -458,6 +458,12 @@ export interface ConversationListItemDto {
    * @memberof ConversationListItemDto
    */
   isPinned: boolean;
+  /**
+   * True when the current user does not have WRITE permission on this conversation.
+   * @type {boolean}
+   * @memberof ConversationListItemDto
+   */
+  isReadonly: boolean;
 }
 /**
  *

--- a/libs/conversation-panel/src/components/ConversationPanel/ConversationPanel.tsx
+++ b/libs/conversation-panel/src/components/ConversationPanel/ConversationPanel.tsx
@@ -7,7 +7,15 @@ import {
   SidebarPanel,
 } from '@epam/ai-dial-sidebar';
 import { DialSkeleton } from '@epam/ai-dial-ui-kit';
-import { type FC, memo, useCallback, useMemo, useRef, useState } from 'react';
+import {
+  type FC,
+  memo,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { List } from 'react-window';
 import { ITEM_ROW_HEIGHT } from '../../constants/virtual-list';
 import { ConversationPanelProps } from '../../models/panel-props';
@@ -64,10 +72,18 @@ export const ConversationPanel: FC<ConversationPanelProps> = memo(
     onPanelResizeStop,
     headerActions,
     onMoveConversation,
+    activeFilter,
+    onActiveFilterChange,
   }) => {
     const { colors, typography } = panelStyles ?? {};
     const [searchQuery, setSearchQuery] = useState('');
     const [activeTab, setActiveTab] = useState(FilterTab.All);
+
+    useEffect(() => {
+      if (activeFilter == null) return;
+      setActiveTab(activeFilter);
+      onActiveFilterChange?.(activeFilter);
+    }, [activeFilter]); // eslint-disable-line react-hooks/exhaustive-deps
     const [expandedGroups, setExpandedGroups] = useState<Set<string>>(
       () => ALL_GROUP_KEYS,
     );
@@ -367,7 +383,10 @@ export const ConversationPanel: FC<ConversationPanelProps> = memo(
         <FilterTabs
           activeTab={activeTab}
           labels={filterLabels}
-          onChange={setActiveTab}
+          onChange={(tab) => {
+            setActiveTab(tab);
+            onActiveFilterChange?.(tab);
+          }}
           tabClassName={typography?.tabClassName}
           tabColorClassName={typography?.tabColorClassName}
         />

--- a/libs/conversation-panel/src/index.ts
+++ b/libs/conversation-panel/src/index.ts
@@ -11,3 +11,4 @@ export type {
 export type { ConversationGroupProps } from './components/ConversationGroup/ConversationGroup';
 export { ConversationGroupKey } from './types/conversation-group-key';
 export { ConversationSource } from './types/conversation-source';
+export { FilterTab } from './types/filter-tab';

--- a/libs/conversation-panel/src/models/panel-props.ts
+++ b/libs/conversation-panel/src/models/panel-props.ts
@@ -2,6 +2,7 @@ import type { DropdownItem } from '@epam/ai-dial-ui-kit';
 import type { ReactNode } from 'react';
 import { ConversationGroupKey } from '../types/conversation-group-key';
 import { ConversationSource } from '../types/conversation-source';
+import { FilterTab } from '../types/filter-tab';
 
 /** Labels for each filter tab — provided as props so the app supplies i18n strings. */
 export interface FilterLabels {
@@ -195,6 +196,17 @@ export interface ConversationPanelProps {
    * - same-group drop → reorder
    */
   onMoveConversation?: (move: ConversationMove) => void;
+  /**
+   * Imperatively sets the active filter tab. When provided the panel switches
+   * to this tab; the user can still change it afterwards. Pass `undefined` to
+   * leave the current tab unchanged.
+   */
+  activeFilter?: FilterTab;
+  /**
+   * Called whenever the active filter tab changes — either because the user
+   * clicked a tab or because `activeFilter` drove a programmatic switch.
+   */
+  onActiveFilterChange?: (tab: FilterTab) => void;
 }
 
 /** Describes a completed drag-and-drop move in the conversation panel. */


### PR DESCRIPTION
## Description of changes

Fix issues with duplicate:
1) metadata was not updated
2) name was created incorrectly

Also added isReadonly field and use it for duplication button, and hiding delete and rename.
And also if user is in readonly conversation and duplicate it - automatically select duplicated conversation.

## Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #7086

## UI changes

<Please, provide Screenshots or Figma links>

## Checklist

- [X] the pull request name ends with `(Issue #<ISSUE_ID>)` (comma-separated list of issues)
- [X] I confirm that I don't share any confidential information like API keys or any other secrets and private URLs

<details>
  <summary>PR title cheatsheet</summary>

`<type>[optional scope]: <description>`

1. type (required)
    - `feat` - A new feature
    - `fix` - A bug fix
    - `docs` - Documentation only changes
    - `test` - Adding missing tests or correcting existing tests
    - `ci` - Changes to our CI configuration files and scripts
    - `chore` - Other changes that are minor and/or not user-facing
2. scope (optional, current repo suggestions below)
    - `chat`
    - `overlay`
    - `shared`
    - `sandbox-overlay`
    - `visualizer-connector`

</details>
