### PR TITLE
ci: fix development tag conflict

### DIFF
--- a/.github/workflows/deploy-development.yml
+++ b/.github/workflows/deploy-development.yml
@@ -24,7 +24,7 @@ jobs:
             gitlab-project-id: "3016"
 
     name: Deploy to ${{ matrix.environment-name }}
-    uses: epam/ai-dial-ci/.github/workflows/deploy-development.yml@4.6.1
+    uses: epam/ai-dial-ci/.github/workflows/deploy-development.yml@4.7.0
     with:
       gitlab-project-id: ${{ matrix.gitlab-project-id }}
       environment-name: ${{ matrix.environment-name }}
@@ -47,7 +47,7 @@ jobs:
             gitlab-project-id: "3351"
 
     name: Deploy to ${{ matrix.environment-name }}
-    uses: epam/ai-dial-ci/.github/workflows/deploy-development.yml@4.6.1
+    uses: epam/ai-dial-ci/.github/workflows/deploy-development.yml@4.7.0
     with:
       gitlab-project-id: ${{ matrix.gitlab-project-id }}
       environment-name: ${{ matrix.environment-name }}

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -16,6 +16,6 @@ concurrency:
 
 jobs:
   pr-title-check:
-    uses: epam/ai-dial-ci/.github/workflows/pr-title-check.yml@4.6.1
+    uses: epam/ai-dial-ci/.github/workflows/pr-title-check.yml@4.7.0
     secrets:
       ACTIONS_BOT_TOKEN: ${{ secrets.ACTIONS_BOT_TOKEN }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -30,7 +30,7 @@ jobs:
         run: npm run validate:agent-docs
 
   run_tests:
-    uses: epam/ai-dial-ci/.github/workflows/node_pr.yml@4.6.1
+    uses: epam/ai-dial-ci/.github/workflows/node_pr.yml@4.7.0
     secrets: inherit
     with:
       node-version: 24

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,13 +22,14 @@ permissions:
 
 jobs:
   release:
-    uses: epam/ai-dial-ci/.github/workflows/node_release.yml@4.6.1
+    uses: epam/ai-dial-ci/.github/workflows/node_release.yml@4.7.0
     with:
       promote: ${{ github.event_name == 'workflow_dispatch' && inputs.promote }}
       node-version: 24
       filter-version: '1\.[0-9]+'
       primary-branch-pattern: '^development-1\.0$'
       release-branch-pattern: '^release-1\.[0-9]+$'
+      docker-development-tag: 'development-1.0'
       maximize-build-space: true
       draft-stable-releases: true
     secrets: inherit


### PR DESCRIPTION
## Description of changes

<!-- Please explain the changes you made right below this line. -->

- Release workflow in `development` and `development-1.0` branches overwrite "development" image tag. This fix will force `development-1.0` tag for release workflow in `development-1.0` branch.
- Bump CI version

## Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #<ISSUE_ID>

## UI changes

<Please, provide Screenshots or Figma links>

## Checklist

- [ ] the pull request name ends with `(Issue #<ISSUE_ID>)` (comma-separated list of issues)
- [X] I confirm that I don't share any confidential information like API keys or any other secrets and private URLs

<details>
  <summary>PR title cheatsheet</summary>

`<type>[optional scope]: <description>`

1. type (required)
    - `feat` - A new feature
    - `fix` - A bug fix
    - `docs` - Documentation only changes
    - `test` - Adding missing tests or correcting existing tests
    - `ci` - Changes to our CI configuration files and scripts
    - `chore` - Other changes that are minor and/or not user-facing
2. scope (optional, current repo suggestions below)
    - `chat`
    - `overlay`
    - `shared`
    - `sandbox-overlay`
    - `visualizer-connector`

</details>
