### PR TITLE
fix: Hide attach button if attachments are not allowed, fix attachments logic for edit, Issue #7363

### DIFF
--- a/apps/chat/src/components/ConversationView/ConversationMessageItem.tsx
+++ b/apps/chat/src/components/ConversationView/ConversationMessageItem.tsx
@@ -3,6 +3,7 @@ import {
   isStatusMessage,
   MessageRole,
   type Attachment,
+  type AttachmentErrorReason,
   type DisplayAttachment,
   type MessageRating,
   type Message as MessageType,
@@ -91,6 +92,10 @@ interface Props {
   thinkingLabel: string;
   executedLabel: string;
   stepsLabel: (count: number) => string;
+  validateAttachment?: (
+    attachment: Attachment,
+  ) => AttachmentErrorReason | undefined;
+  hideAttachFile?: boolean;
 }
 
 const ConversationMessageItem: FC<Props> = ({
@@ -128,6 +133,8 @@ const ConversationMessageItem: FC<Props> = ({
   thinkingLabel,
   executedLabel,
   stepsLabel,
+  validateAttachment,
+  hideAttachFile,
 }) => {
   const { t } = useTranslation();
   const { currentTheme } = useTheme();
@@ -192,6 +199,8 @@ const ConversationMessageItem: FC<Props> = ({
             className="w-full max-w-[748px]"
             pendingDropFiles={pendingDropFiles}
             onDropFilesConsumed={onDropFilesConsumed}
+            validateAttachment={validateAttachment}
+            hideAttachFile={hideAttachFile}
           />
         </Suspense>
       </div>

--- a/apps/chat/src/components/ConversationView/ConversationView.tsx
+++ b/apps/chat/src/components/ConversationView/ConversationView.tsx
@@ -1,5 +1,4 @@
 import {
-  AttachmentErrorReason,
   DisplayAttachment,
   isStatusMessage,
   MessageRole,
@@ -35,7 +34,6 @@ import {
 import { useTranslation } from 'react-i18next';
 import { MAX_SELECTABLE_FILE_SIZE_BYTES } from '../../constants/files';
 import {
-  AttachmentsI18nKeys,
   BasicI18nKeys,
   ButtonsI18nKeys,
   ChatI18nKeys,
@@ -47,14 +45,10 @@ import {
 } from '../../constants/translation-keys';
 import { useUser } from '../../context/auth/UserContext';
 import { useDeployments } from '../../context/DeploymentsContext';
-import { useNotification } from '../../context/NotificationContext';
+import { useAttachmentValidation } from '../../hooks/attachment/useAttachmentValidation';
 import { useIsMobile } from '../../hooks/breakpoint/useBreakpoint';
 import { useKeyboardShortcutPreference } from '../../hooks/keyboard-shortcut/useKeyboardShortcutPreference';
 import { usePageFileDrag } from '../../hooks/usePageFileDrag';
-import {
-  isMimeTypeAllowed,
-  mimeTypesToExtensionLabels,
-} from '../../utils/attachment-mime';
 import { dialFilesToAttachments } from '../../utils/dial-file-to-attachment';
 import { resolveCatalogIconUrl } from '../../utils/icon-path';
 import type { AttachResult } from '../DialFileManagerModal/types/attach-result';
@@ -153,46 +147,13 @@ const ConversationView: FC<Props> = ({
     isLoading,
     error,
   } = useDeployments();
-  const { showNotification } = useNotification();
-
   const selectedDeployment = useMemo(
     () => items.find((item) => item.id === selectedItemId),
     [items, selectedItemId],
   );
 
-  const inputAttachmentTypes = useMemo(
-    () => selectedDeployment?.inputAttachmentTypes ?? [],
-    [selectedDeployment],
-  );
-
-  const isAttachmentsAllowed = selectedDeployment?.inputAttachmentTypes != null;
-
-  const unsupportedTypeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
-    null,
-  );
-
-  const validateAttachment = useCallback(
-    (attachment: Attachment): AttachmentErrorReason | undefined => {
-      if (!isMimeTypeAllowed(attachment.contentType, inputAttachmentTypes)) {
-        if (unsupportedTypeTimerRef.current != null) {
-          clearTimeout(unsupportedTypeTimerRef.current);
-        }
-        unsupportedTypeTimerRef.current = setTimeout(() => {
-          showNotification({
-            variant: NotificationVariant.Error,
-            title: t(AttachmentsI18nKeys.UnsupportedTypeTitle),
-            message: t(AttachmentsI18nKeys.UnsupportedTypeMessage, {
-              formats: mimeTypesToExtensionLabels(inputAttachmentTypes),
-            }),
-          });
-          unsupportedTypeTimerRef.current = null;
-        }, 100);
-        return AttachmentErrorReason.UnsupportedType;
-      }
-      return undefined;
-    },
-    [inputAttachmentTypes, showNotification, t],
-  );
+  const { inputAttachmentTypes, isAttachmentsAllowed, validateAttachment } =
+    useAttachmentValidation(selectedDeployment);
 
   const { isDragging, pendingFiles, onFilesConsumed } = usePageFileDrag(
     isAttachmentsAllowed,
@@ -485,6 +446,10 @@ const ConversationView: FC<Props> = ({
                       ? onFilesConsumed
                       : undefined
                   }
+                  validateAttachment={
+                    selectedDeployment != null ? validateAttachment : undefined
+                  }
+                  hideAttachFile={!isAttachmentsAllowed}
                 />
               );
             })}
@@ -555,13 +520,18 @@ const ConversationView: FC<Props> = ({
                     : undefined
                 }
                 autoFocus={!isMobile}
-                onDialFileSystemClick={() => setIsDialFileManagerOpen(true)}
+                onDialFileSystemClick={
+                  isAttachmentsAllowed
+                    ? () => setIsDialFileManagerOpen(true)
+                    : undefined
+                }
                 dialFileSystemLabel={t(
                   ConversationI18nKeys.AttachMenuDialFileSystem,
                 )}
                 validateAttachment={
-                  isAttachmentsAllowed ? validateAttachment : undefined
+                  selectedDeployment != null ? validateAttachment : undefined
                 }
+                hideAttachFile={!isAttachmentsAllowed}
               />
             </Suspense>
             <Suspense fallback={null}>

--- a/apps/chat/src/constants/translation-keys.ts
+++ b/apps/chat/src/constants/translation-keys.ts
@@ -224,6 +224,8 @@ export enum AttachmentsI18nKeys {
   Download = 'attachments.downloadFile',
   UnsupportedTypeTitle = 'attachments.unsupportedType.title',
   UnsupportedTypeMessage = 'attachments.unsupportedType.message',
+  NoAttachmentsAllowedTitle = 'attachments.noAttachmentsAllowed.title',
+  NoAttachmentsAllowedMessage = 'attachments.noAttachmentsAllowed.message',
   NetworkErrorTitle = 'attachments.networkError.title',
   NetworkErrorMessage = 'attachments.networkError.message',
 }

--- a/apps/chat/src/hooks/attachment/useAttachmentValidation.ts
+++ b/apps/chat/src/hooks/attachment/useAttachmentValidation.ts
@@ -1,0 +1,69 @@
+import {
+  AttachmentErrorReason,
+  type Attachment,
+  type DeploymentItem,
+} from '@epam/ai-dial-chat-shared';
+import { NotificationVariant } from '@epam/ai-dial-ui-kit';
+import { useCallback, useMemo, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
+import { AttachmentsI18nKeys } from '../../constants/translation-keys';
+import { useNotification } from '../../context/NotificationContext';
+import {
+  isMimeTypeAllowed,
+  mimeTypesToExtensionLabels,
+} from '../../utils/attachment-mime';
+
+export const useAttachmentValidation = (
+  selectedDeployment: DeploymentItem | undefined,
+) => {
+  const { t } = useTranslation();
+  const { showNotification } = useNotification();
+
+  const inputAttachmentTypes = useMemo(
+    () => selectedDeployment?.inputAttachmentTypes ?? [],
+    [selectedDeployment],
+  );
+
+  const isAttachmentsAllowed =
+    selectedDeployment?.inputAttachmentTypes != null &&
+    selectedDeployment.inputAttachmentTypes.length > 0;
+
+  const unsupportedTypeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  );
+
+  const validateAttachment = useCallback(
+    (attachment: Attachment): AttachmentErrorReason | undefined => {
+      if (!isMimeTypeAllowed(attachment.contentType, inputAttachmentTypes)) {
+        if (unsupportedTypeTimerRef.current != null) {
+          clearTimeout(unsupportedTypeTimerRef.current);
+        }
+        unsupportedTypeTimerRef.current = setTimeout(() => {
+          const noTypesAllowed = inputAttachmentTypes.length === 0;
+          showNotification({
+            variant: NotificationVariant.Error,
+            title: t(
+              noTypesAllowed
+                ? AttachmentsI18nKeys.NoAttachmentsAllowedTitle
+                : AttachmentsI18nKeys.UnsupportedTypeTitle,
+            ),
+            message: t(
+              noTypesAllowed
+                ? AttachmentsI18nKeys.NoAttachmentsAllowedMessage
+                : AttachmentsI18nKeys.UnsupportedTypeMessage,
+              noTypesAllowed
+                ? undefined
+                : { formats: mimeTypesToExtensionLabels(inputAttachmentTypes) },
+            ),
+          });
+          unsupportedTypeTimerRef.current = null;
+        }, 100);
+        return AttachmentErrorReason.UnsupportedType;
+      }
+      return undefined;
+    },
+    [inputAttachmentTypes, showNotification, t],
+  );
+
+  return { inputAttachmentTypes, isAttachmentsAllowed, validateAttachment };
+};

--- a/apps/chat/src/i18n/locales/en.json
+++ b/apps/chat/src/i18n/locales/en.json
@@ -200,6 +200,10 @@
       "title": "File extension not supported",
       "message": "This model can only process {{formats}}. Please upload a file in a supported format."
     },
+    "noAttachmentsAllowed": {
+      "title": "Attachments not supported",
+      "message": "This model does not support file attachments."
+    },
     "networkError": {
       "title": "Network unavailable",
       "message": "Some files were not uploaded because your internet connection was lost.\n Please try again:\n"

--- a/apps/chat/src/pages/ConversationRoute/ConversationRoute.tsx
+++ b/apps/chat/src/pages/ConversationRoute/ConversationRoute.tsx
@@ -41,6 +41,7 @@ import { useAppConfig } from '../../context/AppConfigContext';
 import { useUser } from '../../context/auth/UserContext';
 import { useDeployments } from '../../context/DeploymentsContext';
 import { useNotification } from '../../context/NotificationContext';
+import { useAttachmentValidation } from '../../hooks/attachment/useAttachmentValidation';
 import { useIsMobile } from '../../hooks/breakpoint/useBreakpoint';
 import { useDialFileManagerState } from '../../hooks/files/useDialFileManagerState';
 import { useKeyboardShortcutPreference } from '../../hooks/keyboard-shortcut/useKeyboardShortcutPreference';
@@ -52,10 +53,6 @@ import {
 } from '../../server-api/chat.api';
 import { createConversation as apiCreateConversation } from '../../server-api/conversations.api';
 import { uploadFile } from '../../server-api/files.api';
-import {
-  isMimeTypeAllowed,
-  mimeTypesToExtensionLabels,
-} from '../../utils/attachment-mime';
 import { attachmentsToDtos } from '../../utils/attachment-to-dto';
 import { buildUploadPath } from '../../utils/build-upload-path';
 import { resolveCatalogIconUrl } from '../../utils/icon-path';
@@ -109,42 +106,11 @@ const ConversationRoute: FC = () => {
     [items, selectedItemId],
   );
 
-  const inputAttachmentTypes = useMemo(
-    () => selectedDeployment?.inputAttachmentTypes ?? [],
-    [selectedDeployment],
-  );
-
-  const isAttachmentsAllowed = selectedDeployment?.inputAttachmentTypes != null;
-
-  const unsupportedTypeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
-    null,
-  );
+  const { inputAttachmentTypes, isAttachmentsAllowed, validateAttachment } =
+    useAttachmentValidation(selectedDeployment);
 
   const pendingNetworkFilesRef = useRef<string[]>([]);
   const networkTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  const validateAttachment = useCallback(
-    (attachment: Attachment): AttachmentErrorReason | undefined => {
-      if (!isMimeTypeAllowed(attachment.contentType, inputAttachmentTypes)) {
-        if (unsupportedTypeTimerRef.current != null) {
-          clearTimeout(unsupportedTypeTimerRef.current);
-        }
-        unsupportedTypeTimerRef.current = setTimeout(() => {
-          showNotification({
-            variant: NotificationVariant.Error,
-            title: t(AttachmentsI18nKeys.UnsupportedTypeTitle),
-            message: t(AttachmentsI18nKeys.UnsupportedTypeMessage, {
-              formats: mimeTypesToExtensionLabels(inputAttachmentTypes),
-            }),
-          });
-          unsupportedTypeTimerRef.current = null;
-        }, 100);
-        return AttachmentErrorReason.UnsupportedType;
-      }
-      return undefined;
-    },
-    [inputAttachmentTypes, showNotification, t],
-  );
 
   const { isDragging, pendingFiles, onFilesConsumed } = usePageFileDrag(
     isAttachmentsAllowed,
@@ -418,13 +384,16 @@ const ConversationRoute: FC = () => {
             pendingAttachments={pendingDialAttachments}
             onPendingAttachmentsConsumed={clearPendingDialAttachments}
             autoFocus={!isMobile}
-            onDialFileSystemClick={openDialFileManager}
+            onDialFileSystemClick={
+              isAttachmentsAllowed ? openDialFileManager : undefined
+            }
             dialFileSystemLabel={t(
               ConversationI18nKeys.AttachMenuDialFileSystem,
             )}
             validateAttachment={
-              isAttachmentsAllowed ? validateAttachment : undefined
+              selectedDeployment != null ? validateAttachment : undefined
             }
+            hideAttachFile={!isAttachmentsAllowed}
           />
           <StarterButtons starters={starters} onSelect={handleStarterSelect} />
         </div>

--- a/apps/chat/src/utils/attachment-mime.spec.ts
+++ b/apps/chat/src/utils/attachment-mime.spec.ts
@@ -62,8 +62,8 @@ describe('isMimeTypeAllowed', () => {
     expect(isMimeTypeAllowed('image/png', ['image/jpeg'])).toBe(false);
   });
 
-  it('returns true (allow all) when allowedTypes is empty', () => {
-    expect(isMimeTypeAllowed('application/pdf', [])).toBe(true);
+  it('returns false (reject all) when allowedTypes is empty', () => {
+    expect(isMimeTypeAllowed('application/pdf', [])).toBe(false);
   });
 
   it('returns true when allowedTypes contains the global wildcard "*"', () => {

--- a/apps/chat/src/utils/attachment-mime.ts
+++ b/apps/chat/src/utils/attachment-mime.ts
@@ -32,13 +32,13 @@ export const mimeTypesToExtensionLabels = (types: string[]): string => {
  * - Exact match: `'application/pdf'` allows `'application/pdf'`.
  * - Wildcard prefix: `'image/*'` allows any `'image/...'` MIME type.
  *
- * Returns `true` when `allowedTypes` is empty (no restriction applied).
+ * Returns `false` when `allowedTypes` is empty (no attachment types allowed).
  */
 export const isMimeTypeAllowed = (
   mimeType: string,
   allowedTypes: string[],
 ): boolean => {
-  if (allowedTypes.length === 0) return true;
+  if (allowedTypes.length === 0) return false;
   return allowedTypes.some((allowed) => {
     if (allowed === '*' || allowed === '*/*') return true;
     if (allowed.endsWith('/*')) {

--- a/libs/conversation-input/src/components/AddAttachmentButton/AddAttachmentButton.tsx
+++ b/libs/conversation-input/src/components/AddAttachmentButton/AddAttachmentButton.tsx
@@ -30,8 +30,8 @@ export interface ExtraMenuItem {
 
 /** Props accepted by the `AddAttachmentButton` component. */
 interface AddAttachmentButtonProps {
-  /** Callback invoked when the user picks "Attach file". */
-  onAttachClick: () => void;
+  /** Callback invoked when the user picks "Attach file". When absent, the "Attach file" item is not rendered. */
+  onAttachClick?: () => void;
   /** Label for the "Attach file" menu item. */
   attachLabel: string;
   /** Aria-label for the + trigger button. */
@@ -66,16 +66,22 @@ export const AddAttachmentButton: FC<AddAttachmentButtonProps> = ({
 
   const menuItems = useMemo(
     () => [
-      {
-        key: 'attach',
-        label: attachLabel,
-        icon: <IconPaperclip size={BASE_ICON_SIZE} aria-hidden />,
-        onClick: onAttachClick,
-      },
+      ...(onAttachClick != null
+        ? [
+            {
+              key: 'attach',
+              label: attachLabel,
+              icon: <IconPaperclip size={BASE_ICON_SIZE} aria-hidden />,
+              onClick: onAttachClick,
+            },
+          ]
+        : []),
       ...(extraMenuItems ?? []),
     ],
     [attachLabel, onAttachClick, extraMenuItems],
   );
+
+  if (menuItems.length === 0) return null;
 
   if (isMobile) {
     return (

--- a/libs/conversation-input/src/components/EditMessageInput/EditMessageInput.tsx
+++ b/libs/conversation-input/src/components/EditMessageInput/EditMessageInput.tsx
@@ -31,6 +31,8 @@ export const EditMessageInput: FC<EditMessageInputProps> = ({
   className,
   pendingDropFiles: externalPendingFiles,
   onDropFilesConsumed,
+  validateAttachment,
+  hideAttachFile = false,
 }) => {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [pendingDropFiles, setPendingDropFiles] = useState<File[]>([]);
@@ -107,27 +109,32 @@ export const EditMessageInput: FC<EditMessageInputProps> = ({
         className="max-w-full"
         prefixAttachments={keptAttachments}
         onRemovePrefixAttachment={handleRemovePreExisting}
+        validateAttachment={validateAttachment}
       />
 
       {/* Action row — outside the bordered box */}
       <div className="flex items-center justify-between">
         <div className="flex">
-          <input
-            ref={fileInputRef}
-            type="file"
-            multiple
-            className="sr-only"
-            aria-hidden
-            tabIndex={-1}
-            onChange={handleFileChange}
-          />
-          <AddAttachmentButton
-            onAttachClick={() => fileInputRef.current?.click()}
-            attachLabel={attachLabel}
-            addMenuLabel={addMenuLabel}
-            menuTitle={menuTitle}
-            menuCloseLabel={menuCloseLabel}
-          />
+          {!hideAttachFile && (
+            <>
+              <input
+                ref={fileInputRef}
+                type="file"
+                multiple
+                className="sr-only"
+                aria-hidden
+                tabIndex={-1}
+                onChange={handleFileChange}
+              />
+              <AddAttachmentButton
+                onAttachClick={() => fileInputRef.current?.click()}
+                attachLabel={attachLabel}
+                addMenuLabel={addMenuLabel}
+                menuTitle={menuTitle}
+                menuCloseLabel={menuCloseLabel}
+              />
+            </>
+          )}
         </div>
 
         <div className="flex gap-2">

--- a/libs/conversation-input/src/components/Input/Input.tsx
+++ b/libs/conversation-input/src/components/Input/Input.tsx
@@ -74,6 +74,7 @@ export const Input: FC<InputProps> = ({
   initialAttachments = [],
   isStacked = false,
   hideAddButton = false,
+  hideAttachFile = false,
   hideActionBar = false,
   renderFooterActions,
   isInputDisabled = false,
@@ -516,7 +517,11 @@ export const Input: FC<InputProps> = ({
                 onChange={handleFileChange}
               />
               <AddAttachmentButton
-                onAttachClick={() => fileInputRef.current?.click()}
+                onAttachClick={
+                  hideAttachFile
+                    ? undefined
+                    : () => fileInputRef.current?.click()
+                }
                 attachLabel={attachLabel}
                 addMenuLabel={addMenuLabel}
                 menuTitle={menuTitle}

--- a/libs/conversation-input/src/models/ConversationInput.ts
+++ b/libs/conversation-input/src/models/ConversationInput.ts
@@ -90,6 +90,18 @@ export interface EditMessageInputProps {
   pendingDropFiles?: File[];
   /** Called after the files have been consumed, signalling the parent to clear its state. */
   onDropFilesConsumed?: () => void;
+  /**
+   * Called synchronously for each attachment after it is added, before upload begins.
+   * Return an `AttachmentErrorReason` to reject the attachment (it enters error state
+   * and `onUploadAttachment` is NOT called). Return `undefined` to allow normal upload.
+   */
+  validateAttachment?: (
+    attachment: Attachment,
+  ) => AttachmentErrorReason | undefined;
+  /**
+   * When `true`, the "Attach file" button is hidden.
+   */
+  hideAttachFile?: boolean;
 }
 
 /** Props accepted by the `ConversationInput` component. */
@@ -191,4 +203,10 @@ export interface ConversationInputProps {
   validateAttachment?: (
     attachment: Attachment,
   ) => AttachmentErrorReason | undefined;
+  /**
+   * When `true`, the "Attach file" item is removed from the attach menu.
+   * Other menu items (e.g. DIAL file system) remain visible. When no items
+   * remain in the menu the entire attach (+) button is hidden automatically.
+   */
+  hideAttachFile?: boolean;
 }

--- a/libs/conversation-input/src/models/Input.ts
+++ b/libs/conversation-input/src/models/Input.ts
@@ -150,6 +150,12 @@ export interface InputProps {
    */
   hideAddButton?: boolean;
   /**
+   * When `true`, the "Attach file" item is removed from the attach menu.
+   * Other menu items (e.g. DIAL file system) remain visible. When no items
+   * remain in the menu the entire attach (+) button is hidden automatically.
+   */
+  hideAttachFile?: boolean;
+  /**
    * When `true`, the entire action bar row (attach button, send/stop button,
    * model selector, and any `renderFooterActions` content) is not rendered.
    * The bordered box contains only the attachment tray and textarea. Use in


### PR DESCRIPTION
## Description of changes

1) If model allowed attachments is undefined or [] - hide attachment button completely
2) Unify logic of attachment verification for new chat, input in conversation, edit message

## Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #7363

## UI changes

<Please, provide Screenshots or Figma links>

## Checklist

- [X] the pull request name ends with `(Issue #<ISSUE_ID>)` (comma-separated list of issues)
- [X] I confirm that I don't share any confidential information like API keys or any other secrets and private URLs

<details>
  <summary>PR title cheatsheet</summary>

`<type>[optional scope]: <description>`

1. type (required)
    - `feat` - A new feature
    - `fix` - A bug fix
    - `docs` - Documentation only changes
    - `test` - Adding missing tests or correcting existing tests
    - `ci` - Changes to our CI configuration files and scripts
    - `chore` - Other changes that are minor and/or not user-facing
2. scope (optional, current repo suggestions below)
    - `chat`
    - `overlay`
    - `shared`
    - `sandbox-overlay`
    - `visualizer-connector`

</details>
