### PR TITLE
feat: Support PDF in canvas, Issue #7213

### DIFF
--- a/apps/chat/src/app/app.tsx
+++ b/apps/chat/src/app/app.tsx
@@ -87,10 +87,14 @@ const App: FC = () => {
     if (pathname === ROUTES.Catalog) closeHistoryPanel();
   }, [pathname]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  const { closeCanvas } = useAttachmentCanvas();
+  const { closeCanvas, isOpen: isCanvasOpen } = useAttachmentCanvas();
   useEffect(() => {
     closeCanvas();
   }, [pathname]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  useEffect(() => {
+    if (isCanvasOpen) closeHistoryPanel();
+  }, [isCanvasOpen]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const matchRoot = useMatch(ROUTES.Root);
   const matchConversation = useMatch(`${ROUTES.Conversations}/*`);

--- a/apps/chat/src/app/app.tsx
+++ b/apps/chat/src/app/app.tsx
@@ -57,6 +57,9 @@ const App: FC = () => {
   const navigate = useNavigate();
   const { pathname } = useLocation();
   const isMobile = useIsMobile();
+  const canvasDefaultWidth = isMobile
+    ? undefined
+    : Math.min(1500, Math.round(window.innerWidth * (2 / 3)));
   const { currentTheme } = useTheme();
   const codeBlockTheme =
     currentTheme === ThemeId.Light ? CodeBlockTheme.Light : CodeBlockTheme.Dark;
@@ -203,6 +206,7 @@ const App: FC = () => {
           copyJsonLabel={t(ButtonsI18nKeys.CopyAsJson)}
           copiedJsonLabel={t(ButtonsI18nKeys.Copied)}
           isMobile={isMobile}
+          defaultWidth={canvasDefaultWidth}
           codeBlockTheme={codeBlockTheme}
         />
       )}

--- a/apps/chat/src/components/ConversationView/tests/ConversationMessageItem.spec.tsx
+++ b/apps/chat/src/components/ConversationView/tests/ConversationMessageItem.spec.tsx
@@ -12,6 +12,15 @@ vi.mock('../../../hooks/attachment/useAttachmentAction', () => ({
   }),
 }));
 
+vi.mock('@epam/ai-dial-attachment-canvas', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@epam/ai-dial-attachment-canvas')>();
+  return {
+    ...actual,
+    useAttachmentCanvas: () => ({ openCanvas: vi.fn(), closeCanvas: vi.fn() }),
+  };
+});
+
 vi.mock('../../../context/ThemeContext', () => ({
   useTheme: () => ({ currentTheme: 'dark' }),
 }));

--- a/apps/chat/src/hooks/attachment/tests/useOpenAttachmentCanvas.spec.ts
+++ b/apps/chat/src/hooks/attachment/tests/useOpenAttachmentCanvas.spec.ts
@@ -1,7 +1,8 @@
+import type { Annotation, DisplayAttachment } from '@epam/ai-dial-chat-shared';
 import { AttachmentType } from '@epam/ai-dial-chat-shared';
-import type { DisplayAttachment } from '@epam/ai-dial-chat-shared';
 import { renderHook } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { annotationsToPdfHighlights } from '../../../utils/annotation';
 import { useOpenAttachmentCanvas } from '../useOpenAttachmentCanvas';
 
 const mockOpenCanvas = vi.fn();
@@ -18,6 +19,7 @@ vi.mock('@epam/ai-dial-attachment-canvas', async (importOriginal) => {
 const mockResolveMarkdown = vi.fn();
 const mockResolveJson = vi.fn();
 const mockResolveText = vi.fn();
+const mockResolvePdf = vi.fn();
 
 vi.mock('../../../utils/attachment-canvas', () => ({
   resolveImageCanvasContent: vi.fn(),
@@ -25,6 +27,7 @@ vi.mock('../../../utils/attachment-canvas', () => ({
     mockResolveMarkdown(...args),
   resolveJsonCanvasContent: (...args: unknown[]) => mockResolveJson(...args),
   resolveTextCanvasContent: (...args: unknown[]) => mockResolveText(...args),
+  resolvePdfCanvasContent: (...args: unknown[]) => mockResolvePdf(...args),
 }));
 
 const makeAttachment = (
@@ -157,5 +160,208 @@ describe('useOpenAttachmentCanvas routing', () => {
     expect(opened).toBe(true);
     expect(mockOpenCanvas).toHaveBeenCalledOnce();
     expect(mockResolveMarkdown).toHaveBeenCalledOnce();
+  });
+
+  it('routes application/pdf MIME type to the PDF resolver', async () => {
+    const pdfContent = {
+      type: 'pdf' as const,
+      url: 'https://example.com/doc.pdf',
+    };
+    mockResolvePdf.mockReturnValue(pdfContent);
+
+    const { result } = renderHook(() => useOpenAttachmentCanvas());
+    const opened = await result.current.openAttachmentCanvas(
+      makeAttachment('doc.pdf', 'application/pdf'),
+    );
+
+    expect(opened).toBe(true);
+    expect(mockResolvePdf).toHaveBeenCalledOnce();
+    expect(mockResolveMarkdown).not.toHaveBeenCalled();
+    expect(mockResolveJson).not.toHaveBeenCalled();
+    expect(mockResolveText).not.toHaveBeenCalled();
+    expect(mockOpenCanvas).toHaveBeenCalledWith(pdfContent, 'doc.pdf');
+  });
+
+  it('routes .pdf extension to the PDF resolver', async () => {
+    const pdfContent = {
+      type: 'pdf' as const,
+      url: 'https://example.com/report.pdf',
+    };
+    mockResolvePdf.mockReturnValue(pdfContent);
+
+    const { result } = renderHook(() => useOpenAttachmentCanvas());
+    const opened = await result.current.openAttachmentCanvas(
+      makeAttachment('report.pdf'),
+    );
+
+    expect(opened).toBe(true);
+    expect(mockResolvePdf).toHaveBeenCalledOnce();
+    expect(mockResolveMarkdown).not.toHaveBeenCalled();
+    expect(mockResolveJson).not.toHaveBeenCalled();
+    expect(mockResolveText).not.toHaveBeenCalled();
+  });
+
+  it('opens unsupported canvas when application/pdf MIME resolver returns null', async () => {
+    mockResolvePdf.mockReturnValue(null);
+
+    const { result } = renderHook(() => useOpenAttachmentCanvas());
+    const opened = await result.current.openAttachmentCanvas(
+      makeAttachment('doc.pdf', 'application/pdf'),
+    );
+
+    expect(opened).toBe(true);
+    expect(mockResolvePdf).toHaveBeenCalledOnce();
+    expect(mockOpenCanvas).toHaveBeenCalledOnce();
+  });
+
+  it('returns false when .pdf extension resolver returns null', async () => {
+    mockResolvePdf.mockReturnValue(null);
+
+    const { result } = renderHook(() => useOpenAttachmentCanvas());
+    const opened = await result.current.openAttachmentCanvas(
+      makeAttachment('report.pdf'),
+    );
+
+    expect(opened).toBe(false);
+    expect(mockOpenCanvas).not.toHaveBeenCalled();
+  });
+});
+
+describe('annotationsToPdfHighlights', () => {
+  it('maps a single annotation with one pdf_bbox selector to a highlight', () => {
+    const annotations: Annotation[] = [
+      {
+        index: 0,
+        body: {
+          selector: {
+            type: 'pdf_bbox',
+            page: 1,
+            x1: 10,
+            y1: 20,
+            x2: 100,
+            y2: 50,
+          },
+        },
+      },
+    ];
+
+    const highlights = annotationsToPdfHighlights(annotations);
+
+    expect(highlights).toHaveLength(1);
+    expect(highlights[0].id).toBe('0');
+    expect(highlights[0].bboxes).toEqual([
+      { page: 1, x1: 10, y1: 20, x2: 100, y2: 50 },
+    ]);
+  });
+
+  it('maps a single annotation with multiple pdf_bbox selectors to one highlight with multiple bboxes', () => {
+    const annotations: Annotation[] = [
+      {
+        index: 3,
+        body: {
+          selector: [
+            { type: 'pdf_bbox', page: 1, x1: 0, y1: 0, x2: 10, y2: 10 },
+            { type: 'pdf_bbox', page: 2, x1: 5, y1: 5, x2: 15, y2: 15 },
+          ],
+        },
+      },
+    ];
+
+    const highlights = annotationsToPdfHighlights(annotations);
+
+    expect(highlights).toHaveLength(1);
+    expect(highlights[0].id).toBe('3');
+    expect(highlights[0].bboxes).toHaveLength(2);
+  });
+
+  it('maps multiple annotations to multiple highlights', () => {
+    const annotations: Annotation[] = [
+      {
+        index: 0,
+        body: {
+          selector: { type: 'pdf_bbox', page: 1, x1: 0, y1: 0, x2: 10, y2: 10 },
+        },
+      },
+      {
+        index: 1,
+        body: {
+          selector: { type: 'pdf_bbox', page: 2, x1: 5, y1: 5, x2: 20, y2: 20 },
+        },
+      },
+    ];
+
+    const highlights = annotationsToPdfHighlights(annotations);
+
+    expect(highlights).toHaveLength(2);
+    expect(highlights[0].id).toBe('0');
+    expect(highlights[1].id).toBe('1');
+  });
+
+  it('uses array position as id when annotation.index is absent', () => {
+    const annotations: Annotation[] = [
+      {
+        body: {
+          selector: { type: 'pdf_bbox', page: 1, x1: 0, y1: 0, x2: 10, y2: 10 },
+        },
+      },
+      {
+        body: {
+          selector: {
+            type: 'pdf_bbox',
+            page: 1,
+            x1: 20,
+            y1: 0,
+            x2: 30,
+            y2: 10,
+          },
+        },
+      },
+    ];
+
+    const highlights = annotationsToPdfHighlights(annotations);
+
+    expect(highlights).toHaveLength(2);
+    expect(highlights[0].id).toBe('0');
+    expect(highlights[1].id).toBe('1');
+  });
+
+  it('skips annotations with no pdf_bbox selectors', () => {
+    const annotations: Annotation[] = [
+      {
+        index: 0,
+        body: { selector: { type: 'text_character_range', start: 0, end: 5 } },
+      },
+      {
+        index: 1,
+        body: {
+          selector: { type: 'pdf_bbox', page: 1, x1: 0, y1: 0, x2: 10, y2: 10 },
+        },
+      },
+    ];
+
+    const highlights = annotationsToPdfHighlights(annotations);
+
+    expect(highlights).toHaveLength(1);
+    expect(highlights[0].id).toBe('1');
+  });
+
+  it('skips annotations with missing selector', () => {
+    const annotations: Annotation[] = [
+      { index: 0, body: {} },
+      {
+        index: 1,
+        body: {
+          selector: { type: 'pdf_bbox', page: 1, x1: 0, y1: 0, x2: 10, y2: 10 },
+        },
+      },
+    ];
+
+    const highlights = annotationsToPdfHighlights(annotations);
+
+    expect(highlights).toHaveLength(1);
+  });
+
+  it('returns an empty array when given an empty list', () => {
+    expect(annotationsToPdfHighlights([])).toEqual([]);
   });
 });

--- a/apps/chat/src/hooks/attachment/useOpenAttachmentCanvas.ts
+++ b/apps/chat/src/hooks/attachment/useOpenAttachmentCanvas.ts
@@ -5,6 +5,7 @@ import {
 } from '@epam/ai-dial-attachment-canvas';
 import {
   AttachmentType,
+  FileExtension,
   MIMEType,
   type DisplayAttachment,
 } from '@epam/ai-dial-chat-shared';
@@ -13,9 +14,85 @@ import {
   resolveImageCanvasContent,
   resolveJsonCanvasContent,
   resolveMarkdownCanvasContent,
+  resolvePdfCanvasContent,
   resolveTextCanvasContent,
 } from '../../utils/attachment-canvas';
 import { resolveDialUrl } from '../../utils/dial-file';
+
+type OpenCanvas = ReturnType<typeof useAttachmentCanvas>['openCanvas'];
+
+async function openFileCanvas(
+  attachment: DisplayAttachment,
+  openCanvas: OpenCanvas,
+): Promise<boolean> {
+  const contentType = attachment.contentType.toLowerCase();
+
+  switch (contentType) {
+    case MIMEType.PDF: {
+      const content = resolvePdfCanvasContent(attachment);
+      openCanvas(
+        content ?? createUnsupportedCanvasContent(resolveDialUrl(attachment)),
+        attachment.name,
+      );
+      return true;
+    }
+    case MIMEType.Markdown: {
+      const content = await resolveMarkdownCanvasContent(attachment);
+      openCanvas(
+        content ?? createUnsupportedCanvasContent(resolveDialUrl(attachment)),
+        attachment.name,
+      );
+      return true;
+    }
+    case MIMEType.JSON: {
+      const content = await resolveJsonCanvasContent(attachment);
+      openCanvas(
+        content ?? createUnsupportedCanvasContent(resolveDialUrl(attachment)),
+        attachment.name,
+      );
+      return true;
+    }
+  }
+
+  const fileName = attachment.name ?? '';
+  const dotIdx = fileName.lastIndexOf('.');
+  const ext = dotIdx !== -1 ? fileName.slice(dotIdx + 1).toLowerCase() : '';
+
+  switch (ext) {
+    case FileExtension.Markdown:
+    case FileExtension.MarkdownAlt: {
+      const content = await resolveMarkdownCanvasContent(attachment);
+      if (content == null) return false;
+      openCanvas(content, attachment.name);
+      return true;
+    }
+    case FileExtension.JSON: {
+      const content = await resolveJsonCanvasContent(attachment);
+      if (content == null) return false;
+      openCanvas(content, attachment.name);
+      return true;
+    }
+    case FileExtension.PDF: {
+      const content = resolvePdfCanvasContent(attachment);
+      if (content == null) return false;
+      openCanvas(content, attachment.name);
+      return true;
+    }
+  }
+
+  if (attachment.name != null && !isTextPreviewable(attachment.name)) {
+    openCanvas(
+      createUnsupportedCanvasContent(resolveDialUrl(attachment)),
+      attachment.name,
+    );
+    return true;
+  }
+
+  const content = await resolveTextCanvasContent(attachment);
+  if (content == null) return false;
+  openCanvas(content, attachment.name);
+  return true;
+}
 
 /**
  * Returns `openAttachmentCanvas`, an async function that opens the attachment
@@ -35,57 +112,8 @@ export const useOpenAttachmentCanvas = () => {
           openCanvas(content, attachment.name);
           return true;
         }
-        case AttachmentType.File: {
-          const contentType = attachment.contentType.toLowerCase();
-
-          if (contentType === MIMEType.Markdown) {
-            const content = await resolveMarkdownCanvasContent(attachment);
-            openCanvas(
-              content ??
-                createUnsupportedCanvasContent(resolveDialUrl(attachment)),
-              attachment.name,
-            );
-            return true;
-          }
-          if (contentType === MIMEType.JSON) {
-            const content = await resolveJsonCanvasContent(attachment);
-            openCanvas(
-              content ??
-                createUnsupportedCanvasContent(resolveDialUrl(attachment)),
-              attachment.name,
-            );
-            return true;
-          }
-
-          const fileName = attachment.name ?? '';
-          const dotIdx = fileName.lastIndexOf('.');
-          const ext =
-            dotIdx !== -1 ? fileName.slice(dotIdx + 1).toLowerCase() : '';
-
-          if (ext === 'md' || ext === 'markdown') {
-            const content = await resolveMarkdownCanvasContent(attachment);
-            if (content == null) return false;
-            openCanvas(content, attachment.name);
-            return true;
-          }
-          if (ext === 'json') {
-            const content = await resolveJsonCanvasContent(attachment);
-            if (content == null) return false;
-            openCanvas(content, attachment.name);
-            return true;
-          }
-          if (attachment.name != null && !isTextPreviewable(attachment.name)) {
-            openCanvas(
-              createUnsupportedCanvasContent(resolveDialUrl(attachment)),
-              attachment.name,
-            );
-            return true;
-          }
-          const content = await resolveTextCanvasContent(attachment);
-          if (content == null) return false;
-          openCanvas(content, attachment.name);
-          return true;
-        }
+        case AttachmentType.File:
+          return openFileCanvas(attachment, openCanvas);
         case AttachmentType.Pasted:
         case AttachmentType.Prompt: {
           const content = await resolveTextCanvasContent(attachment);

--- a/apps/chat/src/hooks/citations/useCitationMarkdownComponents.tsx
+++ b/apps/chat/src/hooks/citations/useCitationMarkdownComponents.tsx
@@ -1,7 +1,9 @@
+import { useAttachmentCanvas } from '@epam/ai-dial-attachment-canvas';
 import type { Annotation, DisplayAttachment } from '@epam/ai-dial-chat-shared';
 import { useCallback, useMemo } from 'react';
 import type { Components } from 'react-markdown';
 import CitationDropdown from '../../components/Citations/CitationDropdown/CitationDropdown';
+import { annotationToPdfCanvasContent } from '../../utils/attachment-canvas';
 import { annotationToDisplayAttachment } from '../../utils/attachment-dto-to-display';
 import {
   injectCitationSentinels,
@@ -27,6 +29,8 @@ export const useCitationMarkdownComponents = (
   citationCard: CitationCardHook,
   onAttachmentPreview: (attachment: DisplayAttachment) => void,
 ): { processedContent: string; markdownComponents: Components } => {
+  const { openCanvas } = useAttachmentCanvas();
+
   const onOpenInBrowser = useCallback((annotation: Annotation) => {
     const url = annotation.body?.source?.attachment?.url;
     if (url) window.open(url, '_blank', 'noopener,noreferrer');
@@ -34,10 +38,17 @@ export const useCitationMarkdownComponents = (
 
   const onPreview = useCallback(
     (annotation: Annotation) => {
+      const pdfContent = annotationToPdfCanvasContent(annotation, groups);
+      if (pdfContent != null) {
+        const fileName =
+          annotation.body?.source?.attachment?.url?.split('/').pop() ?? '';
+        openCanvas(pdfContent, fileName);
+        return;
+      }
       const display = annotationToDisplayAttachment(annotation);
       if (display) onAttachmentPreview(display);
     },
-    [onAttachmentPreview],
+    [groups, openCanvas, onAttachmentPreview],
   );
 
   const processedContent = useMemo(

--- a/apps/chat/src/main.tsx
+++ b/apps/chat/src/main.tsx
@@ -1,5 +1,7 @@
 import { AttachmentCanvasProvider } from '@epam/ai-dial-attachment-canvas';
 import '@epam/ai-dial-ui-kit/styles.css';
+import '@epam/ai-dial-react-pdf-highlighter/styles.css';
+import '@epam/pdf-highlighter-kit/dist/pdf-highlight-viewer.css';
 import { lazy, StrictMode, Suspense } from 'react';
 import * as ReactDOM from 'react-dom/client';
 import { BrowserRouter, Route, Routes } from 'react-router-dom';

--- a/apps/chat/src/pages/Conversation/Conversation.tsx
+++ b/apps/chat/src/pages/Conversation/Conversation.tsx
@@ -188,7 +188,7 @@ export const ConversationPage: FC<Props> = ({ onDuplicateReadonly }) => {
       }
     },
     // conversationRef is a stable ref — intentionally omitted from deps
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+
     [conversationId],
   );
 

--- a/apps/chat/src/test-setup.ts
+++ b/apps/chat/src/test-setup.ts
@@ -1,5 +1,14 @@
 import { vi } from 'vitest';
 
+vi.mock('@epam/pdf-highlighter-kit', () => ({
+  PDFHighlightViewer: () => null,
+}));
+
+vi.mock('@epam/ai-dial-react-pdf-highlighter', () => ({
+  DocumentPreview: () => null,
+  PageThumbnail: () => null,
+}));
+
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
     t: (key: string, params?: Record<string, string>) => {

--- a/apps/chat/src/utils/annotation.ts
+++ b/apps/chat/src/utils/annotation.ts
@@ -1,0 +1,35 @@
+import type { Annotation, PdfBBoxSelector } from '@epam/ai-dial-chat-shared';
+import type { InputHighlightData } from '@epam/pdf-highlighter-kit';
+
+/**
+ * Maps a list of annotations to `InputHighlightData` entries for the PDF viewer.
+ * Annotations whose `body.selector` contains no `pdf_bbox` selectors are skipped.
+ * The highlight `id` is `annotation.index` when present, otherwise the position
+ * in the input array.
+ */
+export const annotationsToPdfHighlights = (
+  annotations: Annotation[],
+): InputHighlightData[] =>
+  annotations.flatMap((annotation, i) => {
+    const selector = annotation.body?.selector;
+    if (selector == null) return [];
+
+    const selectors = Array.isArray(selector) ? selector : [selector];
+    const bboxes = selectors.flatMap((s) => {
+      if (s.type !== 'pdf_bbox') return [];
+      const { page, x1, y1, x2, y2 } = s as PdfBBoxSelector;
+      return [{ page, x1, y1, x2, y2 }];
+    });
+
+    if (bboxes.length === 0) return [];
+    return [{ id: String(annotation.index ?? i), bboxes }];
+  });
+
+/**
+ * Returns a stable string ID for a given annotation, matching the IDs produced
+ * by `annotationsToPdfHighlights`.
+ */
+export const annotationHighlightId = (
+  annotation: Annotation,
+  fallbackIndex: number,
+): string => String(annotation.index ?? fallbackIndex);

--- a/apps/chat/src/utils/attachment-canvas.ts
+++ b/apps/chat/src/utils/attachment-canvas.ts
@@ -2,11 +2,26 @@ import type {
   ImageCanvasContent,
   JsonCanvasContent,
   MarkdownCanvasContent,
+  PdfCanvasContent,
   PlainTextCanvasContent,
 } from '@epam/ai-dial-attachment-canvas';
 import { AttachmentContentType } from '@epam/ai-dial-attachment-canvas';
-import type { Attachment, DisplayAttachment } from '@epam/ai-dial-chat-shared';
-import { resolveDialUrl } from './dial-file';
+import type {
+  Annotation,
+  Attachment,
+  DisplayAttachment,
+} from '@epam/ai-dial-chat-shared';
+import { MIMEType } from '@epam/ai-dial-chat-shared';
+import {
+  annotationHighlightId,
+  annotationsToPdfHighlights,
+} from './annotation';
+import {
+  isDialFileId,
+  resolveDialFileDownloadUrl,
+  resolveDialUrl,
+} from './dial-file';
+import type { AnnotationGroup } from './group-annotations-by-source';
 
 /** Resolves an image canvas content payload from a DisplayAttachment, or `null` if unavailable. */
 export const resolveImageCanvasContent = async (
@@ -59,6 +74,48 @@ export const resolveMarkdownCanvasContent = async (
     return { type: AttachmentContentType.Markdown, text };
   }
   return null;
+};
+
+/**
+ * Builds a `PdfCanvasContent` for a PDF citation annotation, including highlights
+ * for all annotations in the same source group and scroll target for the clicked one.
+ * Returns `null` if the annotation has no PDF source attachment.
+ */
+export const annotationToPdfCanvasContent = (
+  annotation: Annotation,
+  groups: AnnotationGroup[],
+): PdfCanvasContent | null => {
+  const source = annotation.body?.source?.attachment;
+  if (source?.type !== MIMEType.PDF) return null;
+
+  const url = isDialFileId(source.url)
+    ? resolveDialFileDownloadUrl(source.url)
+    : source.url;
+  if (url == null) return null;
+
+  const group = groups.find((g) => g.sourceUrl === source.url);
+  const allAnnotations = group?.annotations ?? [annotation];
+  const selectedIndex = group ? group.annotations.indexOf(annotation) : 0;
+
+  return {
+    type: AttachmentContentType.Pdf,
+    url,
+    highlights: annotationsToPdfHighlights(allAnnotations),
+    selectedHighlightId: annotationHighlightId(annotation, selectedIndex),
+  };
+};
+
+/** Resolves a PDF canvas content payload from a DisplayAttachment, or `null` if unavailable. */
+export const resolvePdfCanvasContent = (
+  attachment: DisplayAttachment,
+): PdfCanvasContent | null => {
+  if ('file' in attachment && (attachment as Attachment).file.size > 0) {
+    const url = URL.createObjectURL((attachment as Attachment).file);
+    return { type: AttachmentContentType.Pdf, url };
+  }
+  const url = resolveDialUrl(attachment);
+  if (url == null) return null;
+  return { type: AttachmentContentType.Pdf, url };
 };
 
 /**

--- a/apps/chat/src/utils/tests/icon-path.spec.ts
+++ b/apps/chat/src/utils/tests/icon-path.spec.ts
@@ -1,10 +1,10 @@
 import { describe, it, expect } from 'vitest';
 import { ApiEndpoints } from '../../server-api/base';
-import { getIconPath } from '../icon-path';
 import {
   resolveDialFileDownloadUrl,
   resolveRelativeDialFilePath,
 } from '../dial-file';
+import { getIconPath } from '../icon-path';
 
 describe('getIconPath', () => {
   it('should return correct URL format for icon name', () => {

--- a/apps/chat/vite.config.mts
+++ b/apps/chat/vite.config.mts
@@ -72,6 +72,14 @@ export default defineConfig(() => ({
         __dirname,
         '../../libs/attachment-input/src/index.ts',
       ),
+      '@epam/ai-dial-react-pdf-highlighter/styles.css': path.resolve(
+        __dirname,
+        '../../libs/attachment-canvas/node_modules/@epam/ai-dial-react-pdf-highlighter/dist/index.css',
+      ),
+      '@epam/pdf-highlighter-kit/dist/pdf-highlight-viewer.css': path.resolve(
+        __dirname,
+        '../../node_modules/@epam/pdf-highlighter-kit/dist/pdf-highlight-viewer.css',
+      ),
     },
   },
   build: {
@@ -104,6 +112,14 @@ export default defineConfig(() => ({
     coverage: {
       reportsDirectory: './test-output/vitest/coverage',
       provider: 'v8' as const,
+    },
+    server: {
+      deps: {
+        inline: [
+          '@epam/pdf-highlighter-kit',
+          '@epam/ai-dial-react-pdf-highlighter',
+        ],
+      },
     },
   },
 }));

--- a/libs/attachment-canvas/package.json
+++ b/libs/attachment-canvas/package.json
@@ -21,8 +21,12 @@
     "@epam/ai-dial-chat-shared": "0.0.1",
     "@epam/ai-dial-sidebar": "0.0.1",
     "@epam/ai-dial-ui-kit": "0.12.0-dev.4",
+    "@epam/pdf-highlighter-kit": ">=0.0.14",
     "@tabler/icons-react": "^3.44.0",
     "react": "^19.0.0",
     "react-json-view-lite": "^2.5.0"
+  },
+  "dependencies": {
+    "@epam/ai-dial-react-pdf-highlighter": "0.2.0-dev.17"
   }
 }

--- a/libs/attachment-canvas/src/components/AttachmentCanvas/AttachmentCanvas.module.scss
+++ b/libs/attachment-canvas/src/components/AttachmentCanvas/AttachmentCanvas.module.scss
@@ -114,6 +114,13 @@
   }
 }
 
+// Remove padding from the first .pdf-container when directly followed by another
+:global {
+  .pdf-container:has(+ .pdf-container) {
+    padding: 0;
+  }
+}
+
 .jsonCollapsedContent {
   margin-inline-end: 0.25rem;
   cursor: pointer;

--- a/libs/attachment-canvas/src/components/AttachmentCanvas/AttachmentCanvas.tsx
+++ b/libs/attachment-canvas/src/components/AttachmentCanvas/AttachmentCanvas.tsx
@@ -107,9 +107,6 @@ const AttachmentCanvasBase: FC<AttachmentCanvasProps> = ({
     [stylesProp],
   );
 
-  const resolvedDefaultWidth =
-    defaultWidth ?? Math.min(maxWidth, Math.round(window.innerWidth * (2 / 3)));
-
   const showCopyMarkdown =
     onCopyMarkdown != null && content.type === AttachmentContentType.Markdown;
   const showCopyJson =
@@ -219,7 +216,7 @@ const AttachmentCanvasBase: FC<AttachmentCanvasProps> = ({
       closeLabel={closeLabel}
       onClose={onClose}
       resizable={!isMobile}
-      defaultWidth={resolvedDefaultWidth}
+      defaultWidth={defaultWidth}
       minWidth={minWidth}
       maxWidth={maxWidth}
       onResizeStop={onResizeStop}

--- a/libs/attachment-canvas/src/components/AttachmentCanvas/AttachmentCanvas.tsx
+++ b/libs/attachment-canvas/src/components/AttachmentCanvas/AttachmentCanvas.tsx
@@ -17,6 +17,7 @@ import 'react-json-view-lite/dist/index.css';
 import type { AttachmentCanvasProps } from '../../models/attachment-canvas';
 import { AttachmentContentType } from '../../types/attachment-canvas';
 import { isDownloadable } from '../../utils/download';
+import { PdfContent } from '../PdfContent/PdfContent';
 import styles from './AttachmentCanvas.module.scss';
 
 const COPY_RESET_MS = 2000;
@@ -38,13 +39,14 @@ const AttachmentCanvasBase: FC<AttachmentCanvasProps> = ({
   copiedJsonLabel = 'Copied!',
   unsupportedLabel = 'Preview is not supported for this file',
   isMobile = false,
-  defaultWidth = 560,
+  defaultWidth,
   minWidth = 320,
-  maxWidth = 960,
+  maxWidth = 1500,
   onResizeStop,
   styles: stylesProp,
   className,
   codeBlockTheme,
+  loadPdf,
 }) => {
   const [isCopiedMarkdown, setIsCopiedMarkdown] = useState(false);
   const [isCopiedJson, setIsCopiedJson] = useState(false);
@@ -105,6 +107,9 @@ const AttachmentCanvasBase: FC<AttachmentCanvasProps> = ({
     [stylesProp],
   );
 
+  const resolvedDefaultWidth =
+    defaultWidth ?? Math.min(maxWidth, Math.round(window.innerWidth * (2 / 3)));
+
   const showCopyMarkdown =
     onCopyMarkdown != null && content.type === AttachmentContentType.Markdown;
   const showCopyJson =
@@ -118,6 +123,8 @@ const AttachmentCanvasBase: FC<AttachmentCanvasProps> = ({
         return 'h-full overflow-auto p-4 flex items-center justify-center';
       case AttachmentContentType.Json:
         return 'h-full overflow-auto';
+      case AttachmentContentType.Pdf:
+        return 'h-full overflow-hidden';
       default:
         return 'h-full overflow-auto p-4';
     }
@@ -180,6 +187,17 @@ const AttachmentCanvasBase: FC<AttachmentCanvasProps> = ({
             </div>
           </div>
         );
+      case AttachmentContentType.Pdf:
+        return (
+          <PdfContent
+            key={content.url}
+            fileName={fileName}
+            url={content.url}
+            highlights={content.highlights ?? []}
+            selectedHighlightId={content.selectedHighlightId}
+            loadPdf={loadPdf}
+          />
+        );
       case AttachmentContentType.Unsupported:
         return <p className="text-center text-secondary">{unsupportedLabel}</p>;
     }
@@ -189,6 +207,7 @@ const AttachmentCanvasBase: FC<AttachmentCanvasProps> = ({
     fileName,
     codeBlockTheme,
     unsupportedLabel,
+    loadPdf,
   ]);
 
   return (
@@ -200,7 +219,7 @@ const AttachmentCanvasBase: FC<AttachmentCanvasProps> = ({
       closeLabel={closeLabel}
       onClose={onClose}
       resizable={!isMobile}
-      defaultWidth={defaultWidth}
+      defaultWidth={resolvedDefaultWidth}
       minWidth={minWidth}
       maxWidth={maxWidth}
       onResizeStop={onResizeStop}

--- a/libs/attachment-canvas/src/components/AttachmentCanvasContainer/AttachmentCanvasContainer.tsx
+++ b/libs/attachment-canvas/src/components/AttachmentCanvasContainer/AttachmentCanvasContainer.tsx
@@ -32,6 +32,8 @@ export interface AttachmentCanvasContainerProps {
   copiedJsonLabel?: string;
   /** Whether the viewport is in mobile breakpoint — disables drag-to-resize. Defaults to `false`. */
   isMobile?: boolean;
+  /** Initial panel width in pixels. When omitted, SidebarPanel uses its own default. */
+  defaultWidth?: number;
   /** Syntax highlight color theme forwarded to MarkdownRenderer code blocks. */
   codeBlockTheme?: CodeBlockTheme;
 }
@@ -49,6 +51,7 @@ export const AttachmentCanvasContainer: FC<AttachmentCanvasContainerProps> =
       copyJsonLabel,
       copiedJsonLabel,
       isMobile = false,
+      defaultWidth,
       codeBlockTheme,
     }) => {
       const { isOpen, content, fileName, closeCanvas } = useAttachmentCanvas();
@@ -97,6 +100,7 @@ export const AttachmentCanvasContainer: FC<AttachmentCanvasContainerProps> =
           copiedJsonLabel={copiedJsonLabel}
           unsupportedLabel={unsupportedLabel}
           isMobile={isMobile}
+          defaultWidth={defaultWidth}
           codeBlockTheme={codeBlockTheme}
         />
       );

--- a/libs/attachment-canvas/src/components/PdfContent/PdfContent.tsx
+++ b/libs/attachment-canvas/src/components/PdfContent/PdfContent.tsx
@@ -1,3 +1,4 @@
+import { useIsMobile } from '@epam/ai-dial-chat-shared';
 import type { PdfViewerApi } from '@epam/ai-dial-react-pdf-highlighter';
 import {
   DocumentPreview,
@@ -21,14 +22,15 @@ export const PdfContent: FC<PdfContentProps> = ({
   selectedHighlightId,
   loadPdf,
 }) => {
+  const isMobile = useIsMobile();
   const [totalPages, setTotalPages] = useState(0);
   const [thumbnails, setThumbnails] = useState<Map<number, string>>(new Map());
   const [selectedPage, setSelectedPage] = useState(1);
   const viewerApiRef = useRef<PdfViewerApi | null>(null);
 
   const thumbnailPageNumbers = useMemo(
-    () => Array.from({ length: totalPages }, (_, i) => i + 1),
-    [totalPages],
+    () => (isMobile ? [] : Array.from({ length: totalPages }, (_, i) => i + 1)),
+    [isMobile, totalPages],
   );
 
   const handleThumbnailsLoaded = useCallback((map: Map<number, string>) => {
@@ -47,7 +49,7 @@ export const PdfContent: FC<PdfContentProps> = ({
   return (
     <div className="flex h-full overflow-hidden">
       {totalPages > 0 && (
-        <div className="w-30 mr-1 shrink-0 overflow-auto pr-0.5">
+        <div className="w-30 me-1 shrink-0 overflow-auto pe-0.5 mobile:hidden">
           {thumbnailPageNumbers.map((pageNum) => (
             <PageThumbnail
               key={pageNum}

--- a/libs/attachment-canvas/src/components/PdfContent/PdfContent.tsx
+++ b/libs/attachment-canvas/src/components/PdfContent/PdfContent.tsx
@@ -1,0 +1,78 @@
+import type { PdfViewerApi } from '@epam/ai-dial-react-pdf-highlighter';
+import {
+  DocumentPreview,
+  PageThumbnail,
+} from '@epam/ai-dial-react-pdf-highlighter';
+import type { InputHighlightData } from '@epam/pdf-highlighter-kit';
+import { type FC, useCallback, useMemo, useRef, useState } from 'react';
+import { fetchBlobFromUrl } from '../../utils/download';
+
+export interface PdfContentProps {
+  url: string;
+  highlights: InputHighlightData[];
+  selectedHighlightId?: string;
+  loadPdf?: (url: string) => Promise<Blob>;
+  fileName?: string;
+}
+
+export const PdfContent: FC<PdfContentProps> = ({
+  url,
+  highlights,
+  selectedHighlightId,
+  loadPdf,
+}) => {
+  const [totalPages, setTotalPages] = useState(0);
+  const [thumbnails, setThumbnails] = useState<Map<number, string>>(new Map());
+  const [selectedPage, setSelectedPage] = useState(1);
+  const viewerApiRef = useRef<PdfViewerApi | null>(null);
+
+  const thumbnailPageNumbers = useMemo(
+    () => Array.from({ length: totalPages }, (_, i) => i + 1),
+    [totalPages],
+  );
+
+  const handleThumbnailsLoaded = useCallback((map: Map<number, string>) => {
+    setThumbnails((prev) => new Map([...prev, ...map]));
+  }, []);
+
+  const handleViewerReady = useCallback((api: PdfViewerApi) => {
+    viewerApiRef.current = api;
+  }, []);
+
+  const handleSelectPage = useCallback((pageNum: number) => {
+    setSelectedPage(pageNum);
+    viewerApiRef.current?.navigateToPage(pageNum);
+  }, []);
+
+  return (
+    <div className="flex h-full overflow-hidden">
+      {totalPages > 0 && (
+        <div className="w-30 mr-1 shrink-0 overflow-auto pr-0.5">
+          {thumbnailPageNumbers.map((pageNum) => (
+            <PageThumbnail
+              key={pageNum}
+              pageNum={pageNum}
+              onSelectPage={handleSelectPage}
+              isSelected={selectedPage === pageNum}
+              isLoading={!thumbnails.has(pageNum)}
+              thumbnailUrl={thumbnails.get(pageNum) ?? null}
+            />
+          ))}
+        </div>
+      )}
+      <div className="min-w-0 flex-1 overflow-hidden">
+        <DocumentPreview
+          fileUrl={url}
+          loadFileCb={loadPdf ?? fetchBlobFromUrl}
+          highlights={highlights}
+          selectedHighlightId={selectedHighlightId}
+          showOccurrences={false}
+          onTotalPagesChange={setTotalPages}
+          thumbnailPageNumbers={thumbnailPageNumbers}
+          onThumbnailsLoaded={handleThumbnailsLoaded}
+          onViewerReady={handleViewerReady}
+        />
+      </div>
+    </div>
+  );
+};

--- a/libs/attachment-canvas/src/index.ts
+++ b/libs/attachment-canvas/src/index.ts
@@ -18,6 +18,7 @@ export type {
   ImageCanvasContent,
   MarkdownCanvasContent,
   JsonCanvasContent,
+  PdfCanvasContent,
   UnsupportedCanvasContent,
   AttachmentCanvasColors,
   AttachmentCanvasTypography,

--- a/libs/attachment-canvas/src/models/attachment-canvas.ts
+++ b/libs/attachment-canvas/src/models/attachment-canvas.ts
@@ -1,5 +1,6 @@
 import type { CodeBlockTheme } from '@epam/ai-dial-chat-shared';
 import type { SidebarPanelStyles } from '@epam/ai-dial-sidebar';
+import type { InputHighlightData } from '@epam/pdf-highlighter-kit';
 import type { CSSProperties } from 'react';
 import { AttachmentContentType } from '../types/attachment-canvas';
 
@@ -35,6 +36,18 @@ export interface JsonCanvasContent {
   value: unknown;
 }
 
+/** Content payload for PDF file attachments. */
+export interface PdfCanvasContent {
+  /** Discriminates the content type to select the correct renderer. */
+  type: AttachmentContentType.Pdf;
+  /** Resolved download URL or object URL for the PDF file. */
+  url: string;
+  /** Highlight regions to render over the PDF pages. */
+  highlights?: InputHighlightData[];
+  /** ID of the highlight to scroll to and select on initial load. */
+  selectedHighlightId?: string;
+}
+
 /** Content payload for attachments whose format cannot be previewed. */
 export interface UnsupportedCanvasContent {
   /** Discriminates the content type to select the correct renderer. */
@@ -49,6 +62,7 @@ export type AttachmentCanvasContent =
   | ImageCanvasContent
   | MarkdownCanvasContent
   | JsonCanvasContent
+  | PdfCanvasContent
   | UnsupportedCanvasContent;
 
 /** Themeable color overrides for the AttachmentCanvas content body. */
@@ -128,11 +142,11 @@ export interface AttachmentCanvasProps {
   copiedJsonLabel?: string;
   /** Whether the viewport is in mobile breakpoint — disables drag-to-resize. */
   isMobile?: boolean;
-  /** Initial panel width in pixels (when resizable). Defaults to `560`. */
+  /** Initial panel width in pixels (when resizable). Defaults to `min(maxWidth, 2/3 of viewport width)`. */
   defaultWidth?: number;
   /** Minimum panel width in pixels (when resizable). Defaults to `320`. */
   minWidth?: number;
-  /** Maximum panel width in pixels (when resizable). Defaults to `960`. */
+  /** Maximum panel width in pixels (when resizable). Defaults to `1500`. */
   maxWidth?: number;
   /** Called with the new width in pixels after the user finishes a resize drag. */
   onResizeStop?: (width: number) => void;
@@ -142,4 +156,10 @@ export interface AttachmentCanvasProps {
   className?: string;
   /** Syntax highlight color theme forwarded to MarkdownRenderer code blocks. */
   codeBlockTheme?: CodeBlockTheme;
+  /**
+   * Fetches a PDF file by URL and returns its bytes as a `Blob`. Used when
+   * content type is `Pdf` to load the file before rendering. Defaults to a
+   * plain `fetch` if not provided.
+   */
+  loadPdf?: (url: string) => Promise<Blob>;
 }

--- a/libs/attachment-canvas/src/test-setup.ts
+++ b/libs/attachment-canvas/src/test-setup.ts
@@ -1,1 +1,11 @@
 // Vitest setup for attachment-canvas
+import { vi } from 'vitest';
+
+vi.mock('@epam/pdf-highlighter-kit', () => ({
+  PDFHighlightViewer: () => null,
+}));
+
+vi.mock('@epam/ai-dial-react-pdf-highlighter', () => ({
+  DocumentPreview: () => null,
+  PageThumbnail: () => null,
+}));

--- a/libs/attachment-canvas/src/types/attachment-canvas.ts
+++ b/libs/attachment-canvas/src/types/attachment-canvas.ts
@@ -4,5 +4,6 @@ export enum AttachmentContentType {
   Image = 'image',
   Markdown = 'markdown',
   Json = 'json',
+  Pdf = 'pdf',
   Unsupported = 'unsupported',
 }

--- a/libs/attachment-canvas/src/utils/download.ts
+++ b/libs/attachment-canvas/src/utils/download.ts
@@ -9,10 +9,18 @@ export const isDownloadable = (content: AttachmentCanvasContent): boolean => {
     case AttachmentContentType.Markdown:
     case AttachmentContentType.Json:
     case AttachmentContentType.Image:
+    case AttachmentContentType.Pdf:
       return true;
     case AttachmentContentType.Unsupported:
       return content.url != null;
   }
+};
+
+/** Fetches a URL and returns its response body as a `Blob`. */
+export const fetchBlobFromUrl = async (url: string): Promise<Blob> => {
+  const r = await fetch(url);
+  if (!r.ok) throw new Error(`HTTP ${r.status}`);
+  return r.blob();
 };
 
 /** Triggers a browser download for the given canvas content. */
@@ -46,6 +54,7 @@ export const downloadAttachmentContent = (
       revokeAfter = true;
       break;
     case AttachmentContentType.Image:
+    case AttachmentContentType.Pdf:
       href = content.url;
       break;
     case AttachmentContentType.Unsupported:

--- a/libs/attachment-canvas/vite.config.mts
+++ b/libs/attachment-canvas/vite.config.mts
@@ -52,5 +52,13 @@ export default defineConfig(() => ({
       reportsDirectory: './test-output/vitest/coverage',
       provider: 'v8' as const,
     },
+    server: {
+      deps: {
+        inline: [
+          '@epam/pdf-highlighter-kit',
+          '@epam/ai-dial-react-pdf-highlighter',
+        ],
+      },
+    },
   },
 }));

--- a/libs/chat-shared/src/hooks/useIsMobile.ts
+++ b/libs/chat-shared/src/hooks/useIsMobile.ts
@@ -1,17 +1,12 @@
 import { useEffect, useState } from 'react';
 
-const MOBILE_MAX = '(max-width: 768px)';
+const MOBILE_QUERY = '(max-width: 768px)';
 
 const resolveIsMobile = (): boolean =>
   typeof window !== 'undefined' &&
   typeof window.matchMedia === 'function' &&
-  window.matchMedia(MOBILE_MAX).matches;
+  window.matchMedia(MOBILE_QUERY).matches;
 
-/**
- * Returns `true` when the viewport is below the `large_tablet` breakpoint (< 1024 px).
- * Self-contained mirror of the host app's `useIsMobile`; uses the same pixel boundary
- * so JS-driven branches and Tailwind responsive prefixes resolve to the same band.
- */
 export const useIsMobile = (): boolean => {
   const [isMobile, setIsMobile] = useState(resolveIsMobile);
 
@@ -21,7 +16,7 @@ export const useIsMobile = (): boolean => {
       typeof window.matchMedia !== 'function'
     )
       return;
-    const mql = window.matchMedia(MOBILE_MAX);
+    const mql = window.matchMedia(MOBILE_QUERY);
     const onChange = () => setIsMobile(mql.matches);
     mql.addEventListener('change', onChange);
     return () => mql.removeEventListener('change', onChange);

--- a/libs/chat-shared/src/index.ts
+++ b/libs/chat-shared/src/index.ts
@@ -25,3 +25,4 @@ export * from './components/MarkdownRenderer/MarkdownRenderer';
 export * from './components/MarkdownRenderer/MDMessageViewer';
 export * from './components/MarkdownRenderer/CodeBlock/CodeBlock';
 export * from './components/MarkdownRenderer/Table/MarkdownTable';
+export * from './hooks/useIsMobile';

--- a/libs/chat-shared/src/models/annotation.ts
+++ b/libs/chat-shared/src/models/annotation.ts
@@ -8,12 +8,29 @@ export interface TextCharacterRangeSelector {
   end: number;
 }
 
+/** Selector that targets an axis-aligned bounding box on a specific PDF page. */
+export interface PdfBBoxSelector {
+  /** Discriminator — always `'pdf_bbox'`. */
+  type: 'pdf_bbox';
+  /** 1-based PDF page number. */
+  page: number;
+  /** Left edge coordinate. */
+  x1: number;
+  /** Top edge coordinate. */
+  y1: number;
+  /** Right edge coordinate. */
+  x2: number;
+  /** Bottom edge coordinate. */
+  y2: number;
+}
+
 /**
  * Discriminated union of all recognised annotation selector shapes.
  * Unknown selector types are preserved as an open record to allow forward-compatibility.
  */
 export type AnnotationSelector =
   | TextCharacterRangeSelector
+  | PdfBBoxSelector
   | { type: string; [key: string]: unknown };
 
 /** Identifies the part of the message (or a related resource) that the annotation refers to. */

--- a/libs/chat-shared/src/types/mime-type.ts
+++ b/libs/chat-shared/src/types/mime-type.ts
@@ -47,3 +47,14 @@ export enum MIMEType {
   /** SVG vector image. */
   SVG = 'image/svg+xml',
 }
+
+/**
+ * Well-known file extension constants used as fallback when a MIME type is
+ * unavailable or unreliable.
+ */
+export enum FileExtension {
+  PDF = 'pdf',
+  Markdown = 'md',
+  MarkdownAlt = 'markdown',
+  JSON = 'json',
+}

--- a/libs/conversation-input/src/components/AddAttachmentButton/AddAttachmentButton.tsx
+++ b/libs/conversation-input/src/components/AddAttachmentButton/AddAttachmentButton.tsx
@@ -13,7 +13,7 @@ import {
   useMemo,
   useState,
 } from 'react';
-import { useIsMobile } from '../../hooks/useIsMobile';
+import { useIsMobile } from '@epam/ai-dial-chat-shared';
 import type { ChatSettingsConfig } from '../../models/Input';
 import { BottomSheet } from '../BottomSheet/BottomSheet';
 import { ChatSettingsBottomSheet } from '../ChatSettingsBottomSheet/ChatSettingsBottomSheet';

--- a/libs/conversation-input/src/components/Input/Input.tsx
+++ b/libs/conversation-input/src/components/Input/Input.tsx
@@ -2,7 +2,11 @@ import {
   AttachmentTray,
   useClipboardPaste,
 } from '@epam/ai-dial-attachment-input';
-import { buildCssVars, mergeClasses } from '@epam/ai-dial-chat-shared';
+import {
+  buildCssVars,
+  mergeClasses,
+  useIsMobile,
+} from '@epam/ai-dial-chat-shared';
 import {
   BASE_ICON_SIZE,
   DIAL_ICON_SIZE,
@@ -19,11 +23,10 @@ import {
 } from 'react';
 import { useAttachments } from '../../hooks/useAttachments';
 import { useInputHistoryNavigation } from '../../hooks/useInputHistoryNavigation';
-import { useIsMobile } from '../../hooks/useIsMobile';
 import { useMessageState } from '../../hooks/useMessageState';
 import { useVoiceRecorder } from '../../hooks/useVoiceRecorder';
-import { SendOnEnter } from '../../models/Input';
 import type { InputProps } from '../../models/Input';
+import { SendOnEnter } from '../../models/Input';
 import { AddAttachmentButton } from '../AddAttachmentButton/AddAttachmentButton';
 import { VoiceBar } from '../VoiceBar/VoiceBar';
 import { SendButton } from './Buttons/SendButton';

--- a/openspec/specs/canvas/spec.md
+++ b/openspec/specs/canvas/spec.md
@@ -40,6 +40,7 @@ The canvas closes when the URL `pathname` changes (conversation switch, catalog 
 - **Resizability**: enabled on desktop, disabled on mobile (`isMobile` prop from `useIsMobile()`).
 - **Width defaults**: 560 px default, 320 px min, 960 px max. Width is not persisted between sessions.
 - **Both panels**: `ConversationSourcesPanel` and `AttachmentCanvas` cannot be open simultaneously. Opening the canvas from the source panel closes the source panel first (calls `closeSourcesPanel()` before `openCanvas()`). Opening the canvas from any other surface does not affect the source panel state.
+- **Conversation panel**: The conversation history panel (`isHistoryPanelOpen`) is automatically closed when the canvas opens. Implemented via a `useEffect` in `apps/chat/src/app/app.tsx` that watches `isCanvasOpen` and calls `closeHistoryPanel()` whenever it becomes `true`.
 
 #### i18n
 
@@ -82,8 +83,10 @@ None. The canvas is always available to authenticated users.
 |---|---|---|
 | `text/markdown` MIME | `resolveMarkdownCanvasContent` | `MarkdownCanvasContent` |
 | `application/json` MIME | `resolveJsonCanvasContent` | `JsonCanvasContent` or `PlainTextCanvasContent` |
+| `application/pdf` MIME | `resolvePdfCanvasContent` | `PdfCanvasContent` |
 | `md`, `markdown` extension | `resolveMarkdownCanvasContent` | `MarkdownCanvasContent` |
 | `json` extension | `resolveJsonCanvasContent` | `JsonCanvasContent` or `PlainTextCanvasContent` (parse failure) |
+| `pdf` extension | `resolvePdfCanvasContent` | `PdfCanvasContent` |
 | `image/*` MIME | `resolveImageCanvasContent` | `ImageCanvasContent` |
 | Other text-previewable (see `TEXT_EXTENSIONS`) | `resolveTextCanvasContent` | `PlainTextCanvasContent` |
 | Everything else | `createUnsupportedCanvasContent` | `UnsupportedCanvasContent` |
@@ -98,6 +101,7 @@ Extension checks for `md`/`markdown` and `json` run *before* the generic `isText
 | `PlainText` | `text: string` | `<pre>` with `whitespace-pre-wrap break-words` |
 | `Markdown` | `text: string` | `MarkdownRenderer` from `@epam/ai-dial-chat-shared`, neutral defaults |
 | `Json` | `value: unknown` | `react-json-view-lite` `JsonView`, container has `dir="ltr"` |
+| `Pdf` | `url: string; highlights?: InputHighlightData[]; selectedHighlightId?: string` | `PdfContent` (thumbnail sidebar + `DocumentPreview` from `@epam/ai-dial-react-pdf-highlighter`) |
 | `Unsupported` | — | Centered "Preview not supported" message |
 
 ---
@@ -185,8 +189,82 @@ The reload is guarded by `!abortRef.current` to skip if the user has already sta
 
 ---
 
+### PDF rendering
+
+#### Trigger
+
+`useOpenAttachmentCanvas` routes to `resolvePdfCanvasContent` when `contentType === 'application/pdf'` (MIME, checked first) or when the lowercased file extension is `pdf`. PDF routing runs before the generic `isTextPreviewable` branch.
+
+#### Content resolution
+
+`resolvePdfCanvasContent` in `apps/chat/src/utils/attachment-canvas.ts`:
+
+1. If the attachment is a local file (`'file' in attachment` and `attachment.file.size > 0`): return `{ type: AttachmentContentType.Pdf, url: URL.createObjectURL(attachment.file) }`.
+2. Resolve the download URL via `resolveDialUrl(attachment)`. If `null`, return `null`.
+3. Return `{ type: AttachmentContentType.Pdf, url }`.
+
+No server fetch is performed at resolution time; `DocumentPreview` handles file loading internally.
+
+#### Rendering
+
+The `PdfContent` component (`libs/attachment-canvas/src/components/AttachmentCanvas/PdfContent.tsx`) wraps `DocumentPreview` and adds a thumbnail sidebar.
+
+**Layout** — `flex h-full overflow-hidden`:
+- **Thumbnail sidebar** (`w-30 shrink-0 overflow-auto`) — rendered once `totalPages > 0`. Displays one `PageThumbnail` per page. Clicking a thumbnail calls `viewerApiRef.current?.navigateToPage(pageNum)` and updates `selectedPage` state.
+- **Viewer pane** (`min-w-0 flex-1 overflow-hidden`) — contains `DocumentPreview`.
+
+`DocumentPreview` props:
+
+| Prop | Value |
+|---|---|
+| `fileUrl` | `content.url` — resolved URL or object URL |
+| `loadFileCb` | `loadPdf` prop (optional); falls back to `fetchBlobFromUrl` from `libs/attachment-canvas/src/utils/download.ts` (fetches the URL, throws on non-OK status, returns `Blob`) |
+| `highlights` | `content.highlights ?? []` — highlight regions; empty when no citation context |
+| `selectedHighlightId` | `content.selectedHighlightId` — viewer scrolls to this highlight on load |
+| `showOccurrences` | `false` — occurrence counter suppressed |
+| `thumbnailPageNumbers` | `[1 … totalPages]` — drives thumbnail generation inside the library |
+| `onTotalPagesChange` | sets `totalPages` state, which controls sidebar visibility and `thumbnailPageNumbers` |
+| `onThumbnailsLoaded` | merges newly loaded thumbnail URLs into `thumbnails` state (`Map<number, string>`) |
+| `onViewerReady` | stores the `PdfViewerApi` reference used for programmatic page navigation |
+
+No `title` prop is passed — toolbar title is hidden.
+
+Body wrapper class: `h-full overflow-hidden` — no padding; the viewer manages its own scrolling.
+
+The `loadPdf` prop is optional on `PdfContent`, `AttachmentCanvas`, and `AttachmentCanvasContainer`. The default (`fetchBlobFromUrl`) works for cookie-based DIAL auth. The app layer can supply a custom `loadPdf` callback if it needs to add auth headers.
+
+#### Download
+
+PDF is downloadable. `isDownloadable` returns `true` for `PdfCanvasContent`. `downloadAttachmentContent` uses `content.url` as the anchor `href` directly (same pattern as `ImageCanvasContent`).
+
+---
+
 ### Citation preview
 
-When a user clicks "Preview" in a `CitationDropdown`, `annotationToDisplayAttachment` converts the annotation's backing `AttachmentResource` to a `DisplayAttachment`. The canvas opens with the full source file. The `Annotation.body` fields (`quote`, `selector`, `configuration`) are **not** carried through; no highlighted region is shown.
+When a user clicks "Preview" in a `CitationDropdown`, `useCitationMarkdownComponents.onPreview` opens the canvas with the full source file.
 
-A future "citation-aware" mode would pass the full `Annotation` to the canvas and render document-level highlights. Out of scope for this iteration.
+#### PDF sources (highlights)
+
+When `annotation.body.source.attachment.type === 'application/pdf'`:
+
+1. Find the `AnnotationGroup` that owns the clicked annotation (by `sourceUrl`).
+2. `annotationsToPdfHighlights(group.annotations)` — maps every annotation whose `body.selector` contains one or more `PdfBBoxSelector` entries (`type: 'pdf_bbox'`) to an `InputHighlightData`. Each annotation becomes one highlight whose `bboxes` list collects all its `pdf_bbox` selectors. The highlight `id` is `annotation.index` when present, otherwise the annotation's position in the group.
+3. `selectedHighlightId` is computed for the clicked annotation using the same ID formula, so the viewer scrolls to it on load.
+4. `openCanvas` is called directly with `PdfCanvasContent { type: Pdf, url, highlights, selectedHighlightId }`.
+5. Annotations whose `body.selector` carries no `pdf_bbox` entries produce no highlight and are silently skipped.
+
+#### Non-PDF sources
+
+`annotationToDisplayAttachment` converts the annotation's `AttachmentResource` to a `DisplayAttachment` and calls `onAttachmentPreview` — the generic canvas open path.
+
+#### Selector type
+
+`AnnotationBody.selector` may be a single `AnnotationSelector` or an array. Only entries with `type === 'pdf_bbox'` are mapped; all other selector types are ignored. The `PdfBBoxSelector` shape:
+
+```ts
+interface PdfBBoxSelector {
+  type: 'pdf_bbox';
+  page: number;   // 1-based
+  x1: number; y1: number; x2: number; y2: number;
+}
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
       "dependencies": {
         "@epam/ai-dial-typescript-sdk": "^0.1.0-dev.24",
         "@epam/ai-dial-ui-kit": "0.12.0-dev.4",
+        "@epam/pdf-highlighter-kit": "^0.0.18",
         "@nestjs/cache-manager": "^3.1.2",
         "@nestjs/common": "^11.0.0",
         "@nestjs/core": "^11.0.0",
@@ -31,6 +32,7 @@
         "i18next": "^26.2.0",
         "i18next-browser-languagedetector": "^8.2.1",
         "mime-types": "^3.0.2",
+        "pdfjs-dist": "5.4.149",
         "polished": "^4.3.1",
         "randomcolor": "^0.6.2",
         "react": "^19.2.6",
@@ -156,12 +158,40 @@
       "name": "@epam/ai-dial-attachment-canvas",
       "version": "0.0.1",
       "license": "Apache-2.0",
+      "dependencies": {
+        "@epam/ai-dial-react-pdf-highlighter": "0.2.0-dev.17"
+      },
       "peerDependencies": {
         "@epam/ai-dial-chat-shared": "0.0.1",
         "@epam/ai-dial-sidebar": "0.0.1",
         "@epam/ai-dial-ui-kit": "0.12.0-dev.4",
+        "@epam/pdf-highlighter-kit": ">=0.0.14",
         "@tabler/icons-react": "^3.44.0",
-        "react": "^19.0.0"
+        "react": "^19.0.0",
+        "react-json-view-lite": "^2.5.0"
+      }
+    },
+    "libs/attachment-canvas/node_modules/@epam/ai-dial-react-pdf-highlighter": {
+      "version": "0.2.0-dev.17",
+      "resolved": "https://registry.npmjs.org/@epam/ai-dial-react-pdf-highlighter/-/ai-dial-react-pdf-highlighter-0.2.0-dev.17.tgz",
+      "integrity": "sha512-K22dROJ7SILFYGUlrDebQrE/dUmi398GYOp+SsC3R34fwPIV7B23pjvLkNT2E2JPLiusGW11s58Iew9IHNsBZA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=22.2.0",
+        "npm": ">=10.7.0"
+      },
+      "peerDependencies": {
+        "@epam/ai-dial-ui-kit": ">=0.12.0-0",
+        "@epam/pdf-highlighter-kit": ">=0.0.18",
+        "@tabler/icons-react": "^3.44.0",
+        "pdfjs-dist": ">=4.0.0",
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@tabler/icons-react": {
+          "optional": true
+        }
       }
     },
     "libs/attachment-input": {
@@ -2340,6 +2370,18 @@
       "resolved": "libs/chat-api-client",
       "link": true
     },
+    "node_modules/@epam/pdf-highlighter-kit": {
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/@epam/pdf-highlighter-kit/-/pdf-highlighter-kit-0.0.18.tgz",
+      "integrity": "sha512-s2XmS9o+SczOu6hy16SxW5laEtI3l6En9YGZU9+j3aL2tdykT/+txXhQZtnJN/CJ0+kBRBuGyacFvT6H2ARPEA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "pdfjs-dist": "^5.4.149"
+      }
+    },
     "node_modules/@epic-web/invariant": {
       "version": "1.0.0",
       "dev": true,
@@ -2552,6 +2594,8 @@
     },
     "node_modules/@floating-ui/core": {
       "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -2560,6 +2604,8 @@
     },
     "node_modules/@floating-ui/dom": {
       "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -2569,6 +2615,8 @@
     },
     "node_modules/@floating-ui/react": {
       "version": "0.27.19",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.27.19.tgz",
+      "integrity": "sha512-31B8h5mm8YxotlE7/AU/PhNAl8eWxAmjL/v2QOxroDNkTFLk3Uu82u63N3b6TXa4EGJeeZLVcd/9AlNlVqzeog==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -2583,6 +2631,8 @@
     },
     "node_modules/@floating-ui/react-dom": {
       "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.8.tgz",
+      "integrity": "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -2595,6 +2645,8 @@
     },
     "node_modules/@floating-ui/utils": {
       "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
       "license": "MIT",
       "peer": true
     },
@@ -3761,6 +3813,8 @@
     },
     "node_modules/@module-federation/cli/node_modules/typescript": {
       "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
@@ -3833,6 +3887,8 @@
     },
     "node_modules/@module-federation/manifest/node_modules/typescript": {
       "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
@@ -4006,6 +4062,8 @@
     },
     "node_modules/@module-federation/node/node_modules/typescript": {
       "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
@@ -4095,6 +4153,8 @@
     },
     "node_modules/@monaco-editor/loader": {
       "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/loader/-/loader-1.7.0.tgz",
+      "integrity": "sha512-gIwR1HrJrrx+vfyOhYmCZ0/JcWqG5kbfG7+d3f/C1LXk2EvzAbHSg3MQ5lO2sMlo9izoAZ04shohfKLVT6crVA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -4103,6 +4163,8 @@
     },
     "node_modules/@monaco-editor/react": {
       "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/react/-/react-4.7.0.tgz",
+      "integrity": "sha512-cyzXQCtO47ydzxpQtCGSQGOC8Gk3ZUeBXFAxD+CWXYFo5OqZyZUonFl0DwUlTyAfRHntBfw2p3w4s9R6oe1eCA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -4112,6 +4174,256 @@
         "monaco-editor": ">= 0.25.0 < 1",
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@napi-rs/canvas": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.100.tgz",
+      "integrity": "sha512-xglYA6q3XO5P3BNJYxVZ1IV7DLVjp1Py6nwag88YntrS+3vKHyYcMqXVS4ZztJmwz2uGvz1FWhI/4LgbR5uQDA==",
+      "license": "MIT",
+      "optional": true,
+      "workspaces": [
+        "e2e/*"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas-android-arm64": "0.1.100",
+        "@napi-rs/canvas-darwin-arm64": "0.1.100",
+        "@napi-rs/canvas-darwin-x64": "0.1.100",
+        "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.100",
+        "@napi-rs/canvas-linux-arm64-gnu": "0.1.100",
+        "@napi-rs/canvas-linux-arm64-musl": "0.1.100",
+        "@napi-rs/canvas-linux-riscv64-gnu": "0.1.100",
+        "@napi-rs/canvas-linux-x64-gnu": "0.1.100",
+        "@napi-rs/canvas-linux-x64-musl": "0.1.100",
+        "@napi-rs/canvas-win32-arm64-msvc": "0.1.100",
+        "@napi-rs/canvas-win32-x64-msvc": "0.1.100"
+      }
+    },
+    "node_modules/@napi-rs/canvas-android-arm64": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.100.tgz",
+      "integrity": "sha512-hjhCKhntPv9+t4ckHymdx0phYNcVW+GKQR6Lzw2zE+pOVjOplSmtx9nNNknTjbEDLcuLZqA1y8ufKg1XfgftzQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-arm64": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.100.tgz",
+      "integrity": "sha512-2PcswRaC7Ly645DGt88///zuFDhJxJYdKAs1uU3mfk1atYkXufgcgLfBpk6Tm12nCQBaNt1wpybuPZ4qOhTo8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-x64": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.100.tgz",
+      "integrity": "sha512-ePNZtj7pNIva/siZMg+HmbeozkIjqUIYdoymH8HaA3qK7LfzFN4WMBM8G6HQ9ZC+H3+Dnn5pqtiXpgLykaPOhw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.100.tgz",
+      "integrity": "sha512-d5cDB48oWFGU8/XPhUOFAlySgb/VAu7D+s8fi55K1Pcfg8aPplHWqMgibhVLU8ky7Pyg/fuiVLz4Nf3JrSTuUA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-gnu": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.100.tgz",
+      "integrity": "sha512-rDxgxRu69RvDlX/bh9o22DxLsGr8EqsNgotL9+RwQE1S0b0cqeatqsw6aW45mukm0B42DIAaAacKaYQ8cqS1nw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-musl": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.100.tgz",
+      "integrity": "sha512-K3mDW66N+xT2/V439u1alFANiBUjdEx2gLiNYnCmUsva5jZMxWTjafBYwTzYK+EMFMHrUoabuU+T1BIP5CgbYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.100.tgz",
+      "integrity": "sha512-mooqUBTIsccZpnoQC4NgrC1v6C1vof39etLNMnBwCY+p0gajWJvAHLGQ6g/gGyS5YrpDW+GefSN4+Cvcr08UWw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-gnu": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.100.tgz",
+      "integrity": "sha512-1eCvkDCazm7FFhsT7DfGOdSaHgZVK3bt/dSBl5EWHOWmnz+I7j8tPseJqqD81NF+MH21jKUK4wQSDjN0mdhnTg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-musl": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.100.tgz",
+      "integrity": "sha512-20arT6lnI19S68qNlii73TSEDbECNgzMz2EpldC1V3mZFuRkeujXkcebRk0LRJe9SEUAooYiLokfMViY8IX7yA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-arm64-msvc": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-arm64-msvc/-/canvas-win32-arm64-msvc-0.1.100.tgz",
+      "integrity": "sha512-DZFFT1wIAg37LJw37yhMRFfjATd3vTQzjZ1Yki8u2vhO6Hi5VE6BVaGQ1aaDu7xb4iMErz+9EOwjpS7xcxFeBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-x64-msvc": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.100.tgz",
+      "integrity": "sha512-MyT1j3mHC2+Lu4pBi9mKyMJhtP6U7k7EldY7sj/uS5gJA65gTXt8MefJQXLJo5d/vZbuWmfxzkEUNc/urV3pHA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
       }
     },
     "node_modules/@napi-rs/nice": {
@@ -5423,6 +5735,8 @@
     },
     "node_modules/@nx/module-federation/node_modules/typescript": {
       "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
@@ -9517,6 +9831,8 @@
     },
     "node_modules/@types/trusted-types": {
       "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "license": "MIT",
       "optional": true,
       "peer": true
@@ -9765,6 +10081,8 @@
     },
     "node_modules/@uiw/copy-to-clipboard": {
       "version": "1.0.21",
+      "resolved": "https://registry.npmjs.org/@uiw/copy-to-clipboard/-/copy-to-clipboard-1.0.21.tgz",
+      "integrity": "sha512-apdzZJyJC/IEj21N22ry1H022pgpSA+FwNKxmvOGQ9rUMdyRbHf1nZq2UwqnfGOuTr7iOKLzNgWsCJtAwyAZpw==",
       "license": "MIT",
       "peer": true,
       "funding": {
@@ -9773,6 +10091,8 @@
     },
     "node_modules/@uiw/react-markdown-preview": {
       "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@uiw/react-markdown-preview/-/react-markdown-preview-5.2.1.tgz",
+      "integrity": "sha512-JjvcHveT6glhlJYJx1XGBZij6wkw+VwREV6Z6m/GpsjPPdLjF1x8nlPBSB/ATyUF4lD7C8ttMkCqVH9N9XMgEA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -9800,6 +10120,8 @@
     },
     "node_modules/@uiw/react-md-editor": {
       "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@uiw/react-md-editor/-/react-md-editor-4.1.1.tgz",
+      "integrity": "sha512-yZqV5twN/sSfpce4cO/1bqy16o7v2oW324VNh2gcnsSpzOr2jEHpchM+ElD1y+ivUmFXcDZ5Ky5TOuPZg4qL6g==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -11832,6 +12154,8 @@
     },
     "node_modules/bcp-47-match": {
       "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/bcp-47-match/-/bcp-47-match-2.0.3.tgz",
+      "integrity": "sha512-JtTezzbAibu8G0R9op9zb3vcWZd9JF6M0xOYGPn0fNCd7wOpRB1mU2mH9T8gaBGbAAyIIVgB2G7xG0GP98zMAQ==",
       "license": "MIT",
       "peer": true,
       "funding": {
@@ -13189,6 +13513,8 @@
     },
     "node_modules/css-selector-parser": {
       "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/css-selector-parser/-/css-selector-parser-3.3.0.tgz",
+      "integrity": "sha512-Y2asgMGFqJKF4fq4xHDSlFYIkeVfRsm69lQC1q9kbEsH5XtnINTMrweLkjYMeaUgiXBy/uvKeO/a1JHTNnmB2g==",
       "funding": [
         {
           "type": "github",
@@ -13740,6 +14066,8 @@
     },
     "node_modules/direction": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/direction/-/direction-2.0.1.tgz",
+      "integrity": "sha512-9S6m9Sukh1cZNknO1CWAr2QAWsbKLafQiyM5gZ7VgXHeuaoUwffKN4q6NC4A/Mf9iiPlOXQEKW/Mv/mh9/3YFA==",
       "license": "MIT",
       "peer": true,
       "bin": {
@@ -16062,6 +16390,8 @@
     },
     "node_modules/github-slugger": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz",
+      "integrity": "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==",
       "license": "ISC",
       "peer": true
     },
@@ -16353,6 +16683,8 @@
     },
     "node_modules/hast-util-from-html": {
       "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hast-util-from-html/-/hast-util-from-html-2.0.3.tgz",
+      "integrity": "sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -16370,6 +16702,8 @@
     },
     "node_modules/hast-util-from-html/node_modules/entities": {
       "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
       "license": "BSD-2-Clause",
       "peer": true,
       "engines": {
@@ -16381,6 +16715,8 @@
     },
     "node_modules/hast-util-from-html/node_modules/parse5": {
       "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -16392,6 +16728,8 @@
     },
     "node_modules/hast-util-from-parse5": {
       "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-8.0.3.tgz",
+      "integrity": "sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -16411,6 +16749,8 @@
     },
     "node_modules/hast-util-has-property": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-has-property/-/hast-util-has-property-3.0.0.tgz",
+      "integrity": "sha512-MNilsvEKLFpV604hwfhVStK0usFY/QmM5zX16bo7EjnAEGofr5YyI37kzopBlZJkHD4t887i+q/C8/tr5Q94cA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -16423,6 +16763,8 @@
     },
     "node_modules/hast-util-heading-rank": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-heading-rank/-/hast-util-heading-rank-3.0.0.tgz",
+      "integrity": "sha512-EJKb8oMUXVHcWZTDepnr+WNbfnXKFNf9duMesmr4S8SXTJBJ9M4Yok08pu9vxdJwdlGRhVumk9mEhkEvKGifwA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -16435,6 +16777,8 @@
     },
     "node_modules/hast-util-is-element": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz",
+      "integrity": "sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -16458,6 +16802,8 @@
     },
     "node_modules/hast-util-raw": {
       "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/hast-util-raw/-/hast-util-raw-9.1.0.tgz",
+      "integrity": "sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -16482,6 +16828,8 @@
     },
     "node_modules/hast-util-raw/node_modules/entities": {
       "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
       "license": "BSD-2-Clause",
       "peer": true,
       "engines": {
@@ -16493,6 +16841,8 @@
     },
     "node_modules/hast-util-raw/node_modules/parse5": {
       "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -16504,6 +16854,8 @@
     },
     "node_modules/hast-util-select": {
       "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/hast-util-select/-/hast-util-select-6.0.4.tgz",
+      "integrity": "sha512-RqGS1ZgI0MwxLaKLDxjprynNzINEkRHY2i8ln4DDjgv9ZhcYVIHN9rlpiYsqtFwrgpYU361SyWDQcGNIBVu3lw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -16530,6 +16882,8 @@
     },
     "node_modules/hast-util-to-html": {
       "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
+      "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -16577,6 +16931,8 @@
     },
     "node_modules/hast-util-to-parse5": {
       "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-to-parse5/-/hast-util-to-parse5-8.0.1.tgz",
+      "integrity": "sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -16595,6 +16951,8 @@
     },
     "node_modules/hast-util-to-string": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-to-string/-/hast-util-to-string-3.0.1.tgz",
+      "integrity": "sha512-XelQVTDWvqcl3axRfI0xSeoVKzyIFPwsAGSLIsKdJKQMXDYJS4WYrBNF/8J7RdhIcFI2BOHgAifggsvsxp/3+A==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -16775,6 +17133,8 @@
     },
     "node_modules/html-void-elements": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+      "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
       "license": "MIT",
       "peer": true,
       "funding": {
@@ -19339,6 +19699,8 @@
     },
     "node_modules/marked": {
       "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",
+      "integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==",
       "license": "MIT",
       "peer": true,
       "bin": {
@@ -20335,6 +20697,8 @@
     },
     "node_modules/monaco-editor": {
       "version": "0.55.1",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz",
+      "integrity": "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -21459,6 +21823,8 @@
     },
     "node_modules/parse-numeric-range": {
       "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/parse-numeric-range/-/parse-numeric-range-1.3.0.tgz",
+      "integrity": "sha512-twN+njEipszzlMJd4ONUYgSfZPDxgHhT9Ahed5uTigpQn90FggW4SA/AIPq/6a149fTbE9qBEcSwE3FAEp6wQQ==",
       "license": "ISC",
       "peer": true
     },
@@ -21552,6 +21918,18 @@
     "node_modules/pathe": {
       "version": "2.0.3",
       "license": "MIT"
+    },
+    "node_modules/pdfjs-dist": {
+      "version": "5.4.149",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-5.4.149.tgz",
+      "integrity": "sha512-Xe8/1FMJEQPUVSti25AlDpwpUm2QAVmNOpFP0SIahaPIOKBKICaefbzogLdwey3XGGoaP4Lb9wqiw2e9Jqp0LA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20.16.0 || >=22.3.0"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas": "^0.1.77"
+      }
     },
     "node_modules/pend": {
       "version": "1.2.0",
@@ -23302,6 +23680,8 @@
     },
     "node_modules/rehype": {
       "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/rehype/-/rehype-13.0.2.tgz",
+      "integrity": "sha512-j31mdaRFrwFRUIlxGeuPXXKWQxet52RBQRvCmzl5eCefn/KGbomK5GMHNMsOJf55fgo3qw5tST5neDuarDYR2A==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -23317,6 +23697,8 @@
     },
     "node_modules/rehype-attr": {
       "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/rehype-attr/-/rehype-attr-4.0.2.tgz",
+      "integrity": "sha512-v4+gw7pvUVLbG/dUpLgBE6r3TWTBYJ7z+sfAH3zapmM5CKzk5+CopFQgr4gMR6OBSKl/qpI6HR7gv1Cbig0uow==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -23332,6 +23714,8 @@
     },
     "node_modules/rehype-attr/node_modules/unist-util-visit": {
       "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.0.0.tgz",
+      "integrity": "sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -23346,6 +23730,8 @@
     },
     "node_modules/rehype-autolink-headings": {
       "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/rehype-autolink-headings/-/rehype-autolink-headings-7.1.0.tgz",
+      "integrity": "sha512-rItO/pSdvnvsP4QRB1pmPiNHUskikqtPojZKJPPPAVx9Hj8i8TwMBhofrrAYRhYOOBZH9tgmG5lPqDLuIWPWmw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -23363,6 +23749,8 @@
     },
     "node_modules/rehype-ignore": {
       "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/rehype-ignore/-/rehype-ignore-2.0.3.tgz",
+      "integrity": "sha512-IzhP6/u/6sm49sdktuYSmeIuObWB+5yC/5eqVws8BhuGA9kY25/byz6uCy/Ravj6lXUShEd2ofHM5MyAIj86Sg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -23379,6 +23767,8 @@
     },
     "node_modules/rehype-parse": {
       "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/rehype-parse/-/rehype-parse-9.0.1.tgz",
+      "integrity": "sha512-ksCzCD0Fgfh7trPDxr2rSylbwq9iYDkSn8TCDmEJ49ljEUBxDVCzCHv7QNzZOfODanX4+bWQ4WZqLCRWYLfhag==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -23393,6 +23783,8 @@
     },
     "node_modules/rehype-prism-plus": {
       "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/rehype-prism-plus/-/rehype-prism-plus-2.0.2.tgz",
+      "integrity": "sha512-jTHb8ZtQHd2VWAAKeCINgv/8zNEF0+LesmwJak69GemoPVN9/8fGEARTvqOpKqmN57HwaM9z8UKBVNVJe8zggw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -23406,6 +23798,8 @@
     },
     "node_modules/rehype-raw": {
       "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-raw/-/rehype-raw-7.0.0.tgz",
+      "integrity": "sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -23420,6 +23814,8 @@
     },
     "node_modules/rehype-rewrite": {
       "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/rehype-rewrite/-/rehype-rewrite-4.0.4.tgz",
+      "integrity": "sha512-L/FO96EOzSA6bzOam4DVu61/PB3AGKcSPXpa53yMIozoxH4qg1+bVZDF8zh1EsuxtSauAhzt5cCnvoplAaSLrw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -23436,6 +23832,8 @@
     },
     "node_modules/rehype-slug": {
       "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-slug/-/rehype-slug-6.0.0.tgz",
+      "integrity": "sha512-lWyvf/jwu+oS5+hL5eClVd3hNdmwM1kAC0BUvEGD19pajQMIzcNUd/k9GsfQ+FfECvX+JE+e9/btsKH0EjJT6A==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -23452,6 +23850,8 @@
     },
     "node_modules/rehype-stringify": {
       "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/rehype-stringify/-/rehype-stringify-10.0.1.tgz",
+      "integrity": "sha512-k9ecfXHmIPuFVI61B9DeLPN0qFHfawM6RsuX48hoqlaKSF61RskNjSm1lI8PhBEM0MRdLxVVm4WmTqJQccH9mA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -23482,6 +23882,8 @@
     },
     "node_modules/remark-github-blockquote-alert": {
       "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/remark-github-blockquote-alert/-/remark-github-blockquote-alert-1.3.1.tgz",
+      "integrity": "sha512-OPNnimcKeozWN1w8KVQEuHOxgN3L4rah8geMOLhA5vN9wITqU4FWD+G26tkEsCGHiOVDbISx+Se5rGZ+D1p0Jg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -25111,6 +25513,8 @@
     },
     "node_modules/state-local": {
       "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/state-local/-/state-local-1.0.7.tgz",
+      "integrity": "sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==",
       "license": "MIT",
       "peer": true
     },
@@ -25651,7 +26055,9 @@
       }
     },
     "node_modules/tabbable": {
-      "version": "6.4.0",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.5.0.tgz",
+      "integrity": "sha512-wieBHXygIm7OyQOu5hQlkk62/WyCFYGlWg7L6/ZCUZwx0o398Zkn4pVmMyfYhfMG8kGrj/Krt8eIk6UKC6VzwA==",
       "license": "MIT",
       "peer": true
     },
@@ -26648,6 +27054,8 @@
     },
     "node_modules/unist-util-filter": {
       "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-filter/-/unist-util-filter-5.0.1.tgz",
+      "integrity": "sha512-pHx7D4Zt6+TsfwylH9+lYhBhzyhEnCXs/lbq/Hstxno5z4gVdyc2WEW0asfjGKPyG4pEKrnBv5hdkO6+aRnQJw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -26926,6 +27334,8 @@
     },
     "node_modules/vfile-location": {
       "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-5.0.3.tgz",
+      "integrity": "sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -27248,6 +27658,8 @@
     },
     "node_modules/web-namespaces": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
+      "integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==",
       "license": "MIT",
       "peer": true,
       "funding": {

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
   "dependencies": {
     "@epam/ai-dial-typescript-sdk": "^0.1.0-dev.24",
     "@epam/ai-dial-ui-kit": "0.12.0-dev.4",
+    "@epam/pdf-highlighter-kit": "^0.0.18",
     "@nestjs/cache-manager": "^3.1.2",
     "@nestjs/common": "^11.0.0",
     "@nestjs/core": "^11.0.0",
@@ -111,6 +112,7 @@
     "i18next": "^26.2.0",
     "i18next-browser-languagedetector": "^8.2.1",
     "mime-types": "^3.0.2",
+    "pdfjs-dist": "5.4.149",
     "polished": "^4.3.1",
     "randomcolor": "^0.6.2",
     "react": "^19.2.6",


### PR DESCRIPTION
## Description of changes

Add PDF support in canvas. 

Added passing of highlights, but didn't test - need to verify on real app.

Also increased canvas size as per design:

<img width="942" height="554" alt="image" src="https://github.com/user-attachments/assets/4a6ce32b-5f65-4f58-9022-2caf2490e70d" />

But need to discuss how it should look like when conversation panel is opened, now it's like this:
<img width="1919" height="1030" alt="image" src="https://github.com/user-attachments/assets/dd9fffcc-5a71-4f4e-968b-3a7d12d96116" />

And need to think what to do with thumbnails on mobile, whether to hide them or make as a panel
<img width="513" height="916" alt="image" src="https://github.com/user-attachments/assets/b863bbac-e20e-446d-afb6-85557759bb78" />


## Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #7213

## UI changes

<img width="1916" height="1077" alt="image" src="https://github.com/user-attachments/assets/836ab557-b92c-4904-b133-b304aed80c49" />


## Checklist

- [X] the pull request name ends with `(Issue #<ISSUE_ID>)` (comma-separated list of issues)
- [X] I confirm that I don't share any confidential information like API keys or any other secrets and private URLs

<details>
  <summary>PR title cheatsheet</summary>

`<type>[optional scope]: <description>`

1. type (required)
    - `feat` - A new feature
    - `fix` - A bug fix
    - `docs` - Documentation only changes
    - `test` - Adding missing tests or correcting existing tests
    - `ci` - Changes to our CI configuration files and scripts
    - `chore` - Other changes that are minor and/or not user-facing
2. scope (optional, current repo suggestions below)
    - `chat`
    - `overlay`
    - `shared`
    - `sandbox-overlay`
    - `visualizer-connector`

</details>
