### PR TITLE
feat: port SDLC code-review agent to ai-dial-chat

### DIFF
--- a/.github/actions/pr-trust-gate/action.yml
+++ b/.github/actions/pr-trust-gate/action.yml
@@ -1,0 +1,204 @@
+name: PR trust gate (M2 reject + fork gate)
+description: >
+  Round-0 gate for AI-agent dispatchers (ADR-0005 M1/M2). Classifies the PR
+  source as trusted (same-repo branch / allowlisted author / trust label) or
+  untrusted (fork), and rejects the run if the PR diff touches agent-trust
+  paths (.claude, CLAUDE.md, .mcp.json, workflows, actions, agents) or adds
+  symlinks. Non-PR events (schedule / workflow_dispatch) are a no-op: they run
+  from the trusted default branch and have no fork surface.
+
+inputs:
+  event_name:
+    description: 'github.event_name (e.g. pull_request, pull_request_target, schedule).'
+    required: true
+  pr:
+    description: "toJSON(github.event.pull_request). Empty or 'null' for non-PR events."
+    required: false
+    default: ''
+  repo:
+    description: 'github.repository (owner/name) — used for the PR-files API call.'
+    required: true
+  github_token:
+    description: 'Token for the gh PR-files API call (github.token is sufficient).'
+    required: true
+  trust_paths:
+    description: >
+      Newline-separated globs that are agent-trust surfaces. A PR touching any
+      of these cannot run the agents. Supports `dir/**` (prefix), `**/name`
+      (basename at any depth incl. root), and exact paths. Case-insensitive.
+    required: false
+    default: |
+      .claude/**
+      **/CLAUDE.md
+      .mcp.json
+      .claude.json
+      .github/workflows/**
+      .github/actions/**
+      agents/**
+  allowed_associations:
+    description: 'Comma-separated author_association values trusted on a fork PR.'
+    required: false
+    default: 'OWNER,MEMBER,COLLABORATOR'
+  trust_label:
+    description: >
+      Optional label that, when present on a fork PR, authorizes the run (the
+      human trust boundary, per ADR-0005 worked example 1). Empty = no label override.
+    required: false
+    default: ''
+  apply_reject_to:
+    description: "Which PRs get the M2 trust-path reject: 'all' (recommended, also catches insiders) or 'external' (untrusted only)."
+    required: false
+    default: 'all'
+  fail_on_untrusted:
+    description: >
+      'true' (default) hard-blocks untrusted (fork) PRs — the internal-only
+      posture. Set 'false' for fork-facing dispatchers that branch on the
+      `trusted` output to run a locked-down M1-M6 flow instead of blocking.
+    required: false
+    default: 'true'
+
+outputs:
+  trusted:
+    description: "'true' if the PR source is trusted, else 'false'. 'true' for non-PR events."
+    value: ${{ steps.gate.outputs.trusted }}
+  reason:
+    description: 'Human-readable basis for the trust decision.'
+    value: ${{ steps.gate.outputs.reason }}
+
+runs:
+  using: composite
+  steps:
+    - id: gate
+      shell: bash
+      env:
+        EVENT_NAME: ${{ inputs.event_name }}
+        PR_JSON: ${{ inputs.pr }}
+        REPO: ${{ inputs.repo }}
+        GH_TOKEN: ${{ inputs.github_token }}
+        TRUST_PATHS: ${{ inputs.trust_paths }}
+        ALLOWED_ASSOC: ${{ inputs.allowed_associations }}
+        TRUST_LABEL: ${{ inputs.trust_label }}
+        APPLY_REJECT: ${{ inputs.apply_reject_to }}
+        FAIL_ON_UNTRUSTED: ${{ inputs.fail_on_untrusted }}
+      run: |
+        set -euo pipefail
+        python3 - <<'PY'
+        import json, os, sys, subprocess, fnmatch
+
+        def emit(k, v):
+            with open(os.environ["GITHUB_OUTPUT"], "a") as f:
+                f.write(f"{k}={v}\n")
+
+        def fail(msg):
+            sys.stderr.write(f"::error::{msg}\n")
+            sys.exit(1)
+
+        event = os.environ["EVENT_NAME"]
+        pr_raw = (os.environ.get("PR_JSON") or "").strip()
+
+        # Non-PR events run from the trusted default branch — nothing to gate.
+        if not pr_raw or pr_raw == "null":
+            print(f"::notice::{event} is not a PR event — trust gate not applicable.")
+            emit("trusted", "true")
+            emit("reason", "non-pr-event")
+            sys.exit(0)
+
+        pr = json.loads(pr_raw)
+        number = pr.get("number")
+        base_repo = ((pr.get("base") or {}).get("repo") or {}).get("full_name")
+        head_repo = ((pr.get("head") or {}).get("repo") or {}).get("full_name")
+        assoc = pr.get("author_association", "") or ""
+        labels = {(l or {}).get("name") for l in (pr.get("labels") or [])}
+
+        allowed = {a.strip() for a in os.environ["ALLOWED_ASSOC"].split(",") if a.strip()}
+        trust_label = (os.environ.get("TRUST_LABEL") or "").strip()
+
+        # --- Fork gate: classify the PR source ---------------------------------
+        # Same-repo branch ⇒ author had write access ⇒ trusted (ADR-0005 §Trust
+        # boundary). Forks need an explicit allow: allowlisted association or a
+        # maintainer-applied trust label.
+        same_repo = bool(base_repo and head_repo and base_repo == head_repo)
+        if same_repo:
+            trusted, why = True, "same-repo branch (push requires write access)"
+        elif assoc in allowed:
+            trusted, why = True, f"author_association={assoc}"
+        elif trust_label and trust_label in labels:
+            trusted, why = True, f"trust label '{trust_label}' present"
+        else:
+            trusted, why = False, f"fork PR from {head_repo} (author_association={assoc}, no trust label)"
+
+        print(f"::notice::PR #{number} trust={str(trusted).lower()} — {why}")
+        emit("trusted", str(trusted).lower())
+        emit("reason", why)
+
+        # --- M2 reject: trust-path edits + symlinks ----------------------------
+        apply = os.environ["APPLY_REJECT"]
+        do_reject = apply == "all" or (apply == "external" and not trusted)
+
+        if do_reject:
+            globs = [g.strip() for g in os.environ["TRUST_PATHS"].splitlines() if g.strip()]
+
+            def path_matches(path, glob):
+                p = path.lower().lstrip("./")
+                g = glob.lower().lstrip("./")
+                if g.endswith("/**"):                       # dir/** → under dir/
+                    base = g[:-3]
+                    return p == base or p.startswith(base + "/")
+                if g.startswith("**/"):                      # **/name → any depth incl. root
+                    suffix = g[3:]
+                    return p == suffix or p.endswith("/" + suffix)
+                return p == g or fnmatch.fnmatch(p, g)       # exact / glob
+
+            # Changed files via the API: reflects the current PR head with no
+            # local history / merge-base gymnastics. --paginate for large PRs.
+            res = subprocess.run(
+                ["gh", "api", "--paginate",
+                 f"repos/{os.environ['REPO']}/pulls/{number}/files",
+                 "--jq", ".[].filename"],
+                capture_output=True, text=True)
+            if res.returncode != 0:
+                fail(f"could not list PR files: {res.stderr.strip()}")
+            changed = [l for l in res.stdout.splitlines() if l]
+
+            offenders = [(p, next(g for g in globs if path_matches(p, g)))
+                         for p in changed if any(path_matches(p, g) for g in globs)]
+
+            # Symlinks introduced by the PR (mode 120000 in the head tree).
+            sym = []
+            if changed:
+                subprocess.run(
+                    ["git", "fetch", "--no-tags", "--depth=1", "origin",
+                     f"refs/pull/{number}/head"],
+                    check=False, capture_output=True)
+                ls = subprocess.run(["git", "ls-tree", "-r", "FETCH_HEAD"],
+                                    capture_output=True, text=True)
+                symset = set()
+                for line in ls.stdout.splitlines():
+                    meta, _, path = line.partition("\t")
+                    parts = meta.split()
+                    if parts and parts[0] == "120000":
+                        symset.add(path)
+                sym = [p for p in changed if p in symset]
+
+            if offenders or sym:
+                for p, g in offenders:
+                    sys.stderr.write(f"::error::PR touches agent-trust path '{p}' (matched '{g}')\n")
+                for p in sym:
+                    sys.stderr.write(f"::error::PR adds/modifies symlink '{p}' (symlinks rejected)\n")
+                fail(
+                    f"M2 reject: {len(offenders)} trust-path edit(s), {len(sym)} symlink(s). "
+                    "A PR that touches agent-trust files (or adds symlinks) cannot run the "
+                    "AI agents — it is a config-poisoning / prompt-injection vector. Split "
+                    "trust-file changes into a separate, human-reviewed PR.")
+            print(f"::notice::M2 reject passed — no trust-path edits or symlinks in {len(changed)} changed file(s).")
+        else:
+            print("::notice::M2 reject skipped (apply_reject_to=external and PR is trusted).")
+
+        # --- Fork-gate enforcement ---------------------------------------------
+        if not trusted and os.environ["FAIL_ON_UNTRUSTED"] == "true":
+            hint = f"add the '{trust_label}' label" if trust_label else "configure a trust_label and apply it"
+            fail(
+                f"Fork gate: untrusted PR ({why}). Secret-bearing agents will not run. "
+                f"A maintainer can {hint} to authorize, or set fail_on_untrusted=false "
+                "to run a locked-down (ADR-0005 M1-M6) fork flow.")
+        PY

--- a/.github/actions/run-claude-stage/action.yml
+++ b/.github/actions/run-claude-stage/action.yml
@@ -1,0 +1,466 @@
+name: 'Run Claude Stage'
+description: 'Run a Claude-powered DIAL SDLC stage. An agent is a manifest + skill ref; the action composes a uniform prompt that delegates work to the skill, runs Claude with --json-schema, validates the output, and posts a sticky PR comment.'
+
+inputs:
+  stage_name:
+    description: 'Stage identifier (kebab-case). Pinned into the output schema and sticky-comment marker.'
+    required: true
+  skill:
+    description: 'Local skill the agent wraps. Must be addressable as `/<skill>` (e.g. code-review-and-quality, opsx:verify).'
+    required: true
+  allowed_tools:
+    description: 'Comma-separated allowed tools (e.g. "Read,Grep,Glob,Skill"). Should include the tools the wrapped skill needs plus `Skill` itself.'
+    required: true
+  agent_version:
+    description: 'Stage/agent version (semver) recorded into the output envelope.'
+    required: false
+    default: 'unknown'
+  model:
+    description: 'Claude model to invoke (e.g. claude-sonnet-4-6). Empty means use claude-code-action default.'
+    required: false
+    default: ''
+  max_turns:
+    description: 'Max Claude turns. 18 covers a typical multi-step agent (e.g. spec-validation: CLI floor + diff scoping + drift check via Grep/Read + Write); reviewer agents typically use 5-8. Raise per-stage via the manifest if a heavier agent needs more.'
+    required: false
+    default: '18'
+  show_full_output:
+    description: 'When "true", claude-code-action streams full Claude prompts/responses to the GHA log. Useful for debugging on a sandbox base; set to "false" before agents see real secrets in their prompts.'
+    required: false
+    default: 'false'
+  upstream_artifacts:
+    description: 'Comma-separated names of upstream agents whose stage-output.json artifacts have been downloaded into upstream/<name>/ (same value the calling workflow passes to the gh run download step). Used to render the per-agent upstream-inputs section of the composed prompt.'
+    required: false
+    default: ''
+  private_output:
+    description: 'When "true", encrypt stage-output.json (openssl, key from SDLC_ARTIFACT_KEY in env) before uploading it as an artifact, so the artifact is not readable on a public repo. Local plaintext is consumed on the runner first (verify/render/SARIF) then removed.'
+    required: false
+    default: 'false'
+  emit_sarif:
+    description: 'When "true", convert payload.findings[] to SARIF and upload to GitHub code scanning (Security tab). Scoped to ANALYSIS_REF_FULL/ANALYSIS_SHA from env when set (the scanned branch), else the current ref/sha.'
+    required: false
+    default: 'false'
+
+outputs:
+  message:
+    description: 'Validated sticky JSON payload from the stage.'
+    value: ${{ steps.extract.outputs.json }}
+  status:
+    description: 'Stage status (passed | passed_with_findings | failed).'
+    value: ${{ steps.extract.outputs.status }}
+
+runs:
+  using: composite
+  steps:
+    - name: Validate ANTHROPIC_API_KEY env
+      shell: bash
+      run: |
+        if [ -z "${ANTHROPIC_API_KEY:-}" ]; then
+          echo "::error::ANTHROPIC_API_KEY env is not set. Set it on the calling job from secrets.ANTHROPIC_API_KEY."
+          exit 1
+        fi
+
+    - name: Prepare prompt, schema, and Claude args
+      id: prep
+      shell: bash
+      env:
+        STAGE_NAME: ${{ inputs.stage_name }}
+        SKILL: ${{ inputs.skill }}
+        ALLOWED_TOOLS: ${{ inputs.allowed_tools }}
+        MAX_TURNS: ${{ inputs.max_turns }}
+        MODEL: ${{ inputs.model }}
+        SHOW_FULL_OUTPUT: ${{ inputs.show_full_output }}
+        UPSTREAM_ARTIFACTS: ${{ inputs.upstream_artifacts }}
+        RUNNER_TEMP: ${{ runner.temp }}
+      run: |
+        set -euo pipefail
+        if [ -z "${SKILL}" ]; then
+          echo "::error::skill input is required (agents wrap a local skill)"
+          exit 1
+        fi
+
+        # Build agent-facing schema AND compose the prompt. Schema: strip
+        # envelope fields the renderer injects, pin `stage` to a literal const
+        # so Claude can't mismatch. Prompt: load the universal wrapper
+        # template (.github/claude/prompts/agent-wrapper.md) and substitute
+        # `{{stage}}` and `{{skill}}` — no per-agent prompt file is involved.
+        SCHEMA_PATH="${RUNNER_TEMP}/agent-schema.json"
+        COMPOSED_PROMPT_PATH="${RUNNER_TEMP}/composed-prompt.md"
+        WRAPPER_PATH=".github/claude/prompts/agent-wrapper.md"
+        export STAGE_NAME SKILL SCHEMA_PATH COMPOSED_PROMPT_PATH WRAPPER_PATH
+        python3 - <<'PY'
+        import json, os
+
+        # --- Agent-facing schema --------------------------------------------
+        with open('.github/claude/schemas/stage-message.schema.json') as f:
+            s = json.load(f)
+        # Envelope fields are injected by render-stage-comment.py; agents must not write them.
+        for k in ('contract_version', 'agent_version', 'run_id', 'trigger'):
+            s.get('properties', {}).pop(k, None)
+        s['required'] = [r for r in s.get('required', []) if r != 'contract_version']
+        stage = os.environ['STAGE_NAME']
+        s.setdefault('properties', {}).setdefault('stage', {'type': 'string'})['const'] = stage
+        with open(os.environ['SCHEMA_PATH'], 'w') as f:
+            json.dump(s, f)
+
+        # --- Composed prompt ------------------------------------------------
+        # IMPORTANT: substitute {{base_ref}} with the real branch name HERE,
+        # not at runtime via ${GITHUB_BASE_REF} in Claude's Bash command. The
+        # Claude Code Bash tool rejects commands containing shell variable
+        # expansion (`Contains expansion` / `Contains simple_expansion`) for
+        # safety — anything Claude types into a Bash tool call must be
+        # literal. So we expand the base ref at compose time and Claude sees
+        # `git diff origin/<actual-branch>...HEAD`.
+        base_ref = os.environ.get('GITHUB_BASE_REF', 'main')
+
+        # Render the upstream-inputs section from the comma-separated `needs`
+        # list the calling workflow plumbs through (same value used by the
+        # gh-run-download step). Explicit per-agent lines beat a generic
+        # placeholder: the agent is told the exact file(s) to read rather than
+        # having to discover them. Skills stay agnostic of CI plumbing.
+        upstream_raw = os.environ.get('UPSTREAM_ARTIFACTS', '')
+        upstream_names = [n.strip() for n in upstream_raw.split(',') if n.strip()]
+        if upstream_names:
+            upstream_inputs = '\n'.join(
+                f'  - `upstream/{n}/stage-output.json` — the `{n}` agent\'s output '
+                f'envelope; its agent-specific data (findings, reports, etc.) is under `payload`.'
+                for n in upstream_names
+            )
+        else:
+            upstream_inputs = '  - none declared; this agent runs independently on the PR diff and working tree.'
+
+        with open(os.environ['WRAPPER_PATH']) as f:
+            template = f.read()
+        composed = (template
+                    .replace('{{stage}}', stage)
+                    .replace('{{skill}}', os.environ['SKILL'])
+                    .replace('{{base_ref}}', base_ref)
+                    .replace('{{upstream_inputs}}', upstream_inputs))
+        with open(os.environ['COMPOSED_PROMPT_PATH'], 'w') as f:
+            f.write(composed)
+        PY
+        echo "Agent-facing schema written to $SCHEMA_PATH"
+        echo "Composed prompt written to $COMPOSED_PROMPT_PATH ($(wc -c < "$COMPOSED_PROMPT_PATH") bytes)"
+        PROMPT_CONTENT="$(cat "$COMPOSED_PROMPT_PATH")"
+
+        # 3) Build claude_args. Allowed tools, model, and (when toggled)
+        # the verbose flag all go through the CLI via claude_args; the
+        # action exposes none as direct inputs.
+        #
+        # NOTE: --json-schema is intentionally NOT used. The
+        # claude-code-action structured_output path buffers Claude's
+        # output entirely (no live streaming for ~5-15min) regardless of
+        # version. We instead instruct the agent in the prompt to write
+        # its JSON response to `stage-output.json` via the Write tool,
+        # and the verify step below just confirms the file exists. The
+        # renderer (render-stage-comment.py) performs the same shape
+        # validation that --json-schema would have given us.
+        ARGS="--max-turns ${MAX_TURNS}"
+        if [ "${SHOW_FULL_OUTPUT}" = "true" ]; then
+          # `--verbose` streams tool-use events with full detail. Costs
+          # log volume; useful when an agent is misbehaving. Gated by
+          # show_full_output so production runs stay quieter.
+          ARGS="${ARGS} --verbose"
+        fi
+        if [ -n "${MODEL}" ]; then
+          # In DIAL mode (SDLC_DIAL_MODE=1, set by run-agent's inference-route
+          # step) route the model through DIAL's Anthropic-compatible deployment
+          # as `dial,anthropic.<model>`. Manifests stay provider-agnostic
+          # (model: claude-sonnet-4-6); the platform adds the routing.
+          if [ "${SDLC_DIAL_MODE:-}" = "1" ]; then
+            # Route to the DIAL deployment: prefer the explicit DIAL_MODEL id
+            # (set by run-agent from vars.DIAL_MODEL — DIAL deployment names
+            # rarely match Anthropic model strings), else assume an
+            # `anthropic.<model>` deployment exists.
+            ARGS="${ARGS} --model dial,${SDLC_DIAL_MODEL:-anthropic.${MODEL}}"
+          else
+            ARGS="${ARGS} --model ${MODEL}"
+          fi
+        fi
+        # Append `Write` to allowed_tools so the agent can produce
+        # stage-output.json. Every agent needs this — structural, not
+        # agent-specific, so we don't burden manifests with it.
+        ARGS="${ARGS} --allowed-tools '${ALLOWED_TOOLS},Write'"
+
+        echo "claude_args=${ARGS}" >> "$GITHUB_OUTPUT"
+        {
+          echo "prompt<<PROMPT_EOF"
+          echo "$PROMPT_CONTENT"
+          echo "PROMPT_EOF"
+        } >> "$GITHUB_OUTPUT"
+
+    - name: Pre-flight state dump
+      # Diagnostic only — dumps cwd, env, skill discovery paths, composed
+      # prompt, and the agent-facing schema before invoking Claude. Off by
+      # default in production; toggle via `show_full_output: 'true'` to
+      # debug a misbehaving agent.
+      if: inputs.show_full_output == 'true'
+      shell: bash
+      env:
+        SCHEMA_PATH: ${{ runner.temp }}/agent-schema.json
+        COMPOSED_PROMPT_PATH: ${{ runner.temp }}/composed-prompt.md
+        STAGE_NAME: ${{ inputs.stage_name }}
+        SKILL: ${{ inputs.skill }}
+        ALLOWED_TOOLS: ${{ inputs.allowed_tools }}
+      run: |
+        set -euo pipefail
+        echo "::group::stage + cwd + tree state"
+        echo "stage_name=$STAGE_NAME"
+        echo "skill=$SKILL"
+        echo "allowed_tools=$ALLOWED_TOOLS"
+        echo "cwd=$(pwd)"
+        echo "ANTHROPIC_API_KEY set? $([ -n "${ANTHROPIC_API_KEY:-}" ] && echo yes || echo NO)"
+        echo "--- .claude/ in cwd ---"
+        ls -la .claude/ 2>/dev/null || echo "(missing)"
+        echo "--- .claude/skills/ ---"
+        ls -la .claude/skills/ 2>/dev/null || echo "(missing)"
+        echo "--- .claude/commands/opsx/ ---"
+        ls -la .claude/commands/opsx/ 2>/dev/null || echo "(missing)"
+        echo "--- target skill SKILL.md ---"
+        ls -la ".claude/skills/${SKILL}/SKILL.md" 2>/dev/null || echo "(missing — Claude will not find /$SKILL)"
+        echo "::endgroup::"
+        echo "::group::composed prompt (full)"
+        cat "$COMPOSED_PROMPT_PATH"
+        echo "::endgroup::"
+        echo "::group::agent-facing schema"
+        cat "$SCHEMA_PATH"
+        echo "::endgroup::"
+
+    - name: Run Claude
+      id: claude
+      uses: anthropics/claude-code-action@11ba60486e4aec9ddfeafcf4bb3f00b028ac2c16 # v1.0.142
+      with:
+        anthropic_api_key: ${{ env.ANTHROPIC_API_KEY }}
+        # Pass the runner's GITHUB_TOKEN directly so the action skips its
+        # OIDC → Claude-App-token exchange. We do not install the Claude
+        # Code GitHub App on this repo; we render our own sticky comments
+        # in a later step (see "Post sticky PR comment" below) using the
+        # same token via `gh api`.
+        github_token: ${{ github.token }}
+        # When the caller sets `show_full_output: "true"` we surface Claude's
+        # prompts and tool calls in the GHA log. The action's default hides
+        # them for security; visibility is essential on the sandbox base
+        # while wiring is shaken out.
+        show_full_output: ${{ inputs.show_full_output }}
+        prompt: ${{ steps.prep.outputs.prompt }}
+        claude_args: ${{ steps.prep.outputs.claude_args }}
+
+    - name: Persist input prompt (audit)
+      # Baseline audit (ADR-0005): persist INPUT alongside output, so a run can
+      # be reconstructed from "what was sent" + "what came back". Captures the
+      # composed prompt + agent-facing schema. `always()` so a failed/garbled
+      # agent run is still auditable. Encrypted for private_output agents to
+      # match the output artifact (public repo → world-downloadable artifacts);
+      # the prompt is wrapper boilerplate + skill/upstream names today, but
+      # encrypting keeps the "private agent ⇒ ciphertext" invariant if the
+      # composition ever starts inlining sensitive context.
+      # Guard inside bash, not via hashFiles(): hashFiles only globs under
+      # GITHUB_WORKSPACE, and the prompt lives in runner.temp.
+      if: always()
+      shell: bash
+      env:
+        PRIVATE_OUTPUT: ${{ inputs.private_output }}
+        RUNNER_TEMP: ${{ runner.temp }}
+      run: |
+        set -euo pipefail
+        if [ ! -f "${RUNNER_TEMP}/composed-prompt.md" ]; then
+          echo "::notice::no composed prompt to persist (prep did not complete)"
+          exit 0
+        fi
+        AUDIT_DIR="${RUNNER_TEMP}/stage-input"
+        mkdir -p "$AUDIT_DIR"
+        cp "${RUNNER_TEMP}/composed-prompt.md" "$AUDIT_DIR/composed-prompt.md"
+        [ -f "${RUNNER_TEMP}/agent-schema.json" ] && cp "${RUNNER_TEMP}/agent-schema.json" "$AUDIT_DIR/agent-schema.json" || true
+        if [ "${PRIVATE_OUTPUT}" = "true" ]; then
+          if [ -z "${SDLC_ARTIFACT_KEY:-}" ]; then
+            echo "::error::private_output is true but SDLC_ARTIFACT_KEY is not in env — cannot encrypt the audit input. Add it to the agent manifest \`secrets:\` and repo/org Actions secrets."
+            exit 1
+          fi
+          for f in "$AUDIT_DIR"/*; do
+            openssl enc -aes-256-cbc -pbkdf2 -salt -in "$f" -out "$f.enc" -pass env:SDLC_ARTIFACT_KEY
+            rm -f "$f"
+          done
+          echo "Persisted encrypted audit input (private agent)."
+        else
+          echo "Persisted audit input (plaintext)."
+        fi
+
+    - name: Upload input prompt artifact
+      # if-no-files-found: ignore — the dir is absent when prep didn't complete
+      # (the persist step above exits early); no audit input to upload then.
+      if: always()
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      with:
+        name: stage-input-${{ inputs.stage_name }}
+        path: ${{ runner.temp }}/stage-input/
+        retention-days: 90
+        if-no-files-found: ignore
+
+    - name: Verify stage-output.json
+      shell: bash
+      run: |
+        set -euo pipefail
+        if [ ! -f stage-output.json ]; then
+          echo "::error::Claude did not write stage-output.json. The agent must use the Write tool to create the file at the repo root with its final JSON response. Check the Run Claude step's log for what happened."
+          exit 1
+        fi
+        echo "stage-output.json present ($(wc -c < stage-output.json) bytes)"
+        # Do NOT cat the file: this repo is PUBLIC and run logs are world-
+        # readable, so dumping the findings here would leak internal security
+        # data. The renderer validates shape in the next step; the artifact
+        # carries the full content for the (private, in-run) chain handoff.
+
+    - name: Validate and render sticky comment
+      id: extract
+      shell: bash
+      env:
+        STAGE_NAME: ${{ inputs.stage_name }}
+        AGENT_VERSION: ${{ inputs.agent_version }}
+      run: python3 ./.github/claude/scripts/render-stage-comment.py
+
+    - name: Scrub output (M4 — secret scan + URL/HTML neutralize)
+      # ADR-0005 M4: deterministic, LLM-free, fail-closed gate on the rendered
+      # PUBLIC body before any posting step. Fails the stage on a secret hit
+      # (stops "Comment and Control") and neutralizes outbound-exfil vectors
+      # (zero-click images, non-allowlisted links, dangerous HTML). The posting
+      # steps below consume `steps.scrub.outputs.comment` — the scrubbed body —
+      # never the raw render. Only runs for public (non-private_output) agents;
+      # private agents publish counts-only aggregates, not this body.
+      id: scrub
+      if: inputs.private_output != 'true' && steps.extract.outputs.comment != ''
+      shell: bash
+      env:
+        BODY: ${{ steps.extract.outputs.comment }}
+        GITHUB_SERVER_URL: ${{ github.server_url }}
+      run: python3 ./.github/claude/scripts/scrub-output.py
+
+    - name: Emit SARIF to code scanning
+      # Convert payload.findings[] -> SARIF and upload to the Security tab (a
+      # write-access-gated surface, unlike public PR comments/summaries). Runs
+      # on the local plaintext, BEFORE the encrypt step removes it. Scoped to
+      # the scanned branch/commit (ANALYSIS_*) when analysis_ref is set, so
+      # alerts render against real code; falls back to the current ref/sha.
+      if: inputs.emit_sarif == 'true' && hashFiles('stage-output.json') != ''
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+        REPO: ${{ github.repository }}
+      run: |
+        set -euo pipefail
+        python3 ./.github/claude/scripts/findings-to-sarif.py stage-output.json triage.sarif
+        SARIF_REF="${ANALYSIS_REF_FULL:-$GITHUB_REF}"
+        SARIF_SHA="${ANALYSIS_SHA:-$GITHUB_SHA}"
+        B64="$(gzip -c triage.sarif | base64 -w0)"
+        echo "Uploading SARIF for ${SARIF_REF}@${SARIF_SHA:0:7}"
+        gh api -X POST "repos/${REPO}/code-scanning/sarifs" \
+          -f commit_sha="${SARIF_SHA}" \
+          -f ref="${SARIF_REF}" \
+          -f sarif="${B64}" \
+          && echo "SARIF accepted by code scanning." \
+          || { echo "::warning::SARIF upload failed (code scanning may be disabled, or ref/sha not accepted). Triage still succeeded."; }
+
+    - name: Publish aggregate report (sensitive agents)
+      # private_output (sensitive) agents publish ONLY aggregate counts — no file
+      # paths, per-finding verdicts, or any detail — to the Actions run's job
+      # summary (the pipeline view), NOT a PR comment: these are batch/scheduled
+      # agents over a standing backlog, not PR reviewers. Counts are safe on a
+      # public repo. Runs on the local plaintext, BEFORE the encrypt step removes it.
+      if: inputs.private_output == 'true' && hashFiles('stage-output.json') != ''
+      shell: bash
+      run: |
+        set -euo pipefail
+        python3 ./.github/claude/scripts/findings-aggregate.py stage-output.json >> "$GITHUB_STEP_SUMMARY"
+        echo "Published aggregate counts to the job summary."
+
+    - name: Encrypt stage output (private agents)
+      # Runs AFTER the renderer (and any SARIF emitter) have consumed the local
+      # plaintext. Encrypts stage-output.json -> stage-output.json.enc and
+      # removes the plaintext, so only ciphertext is uploaded as an artifact —
+      # required on a PUBLIC repo, where artifacts are world-downloadable. The
+      # key (SDLC_ARTIFACT_KEY) is injected by run-agent from the manifest's
+      # declared secrets; the downstream agent's run-agent decrypts it.
+      if: inputs.private_output == 'true' && hashFiles('stage-output.json') != ''
+      shell: bash
+      run: |
+        set -euo pipefail
+        if [ -z "${SDLC_ARTIFACT_KEY:-}" ]; then
+          echo "::error::private_output is true but SDLC_ARTIFACT_KEY is not in env. Add it to the agent's manifest \`secrets:\` list and the repo/org Actions secrets."
+          exit 1
+        fi
+        openssl enc -aes-256-cbc -pbkdf2 -salt \
+          -in stage-output.json -out stage-output.json.enc -pass env:SDLC_ARTIFACT_KEY
+        rm -f stage-output.json
+        echo "Encrypted stage-output.json -> stage-output.json.enc (plaintext removed)"
+
+    - name: Upload stage output artifact
+      # Uploads whichever exists: stage-output.json (public agents) or
+      # stage-output.json.enc (private_output agents). The artifact name is the
+      # same either way; the downstream decrypt step handles the .enc variant.
+      if: always() && (hashFiles('stage-output.json') != '' || hashFiles('stage-output.json.enc') != '')
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      with:
+        name: stage-output-${{ inputs.stage_name }}
+        path: |
+          stage-output.json
+          stage-output.json.enc
+        retention-days: 90
+        if-no-files-found: warn
+
+    - name: Publish to job summary
+      # FULL detail — only for NON-sensitive agents (private_output != true).
+      # Sensitive agents use the aggregate (counts-only) step above instead,
+      # because this repo is public and the job summary is world-readable.
+      if: inputs.private_output != 'true' && steps.scrub.outputs.comment != ''
+      shell: bash
+      env:
+        STAGE_NAME: ${{ inputs.stage_name }}
+        BODY: ${{ steps.scrub.outputs.comment }}
+      run: |
+        {
+          echo "## ${STAGE_NAME}"
+          echo ""
+          echo "${BODY}"
+        } >> "$GITHUB_STEP_SUMMARY"
+
+    - name: Post sticky PR comment
+      # FULL detail — only for NON-sensitive agents (private_output != true).
+      # Sensitive agents post the aggregate (counts-only) sticky comment above.
+      if: github.event_name == 'pull_request' && inputs.private_output != 'true' && steps.scrub.outputs.comment != ''
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+        REPO: ${{ github.repository }}
+        STAGE_NAME: ${{ inputs.stage_name }}
+        BODY: ${{ steps.scrub.outputs.comment }}
+      run: |
+        set -euo pipefail
+        MARKER="<!-- dial-sdlc:${STAGE_NAME} -->"
+        EXISTING_ID="$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
+          | jq -r --arg m "$MARKER" '.[] | select(.body | startswith($m)) | .id' \
+          | head -n1)"
+        if [ -n "$EXISTING_ID" ]; then
+          gh api -X PATCH "repos/${REPO}/issues/comments/${EXISTING_ID}" -f body="$BODY" > /dev/null
+          echo "Updated sticky comment $EXISTING_ID"
+        else
+          gh api -X POST "repos/${REPO}/issues/${PR_NUMBER}/comments" -f body="$BODY" > /dev/null
+          echo "Created sticky comment for stage ${STAGE_NAME}"
+        fi
+
+    - name: Enforce stage gate (fail job on status=failed)
+      # The job-failing gate is DELIBERATELY the LAST step. The renderer used to
+      # exit 1 on a well-formed status=failed, but that ran in the same step that
+      # produced the comment body — so every step after it (scrub, job summary,
+      # PR comment, aggregate, artifact upload) was skipped and the blocking
+      # findings never reached the PR. Now the renderer stays exit-0 on a valid
+      # failed result, all surfacing steps run, and THEN we fail the job here.
+      # `always()` so a failed status still gates even if an earlier surfacing
+      # step was skipped (e.g. private agents post no PR comment). Genuine render
+      # errors (bad JSON / invalid fields) already failed the extract step and
+      # the job; this only adds the gate for the valid-but-failed case.
+      if: always() && steps.extract.outputs.status == 'failed'
+      shell: bash
+      env:
+        STAGE_NAME: ${{ inputs.stage_name }}
+      run: |
+        echo "::error::Stage ${STAGE_NAME} reported status=failed — blocking findings surfaced in the PR comment / job summary above."
+        exit 1

--- a/.github/claude/ADDING_AN_AGENT.md
+++ b/.github/claude/ADDING_AN_AGENT.md
@@ -1,0 +1,106 @@
+# Adding an Agent to the DIAL SDLC Pipeline
+
+The runtime is **manifest-driven** and **skill-only**: an agent is a
+manifest that points to a local Claude skill. The platform handles the
+rest — GHA wiring, permissions, prompt composition, output validation,
+sticky comments, and artifacts.
+
+This page is the **quickstart**. For exhaustive field-by-field detail,
+chaining rules, output contract, and skill-authoring guidance, see
+[`AGENT_REFERENCE.md`](./AGENT_REFERENCE.md). For platform-maintainer
+concerns (framework relationship, doc-update triggers, supported
+permissions), see [`PLATFORM_REFERENCE.md`](./PLATFORM_REFERENCE.md).
+
+---
+
+## Where things live
+
+```
+agents/<name>/agent.yml         your manifest
+.claude/skills/<skill>/SKILL.md the skill it wraps
+```
+
+That's the entire surface you touch. Everything else under `.github/` is
+platform code — don't edit per-agent.
+
+---
+
+## The recipe — one step
+
+1. **Make sure the skill exists.** If you're wrapping a published Claude
+   skill, install it under `.claude/skills/<skill>/SKILL.md`. If your task
+   needs custom orchestration (CLI calls, multi-step logic), put it
+   *inside* the skill — never in the agent. See
+   [`AGENT_REFERENCE.md`](./AGENT_REFERENCE.md) → *Writing a skill for an
+   agent* for skill structure and the "I have a prompt not a skill"
+   conversion path.
+
+2. **Copy the template manifest and edit four fields:**
+
+   ```bash
+   cp -r agents/_template agents/my-agent
+   ```
+
+   In `agents/my-agent/agent.yml`:
+
+   - `name:` → `my-agent` (kebab-case)
+   - `skill:` → the local skill the agent wraps (e.g. `my-skill`,
+     `opsx:verify`, `code-review-and-quality`)
+   - `allowed_tools:` → the smallest set the skill needs, plus `Skill`
+   - Optional: `agent_version`, `description`, `model`, `phase`,
+     `cost_class`
+
+Commit. The next PR runs the agent automatically — no workflow YAML to
+edit, no dispatcher changes, no prompt to write.
+
+---
+
+## Minimal manifest
+
+```yaml
+contract_version: "0.1"
+name: my-agent
+skill: my-skill
+triggers: [pull_request]
+allowed_tools: "Read,Grep,Glob,Skill"
+```
+
+Five fields. That's the entire required surface.
+
+---
+
+## PR agents vs batch/scheduled agents
+
+The minimal manifest above is a **PR agent** — it runs on `pull_request` and
+posts a sticky comment. Agents can also run on a schedule or manual dispatch
+(triage a standing backlog, nightly audits) by declaring
+`triggers: [pull_request, schedule, workflow_dispatch]`, and can keep their
+output private (encrypted artifact + counts-only job summary) with
+`private_output: true`. See
+[`../../docs/sdlc/scheduled-batch-agents.md`](../../docs/sdlc/scheduled-batch-agents.md)
+for the as-built batch pattern and
+[`AGENT_REFERENCE.md`](./AGENT_REFERENCE.md) for `secrets`, `analysis_ref`,
+`private_output`, and `emit_sarif`.
+
+---
+
+## Disabling a live agent
+
+Set the kill-switch variable `STAGE_<NAME_UPPER>_ENABLED=false` in
+**Settings → Variables → Actions** — e.g., `STAGE_MY_AGENT_ENABLED=false`.
+The matcher omits the agent at discovery; no runner time spent. Delete
+the variable to re-enable. Details and conventions in
+[`AGENT_REFERENCE.md`](./AGENT_REFERENCE.md) → *Kill switch*.
+
+---
+
+## When to read what
+
+| You want to… | Open |
+|---|---|
+| Add an agent right now | This doc (you're here) |
+| Look up a manifest field, tool tier, or output convention | [`AGENT_REFERENCE.md`](./AGENT_REFERENCE.md) |
+| Make your agent depend on another agent's output | [`AGENT_REFERENCE.md`](./AGENT_REFERENCE.md) → *Chaining* |
+| Write a skill from scratch or adopt an external one | [`AGENT_REFERENCE.md`](./AGENT_REFERENCE.md) → *Writing a skill for an agent* |
+| Understand framework relationship, supported permissions, cross-run state | [`PLATFORM_REFERENCE.md`](./PLATFORM_REFERENCE.md) |
+| Change platform code (new trigger, new permission tier, output schema, etc.) | [`PLATFORM_REFERENCE.md`](./PLATFORM_REFERENCE.md) → *What requires a doc update* |

--- a/.github/claude/AGENT_REFERENCE.md
+++ b/.github/claude/AGENT_REFERENCE.md
@@ -1,0 +1,450 @@
+# Agent Reference
+
+Exhaustive lookup material for agent authors. The quickstart is
+[`ADDING_AN_AGENT.md`](./ADDING_AN_AGENT.md). Platform-maintainer concerns
+live in [`PLATFORM_REFERENCE.md`](./PLATFORM_REFERENCE.md).
+
+---
+
+## File layout
+
+```
+agents/
+├── _template/                          # copy this for new agents
+│   └── agent.yml                       # manifest only — no per-agent prompt.md
+├── snyk-jira-ingest/                   # worked example: batch producer (secrets)
+│   └── agent.yml
+└── snyk-triage/                        # worked example: batch chain + analysis_ref + private_output
+    └── agent.yml
+# (agents/_*/ are disabled pilots — underscore prefix; the matcher skips them.)
+
+.claude/
+├── skills/<skill>/SKILL.md             # reusable agent logic lives here
+└── commands/<group>/<skill>.md         # slash-command-style skills (e.g. opsx:verify)
+
+.github/
+├── actions/
+│   ├── run-claude-stage/action.yml     # composite action; do not edit per-agent
+│   └── pr-trust-gate/action.yml        # round-0 trust gate (ADR-0005); do not edit per-agent
+├── claude/
+│   ├── ADDING_AN_AGENT.md              # quickstart
+│   ├── AGENT_REFERENCE.md              # this doc
+│   ├── PLATFORM_REFERENCE.md           # platform-maintainer reference
+│   ├── prompts/agent-wrapper.md        # universal prompt template (intro + inputs + constraints + task + output)
+│   ├── schemas/agent-manifest.schema.json
+│   ├── schemas/stage-message.schema.json
+│   └── scripts/{render-stage-comment.py, match-agents.py, scrub-output.py, findings-to-sarif.py, findings-aggregate.py}
+└── workflows/
+    ├── dispatch-core.yml               # shared dispatch pipeline; do not edit per-agent
+    ├── dispatch-pr.yml                 # pull_request entry point
+    ├── dispatch-schedule.yml           # schedule + workflow_dispatch entry point
+    ├── run-agent.yml                   # reusable per-agent runner; do not edit per-agent
+    └── stage-security-review.yml       # specialized self-triggered exception
+```
+
+## Two agent shapes
+
+- **Manifest + skill agent** — the common case (and the only path supported
+  by `agents/`). Declare `agent.yml`, point `skill:` at a local skill,
+  commit. The dispatcher picks it up automatically.
+- **Specialized self-triggered workflow** — for purpose-built actions
+  (Trivy, Semgrep, `claude-code-security-review`, etc.) that don't fit the
+  composite action's generic shape. Each gets its own
+  `.github/workflows/stage-<name>.yml`. `stage-security-review.yml` is the
+  reference. Documented exception; don't reach for it unless you have a
+  specific third-party action to wrap.
+
+---
+
+## How the prompt is composed
+
+You never write a prompt. The composite action loads a universal template
+at [`prompts/agent-wrapper.md`](./prompts/agent-wrapper.md) and substitutes
+four placeholders, all derived from your manifest / the run context:
+
+- `{{stage}}` — your agent name.
+- `{{skill}}` — the skill it wraps.
+- `{{base_ref}}` — the PR base branch, expanded at compose time (the Bash
+  tool rejects shell expansion, so the diff command can't use `$GITHUB_BASE_REF`).
+- `{{upstream_inputs}}` — per-agent lines for each `needs:` artifact, or a
+  "runs independently" note.
+
+Identical shape for every agent — `## Inputs`, a `## Tool constraints`
+section (the Bash allowlist denies un-listed commands, shell expansion,
+pipes, redirects), a `## Turn budget` directive (write `stage-output.json`
+before the limit — a partial result beats no file), `## Task` (invoke
+`/{{skill}}`; the **wrapper owns input/output plumbing**, the skill owns
+methodology), and `## Output` (write JSON via the `Write` tool; the platform
+injects the envelope and posts — never the agent).
+
+Authors cannot drift the inputs framing, the output contract, or the
+envelope discipline by editing prompts, because there are no per-agent
+prompts to edit. To change the wording everyone sees, edit the template
+file directly — one place, one diff.
+
+---
+
+## What the manifest declares
+
+```yaml
+contract_version: "0.1"
+name: code-review
+skill: code-review-and-quality
+agent_version: "0.1.0"
+description: "AI code review wrapping the local /code-review-and-quality skill."
+triggers: [pull_request]
+allowed_tools: "Read,Grep,Glob,Bash(git diff:*),Skill"
+model: claude-sonnet-4-6
+phase: pilot
+cost_class: light
+```
+
+| Field | Required? | What |
+|---|---|---|
+| `contract_version` | Yes | Pin the manifest schema version. Currently `"0.1"` |
+| `name` | Yes | Kebab-case. Surfaces in PR comments and the kill-switch var |
+| `skill` | Yes | The local skill the agent wraps. Must be addressable as `/<skill>` |
+| `triggers` | Yes | List of events: `pull_request`, `schedule`, `workflow_dispatch`. A batch agent declares `[pull_request, schedule, workflow_dispatch]`. Filters apply to PR events only |
+| `allowed_tools` | Yes | Comma-separated Claude tool allowlist (see tiers below) |
+| `agent_version` | No | Recorded in the output envelope; defaults to `"unknown"` |
+| `description` | No | One-line description for the catalog |
+| `model` | No | Claude model (e.g. `claude-sonnet-4-6`); empty uses action default |
+| `phase` | No | `sandbox` / `pilot` / `production` |
+| `cost_class` | No | `light` (<$0.50/run) / `medium` / `heavy` |
+| `needs` | No | List of upstream agent names. Platform downloads their `stage-output.json` into `upstream/{name}/` before this agent runs. See *Chaining* below |
+| `timeout_minutes` | No | Per-agent timeout (default 15, max 360). Honored by `run-agent.yml` |
+| `permissions` | No | GHA permissions the runner needs (e.g. `checks: write`). Validated against the platform-supported set; manifest rejected at discovery if it exceeds. See [`PLATFORM_REFERENCE.md`](./PLATFORM_REFERENCE.md) → *Supported permissions* |
+| `concurrency` | No | `{group, cancel_in_progress}` override. Default group: `dispatch-pr-<name>-<ref>` |
+| `triggers[].filters` | No | `{branches, labels}` filtering of triggers. `branches` matches PR target; `labels` requires all listed labels present. `paths` is reserved for v0.3 |
+| `kill_switch_var` | No | Override the derived var name (rarely needed) |
+| `tools.extra` | No | CLI tools to install on the runner before the agent runs. Items can be a string (npm package name) or `{name, install}` for non-npm tools. See *CLI dependencies* below |
+| `max_turns` | No | Max Claude turns (default 18, max 60). Honored by the composite action |
+| `secrets` | No | Secret names to inject into the agent's job env. `run-agent.yml` promotes **only** these from the inherited bag and fails loudly if any is absent. The model never types them — committed helper scripts read them from env. See *Secrets* below |
+| `vars` | No | Non-secret config names injected from GitHub Actions Variables — tune knobs (e.g. `JIRA_MAX_FINDINGS`) without editing the skill |
+| `analysis_ref` | No | Git ref whose source the platform overlays before the agent runs, so it inspects *that* branch's code (e.g. the branch a scanner ran on) instead of the checkout. Framework paths (`.github`/`.claude`/`agents`) are preserved. See [`PLATFORM_REFERENCE.md`](./PLATFORM_REFERENCE.md) → *Analysis-ref overlay* |
+| `private_output` | No | `true` → the agent's `stage-output.json` (and audit input) are AES-encrypted (`SDLC_ARTIFACT_KEY`) before upload, and the public surface is **counts-only** to the job summary, not a sticky comment. For sensitive/batch agents on a public repo |
+| `emit_sarif` | No | `true` → convert `payload.findings[]` to SARIF and upload to the Security tab, scoped to `analysis_ref`'s commit |
+| `context_tier` | No | `A` (triggering repo only, default). `B`/`C` reserved; not yet wired |
+
+Manifests are validated against [`schemas/agent-manifest.schema.json`](./schemas/agent-manifest.schema.json) at every dispatch. Schema violations fail the discover job with a clear path to the offending field — no broken agent reaches the matrix. Per-agent `prompt.md` files are rejected (the runner fails loudly if it finds one).
+
+### CLI dependencies (`tools.extra`)
+
+If your skill shells out to a CLI that the GitHub runner doesn't ship
+by default (e.g., `openspec`, `trivy`, `prettier`), declare it in the
+manifest. Three shapes, in order of complexity:
+
+```yaml
+tools:
+  extra:
+    # 1. String — npm package, latest stable.
+    #    Quote scoped packages (YAML treats leading `@` as special).
+    - "@fission-ai/openspec"
+
+    # 2. Object with version — npm package, pinned to a specific version.
+    #    Equivalent to: npm install -g @fission-ai/openspec@1.3.1
+    - name: "@fission-ai/openspec"
+      version: "1.3.1"
+
+    # 3. Object with install — arbitrary shell command (non-npm tools).
+    #    `{{version}}` placeholder in `install` is substituted from
+    #    the sibling `version` field (or empty string if omitted).
+    - name: trivy
+      version: "0.69.0"
+      install: "curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin v{{version}}"
+```
+
+The runner iterates `tools.extra` before invoking the agent:
+
+- **String** or **`{name, version?}`** → `npm install -g <name>[@<version>]`
+- **`{name, version?, install}`** → shell-execute `install` after
+  substituting `{{version}}` with the sibling `version` value
+
+Failure exits early — Claude isn't invoked if any dependency fails to
+install (loud, not silent). Agents without `tools.extra` pay zero
+install cost; the step is conditional on the array being non-empty.
+
+After install, the binary the tool ships is on `$PATH` and any
+`Bash(<binary>:*)` tool call the agent makes will work.
+
+**Version pinning is recommended for reproducibility.** Bare strings
+and `{name}` without `version` resolve to the latest stable, which
+can silently change between runs. Pin the version unless you have a
+specific reason to track latest.
+
+Worked examples (currently disabled pilots — underscore-prefixed dirs):
+
+- `agents/_spec-validation/agent.yml` — short form
+  (`"@fission-ai/openspec"`, latest)
+- `agents/_scan-deps/agent.yml` — long form with version pin
+  (Trivy `v0.69.0` via the official curl-based installer)
+
+### Secrets (`secrets:`)
+
+If your skill's committed helper scripts need a credential (e.g. a Jira PAT),
+declare the env-var name in `secrets:` and add the matching value under
+**Settings → Secrets → Actions**. `run-agent.yml` promotes **only** the
+declared names from the inherited secret bag into the job env (failing loudly
+if any is absent) — adding a secret-using agent needs no platform edit.
+
+The model **never types the secret**: the agent-wrapper forbids shell
+expansion in Bash tool calls, so secrets are referenced only inside committed
+scripts that read them from env. Keep the agent's `allowed_tools` scoped to the
+exact committed script (e.g. `Bash(bash .claude/skills/<skill>/fetch.sh:*)`),
+not a general `Bash`.
+
+`SDLC_ARTIFACT_KEY` is the conventional key for `private_output` agents
+(encrypts the output + audit artifacts). Worked example:
+`agents/snyk-jira-ingest/agent.yml` (`secrets: [JIRA_PAT]`).
+
+### Tool tiers
+
+| Tier | `allowed_tools` value |
+|---|---|
+| read-only + skill | `Read,Grep,Glob,Skill,mcp__dial-context__*` |
+| read-only + git diff + skill | `Read,Grep,Glob,Bash(git diff:*),Skill` |
+| above + extra CLI (e.g. `openspec`) | `Read,Grep,Glob,Bash(git diff:*),Bash(openspec:*),Skill` |
+
+`Skill` is always required (every agent invokes a skill). Tools should be
+the smallest set the *skill* needs — review the skill's `Required tools`
+section, mirror it here.
+
+Write-permission tiers are not exposed today — `run-agent.yml` hardcodes
+`contents: read` for safety. When a write-needing agent appears, it gets a
+sibling reusable workflow with the appropriate scopes. See
+[`PLATFORM_REFERENCE.md`](./PLATFORM_REFERENCE.md).
+
+---
+
+## Writing a skill for an agent
+
+Skills are markdown files at `.claude/skills/<skill>/SKILL.md` with YAML
+frontmatter. They are reusable, callable interactively (`/skill`), and
+versioned as a unit. **Custom agent logic belongs here — never inlined
+in the agent layer.**
+
+Minimum SKILL.md:
+
+```markdown
+---
+name: my-skill
+description: One line describing what the skill does and when to use it.
+---
+
+# My Skill
+
+## Overview
+What this skill accomplishes.
+
+## When to use
+Concrete situations where this skill is the right tool.
+
+## Process
+The steps the model should follow.
+
+## Output
+If invoked from an SDLC agent: map output to `payload.findings[]` (for
+reviewer-shaped output) or `payload.comment_markdown` (for everything
+else). If invoked interactively: return a markdown report.
+
+## Required tools
+List of tools the skill expects (e.g. `Read`, `Grep`, `Bash(git diff:*)`,
+`Skill`). The agent author copies this into `allowed_tools:`.
+```
+
+See `.claude/skills/code-review-and-quality/SKILL.md` and
+`.claude/skills/spec-validation/SKILL.md` for worked examples — including
+one (`spec-validation`) that does real orchestration (CLI floor +
+`/opsx:verify` per change + drift check).
+
+### Adopting a third-party skill
+
+1. Review the upstream `SKILL.md` and any bundled scripts.
+2. Copy it into `.claude/skills/<skill>/SKILL.md`.
+3. Note any extra tools it needs and grant them in your agent manifest's
+   `allowed_tools`.
+4. Treat bundled MCP servers as external dependencies and review them too.
+
+### What if I have a prompt, not a skill?
+
+Convert it. A "prompt from the internet" is one frontmatter line away from
+being a skill: save the body as `SKILL.md`, add `name:` + `description:`
+frontmatter, strip any output-format instructions (replaced by the
+platform's schema), and reference it from your agent. **Do not** paste it
+into a `prompt.md` — the runner rejects per-agent prompt files.
+
+---
+
+## Kill switch
+
+Disable an agent without merging a PR by setting a repo or org variable to
+`"false"` in **Settings → Variables → Actions**. The variable name is
+derived from `name:`:
+
+| Manifest `name` | Variable name |
+|---|---|
+| `snyk-triage` | `STAGE_SNYK_TRIAGE_ENABLED` |
+| `snyk-jira-ingest` | `STAGE_SNYK_JIRA_INGEST_ENABLED` |
+
+(Uppercase, hyphens → underscores, prefix `STAGE_`, suffix `_ENABLED`.)
+
+When set to `"false"`, the matcher omits the agent at discovery — no runner
+time is spent. To re-enable, delete or change the variable.
+
+---
+
+## Chaining (depending on another agent)
+
+If your agent needs another agent's output as input, declare it in the
+manifest:
+
+```yaml
+# agents/snyk-triage/agent.yml (abridged)
+contract_version: "0.1"
+name: snyk-triage
+skill: snyk-triage
+triggers: [pull_request, schedule, workflow_dispatch]
+allowed_tools: "Read,Grep,Glob,Bash(git diff:*),Bash(python3:*),Skill"
+needs: [snyk-jira-ingest]       # ← the only chaining-specific line
+```
+
+The platform handles the rest:
+
+- The matcher topologically sorts agents into rounds. Upstream agents go
+  in earlier rounds; downstream agents wait until upstream completes.
+- Before your agent runs, the platform downloads each upstream's
+  `stage-output-{name}` artifact into `upstream/{name}/stage-output.json`.
+- Your skill reads those files like any other input.
+
+### Rules and limits
+
+- **At most 3 rounds** of chaining (the dispatcher caps it).
+- **Upstream killed → downstream skipped.** If `STAGE_SNYK_JIRA_INGEST_ENABLED`
+  is `"false"`, the matcher drops `snyk-triage` too (with a warning).
+- **Cycles fail loudly.** If A needs B and B needs A, the dispatcher
+  aborts at discovery with `::error::Cycle detected in agent needs:`.
+- **Same-run only.** The downloaded artifacts are from *this* dispatcher
+  run, not historical.
+- **Upstream must be in the matched set.** Agent in `needs:` must match
+  the same trigger (e.g., both `pull_request`) and not be filtered out.
+
+---
+
+## Output contract — what the skill must produce
+
+You don't write the output contract into your skill — the platform appends
+it to the composed prompt automatically. What the contract says:
+
+At the end of the run, the agent uses the **`Write` tool** to save a JSON
+object to `stage-output.json` at the repo root. The renderer reads that
+file, validates required fields, injects envelope fields
+(`contract_version`, `agent_version`, `run_id`, `trigger`), and surfaces the
+result. The schema lives at
+[`schemas/stage-message.schema.json`](./schemas/stage-message.schema.json).
+
+**You write the same JSON regardless of how it's surfaced** — the platform
+decides the destination from your manifest:
+
+- **Default (public agent):** the rendered body passes through the M4
+  post-processor (secret scan → fail-closed; URL/HTML neutralize), then posts
+  as a sticky PR comment + full job summary. The plaintext artifact uploads.
+- **`private_output: true`:** only **counts** go to the job summary; the full
+  `stage-output.json` is encrypted and uploaded. No sticky comment. Use this
+  for sensitive/batch agents on a public repo.
+
+Either way, the composed prompt + schema are persisted as `stage-input-<name>`
+for audit (encrypted for private agents). You don't write or trigger any of
+this — just produce valid `stage-output.json`.
+
+`Write` is appended to `allowed_tools` automatically by the platform —
+your manifest doesn't need to declare it.
+
+Failure mode: if the agent doesn't write `stage-output.json`, the
+"Verify stage-output.json" step fails loudly. If the file exists but
+fields are missing or malformed, the renderer fails with a clear error.
+Either way the job fails — no partial output reaches downstream.
+
+> **Aside on `--json-schema`** — the platform used to pass the schema
+> to Claude via `--json-schema=<path>` in `claude_args` for
+> constitutional output enforcement. Empirically (across 9 smoke runs)
+> that path buffers Claude's output for the entire run with no live
+> streaming, regardless of action version. We removed it; the agent
+> writes the file itself, the renderer does the shape validation, and
+> we get live debugging for free. See
+> [`PLATFORM_REFERENCE.md`](./PLATFORM_REFERENCE.md) → *How agents emit
+> output* for the full story.
+
+### Top-level shape
+
+- `stage` (string) — pinned by the platform; you can't mismatch.
+- `status` (enum) — `passed`, `passed_with_findings`, or `failed`.
+- `summary` (string) — one short line for the sticky PR comment.
+- `cost_usd` (number, optional) — token spend if you can compute it.
+- `payload` (object, optional) — agent-specific structured data.
+
+Envelope fields (`contract_version`, `agent_version`, `run_id`, `trigger`)
+are injected by the renderer. **Agents must not write them.**
+
+### Payload conventions (recognized by the renderer)
+
+The schema is intentionally loose at the top level (`additionalProperties: true`)
+and inside `payload` (also open). The renderer recognizes two conventions
+under `payload`:
+
+**`payload.findings[]`** — reviewer convention. Use when your skill emits
+issues. Renderer shows a table.
+
+```json
+{
+  "stage": "code-review",
+  "status": "passed_with_findings",
+  "summary": "3 medium findings on naming/scope; non-blocking",
+  "payload": {
+    "findings": [
+      {
+        "severity": "medium",
+        "file": "libs/foo/src/Bar.tsx",
+        "line": 42,
+        "message": "Component prop name doesn't match the libs/* convention",
+        "suggested_fix": "Rename `data` to `items`"
+      }
+    ]
+  },
+  "cost_usd": 0.31
+}
+```
+
+**`payload.comment_markdown`** — override convention. Use when your output
+isn't reviewer-shaped (test results, benchmark numbers, generated code
+summaries, etc.). The string replaces the default body verbatim.
+
+```json
+{
+  "stage": "test-gen",
+  "status": "passed",
+  "summary": "Generated 12 tests; 10 pass on first run.",
+  "payload": {
+    "comment_markdown": "| Suite | Generated | Passing |\n|---|---|---|\n| libs/foo | 5 | 4 |\n| libs/bar | 7 | 6 |\n\nFailures noted in [run artifact](…).",
+    "tests_generated": 12,
+    "tests_passing": 10
+  }
+}
+```
+
+Other keys under `payload` are passed through unchanged. Downstream agents
+that declare `needs: [my-agent]` can read whatever schema you emit.
+
+---
+
+## What you do *not* have to know
+
+- How `pull_request` events route to your agent — dispatcher does it.
+- How GHA permissions, concurrency, secrets, sticky comments, and artifacts
+  get wired — the reusable workflow and composite action handle all of it.
+- How the prompt is built — the platform composes it from your manifest.
+- How envelope fields are injected or outputs validated — the script does it.
+- How the kill switch is checked — the matcher reads `vars.STAGE_*_ENABLED`.
+
+If your change touches the platform (new trigger event, new permission
+tier, output schema, sticky-comment format, inter-agent dependencies), see
+[`PLATFORM_REFERENCE.md`](./PLATFORM_REFERENCE.md).

--- a/.github/claude/PLATFORM_REFERENCE.md
+++ b/.github/claude/PLATFORM_REFERENCE.md
@@ -1,0 +1,540 @@
+# Platform Reference — DIAL SDLC Pipeline
+
+For **platform maintainers**, not agent authors. The author quickstart is
+[`ADDING_AN_AGENT.md`](./ADDING_AN_AGENT.md); exhaustive author detail is
+in [`AGENT_REFERENCE.md`](./AGENT_REFERENCE.md).
+
+Covers: framework relationship, dispatch architecture, the security model
+(ADR-0005), the `analysis_ref` overlay, private/encrypted output, context
+tiers, cross-run state consumption, and triggers for updating platform docs.
+
+---
+
+## Framework relationship
+
+This repo is the first consumer of the
+[`ai-native-sdlc-framework`](https://gitlab.deltixhub.com/Deltix/openai-apps/poc/ai-native-sdlc-framework).
+Several artifacts here are **framework-bound** — designed to move upstream
+once the abstractions stress-test against more agents. Until then, they live
+here as canonical; downstream changes happen here first, framework PRs later.
+
+**Framework-bound** (extract when agent #3 lands, or after ~4 weeks of use,
+whichever comes first):
+
+- `.github/actions/run-claude-stage/` — composite action
+- `.github/actions/pr-trust-gate/` — round-0 trust gate (ADR-0005 M1/M2)
+- `.github/claude/scripts/render-stage-comment.py`
+- `.github/claude/scripts/match-agents.py`
+- `.github/claude/scripts/scrub-output.py` — M4 output post-processor
+- `.github/claude/scripts/findings-to-sarif.py` — `emit_sarif` converter
+- `.github/claude/scripts/findings-aggregate.py` — counts-only public surface
+- `.github/claude/schemas/stage-message.schema.json`
+- `.github/claude/schemas/agent-manifest.schema.json`
+- `.github/claude/prompts/agent-wrapper.md`
+- `.github/workflows/dispatch-core.yml` — shared dispatch pipeline
+- `.github/workflows/dispatch-pr.yml`, `.github/workflows/dispatch-schedule.yml` — trigger entry points
+- `.github/workflows/run-agent.yml`
+- `agents/_template/agent.yml`
+- `.github/claude/ADDING_AN_AGENT.md`, `.github/claude/AGENT_REFERENCE.md`, `.github/claude/PLATFORM_REFERENCE.md`
+- The three `docs/sdlc/orchestration*.md` design docs
+
+**Consumer-local** (stays in this repo permanently):
+
+- `agents/<name>/agent.yml` — the manifests for our agents
+- `.github/workflows/stage-security-review.yml` (specialized, won't migrate)
+- `STAGE_*_ENABLED` repo variables
+- The skills under `.claude/skills/` and commands under `.claude/commands/`
+  that agent manifests wrap (consumer-owned — each repo brings its own)
+
+Keep the framework-bound surface DIAL-name-free. When extraction happens, it
+should be a mechanical `git mv` + filename rename, not a refactor.
+
+---
+
+## Dispatch architecture
+
+One reusable core, multiple trigger-specific entry points:
+
+```
+dispatch-pr.yml         (on: pull_request)        ─┐
+dispatch-schedule.yml   (on: schedule,             ├─→ dispatch-core.yml ─→ run-agent.yml (per agent)
+                             workflow_dispatch)    ─┘     gate → discover → round1..3
+```
+
+- **`dispatch-core.yml`** (`workflow_call`) — the shared pipeline. Reads the
+  caller's event from `github.event_name`, runs the round-0 **trust gate**, then
+  the matcher, then fans agents into topologically-sorted rounds via
+  `run-agent.yml`. One core serves every trigger without modification.
+- **`dispatch-pr.yml`** — `on: pull_request` (PR-gating agents).
+- **`dispatch-schedule.yml`** — `on: schedule` (cron) + `workflow_dispatch`
+  (manual). For batch agents over a standing backlog. See
+  [`scheduled-batch-agents.md`](../../docs/sdlc/scheduled-batch-agents.md).
+
+**Default-branch constraint:** GitHub registers `schedule` /
+`workflow_dispatch` only when the workflow file is on the repository's default
+branch. On a non-default sandbox base neither fires; batch agents keep a
+temporary `pull_request` trigger for sandbox testing until the framework lands
+on the default branch.
+
+The job graph is `gate → discover → round1 → round2 → round3`. A failed gate
+skips `discover`, and the rounds gate on `discover` succeeding, so a gate
+failure blocks the entire dispatch.
+
+---
+
+## Manifest validation
+
+Every `agents/<name>/agent.yml` is validated against
+`.github/claude/schemas/agent-manifest.schema.json` at discovery time
+(matcher first step). Schema violations fail the dispatcher with a clear
+JSON Pointer to the offending field — no broken agent reaches the matrix.
+
+The schema accepts most of the framework's v0.1 manifest field set, plus
+a **required `skill:` field**. Per-agent `prompt.md` is not permitted —
+`run-agent.yml` fails loudly if it finds one. All reusable agent logic
+lives in `.claude/skills/<skill>/SKILL.md` (or
+`.claude/commands/<group>/<skill>.md`). The composite action composes
+the full prompt from the manifest at runtime.
+
+**Some manifest fields are still recorded only**, not yet acted on at
+runtime — the schema documents which ones (look for `Recorded only` /
+`not yet wired` notes).
+
+The schema is also referenced by `validate-manifest` if/when we add a CI
+check on `agents/**/agent.yml` changes (framework ROADMAP §4.3, deferred).
+
+### Why the platform forbids per-agent prompts
+
+Two failure modes a freeform per-agent prompt path made easy:
+
+1. **Output-contract drift** — authors editing `prompt.md` could (and did)
+   contradict the schema constraint by including custom "respond as
+   markdown" instructions copied from internet prompts. Forcing prompt
+   composition into the platform removes that surface.
+2. **Hidden reusable logic** — multi-step prompts (CLI floor + LLM
+   judgment + drift check) trapped real value in a per-agent file. As a
+   skill, the same logic is interactively callable, versioned, and
+   reusable across agents.
+
+Trade-off: every agent requires a skill. For "found a prompt online"
+adoption this means saving the prompt as `.claude/skills/<name>/SKILL.md`
+with frontmatter — a 30-second step that pays back in audit/reuse.
+
+---
+
+## Supported permissions
+
+The matcher rejects manifests requesting permissions outside this set:
+
+| Scope | Allowed levels |
+|---|---|
+| `contents` | `read` |
+| `pull-requests` | `write` |
+| `checks` | `write` |
+| `security-events` | `read`, `write` |
+
+Every workflow layer declares the union as its job permissions:
+`run-agent.yml`, the shared `dispatch-core.yml`, and both entry points
+(`dispatch-pr.yml`, `dispatch-schedule.yml`). Manifests that omit the
+`permissions:` field get the same union (the runner runs with those scopes;
+the validator is permissive about absence).
+
+Every layer also grants `actions: read` — **not** an agent-requestable tier,
+so it is absent from `SUPPORTED_PERMISSIONS`. It exists purely so the
+upstream-artifact step (`gh run download` in `run-agent.yml`) can hit the
+Actions API; without it, any `needs:`-based chain fails the download with a
+403. Because a reusable workflow's token is capped by its caller, the grant
+must appear at **every** caller layer (entry point → core → runner), not just
+`run-agent.yml`. Don't remove it while `needs:`-based chaining exists.
+
+The trust gate (`pr-trust-gate`) needs no extra tier — it reads PR files with
+the existing `pull-requests` scope. `issues: write` is **not** in the set; the
+deferred `issue` output channel would add it (see the scheduled-agents archive).
+
+To add a new tier (e.g., `contents: write` for spec-edit agents that
+commit to `specs/`):
+
+1. Add it to `SUPPORTED_PERMISSIONS` in `match-agents.py`.
+2. Grant it in every workflow layer's top-level `permissions:`
+   (`dispatch-pr.yml`, `dispatch-schedule.yml`, `dispatch-core.yml`,
+   `run-agent.yml`).
+3. Document the new tier in this section + `AGENT_REFERENCE.md` → *Tool tiers*.
+
+Don't widen permissions speculatively — every grant is a real privilege
+exposure.
+
+---
+
+## Trigger filters
+
+The matcher honors:
+
+- **`branches`**: PR target branch (`github.event.pull_request.base.ref`)
+  must be in the manifest's `branches:` list.
+- **`labels`**: PR must carry **all** labels listed in `labels:`.
+
+Both are passed to the matcher via `--event-context /tmp/event.json` (dump
+of `toJSON(github.event)` set by the dispatcher).
+
+**Filters apply to PR events only.** They read `github.event.pull_request`,
+which is absent for `schedule` / `workflow_dispatch` — so a scheduled agent
+matches purely on the trigger, and its analyzed branch is controlled by
+`analysis_ref` (and the workflow's checkout), not by a `branches:` filter.
+
+`paths` is reserved (schema accepts it) but **not yet evaluated** — that
+needs a `git diff` against the PR base, which the matcher would do in the
+discover job. Defer until a real path-scoped agent appears.
+
+---
+
+## Specialized self-triggered workflows
+
+Third-party GHA actions (Trivy, Semgrep, `claude-code-security-review`,
+etc.) don't fit the generic Claude composite action. Each gets its own
+`.github/workflows/stage-<name>.yml` that fires on PR directly — it does
+not enter the dispatcher's matrix. The matcher does not need to handle
+these; they're outside the manifest-driven flow.
+
+`stage-security-review.yml` is the reference. When a second specialized
+agent is needed, copy that file.
+
+**Why not a centralized "wrapped runner"?** GHA's `uses:` field doesn't
+accept expressions, so a single runner can't dynamically dispatch to
+`org/action@<sha>` chosen at runtime. Each specialized workflow hardcodes
+its third-party reference. Framework's ROADMAP §4.5 imagines a centralized
+adapter pattern; we deferred it until the first real third-party adoption
+demands more uniformity than per-file copying provides.
+
+---
+
+## Security model (ADR-0005)
+
+The framework's CI AI-agent threat model is
+[`adr/0005-ci-ai-agent-threat-model.md`](https://gitlab.deltixhub.com/Deltix/openai-apps/poc/ai-native-sdlc-framework/-/blob/master/adr/0005-ci-ai-agent-threat-model.md).
+This platform is its "Worked example 2 — orchestrator." The trust boundary
+hinges on **where the PR branch lives, not the trigger name**:
+
+- **Internal** (same-repo branch, `pull_request`) — author had write access ⇒
+  trusted. Baseline controls only. **This is the current tier.**
+- **External** (fork) under `pull_request_target` — untrusted; requires the
+  full M1–M6 stack.
+
+### Round-0 trust gate (`pr-trust-gate`)
+
+Runs first in `dispatch-core.yml`; `discover` depends on it. Two controls:
+
+- **Fork gate (M1):** classifies the PR source — trusted if same-repo branch /
+  `author_association ∈ {OWNER,MEMBER,COLLABORATOR}` / a configured
+  `trust_label` is present; otherwise a fork. Hard-blocks untrusted PRs by
+  default (`fail_on_untrusted: true`), or emits a `trusted` output for
+  fork-facing flows to branch on.
+- **M2 reject:** fails the run if the PR diff touches **agent-trust paths**
+  (`.claude/**`, `**/CLAUDE.md`, `.mcp.json`, `.claude.json`,
+  `.github/workflows/**`, `.github/actions/**`, **`agents/**`**) or adds
+  symlinks. `agents/**` is in the set because a manifest drives `tools.extra` /
+  `secrets:` / `allowed_tools` — an orchestrator-specific trust surface the
+  ADR's generic list omits.
+
+The gate is a **no-op for `schedule` / `workflow_dispatch`** (no PR, trusted
+default branch).
+
+### M2 scrub — overlay exclusions
+
+The `analysis_ref` overlay (below) excludes `.github` / `.claude` / `agents`,
+so an overlaid ref's trust files are never mounted. This is the "scrub before
+mount" half of M2, enforced structurally rather than by step ordering.
+
+### M4 output post-processor (`scrub-output.py`)
+
+Deterministic, LLM-free, fail-closed gate on the rendered **public** body
+before any posting step:
+
+- **Secret scan** → fails the stage (nothing posted) on `sk-ant-` / `sk-` /
+  `AKIA|ASIA` / `ghp_` / `github_pat_` / Slack / JWT / PEM, plus a guarded
+  high-entropy backstop (skips git SHAs / numeric ids). Stops "Comment and
+  Control" credential exfiltration.
+- **URL/HTML neutralize** → strips zero-click images, non-allowlisted links,
+  bare autolinks, and outbound-capable HTML tags; allowlists the GitHub host so
+  the run-details footer survives.
+
+For `private_output` agents the public surface is **counts-only aggregate**, a
+stronger-than-M4 control (no free text reaches the public surface at all), so
+M4 primarily guards non-private agents.
+
+### Baseline (all tiers)
+
+SHA-pin every `uses:`; per-agent kill switch; **persist input AND output** as
+audit artifacts (`stage-input-<name>`, `stage-output-<name>`); structured
+output + advisory verdict (no auto-merge — M6).
+
+### Flipping to `pull_request_target`
+
+`pull_request_target` loads the workflow + secrets from the base branch, so PR
+runs get the framework from base natively (the sandbox-base host becomes
+unnecessary). But it puts secrets in scope for fork PRs — crossing into the
+untrusted tier. Activation checklist: set `trust_label` + `fail_on_untrusted:
+false` on the gate; pin PR-head overlays to `head.sha` (not `head.ref`); lock
+the agent tool surface (M3 — no `Bash`/`WebFetch`/`WebSearch`/MCP on fork
+flows); migrate the inference key to OIDC (ADR-0004). Until then the platform
+stays on internal-only `pull_request`.
+
+---
+
+## Analysis-ref overlay
+
+When a manifest declares `analysis_ref: <branch>`, the agent inspects **that
+ref's code** instead of the triggering checkout — so a batch agent can run
+*from* the default branch while triaging findings scanned against another
+branch. `run-agent.yml`:
+
+```bash
+git fetch --depth=1 origin "$ANALYSIS_REF"
+git checkout FETCH_HEAD -- . ':(exclude).github' ':(exclude).claude' ':(exclude)agents'
+# capture FETCH_HEAD sha → ANALYSIS_SHA / ANALYSIS_REF_FULL for SARIF scoping
+```
+
+It is an **overlay, not a checkout**: the analyzed ref's source replaces the
+working tree *except* the framework paths (`.github`, `.claude`, `agents`),
+which would otherwise be stripped (they live only on the framework branch). The
+exclusions double as the **security boundary** — the analyzed ref can supply
+inert source for the agent to read, but never a skill, workflow, action, or
+manifest the platform would execute. The captured SHA scopes any `emit_sarif`
+upload to the scanned commit.
+
+Limitations: branch tips only (`refs/heads/<ref>`); single ref per agent; the
+overlay is uncommitted, so an agent's `git diff` shows it as changes vs the base
+HEAD.
+
+---
+
+## Private output, SARIF, and the public surface
+
+Three manifest fields control how a sensitive agent's output is handled (this
+repo is **public**, so artifacts and the job summary are world-readable):
+
+- **`private_output: true`** — `stage-output.json` is AES-encrypted
+  (`openssl`, key from `SDLC_ARTIFACT_KEY`) before upload; plaintext is consumed
+  on the runner first (render / SARIF / aggregate) then removed. A downstream
+  agent's `run-agent.yml` decrypts the upstream `.enc` artifact it consumes.
+  The input audit artifact is encrypted the same way.
+- **Aggregate public surface** — instead of a full sticky comment, sensitive
+  agents publish **counts only** (`findings-aggregate.py`) to the Actions **job
+  summary**. No file paths or per-finding verdicts on the public surface.
+- **`emit_sarif: true`** — converts `payload.findings[]` to SARIF 2.1.0 and
+  uploads to GitHub code scanning (the Security tab, a write-gated surface),
+  scoped to `analysis_ref`'s branch/commit. Non-actionable verdicts upload as
+  dismissed. Currently paused for the snyk chain while encryption + the
+  aggregate surface are validated.
+
+Non-private agents keep the full path: M4-scrubbed sticky PR comment + full job
+summary + plaintext artifact.
+
+---
+
+## Context tiers — what workspace the agent sees
+
+Adopted from `ai-native-sdlc-framework` ADR-0001.
+
+| Tier | Workspace | Status |
+|---|---|---|
+| **A** | The triggering repo only (single `actions/checkout`) | **Implemented; the dispatcher uses this today.** |
+| **B** | Triggering repo + sibling repos via additional `actions/checkout` with pinned SHA | Reserved. Requires extending `run-agent.yml` to honor a `sibling_repos:` manifest field, plus a cross-repo token (GitHub App or fine-grained PAT). |
+| **C** | A prebuilt context bundle (versioned tarball) produced upstream | Out of scope for v0.1. |
+
+The manifest field `sibling_repos:` is reserved but not yet read. Don't
+document it as available to authors until Tier B is wired through.
+
+---
+
+## How agents emit output — the `Write`-tool path
+
+The composite action does **not** use `claude-code-action`'s
+`--json-schema` / `structured_output` enforcement. Instead, the agent
+writes its JSON response to `stage-output.json` at the repo root via the
+`Write` tool, and the renderer reads + validates that file. Reasons
+(empirical, established across the v0.1 smoke-test cycle):
+
+- **`--json-schema` buffers all output.** Setting `--json-schema=<path>`
+  in `claude_args` causes the action to hold every tool-use event and
+  every assistant message until end-of-run. No live streaming, no
+  visibility for 5-15 minutes per run, regardless of action version
+  (reproduced on both v1.0.100 and v1.0.133). `--verbose` and
+  `show_full_output: 'true'` don't pierce it.
+- **Without `--json-schema`, the action streams every event live.** A
+  failing or slow agent is debuggable as it runs.
+- **What we give up by not using `--json-schema`**: automatic retry on
+  schema violation (the SDK would re-prompt Claude up to N times if its
+  output didn't match the schema). Modern Claude models are reliable
+  enough at producing valid JSON when given a clear schema description
+  in the prompt + an example that we accept this trade. If the agent
+  ever emits malformed JSON, the renderer fails loudly with a clear
+  error — same end state.
+
+The composite action's prompt-prep step still generates the agent-facing
+schema (subset of `stage-message.schema.json` with envelope fields
+stripped, `stage` pinned via `const`) and writes it to disk. The
+**prompt** describes this schema as the required output shape; the
+**Claude runtime** doesn't enforce it. This keeps the schema as
+documentation + a quick re-enable surface if upstream ships a fix.
+
+### Output shape — conventions, not enforcement
+
+Top-level is open (`additionalProperties: true`) so non-reviewer agents
+can extend without schema churn. Agent-specific structured data goes
+under `payload` (also open). The renderer recognizes two `payload`
+conventions:
+
+- **`payload.findings[]`** — reviewer convention. Rendered as a table.
+  Item shape: `{severity, file?, line?, message, suggested_fix?, requirement_ref?}`.
+- **`payload.comment_markdown`** — override. Replaces the renderer's
+  default body with verbatim markdown. Use for test results, benchmarks,
+  generated code summaries, etc.
+
+These are conventions, not schema requirements. Agents are free to put
+any keys under `payload`; the renderer falls back to summary-only display
+when neither convention is present.
+
+### Runtime path
+
+1. Composite action composes the prompt (4 placeholders: `{{stage}}`,
+   `{{skill}}`, `{{base_ref}}`, `{{upstream_inputs}}`) and the agent-facing
+   schema.
+2. `anthropics/claude-code-action` runs Claude; tool calls stream live
+   (no buffering since no `--json-schema`).
+3. **Persist input** — the composed prompt + schema upload as
+   `stage-input-<name>` (encrypted for `private_output`), with `always()` so a
+   failed run is still auditable.
+4. Agent uses the `Write` tool to save its JSON to `stage-output.json`.
+   `Write` is appended to `allowed_tools` automatically.
+5. "Verify stage-output.json" confirms the file exists (it does **not** cat the
+   contents — public repo, world-readable logs).
+6. `render-stage-comment.py` validates required fields, injects envelope,
+   renders the sticky-comment body.
+7. **M4 scrub** (`scrub-output.py`, non-private agents) — secret scan
+   (fail-closed) + URL/HTML neutralize on the rendered body; posting steps
+   consume the scrubbed output.
+8. **`emit_sarif`** (if enabled) → `findings-to-sarif.py` → Security tab,
+   scoped to `analysis_ref`.
+9. **Aggregate** (`private_output` agents) → counts-only to the job summary.
+10. **Encrypt** (`private_output`) → `stage-output.json.enc`, plaintext removed.
+11. `upload-artifact` ships `stage-output-<name>` (plaintext or `.enc`,
+    90-day retention).
+12. Non-private agents: full job summary + sticky PR comment (scrubbed body)
+    via `gh api`.
+
+**Model requirement**: any Claude model that supports the `Write` tool
+and produces valid JSON when instructed — i.e., any modern Claude. The
+older `--json-schema` requirement (Sonnet 4.5+, Opus 4.5+, Haiku 4.5+)
+no longer applies.
+
+### Debug visibility
+
+Three surfaces are gated on the `show_full_output` composite input
+(default `'false'`) so production runs stay quiet:
+
+- The pre-flight state dump step (cwd, env, skill discovery paths,
+  composed prompt, agent-facing schema) — runs only when toggled on.
+- `--verbose` in `claude_args` — emits richer tool-use event JSON when
+  toggled on; otherwise the action streams at its default verbosity.
+- `show_full_output: 'true'` passed to `claude-code-action` itself —
+  surfaces Claude's prompts and responses in the log instead of
+  obscuring them for security.
+
+All three flip with one input. If an agent is misbehaving, set
+`show_full_output: 'true'` (either temporarily in `run-agent.yml` or via
+a per-stage manifest field if/when we expose one) and re-run.
+
+### Why we still keep the schema file
+
+`stage-message.schema.json` remains the canonical contract. The renderer
+re-validates required fields against it as defense in depth. If
+`anthropics/claude-code-action` ships a fix for the `--json-schema`
+buffering behavior, the path back to constitutional enforcement is one
+line: re-add `--json-schema=${SCHEMA_PATH}` to `ARGS` in the composite
+action. Keep watching:
+<https://github.com/anthropics/claude-code-action/issues>.
+
+---
+
+## Cross-run state — consuming a prior agent's artifact
+
+Every agent's `stage-output.json` is uploaded as a workflow artifact named
+`stage-output-{name}` and kept for 90 days (the composed input prompt is
+uploaded alongside as `stage-input-{name}`). For `private_output` agents both
+are AES-encrypted; `run-agent.yml` decrypts an upstream's `.enc` artifact
+before a downstream agent reads it. The composite action handles all of this;
+agents don't add anything per-stage.
+
+### Same workflow run
+
+Agents declare upstream dependencies via the manifest's `needs:` field. The
+matcher topologically sorts agents into rounds (capped at 3); the dispatcher
+runs each round as a separate matrix job with sequential `needs:`. Before a
+downstream agent runs, `run-agent.yml` downloads each declared upstream's
+`stage-output-{name}` artifact into `upstream/{name}/stage-output.json` —
+the downstream prompt reads them directly. See `AGENT_REFERENCE.md` →
+*Chaining* for the author-facing recipe.
+
+### Different workflow run
+
+Use `actions/download-artifact@v4` plus the GitHub API to find the prior run:
+
+```yaml
+- name: Find prior dispatcher run on this PR
+  id: prior
+  env:
+    GH_TOKEN: ${{ github.token }}
+    PR_NUMBER: ${{ github.event.pull_request.number }}
+    HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+  run: |
+    PRIOR_RUN_ID=$(gh api \
+      "repos/${{ github.repository }}/actions/workflows/dispatch-pr.yml/runs?event=pull_request&status=completed" \
+      --jq ".workflow_runs[] | select(.pull_requests[]?.number==${PR_NUMBER}) | select(.head_sha!=\"${HEAD_SHA}\") | .id" \
+      | head -n1)
+    echo "run-id=${PRIOR_RUN_ID}" >> "$GITHUB_OUTPUT"
+
+- name: Download prior agent's output
+  if: steps.prior.outputs.run-id != ''
+  uses: actions/download-artifact@v4
+  with:
+    name: stage-output-code-review
+    path: prior-runs/
+    run-id: ${{ steps.prior.outputs.run-id }}
+    github-token: ${{ github.token }}
+```
+
+**Do not** parse the sticky PR comment to recover prior state. The sticky
+comment is for humans; the artifact is for machines. Mixing them creates an
+implicit contract on comment shape that rots.
+
+---
+
+## What requires a doc update (not just a manifest change)
+
+Touching any of these means changing platform code, not just an
+`agents/<name>/agent.yml` manifest:
+
+- A new event trigger beyond those wired (`pull_request`, `schedule`,
+  `workflow_dispatch` are done — see *Dispatch architecture*). A new one
+  (`workflow_run`, `repository_dispatch`) needs a new entry-point workflow
+  delegating to `dispatch-core.yml`; the core + matcher already handle any
+  `github.event_name`.
+- A new permission tier (spec-edit, docs-edit, etc.): `run-agent.yml`
+  hardcodes `contents: read`; needs a sibling reusable workflow with write
+  scopes.
+- Changing the output schema (`stage-message.schema.json`) — affects every
+  agent's compliance.
+- Changing the sticky-comment format (`render-stage-comment.py`).
+- Raising `MAX_ROUNDS` past 3 in the matcher: requires adding `roundN`
+  outputs to the discover job and a matching matrix job to `dispatch-pr.yml`.
+- Wiring the reserved `sibling_repos:` manifest field (Tier B context).
+- Lifting the skill-only restriction (e.g., supporting raw task bodies
+  via a `task_file:` manifest field): would require restoring a
+  prompt-file path in the composite action and `run-agent.yml`, plus
+  rewriting the prompt-composition logic to handle both shapes. The
+  restriction is deliberate (see *Why the platform forbids per-agent
+  prompts* above). Reopen only when there's a concrete agent that
+  demonstrably can't be expressed as a skill.
+
+If your change touches any of those, update `ADDING_AN_AGENT.md` and the
+[design docs](../../docs/sdlc/orchestration-research.md) in the same PR.

--- a/.github/claude/prompts/agent-wrapper.md
+++ b/.github/claude/prompts/agent-wrapper.md
@@ -1,0 +1,63 @@
+You are running the **{{stage}}** agent.
+
+## Inputs
+
+- Working tree: the current checkout (repo root).
+- PR diff: `git diff origin/{{base_ref}}...HEAD`.
+- Upstream agent outputs:
+{{upstream_inputs}}
+
+If an upstream artifact is listed above but missing at runtime, treat it as a platform-level race: write `status: "passed"` with a `summary` naming the absent artifact — do not search the workspace for substitutes, and do not run the upstream agent's tooling yourself. If the file exists but is malformed (unparseable JSON, missing the expected `payload`), write `status: "passed_with_findings"` with one `info`-severity finding explaining the parse failure rather than guessing at the contents.
+
+## Tool constraints (read this before invoking the skill)
+
+Your `Bash` tool only accepts the specific patterns in `allowed_tools` (e.g. `Bash(git diff:*)`, `Bash(openspec:*)`, `Bash(trivy:*)`). It denies:
+
+- Any command not matching an allowed prefix (no `cat`, `head`, `tail`, `jq`, `ls`, `find`, `awk`, `sort`, etc.)
+- Shell variable expansion (`$VAR`, `${VAR}` — including `$GITHUB_BASE_REF`, `$GITHUB_WORKSPACE`)
+- Pipes (`|`), redirections (`>`, `>>`, `<`), and command chains (`&&`, `||`, `;`)
+
+For everything that *isn't* an allow-listed CLI invocation:
+
+- **Read files** with the `Read` tool (give an absolute path), not `cat`/`head`.
+- **Search** with the `Grep` tool, not `bash grep` / `awk` pipelines.
+- **Find files** with the `Glob` tool, not `find` / `ls`.
+- **Capture tool output to a file** with the tool's own `--output` flag, not shell `>`.
+
+If the skill body documents a bash one-liner that violates these rules, **translate it** to Claude-tool calls. Burning turns on denied bash commands is the most common failure mode for agents that hit `error_max_turns`.
+
+## Turn budget
+
+You run under a strict turn limit. Be decisive — do not over-analyze or re-verify. Your single most important obligation is to **write `stage-output.json` before you run out of turns**: a partial result with honest gaps (uncertain items marked low-confidence / needs-review) is a SUCCESS; running out of turns with **no file written** is a FAILURE and the worst possible outcome. Plan to write the file well before the limit.
+
+## Task
+
+Invoke the local `/{{skill}}` skill against the inputs above. Follow its **methodology and criteria** verbatim — don't freelance criteria the skill doesn't cover. But the **platform owns input and output plumbing**: where inputs live (above) and how/where results are written (below) are defined *here*, not by the skill. If the skill's instructions about input location or output format/destination differ from this wrapper, **the wrapper wins**. Map the skill's results into the response schema below.
+
+## Output
+
+Your deliverable to the platform is one JSON object written with the **`Write` tool** to `stage-output.json` (repo root). If the skill instructs you to emit its results as separate **report/status files** (e.g. `*-report.md` / `*-report.json`) or in a different envelope format, **don't** — fold those results into `stage-output.json` instead; it is the single source the platform reads. (This is about the result envelope; if the skill's actual job is to produce work-product files, still produce those.) Do **not** print the JSON in chat. The platform reads `stage-output.json`, validates it, injects envelope fields (`contract_version`, `agent_version`, `run_id`, `trigger`), and surfaces the result — you don't post anything yourself.
+
+The JSON object you write must have:
+
+**Required:**
+
+- `stage`: must be `"{{stage}}"` (the renderer rejects mismatches)
+- `status`: `"passed"` (clean), `"passed_with_findings"` (non-blocking results to surface), or `"failed"` (blocking problem)
+- `summary`: one short line summarizing the result (max 280 chars)
+
+**Optional `payload`** (object) — put the skill's results here in **whatever shape fits the skill**. `payload` is open; the shapes below are *helpers the renderer/processors recognize*, not requirements — pick the one that matches your skill's output, or use your own keys:
+
+- `payload.findings[]` — for skills that emit **issues/findings** (scan, review, triage). Shape: `{severity, file?, line?, message, suggested_fix?, requirement_ref?}`. Severity: `info`/`low`/`medium`/`high`/`critical`. Preserve the skill's severity verbatim; don't downgrade. The renderer turns these into a table automatically.
+- `payload.comment_markdown` — a verbatim markdown body (test-suite summaries, benchmark numbers, prose). **Long markdown inside JSON is escape-error-prone** — embedded code fences, nested backticks, and `"` in block quotes can produce malformed JSON; keep it brief (~5 lines) and avoid nested code blocks.
+- Any other keys — agent-specific. `payload` accepts arbitrary structured data for downstream consumers.
+
+Minimum example:
+
+```json
+{
+  "stage": "{{stage}}",
+  "status": "passed",
+  "summary": "No issues found."
+}
+```

--- a/.github/claude/schemas/agent-manifest.schema.json
+++ b/.github/claude/schemas/agent-manifest.schema.json
@@ -1,0 +1,252 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "DIAL SDLC Agent Manifest",
+  "description": "Manifest at agents/<name>/agent.yml. The matcher validates every manifest against this schema at discovery time; violations fail the dispatcher loudly. Accepts the framework's v0.1 fields (some recorded-only today; see PLATFORM_REFERENCE.md for which are runtime-honored).",
+  "type": "object",
+  "required": ["contract_version", "name", "skill", "triggers", "allowed_tools"],
+  "additionalProperties": false,
+  "properties": {
+    "contract_version": {
+      "type": "string",
+      "enum": ["0.1"],
+      "description": "Manifest schema version. Matcher rejects unrecognized versions."
+    },
+    "name": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9-]*$",
+      "description": "Kebab-case agent name. Surfaces in PR comments, artifacts, kill-switch var name."
+    },
+    "skill": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9:-]*$",
+      "description": "Local skill the agent wraps. Must be addressable as `/<skill>` in a Claude prompt (e.g. `code-review-and-quality`, `opsx:verify`). Skill-only: no per-agent prompt.md is permitted; the composite action composes a uniform prompt that delegates work to this skill. Reusable agent logic belongs in `.claude/skills/` or `.claude/commands/`, not inlined in agents/."
+    },
+    "agent_version": {
+      "type": "string",
+      "description": "Semver-ish; recorded into the output envelope."
+    },
+    "version": {
+      "type": "string",
+      "description": "Framework's `version` field (alias of agent_version). Recorded but not used by the matcher."
+    },
+    "description": {
+      "type": "string"
+    },
+    "owner_column": {
+      "type": "string",
+      "description": "Framework catalog field. Recorded only."
+    },
+    "catalog_cell": {
+      "type": "string",
+      "description": "Framework catalog field. Recorded only."
+    },
+    "source": {
+      "type": "object",
+      "description": "Pin info for adopted/forked agents (origin/url/sha). Recorded only.",
+      "additionalProperties": true
+    },
+    "license": {
+      "type": "string"
+    },
+    "vetting_report": {
+      "type": "string",
+      "description": "Path to vet-agent report. Recorded only; not validated."
+    },
+    "triggers": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "oneOf": [
+          { "type": "string" },
+          {
+            "type": "object",
+            "required": ["on"],
+            "additionalProperties": false,
+            "properties": {
+              "on": {
+                "type": "string",
+                "enum": ["pull_request", "push", "schedule", "workflow_dispatch", "workflow_run"]
+              },
+              "filters": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "paths": {
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "description": "Path globs. NOT YET HONORED by matcher (v0.3)."
+                  },
+                  "branches": {
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "description": "Target branches (e.g. PR base). Honored by matcher."
+                  },
+                  "labels": {
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "description": "Required labels (all must be present). Honored by matcher."
+                  }
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    "allowed_tools": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Comma-separated Claude tool allowlist (passed to claude-code-action via --allowed-tools)."
+    },
+    "needs": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Upstream agents this one depends on. Topologically sorted into rounds by the matcher (cap 3)."
+    },
+    "context_tier": {
+      "type": "string",
+      "enum": ["A", "B", "C"],
+      "description": "A=triggering repo only (default). B=sibling repos via additional checkout. C=context bundle. Only A is implemented today."
+    },
+    "sibling_repos": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "For tier B. Reserved; not yet wired."
+    },
+    "permissions": {
+      "type": "object",
+      "description": "GHA permissions the runner job needs. Matcher validates against platform-supported set; fails loudly if exceeded.",
+      "additionalProperties": {
+        "type": "string",
+        "enum": ["read", "write", "none"]
+      }
+    },
+    "secrets": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Declared secret names to inject into the agent's job env. run-agent.yml promotes ONLY these from the inherited secret bag (toJSON(secrets)) into $GITHUB_ENV before invoking the agent, and fails loudly if a declared secret is absent. The wrapped skill reads them via committed helper scripts — the model never types secret values (the agent-wrapper forbids shell expansion in Bash tool calls). ANTHROPIC_API_KEY is always passed and need not be declared."
+    },
+    "vars": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Declared NON-secret config names to inject into the agent's job env from the GitHub Actions Variables (`vars`) context. run-agent.yml promotes ONLY these into $GITHUB_ENV before the agent runs; missing ones are skipped (the skill's own default applies). Use for operational knobs an operator changes in Settings → Variables (e.g. JIRA_MAX_FINDINGS) without editing the skill. Sensitive values belong in `secrets`, not here.",
+      "default": []
+    },
+    "private_output": {
+      "type": "boolean",
+      "description": "When true, the agent's stage-output.json is AES-encrypted (openssl, key from the SDLC_ARTIFACT_KEY secret) before it is uploaded as an artifact, and any encrypted upstream artifacts it downloads are decrypted on the runner before the agent reads them. Use for agents whose output is internal/sensitive on a PUBLIC repo (artifacts are world-downloadable). Requires SDLC_ARTIFACT_KEY in this agent's `secrets:` list. Local plaintext (used by the renderer / SARIF emitter on the runner) is never uploaded.",
+      "default": false
+    },
+    "emit_sarif": {
+      "type": "boolean",
+      "description": "When true, the platform converts the agent's payload.findings[] into SARIF 2.1.0 and uploads it to GitHub code scanning (Security tab) — a write-access-gated surface, unlike public PR comments/summaries. Findings with non-actionable verdicts (FALSE_POSITIVE/NOT_APPLICABLE/DUPLICATE) are uploaded as dismissed. If analysis_ref is set, the SARIF is scoped to that branch/commit so alerts render against the scanned code.",
+      "default": false
+    },
+    "analysis_ref": {
+      "type": "string",
+      "description": "Optional git ref whose code the agent should inspect instead of the PR working tree (e.g. the branch a scanner ran against). run-agent.yml fetches it and overlays its source onto the working tree before invoking the agent, preserving the framework paths (.github, .claude) so the composite action and skills keep working. The agent reads the findings' repo-relative paths directly — no skill/prompt awareness of branches needed. Also scopes emit_sarif uploads to this ref/commit."
+    },
+    "tools": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "MCP servers and extra CLI tools available to the runner. `extra` items are installed by run-agent.yml before invoking the agent. `mcp` is recorded; not yet wired.",
+      "properties": {
+        "mcp": { "type": "array", "items": { "type": "string" } },
+        "extra": {
+          "type": "array",
+          "description": "CLI tools to install on the runner before invocation. See AGENT_REFERENCE.md → CLI dependencies for the three valid shapes.",
+          "items": {
+            "oneOf": [
+              {
+                "type": "string",
+                "description": "npm package name; latest stable. Installed via `npm install -g <name>`. Use the object form to pin a version."
+              },
+              {
+                "type": "object",
+                "required": ["name"],
+                "additionalProperties": false,
+                "properties": {
+                  "name":    { "type": "string", "description": "For npm: the package name. For shell: a display name used in logs." },
+                  "version": { "type": "string", "description": "For npm: appended as `@<version>` to the install command (default: latest stable). For shell: available as `{{version}}` placeholder inside `install`." },
+                  "install": { "type": "string", "description": "Shell command to install the tool. When present, overrides the npm path. May reference `{{version}}` for substitution from the sibling `version` field." }
+                }
+              }
+            ]
+          }
+        }
+      }
+    },
+    "invocation": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "action_ref": {
+          "type": "string",
+          "description": "Pinned action ref (org/action@sha). Recorded only; the platform always uses its composite action for native agents. Specialized third-party-action workflows are written as standalone stage-<name>.yml files; see stage-security-review.yml."
+        },
+        "model": {
+          "type": "string",
+          "description": "Claude model. Empty uses action default."
+        }
+      }
+    },
+    "model": {
+      "type": "string",
+      "description": "Top-level shortcut for invocation.model. Either is accepted; top-level takes precedence."
+    },
+    "timeout_minutes": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 360,
+      "description": "Per-agent timeout. Honored by run-agent.yml. Default 15."
+    },
+    "max_turns": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 60,
+      "description": "Max Claude turns for this agent. Honored by run-agent.yml -> composite action. Default 18. Lower it for simple agents — fewer turns means fewer context resends, which cuts input-tokens-per-minute (rate-limit pressure)."
+    },
+    "concurrency": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "group": { "type": "string" },
+        "cancel_in_progress": { "type": "boolean" }
+      },
+      "description": "Concurrency group override. If omitted, platform derives `${workflow}-${name}-${ref}` with cancel-in-progress."
+    },
+    "outputs": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["channel"],
+        "additionalProperties": true,
+        "properties": {
+          "channel": {
+            "type": "string",
+            "enum": ["pr-comment", "check", "artifact", "issue"]
+          },
+          "format": { "type": "string" },
+          "sticky": { "type": "boolean" }
+        }
+      },
+      "description": "Declared output channels. Recorded; today the platform always emits pr-comment + artifact."
+    },
+    "correlation_id_env": {
+      "type": "string",
+      "description": "Recorded; the run_id envelope field is the canonical correlation ID."
+    },
+    "phase": {
+      "type": "string",
+      "enum": ["sandbox", "pilot", "production"]
+    },
+    "cost_class": {
+      "type": "string",
+      "enum": ["light", "medium", "heavy"]
+    },
+    "kill_switch_var": {
+      "type": "string",
+      "description": "Override the derived STAGE_{NAME_UPPER}_ENABLED var name."
+    }
+  }
+}

--- a/.github/claude/schemas/stage-message.schema.json
+++ b/.github/claude/schemas/stage-message.schema.json
@@ -1,0 +1,79 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "DIAL SDLC Stage Message",
+  "description": "Sticky JSON payload every SDLC stage writes (via Claude --json-schema). Envelope fields (contract_version, agent_version, run_id, trigger) are injected by the renderer — agents do not write them. Top-level is intentionally open (additionalProperties: true). Agent-specific structured data goes under `payload`. The renderer recognizes two payload conventions: `findings[]` (reviewer-shaped issues, rendered as a table) and `comment_markdown` (verbatim body that replaces the default rendering).",
+  "type": "object",
+  "required": ["contract_version", "stage", "status", "summary"],
+  "additionalProperties": true,
+  "properties": {
+    "contract_version": {
+      "type": "string",
+      "enum": ["0.1"],
+      "description": "Schema contract version. Injected by the renderer."
+    },
+    "agent_version": {
+      "type": "string",
+      "description": "Agent version (semver). Injected by the renderer from the workflow's agent_version input."
+    },
+    "run_id": {
+      "type": "string",
+      "description": "Correlation ID — the GitHub Actions run ID. Injected by the renderer."
+    },
+    "trigger": {
+      "type": "object",
+      "description": "Event context that fired this run. Injected by the renderer.",
+      "additionalProperties": false,
+      "properties": {
+        "event": { "type": "string" },
+        "ref":   { "type": "string" },
+        "sha":   { "type": "string" }
+      }
+    },
+    "stage": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9-]*$",
+      "description": "Stage identifier; pinned by the composite action to the workflow's stage_name."
+    },
+    "status": {
+      "type": "string",
+      "enum": ["passed", "passed_with_findings", "failed"]
+    },
+    "summary": {
+      "type": "string",
+      "maxLength": 280,
+      "description": "One short human-readable line for the sticky PR comment."
+    },
+    "cost_usd": { "type": "number", "minimum": 0 },
+    "payload": {
+      "type": "object",
+      "additionalProperties": true,
+      "description": "Agent-specific structured data. Open shape: any keys allowed. The renderer recognizes two well-known sub-conventions.",
+      "properties": {
+        "findings": {
+          "type": "array",
+          "description": "Reviewer convention. Each entry is one issue. Rendered as a table in the sticky comment when present.",
+          "items": {
+            "type": "object",
+            "required": ["severity", "message"],
+            "additionalProperties": true,
+            "properties": {
+              "severity": {
+                "type": "string",
+                "enum": ["info", "low", "medium", "high", "critical"]
+              },
+              "file": { "type": "string" },
+              "line": { "type": "integer", "minimum": 1 },
+              "message": { "type": "string" },
+              "suggested_fix": { "type": "string" },
+              "requirement_ref": { "type": "string" }
+            }
+          }
+        },
+        "comment_markdown": {
+          "type": "string",
+          "description": "Override convention. If set, replaces the renderer's default body (findings table) with this markdown verbatim. Use for non-reviewer agents (test-gen, benchmark, migration, doc-gen)."
+        }
+      }
+    }
+  }
+}

--- a/.github/claude/scripts/findings-aggregate.py
+++ b/.github/claude/scripts/findings-aggregate.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+# Render a COUNTS-ONLY markdown report from a stage-output.json envelope, safe to
+# post on a PUBLIC repo (PR sticky comment / job summary) for `private_output`
+# (sensitive) agents. It emits ONLY aggregate numbers — never file paths, code,
+# messages, Jira descriptions, or any per-finding detail.
+#
+# Usage: findings-aggregate.py <stage-output.json>   (prints markdown to stdout)
+import json, sys
+from collections import Counter
+
+VERDICT_ORDER = ["CONFIRMED", "NEEDS_REVIEW", "DUPLICATE",
+                 "NOT_APPLICABLE", "FALSE_POSITIVE"]
+SEVERITY_ORDER = ["critical", "high", "medium", "low", "info"]
+
+
+def table(title, rows):
+    out = [f"| {title} | Count |", "|---|---:|"]
+    out += [f"| {k} | {v} |" for k, v in rows if v]
+    return "\n".join(out) if len(out) > 2 else ""
+
+
+def main():
+    path = sys.argv[1] if len(sys.argv) > 1 else "stage-output.json"
+    doc = json.load(open(path))
+    stage = doc.get("stage", "stage")
+    status = doc.get("status", "")
+    payload = doc.get("payload") or {}
+
+    # IMPORTANT: never echo the agent-authored `summary` (or any free text) on
+    # this PUBLIC surface — agents put per-finding specifics (vuln class, code
+    # symbols, mechanisms) there. This report is machine-generated from the
+    # structured counts only; the free-text summary stays in the (encrypted)
+    # artifact.
+    lines = [f"## {stage}", "", f"**Status:** `{status}`", ""]
+
+    findings = payload.get("findings") or []
+    if findings:
+        v = Counter((f.get("verdict") or "UNKNOWN").upper() for f in findings)
+        s = Counter((f.get("severity") or "unknown").lower() for f in findings)
+        lines += [f"**Findings triaged:** {len(findings)}", ""]
+        vt = table("Verdict", [(k, v.get(k, 0)) for k in VERDICT_ORDER]
+                   + [(k, c) for k, c in v.items() if k not in VERDICT_ORDER])
+        if vt:
+            lines += [vt, ""]
+        st = table("Adjusted severity", [(k, s.get(k, 0)) for k in SEVERITY_ORDER]
+                   + [(k, c) for k, c in s.items() if k not in SEVERITY_ORDER])
+        if st:
+            lines += [st, ""]
+
+    # Producer (ingest) counts, if present — all numbers, no detail.
+    jira = payload.get("jira") or {}
+    counts = [(k, jira.get(k)) for k in
+              ("fetched_count", "matched_count", "dropped_count", "analyzed_count")
+              if isinstance(jira.get(k), int)]
+    if counts:
+        lines += [table("Ingest", counts), ""]
+
+    lines += ["_Details withheld: this repo is public; per-finding data is internal "
+              "and is not published here._"]
+    print("\n".join(lines))
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/claude/scripts/findings-to-sarif.py
+++ b/.github/claude/scripts/findings-to-sarif.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+# Convert a stage-output.json envelope's `payload.findings[]` into a SARIF 2.1.0
+# document for GitHub code scanning (Security tab). Keeps the triage skill clean
+# — it emits findings[]; the platform produces SARIF here.
+#
+# Mapping:
+#   severity -> SARIF level (critical/high=error, medium=warning, low/info=note)
+#   file/line -> physicalLocation
+#   jira_key -> partialFingerprints (stable dedup across daily runs)
+#   verdict  -> message prefix + properties; triaged-away verdicts
+#              (FALSE_POSITIVE / NOT_APPLICABLE / DUPLICATE) are emitted as
+#              SARIF `suppressions` so they show as dismissed, leaving only
+#              CONFIRMED / NEEDS_REVIEW as open alerts.
+#
+# Usage: findings-to-sarif.py <stage-output.json> <out.sarif>
+import json, sys
+
+SEV2LEVEL = {"critical": "error", "high": "error", "medium": "warning",
+             "low": "note", "info": "note"}
+OPEN_VERDICTS = {"CONFIRMED", "NEEDS_REVIEW"}
+
+
+def main():
+    src_path = sys.argv[1] if len(sys.argv) > 1 else "stage-output.json"
+    out_path = sys.argv[2] if len(sys.argv) > 2 else "triage.sarif"
+
+    doc = json.load(open(src_path))
+    findings = (doc.get("payload") or {}).get("findings") or []
+
+    rules = {}
+    results = []
+    for f in findings:
+        verdict = (f.get("verdict") or "").upper()
+        sev = (f.get("severity") or "info").lower()
+        level = SEV2LEVEL.get(sev, "note")
+        # Rule grouping: prefer an explicit `rule`, else group all triage
+        # findings under one rule. jira_key distinguishes individual alerts.
+        rule_id = f.get("rule") or "snyk-sast-triage"
+        rules.setdefault(rule_id, {
+            "id": rule_id,
+            "name": rule_id,
+            "shortDescription": {"text": "Snyk SAST finding (AI-triaged)"},
+        })
+
+        msg = f"[{verdict or 'UNTRIAGED'}] {f.get('message', '')}".strip()
+        result = {
+            "ruleId": rule_id,
+            "level": level,
+            "message": {"text": msg},
+            "properties": {
+                "verdict": verdict,
+                "jira_key": f.get("jira_key", ""),
+                "original_severity": f.get("original_severity", ""),
+            },
+        }
+        if f.get("file"):
+            phys = {"artifactLocation": {"uri": f["file"]}}
+            line = f.get("line")
+            if isinstance(line, int) and line >= 1:
+                phys["region"] = {"startLine": line}
+            result["locations"] = [{"physicalLocation": phys}]
+        if f.get("jira_key"):
+            result["partialFingerprints"] = {"jiraKey": f["jira_key"]}
+        # Dismiss triaged-away findings so only actionable ones alert.
+        if verdict and verdict not in OPEN_VERDICTS:
+            result["suppressions"] = [{
+                "kind": "external",
+                "justification": f"AI triage verdict: {verdict}",
+            }]
+        results.append(result)
+
+    sarif = {
+        "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+        "version": "2.1.0",
+        "runs": [{
+            "tool": {"driver": {
+                "name": "DIAL Snyk Triage",
+                "informationUri": "https://github.com/epam/ai-dial-chat",
+                "rules": list(rules.values()),
+            }},
+            # Distinct analysis category so triage results coexist with any other
+            # code-scanning tools instead of overwriting each other.
+            "automationDetails": {"id": "snyk-triage/"},
+            "results": results,
+        }],
+    }
+    with open(out_path, "w") as fh:
+        json.dump(sarif, fh, indent=2)
+    print(f"Wrote {out_path}: {len(results)} result(s), "
+          f"{sum(1 for r in results if 'suppressions' not in r)} open / "
+          f"{sum(1 for r in results if 'suppressions' in r)} suppressed.")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/claude/scripts/match-agents.py
+++ b/.github/claude/scripts/match-agents.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+# Discover agents whose manifests match a given GitHub event, validate each
+# manifest against the schema, apply kill-switch vars, honor trigger filters
+# (branches, labels), validate `permissions:` against the platform-supported
+# set, validate the `needs:` DAG (prune agents whose deps are unavailable, fail
+# on cycles), and emit the matched agents as a flat list.
+#
+# Output: {"agents": [...]} — each entry has {name, needs, timeout_minutes,
+# concurrency_group}. The dispatcher runs them all in ONE matrix; each agent
+# waits for its own `needs:` upstreams inside its job, so there are no rounds.
+import argparse
+import glob
+import json
+import os
+import sys
+
+try:
+    import yaml
+except ImportError:
+    sys.stderr.write("::error::PyYAML required. Run: pip install pyyaml\n")
+    sys.exit(2)
+
+try:
+    import jsonschema
+except ImportError:
+    sys.stderr.write("::error::jsonschema required. Run: pip install jsonschema\n")
+    sys.exit(2)
+
+# Disable YAML 1.1 boolean keywords (on/off/yes/no/On/Off/…) at the resolver
+# level so an unquoted `on: pull_request` parses with the string key "on"
+# instead of the boolean True. true/false remain valid booleans.
+for _ch in "yYnNoO":
+    if _ch in yaml.SafeLoader.yaml_implicit_resolvers:
+        yaml.SafeLoader.yaml_implicit_resolvers[_ch] = [
+            (tag, regex)
+            for tag, regex in yaml.SafeLoader.yaml_implicit_resolvers[_ch]
+            if tag != "tag:yaml.org,2002:bool"
+        ]
+
+DEFAULT_TIMEOUT = 15
+
+# Platform-supported permissions. Any manifest requesting permissions OUTSIDE
+# this set is rejected; adding a new permission requires raising the bar in
+# run-agent.yml + dispatcher (see PLATFORM_REFERENCE.md).
+SUPPORTED_PERMISSIONS = {
+    "contents": {"read"},
+    "pull-requests": {"write"},
+    "checks": {"write"},
+    "security-events": {"read", "write"},
+}
+
+
+def fail(msg):
+    sys.stderr.write(f"::error::{msg}\n")
+    sys.exit(1)
+
+
+def warn(msg):
+    sys.stderr.write(f"::warning::{msg}\n")
+
+
+def notice(msg):
+    sys.stderr.write(f"::notice::{msg}\n")
+
+
+def matches_trigger(triggers, event):
+    """Return (matched, filters) — filters from the matching trigger, if any."""
+    for t in triggers or []:
+        if isinstance(t, str) and t == event:
+            return True, {}
+        if isinstance(t, dict) and t.get("on") == event:
+            return True, t.get("filters") or {}
+    return False, {}
+
+
+def passes_filters(filters, event_ctx):
+    """Apply branches + labels filters. `paths` deferred to v0.3."""
+    if not filters:
+        return True
+
+    pr = event_ctx.get("pull_request") or {}
+    branches = filters.get("branches") or []
+    if branches:
+        target = (pr.get("base") or {}).get("ref", "")
+        if target and target not in branches:
+            return False
+
+    required_labels = filters.get("labels") or []
+    if required_labels:
+        pr_labels = {lbl.get("name") for lbl in pr.get("labels") or []}
+        if not all(req in pr_labels for req in required_labels):
+            return False
+
+    return True
+
+
+def kill_switch_var(name):
+    return "STAGE_" + name.upper().replace("-", "_") + "_ENABLED"
+
+
+def validate_permissions(name, perms):
+    """Fail if any declared permission exceeds the platform's supported set."""
+    if not perms:
+        return
+    for scope, level in perms.items():
+        allowed = SUPPORTED_PERMISSIONS.get(scope)
+        if allowed is None:
+            fail(
+                f"agent {name} declares unsupported permission '{scope}'. "
+                f"Platform supports: {sorted(SUPPORTED_PERMISSIONS)}. "
+                f"See .github/claude/PLATFORM_REFERENCE.md → permission tiers."
+            )
+        if level not in allowed:
+            fail(
+                f"agent {name} declares '{scope}: {level}' but platform supports "
+                f"only '{scope}: {sorted(allowed)}'."
+            )
+
+
+def derive_concurrency_group(name, ref):
+    return f"dispatch-pr-{name}-{ref}"
+
+
+def discover_agents(root, event, event_ctx, vars_dict, schema):
+    matched = {}
+    for path in sorted(glob.glob(f"{root}/agents/*/agent.yml")):
+        if os.path.basename(os.path.dirname(path)).startswith("_"):
+            continue
+        try:
+            with open(path) as f:
+                manifest = yaml.safe_load(f) or {}
+        except Exception as e:
+            fail(f"could not load {path}: {e}")
+
+        # Schema validation — fail loudly with the path.
+        try:
+            jsonschema.validate(instance=manifest, schema=schema)
+        except jsonschema.ValidationError as e:
+            fail(f"manifest schema violation in {path}: {e.message} (at {list(e.absolute_path)})")
+
+        name = manifest["name"]
+
+        matched_event, filters = matches_trigger(manifest.get("triggers"), event)
+        if not matched_event:
+            continue
+        if not passes_filters(filters, event_ctx):
+            notice(f"agent {name} skipped by trigger filters (branches/labels mismatch)")
+            continue
+
+        ks_var = manifest.get("kill_switch_var") or kill_switch_var(name)
+        if vars_dict.get(ks_var) == "false":
+            notice(f"agent {name} disabled via {ks_var}=false")
+            continue
+
+        validate_permissions(name, manifest.get("permissions"))
+
+        ref = os.environ.get("GITHUB_REF", "")
+        concurrency = manifest.get("concurrency") or {}
+        entry = {
+            "name": name,
+            "needs": manifest.get("needs") or [],
+            "timeout_minutes": int(manifest.get("timeout_minutes") or DEFAULT_TIMEOUT),
+            "concurrency_group": concurrency.get("group") or derive_concurrency_group(name, ref),
+        }
+        matched[name] = entry
+    return matched
+
+
+def topo_sort_rounds(agents):
+    available = set(agents)
+
+    pruned = {}
+    for name, a in agents.items():
+        missing = set(a["needs"]) - available
+        if missing:
+            warn(f"skipping {name}; needed agents not available: {sorted(missing)}")
+            continue
+        pruned[name] = a
+
+    remaining = dict(pruned)
+    processed = set()
+    rounds = []
+    while remaining:
+        ready = [a for a in remaining.values() if not (set(a["needs"]) - processed)]
+        if not ready:
+            fail(f"Cycle detected in agent `needs:` deps: {sorted(remaining)}")
+        ready.sort(key=lambda a: a["name"])
+        rounds.append(ready)
+        for a in ready:
+            del remaining[a["name"]]
+            processed.add(a["name"])
+    return rounds
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("event", help="GitHub event name (e.g. pull_request)")
+    p.add_argument("--vars", help="Path to JSON dump of the vars context")
+    p.add_argument("--event-context", help="Path to JSON dump of github.event (for filter evaluation)")
+    p.add_argument("--root", default=".", help="Repo root (default: cwd)")
+    args = p.parse_args()
+
+    schema_path = os.path.join(args.root, ".github/claude/schemas/agent-manifest.schema.json")
+    try:
+        with open(schema_path) as f:
+            schema = json.load(f)
+    except FileNotFoundError:
+        fail(f"manifest schema not found: {schema_path}")
+
+    vars_dict = {}
+    if args.vars and os.path.exists(args.vars):
+        with open(args.vars) as f:
+            vars_dict = json.load(f) or {}
+
+    event_ctx = {}
+    if args.event_context and os.path.exists(args.event_context):
+        with open(args.event_context) as f:
+            event_ctx = json.load(f) or {}
+
+    agents = discover_agents(args.root, args.event, event_ctx, vars_dict, schema)
+    # topo_sort_rounds still runs — for cycle detection and for pruning agents
+    # whose `needs:` are unavailable — but we flatten its output: the dispatcher
+    # no longer uses rounds. Every matched agent runs in one matrix and waits for
+    # its own `needs:` upstream jobs, so per-edge scheduling replaces round
+    # barriers (a dependent starts as soon as ITS upstream is done).
+    rounds = topo_sort_rounds(agents)
+    flat = [a for r in rounds for a in r]
+    print(json.dumps({"agents": flat}))
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/claude/scripts/render-stage-comment.py
+++ b/.github/claude/scripts/render-stage-comment.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+# Validate stage-output.json, inject envelope fields, render sticky PR comment.
+# Stdlib only — no PyYAML, no jq dependency. The machine-readable form (with
+# envelope) is written back to the file so the uploaded artifact contains the
+# enriched payload; the human-readable form goes to GITHUB_OUTPUT for the
+# sticky comment.
+#
+# Emits three GitHub Actions outputs:
+#   - json:    compact JSON payload (for needs.X.outputs.message)
+#   - status:  passed | passed_with_findings | failed
+#   - comment: markdown sticky PR comment body
+#
+# Expects env:
+#   STAGE_NAME           required
+#   AGENT_VERSION        optional; defaults to "unknown"
+#   STAGE_OUTPUT_FILE    optional; defaults to "stage-output.json"
+#   GITHUB_*             auto-set by GHA
+import json
+import os
+import sys
+from pathlib import Path
+
+CONTRACT_VERSION = "0.1"
+ICON = {"passed": "✅", "passed_with_findings": "⚠️", "failed": "❌"}
+
+
+def fail(msg):
+    sys.stderr.write(f"::error::{msg}\n")
+    sys.exit(1)
+
+
+def deep_merge(base, override):
+    out = dict(base)
+    for k, v in override.items():
+        if isinstance(v, dict) and isinstance(out.get(k), dict):
+            out[k] = deep_merge(out[k], v)
+        else:
+            out[k] = v
+    return out
+
+
+def build_findings_block(findings, run_url):
+    if not findings:
+        return []
+    lines = ["", "| Severity | Location | Message |", "|---|---|---|"]
+    for f in findings[:10]:
+        sev = f.get("severity", "info")
+        file_path = f.get("file", "—")
+        line_num = f.get("line")
+        loc = f"`{file_path}{':' + str(line_num) if line_num else ''}`"
+        req = f.get("requirement_ref")
+        if req:
+            loc += f" ({req})"
+        msg = (f.get("message") or "").replace("|", "\\|").replace("\n", " ")
+        lines.append(f"| `{sev}` | {loc} | {msg} |")
+    overflow = len(findings) - 10
+    if overflow > 0:
+        lines.append("")
+        lines.append(f"_… and {overflow} more — full output in the [run artifact]({run_url})._")
+    return lines
+
+
+def main():
+    output_file = Path(os.environ.get("STAGE_OUTPUT_FILE", "stage-output.json"))
+    stage_name = os.environ.get("STAGE_NAME")
+    if not stage_name:
+        fail("STAGE_NAME env is required")
+    agent_version = os.environ.get("AGENT_VERSION", "unknown")
+
+    if not output_file.exists():
+        fail(f"Stage did not produce {output_file}. The prompt must instruct Claude to write this file at the repo root.")
+
+    try:
+        payload = json.loads(output_file.read_text())
+    except json.JSONDecodeError as e:
+        # Dump what the agent actually wrote so we can see WHERE the escaping
+        # went wrong. JSON parse errors give char offsets that are hard to
+        # interpret without seeing the source text. 1500 chars is enough to
+        # cover the offset of typical failures while staying readable in
+        # the GHA log.
+        raw = output_file.read_text()
+        sys.stderr.write("::group::stage-output.json (first 1500 chars)\n")
+        sys.stderr.write(raw[:1500])
+        if len(raw) > 1500:
+            sys.stderr.write(f"\n... [truncated; total {len(raw)} bytes]")
+        sys.stderr.write("\n::endgroup::\n")
+        fail(f"{output_file} is not valid JSON: {e}. File contents logged above.")
+
+    envelope = {
+        "contract_version": CONTRACT_VERSION,
+        "agent_version": agent_version,
+        "run_id": os.environ.get("GITHUB_RUN_ID", ""),
+        "trigger": {
+            "event": os.environ.get("GITHUB_EVENT_NAME", ""),
+            "ref": os.environ.get("GITHUB_REF", ""),
+            "sha": os.environ.get("GITHUB_SHA", ""),
+        },
+    }
+    payload = deep_merge(payload, envelope)
+    output_file.write_text(json.dumps(payload, indent=2))
+
+    for field in ("contract_version", "stage", "status", "summary"):
+        if field not in payload:
+            fail(f"{output_file} missing required field: {field}")
+
+    if payload["contract_version"] != CONTRACT_VERSION:
+        fail(f"contract_version mismatch: platform={CONTRACT_VERSION} but payload={payload['contract_version']}")
+
+    if payload["stage"] != stage_name:
+        fail(f"stage field mismatch: workflow stage_name={stage_name} but JSON .stage={payload['stage']}")
+
+    status = payload["status"]
+    if status not in ICON:
+        fail(f"Invalid status: {status} (expected passed | passed_with_findings | failed)")
+
+    summary = payload["summary"]
+    agent_payload = payload.get("payload") or {}
+    findings = agent_payload.get("findings") or []
+    override_md = agent_payload.get("comment_markdown")
+    cost = payload.get("cost_usd")
+    run_url = (
+        f"{os.environ.get('GITHUB_SERVER_URL', 'https://github.com')}"
+        f"/{os.environ.get('GITHUB_REPOSITORY')}"
+        f"/actions/runs/{os.environ.get('GITHUB_RUN_ID')}"
+    )
+
+    parts = [f"<!-- dial-sdlc:{stage_name} -->", f"{ICON[status]} **{stage_name}**: {summary}"]
+    # Body precedence: explicit comment_markdown wins; otherwise render findings
+    # table when present; otherwise leave the summary line alone.
+    if override_md:
+        parts.append("")
+        parts.append(override_md)
+    else:
+        parts.extend(build_findings_block(findings, run_url))
+    parts.append("")
+    footer = f"[Run details]({run_url})"
+    if cost is not None:
+        footer += f" · `${cost}`"
+    parts.append(footer)
+
+    comment = "\n".join(parts)
+    compact_json = json.dumps(payload, separators=(",", ":"))
+
+    github_output = os.environ.get("GITHUB_OUTPUT")
+    if github_output:
+        with open(github_output, "a") as out:
+            out.write(f"json={compact_json}\n")
+            out.write(f"status={status}\n")
+            out.write("comment<<COMMENT_EOF\n")
+            out.write(comment)
+            out.write("\nCOMMENT_EOF\n")
+
+    # NOTE: a well-formed status=failed is NOT an error here — this renderer must
+    # exit 0 so the downstream steps (scrub, job summary, PR comment) still run
+    # and the blocking findings reach the PR. The job is failed by a dedicated
+    # gate step AFTER the comment is posted (see run-claude-stage/action.yml).
+    # Only genuine render errors above (bad JSON, missing/invalid fields) exit 1.
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/claude/scripts/scrub-output.py
+++ b/.github/claude/scripts/scrub-output.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+# M4 (ADR-0005) — deterministic, LLM-free, fail-closed output post-processor.
+#
+# Runs on the rendered PUBLIC body (the text bound for a PR comment / job
+# summary) AFTER render-stage-comment.py and BEFORE any posting step:
+#
+#   1. Secret scan  -> FAIL the stage (exit 1) on any hit. Nothing is posted.
+#      This is the control that actually stops "Comment and Control" (a
+#      prompt-injected agent emitting a credential into a public comment).
+#   2. URL / HTML neutralize -> strip outbound-exfil vectors (zero-click
+#      markdown images, non-allowlisted links, dangerous HTML tags) and emit
+#      the scrubbed body for the posting steps to consume.
+#
+# Schema validation of stage-output.json happens upstream in the renderer;
+# this gate guards the rendered surface, not the artifact shape. It is
+# intentionally LLM-free and dependency-free (stdlib only) so it is
+# deterministic and auditable.
+#
+# I/O: reads the candidate body from env BODY (falls back to stdin). On pass,
+# writes the scrubbed body to GITHUB_OUTPUT as `comment`. Exit 1 = fail-closed.
+
+import math
+import os
+import re
+import sys
+import urllib.parse
+from collections import Counter
+
+
+def notice(m):
+    sys.stderr.write(f"::notice::{m}\n")
+
+
+def err(m):
+    sys.stderr.write(f"::error::{m}\n")
+
+
+body = os.environ.get("BODY")
+if body is None:
+    body = sys.stdin.read()
+
+# --- 1. Secret scan (named patterns) ---------------------------------------
+# Scanned on the RAW body first, so a secret hidden in a URL query
+# (e.g. ![](http://x/?d=sk-ant-…)) is caught before the URL is neutralized.
+SECRET_PATTERNS = {
+    "anthropic-key":     r"sk-ant-[A-Za-z0-9_\-]{20,}",
+    "openai-style-key":  r"\bsk-[A-Za-z0-9]{32,}\b",
+    "aws-access-key":    r"\b(?:AKIA|ASIA)[0-9A-Z]{16}\b",
+    "github-token":      r"\bgh[pousr]_[A-Za-z0-9]{36,}\b",
+    "github-fine-pat":   r"\bgithub_pat_[A-Za-z0-9_]{60,}\b",
+    "slack-token":       r"\bxox[baprs]-[A-Za-z0-9-]{10,}\b",
+    "jwt":               r"\beyJ[A-Za-z0-9_\-]{10,}\.eyJ[A-Za-z0-9_\-]{10,}\.[A-Za-z0-9_\-]{10,}\b",
+    "private-key-block": r"-----BEGIN (?:[A-Z ]+ )?PRIVATE KEY-----",
+}
+
+hits = [name for name, pat in SECRET_PATTERNS.items() if re.search(pat, body)]
+
+
+def shannon(s):
+    n = len(s)
+    if n == 0:
+        return 0.0
+    return -sum((c / n) * math.log2(c / n) for c in Counter(s).values())
+
+
+# High-entropy backstop for unstructured tokens (e.g. a Jira PAT). Guarded
+# against the common non-secret shapes our comments legitimately carry:
+# pure hex (git SHAs / hashes) and pure-digit run ids. Requires a mixed
+# charset + entropy >= 4.0 bits/char to count, to keep false-positives low.
+if os.environ.get("HIGH_ENTROPY_SCAN", "true") != "false":
+    for tok in re.findall(r"[A-Za-z0-9+/=_\-]{32,}", body):
+        if re.fullmatch(r"[0-9a-fA-F]{32,64}", tok) or tok.isdigit():
+            continue
+        if (any(c.isupper() for c in tok) and any(c.islower() for c in tok)
+                and any(c.isdigit() for c in tok) and shannon(tok) >= 4.0):
+            hits.append("high-entropy-token")
+            break
+
+if hits:
+    err(
+        f"M4 secret scan: output contains likely secret(s) {sorted(set(hits))}. "
+        "Output BLOCKED — nothing posted to the PR or job summary. This is the "
+        "fail-closed control against prompt-injection credential exfiltration "
+        "('Comment and Control'). Inspect the run artifact (not the log) to triage."
+    )
+    sys.exit(1)
+
+# --- 2. URL / HTML neutralize ----------------------------------------------
+server = os.environ.get("GITHUB_SERVER_URL", "https://github.com")
+allow_hosts = {urllib.parse.urlparse(server).netloc.lower(), "github.com"}
+
+
+def host_allowed(url):
+    try:
+        h = urllib.parse.urlparse(url.strip()).netloc.lower()
+    except ValueError:
+        return False
+    return bool(h) and any(h == a or h.endswith("." + a) for a in allow_hosts)
+
+
+# Images are zero-click outbound fetches — neutralize unconditionally
+# (we never legitimately embed an image in a stage comment). Done first so the
+# link pass below cannot re-match the image's `](url)` tail.
+scrubbed = re.sub(r"!\[([^\]]*)\]\([^)]*\)",
+                  r"[image removed by output filter: \1]", body)
+
+
+# Links: keep the text; keep the URL only when its host is allowlisted (so the
+# trusted `[Run details](https://github.com/…)` footer survives).
+def link_repl(m):
+    text, url = m.group(1), m.group(2)
+    return m.group(0) if host_allowed(url) else f"{text} (link removed by output filter)"
+
+
+scrubbed = re.sub(r"\[([^\]]*)\]\(([^)]*)\)", link_repl, scrubbed)
+
+# Bare autolinks and outbound-capable HTML tags.
+scrubbed = re.sub(r"<https?://[^>]*>", "(link removed by output filter)",
+                  scrubbed, flags=re.I)
+DANGEROUS_TAGS = "img|a|script|iframe|object|embed|link|video|audio|source|svg|base|form|meta|style"
+scrubbed = re.sub(rf"</?(?:{DANGEROUS_TAGS})\b[^>]*>", "", scrubbed, flags=re.I)
+
+# --- emit ------------------------------------------------------------------
+out_path = os.environ.get("GITHUB_OUTPUT")
+if out_path:
+    with open(out_path, "a") as f:
+        f.write("comment<<__SDLC_M4_EOF__\n")
+        f.write(scrubbed if scrubbed.endswith("\n") else scrubbed + "\n")
+        f.write("__SDLC_M4_EOF__\n")
+else:
+    sys.stdout.write(scrubbed)
+
+notice(f"M4 output filter passed: no secrets; URLs/HTML neutralized "
+       f"({len(body)} -> {len(scrubbed)} chars).")

--- a/.github/workflows/dispatch-core.yml
+++ b/.github/workflows/dispatch-core.yml
@@ -1,0 +1,102 @@
+name: SDLC Dispatch / Core
+
+# Reusable dispatch pipeline shared by every trigger-specific dispatcher
+# (dispatch-pr.yml, dispatch-schedule.yml). It discovers agents whose manifests
+# match the CALLER's event, then runs them ALL in one matrix via run-agent.yml —
+# each agent waits for its own `needs:` upstreams inside its job (no rounds), so
+# a dependent starts as soon as ITS upstream finishes, not the whole level. The
+# triggering event is read from `github.event_name` (reusable workflows inherit
+# the caller's github context), so the same core serves pull_request, schedule,
+# and workflow_dispatch without modification.
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+  pull-requests: write
+  checks: write
+  security-events: write
+  id-token: write   # required by anthropics/claude-code-action for OIDC auth
+  actions: read     # caller cap: run-agent.yml's `gh run download` needs this
+
+jobs:
+  # Round-0 trust gate (ADR-0005 M1/M2). Classifies the PR source and rejects
+  # the run if the PR touches agent-trust paths or adds symlinks. A no-op for
+  # schedule / workflow_dispatch (no PR, runs from the trusted default branch),
+  # so the same core serves every trigger. discover gates on this — a failed
+  # gate blocks the whole dispatch.
+  gate:
+    runs-on: ubuntu-latest
+    outputs:
+      trusted: ${{ steps.trust.outputs.trusted }}
+    steps:
+      # Checkout provides the .git dir the gate needs for its symlink ls-tree.
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - id: trust
+        uses: ./.github/actions/pr-trust-gate
+        with:
+          event_name: ${{ github.event_name }}
+          pr: ${{ toJSON(github.event.pull_request) }}
+          repo: ${{ github.repository }}
+          github_token: ${{ github.token }}
+          # Fork-facing posture (set when AI review opens to external forks):
+          #   trust_label: ai-review-approved   # maintainer label = trust boundary
+          #   fail_on_untrusted: 'false'        # branch on outputs.trusted instead
+          # Defaults (hard-block forks, reject trust-path edits on all PRs) are
+          # correct for the current internal-only (`pull_request`) tier.
+
+  discover:
+    needs: gate
+    runs-on: ubuntu-latest
+    outputs:
+      agents: ${{ steps.match.outputs.agents }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install matcher deps
+        run: pip install --quiet pyyaml jsonschema
+
+      - id: match
+        env:
+          VARS_JSON: ${{ toJSON(vars) }}
+          EVENT_JSON: ${{ toJSON(github.event) }}
+          EVENT_NAME: ${{ github.event_name }}
+          GITHUB_REF: ${{ github.ref }}
+        run: |
+          set -euo pipefail
+          echo "$VARS_JSON" > /tmp/vars.json
+          echo "$EVENT_JSON" > /tmp/event.json
+          echo "Dispatching agents for event: $EVENT_NAME"
+          MATCHED=$(python3 .github/claude/scripts/match-agents.py "$EVENT_NAME" \
+            --vars /tmp/vars.json --event-context /tmp/event.json)
+          echo "Matched: $MATCHED"
+          echo "agents=$(echo "$MATCHED" | python3 -c 'import sys,json; print(json.dumps(json.load(sys.stdin).get("agents", [])))')" >> "$GITHUB_OUTPUT"
+
+  # One matrix over ALL matched agents — no rounds. Every agent starts at once;
+  # those with `needs:` wait for their specific upstream jobs inside run-agent
+  # (the "Wait for and download upstream artifacts" step), so a dependent runs
+  # as soon as ITS upstream finishes rather than waiting on a whole round.
+  # fail-fast: false keeps independent agents running if one fails.
+  run-agents:
+    # Constant middle segment (NOT the agent name). GitHub's "All jobs" sidebar
+    # shows the LEAF reusable job's name — run-agent's `agent` job, which we name
+    # after the agent — so the agent name belongs there, not here. Putting it
+    # here too would double the graph path to `dispatch / <agent> / <agent>`.
+    # With a constant the path reads cleanly as `dispatch / agent / <agent>` in
+    # the graph while the sidebar stays `<agent>`. The upstream-wait step matches
+    # the agent name as the trailing path segment, so this is safe.
+    name: agent
+    needs: discover
+    if: needs.discover.outputs.agents != '[]'
+    strategy:
+      fail-fast: false
+      matrix:
+        agent: ${{ fromJSON(needs.discover.outputs.agents) }}
+    uses: ./.github/workflows/run-agent.yml
+    with:
+      agent_name: ${{ matrix.agent.name }}
+      upstream_artifacts: ${{ join(matrix.agent.needs, ',') }}
+      timeout_minutes: ${{ matrix.agent.timeout_minutes }}
+      concurrency_group: ${{ matrix.agent.concurrency_group }}
+    secrets: inherit

--- a/.github/workflows/dispatch-pr.yml
+++ b/.github/workflows/dispatch-pr.yml
@@ -1,0 +1,19 @@
+name: SDLC Dispatch / PR
+
+on:
+  pull_request:
+    branches: [development-1.0]
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+permissions:
+  contents: read
+  pull-requests: write
+  checks: write
+  security-events: write
+  id-token: write   # required by anthropics/claude-code-action for OIDC auth
+  actions: read     # caller cap: run-agent.yml's `gh run download` needs this
+
+jobs:
+  dispatch:
+    uses: ./.github/workflows/dispatch-core.yml
+    secrets: inherit

--- a/.github/workflows/run-agent.yml
+++ b/.github/workflows/run-agent.yml
@@ -1,0 +1,368 @@
+name: SDLC / Run Agent
+
+on:
+  workflow_call:
+    inputs:
+      agent_name:
+        required: true
+        type: string
+      upstream_artifacts:
+        description: 'Comma-separated agent names whose stage-output artifacts to download into upstream/{name}/ before running.'
+        required: false
+        type: string
+        default: ''
+      timeout_minutes:
+        description: 'Per-agent timeout in minutes (from manifest).'
+        required: false
+        type: number
+        default: 15
+      concurrency_group:
+        description: 'Concurrency group (from manifest or derived by the matcher).'
+        required: false
+        type: string
+        default: ''
+
+permissions:
+  contents: read
+  pull-requests: write
+  checks: write
+  security-events: write
+  id-token: write   # required by anthropics/claude-code-action for OIDC auth
+  actions: read     # `gh run download` (upstream-artifact step) hits the Actions API
+
+jobs:
+  agent:
+    # Name the inner (leaf) reusable job after the agent. GitHub's "All jobs"
+    # sidebar — the primary nav — shows the LEAF reusable job's name, so this is
+    # what makes each matrix row distinguishable (a generic `agent` rendered
+    # every row identically). The dispatcher's matrix job uses a constant middle
+    # segment, so the graph path reads `dispatch / agent / <agent>` (no doubling)
+    # while the sidebar reads `<agent>`. The upstream-wait step matches the agent
+    # name as the trailing path segment.
+    name: ${{ inputs.agent_name }}
+    runs-on: ubuntu-latest
+    # Intentional: reuse the `security-review` environment, which holds the DIAL
+    # key with the Anthropic route + the anthropic.claude-sonnet-4-6 deployment
+    # (same as the claude-security-review workflow). This is the standardized
+    # DIAL inference route for SDLC agents on development-1.0, not leftover
+    # sandbox config. The environment has no protection rules, so it doesn't gate
+    # runs.
+    environment: security-review
+    timeout-minutes: ${{ inputs.timeout_minutes }}
+    concurrency:
+      group: ${{ inputs.concurrency_group != '' && inputs.concurrency_group || format('{0}-{1}-{2}', github.workflow, inputs.agent_name, github.ref) }}
+      cancel-in-progress: true
+    env:
+      # ANTHROPIC_API_KEY MUST be a job-level env: the composite action reads it
+      # via `${{ env.ANTHROPIC_API_KEY }}`, and a composite action's expression
+      # context does NOT see vars set with GITHUB_ENV in caller steps (only its
+      # process env does). DIAL key when DIAL_CORE_URL is set, else the direct
+      # Anthropic key.
+      ANTHROPIC_API_KEY: ${{ vars.DIAL_CORE_URL != '' && secrets.DIAL_API_KEY || secrets.ANTHROPIC_API_KEY }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Configure inference route
+        # ANTHROPIC_API_KEY is the job-level env above. Here we add the DIAL-only
+        # vars that claude-code-action reads from the PROCESS env (GITHUB_ENV DOES
+        # propagate to later steps' / the composite action's process env, even
+        # though it's invisible to their `${{ env.X }}` expressions). In direct-
+        # Anthropic mode these stay unset — exactly the prior behavior.
+        env:
+          DIAL_CORE_URL: ${{ vars.DIAL_CORE_URL }}
+          DIAL_API_KEY: ${{ secrets.DIAL_API_KEY }}
+          # DIAL deployment id to route to (e.g. anthropic.claude-sonnet-4-5-
+          # 20250929-v1:0). DIAL names rarely match Anthropic model strings, so
+          # set this to a deployment your key actually has. If unset, the
+          # platform falls back to `anthropic.<manifest model>`.
+          DIAL_MODEL: ${{ vars.DIAL_MODEL }}
+        run: |
+          set -euo pipefail
+          if [ -n "${DIAL_CORE_URL:-}" ]; then
+            if [ -z "${DIAL_API_KEY:-}" ]; then
+              echo "::error::DIAL_CORE_URL is set but the DIAL_API_KEY secret is missing."
+              exit 1
+            fi
+            base="${DIAL_CORE_URL%/}/anthropic"
+            { echo "ANTHROPIC_BASE_URL=${base}"
+              echo "ANTHROPIC_AUTH_TOKEN=${DIAL_API_KEY}"
+              echo "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1"
+              echo "SDLC_DIAL_MODE=1"
+              if [ -n "${DIAL_MODEL:-}" ]; then echo "SDLC_DIAL_MODEL=${DIAL_MODEL}"; fi
+            } >> "$GITHUB_ENV"
+            echo "Inference route: DIAL (${base}) deployment=${DIAL_MODEL:-anthropic.<manifest model>}"
+          else
+            echo "Inference route: direct Anthropic"
+          fi
+
+      - name: Install YAML parser
+        run: pip install --quiet pyyaml
+
+      - name: Wait for and download upstream artifacts
+        # No rounds: every matched agent starts at once, so a `needs:` upstream
+        # may still be running. For each one, poll until its artifact is ready
+        # (download succeeds), or until its job finishes WITHOUT one (failed /
+        # cancelled) — then proceed and let the agent-wrapper handle the absent
+        # artifact. This gives per-edge scheduling: a dependent waits only for
+        # ITS upstream, not a whole round.
+        if: inputs.upstream_artifacts != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          UPSTREAM: ${{ inputs.upstream_artifacts }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          set -uo pipefail   # NOT -e: the download retries are expected to fail until ready
+          mkdir -p upstream
+          IFS=',' read -ra NAMES <<< "$UPSTREAM"
+          for name in "${NAMES[@]}"; do
+            [ -z "$name" ] && continue
+            echo "Waiting for upstream agent: ${name}"
+            got=0
+            for i in $(seq 1 160); do   # ~40 min cap (160 × 15s)
+              if gh run download "$RUN_ID" -R "$REPO" -n "stage-output-${name}" -D "upstream/${name}/" 2>/dev/null; then
+                echo "  ✓ downloaded stage-output-${name}"; got=1; break
+              fi
+              # Break early if the upstream JOB has finished without an artifact.
+              # The dispatcher's matrix job is named after the agent, so the
+              # agent name is always a path segment of the job's full name
+              # (e.g. "dispatch / <agent> / …") — match it as a segment.
+              concl=$(gh api "repos/${REPO}/actions/runs/${RUN_ID}/jobs" --paginate \
+                --jq "[.jobs[] | select(.name | test(\"(^| / )${name}( / |\$)\")) | .conclusion] | map(select(. != null)) | last // \"\"" 2>/dev/null || echo "")
+              if [ -n "$concl" ] && [ "$concl" != "success" ]; then
+                echo "::warning::upstream ${name} finished as '${concl}' with no artifact; proceeding without it"
+                break
+              fi
+              sleep 15
+            done
+            [ "$got" = 1 ] || echo "::notice::upstream ${name} not available; the agent will note the absent artifact"
+          done
+          echo "Upstream payloads available at:"
+          find upstream/ -type f -name 'stage-output.json' 2>/dev/null || true
+
+      - name: Load manifest
+        id: manifest
+        env:
+          AGENT_NAME: ${{ inputs.agent_name }}
+        run: |
+          set -euo pipefail
+          MANIFEST="agents/${AGENT_NAME}/agent.yml"
+          if [ ! -f "$MANIFEST" ]; then
+            echo "::error::Manifest not found: $MANIFEST"
+            exit 1
+          fi
+          # Skill-only: no per-agent prompt.md. The composite action composes
+          # the full prompt from the manifest's `skill:` value. Fail loudly if
+          # a stray prompt.md is committed — it has no effect and signals drift.
+          if [ -f "agents/${AGENT_NAME}/prompt.md" ]; then
+            echo "::error::agents/${AGENT_NAME}/prompt.md exists but is no longer honored. Remove the file and put any reusable agent logic into a Claude skill at .claude/skills/<skill>/SKILL.md or .claude/commands/<skill>.md."
+            exit 1
+          fi
+          python3 - <<'EOF' >> "$GITHUB_OUTPUT"
+          import json, os, yaml
+          with open(f"agents/{os.environ['AGENT_NAME']}/agent.yml") as f:
+              m = yaml.safe_load(f) or {}
+          skill = m.get("skill")
+          if not skill:
+              raise SystemExit("::error::manifest missing required field: skill (agents must wrap a local skill)")
+          tools = m.get("allowed_tools")
+          if not tools:
+              raise SystemExit("::error::manifest missing required field: allowed_tools")
+          # tools.extra: optional list of CLI tools to install on the runner
+          # before invocation. Items can be either:
+          #   - a string (npm package name; installed via npm install -g)
+          #   - an object {name, install} where `install` is a shell command
+          # Emit as a single JSON line; the install step dispatches on shape.
+          extra = (m.get("tools") or {}).get("extra") or []
+          # secrets: declared env-var names the agent needs. The inject step
+          # below promotes ONLY these from the inherited secret bag into the
+          # job env. Emit as a JSON list (empty list when none declared).
+          secrets = m.get("secrets") or []
+          print(f"skill={skill}")
+          print(f"allowed_tools={tools}")
+          print(f"agent_version={m.get('agent_version', 'unknown')}")
+          print(f"model={m.get('model', '')}")
+          print(f"max_turns={m.get('max_turns', 18)}")
+          print(f"tools_extra_json={json.dumps(extra)}")
+          print(f"secrets_json={json.dumps(secrets)}")
+          # vars: declared NON-secret config names to inject from the Actions
+          # Variables context (operator-tunable knobs, e.g. JIRA_MAX_FINDINGS).
+          print(f"vars_json={json.dumps(m.get('vars') or [])}")
+          # private_output: encrypt this agent's artifact and decrypt encrypted
+          # upstream artifacts (public-repo leak protection). See the encrypt
+          # step in run-claude-stage and the decrypt step below.
+          print(f"private_output={str(m.get('private_output', False)).lower()}")
+          # analysis_ref: overlay this ref's source for the agent to inspect.
+          # emit_sarif: convert findings[] -> SARIF and upload to code scanning.
+          print(f"analysis_ref={m.get('analysis_ref', '')}")
+          print(f"emit_sarif={str(m.get('emit_sarif', False)).lower()}")
+          EOF
+
+      - name: Install agent-declared CLI tools
+        # Iterates `tools.extra` from the manifest. Three shapes:
+        #   - "pkg"                                          → npm install -g pkg
+        #   - {name: "pkg", version: "1.2.3"}                → npm install -g pkg@1.2.3
+        #   - {name: "x", version?: ..., install: "...{{version}}..."} → shell, with
+        #     {{version}} substituted from the sibling version field
+        # Failure exits early before Claude is invoked — loud failure, not silent.
+        # Agents without extra deps pay zero install cost (step skipped when array is empty).
+        if: steps.manifest.outputs.tools_extra_json != '[]' && steps.manifest.outputs.tools_extra_json != ''
+        env:
+          EXTRA_JSON: ${{ steps.manifest.outputs.tools_extra_json }}
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json, os, subprocess, sys
+          extra = json.loads(os.environ['EXTRA_JSON'])
+          for entry in extra:
+              if isinstance(entry, str):
+                  print(f"::group::npm install -g {entry}")
+                  subprocess.run(["npm", "install", "-g", entry], check=True)
+                  print("::endgroup::")
+                  continue
+              if not isinstance(entry, dict) or "name" not in entry:
+                  sys.stderr.write(f"::error::Invalid tools.extra entry shape: {entry!r}\n")
+                  sys.exit(1)
+              name = entry["name"]
+              version = entry.get("version")
+              install = entry.get("install")
+              if install:
+                  # Shell form. Substitute {{version}} placeholder (empty when no version).
+                  cmd = install.replace("{{version}}", version or "")
+                  label = f"{name}" + (f" v{version}" if version else "")
+                  print(f"::group::install {label}")
+                  print(f"+ {cmd}")
+                  subprocess.run(cmd, shell=True, check=True)
+                  print("::endgroup::")
+              else:
+                  # npm form, optionally pinned via @-syntax.
+                  pkg = f"{name}@{version}" if version else name
+                  print(f"::group::npm install -g {pkg}")
+                  subprocess.run(["npm", "install", "-g", pkg], check=True)
+                  print("::endgroup::")
+          PY
+
+      - name: Inject declared secrets
+        # Generic secret plumbing: promote ONLY the secrets a manifest declares
+        # (`secrets:` in agents/<name>/agent.yml) from the inherited secret bag
+        # into the job env, so the wrapped skill's committed helper scripts can
+        # read them. Adding a new secret-using agent needs NO platform edit —
+        # declare the name here and add the matching Actions secret.
+        #
+        # Why this shape: GitHub has no dynamic `secrets[name]` access, so we
+        # take the whole bag via toJSON(secrets) and select the declared names.
+        # Claude never types secret values (the agent-wrapper forbids shell
+        # expansion in Bash tool calls); secrets are referenced only inside
+        # committed scripts that read them from env. We print names only, never
+        # values — and GHA masks registered secret values in logs regardless.
+        if: steps.manifest.outputs.secrets_json != '[]' && steps.manifest.outputs.secrets_json != ''
+        env:
+          SECRETS_JSON: ${{ toJSON(secrets) }}
+          DECLARED: ${{ steps.manifest.outputs.secrets_json }}
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json, os
+          allsec = json.loads(os.environ["SECRETS_JSON"])
+          declared = json.loads(os.environ["DECLARED"])
+          missing = [n for n in declared if not allsec.get(n)]
+          if missing:
+              raise SystemExit(
+                  f"::error::Declared secrets unavailable to run-agent: {missing}. "
+                  "Add them under repo/org Settings -> Secrets -> Actions, or fix "
+                  "the manifest `secrets:` list.")
+          with open(os.environ["GITHUB_ENV"], "a") as fh:
+              for name in declared:
+                  fh.write(f"{name}<<__SDLC_SECRET_EOF__\n{allsec[name]}\n__SDLC_SECRET_EOF__\n")
+          print(f"Injected {len(declared)} declared secret(s) into job env: {', '.join(declared)}")
+          PY
+
+      - name: Inject declared vars
+        # Non-secret counterpart of secret injection: promote ONLY the Actions
+        # Variables a manifest declares (`vars:`) into the job env, so an
+        # operator can tune knobs (e.g. JIRA_MAX_FINDINGS) in Settings ->
+        # Variables WITHOUT editing the skill. Missing vars are skipped — the
+        # skill's own default applies — so this never fails the run.
+        if: steps.manifest.outputs.vars_json != '[]' && steps.manifest.outputs.vars_json != ''
+        env:
+          VARS_JSON: ${{ toJSON(vars) }}
+          DECLARED: ${{ steps.manifest.outputs.vars_json }}
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json, os
+          allvars = json.loads(os.environ["VARS_JSON"])
+          declared = json.loads(os.environ["DECLARED"])
+          injected = []
+          with open(os.environ["GITHUB_ENV"], "a") as fh:
+              for name in declared:
+                  val = allvars.get(name)
+                  if val not in (None, ""):
+                      fh.write(f"{name}<<__SDLC_VAR_EOF__\n{val}\n__SDLC_VAR_EOF__\n")
+                      injected.append(name)
+          print(f"Injected vars: {injected or '(none set; skill defaults apply)'}")
+          PY
+
+      - name: Decrypt upstream artifacts
+        # Upstream producers flagged `private_output` upload their stage-output
+        # AES-encrypted (.enc). Decrypt any here — after secret injection, so
+        # SDLC_ARTIFACT_KEY is in the env — into the plaintext path the agent
+        # expects (upstream/<name>/stage-output.json). No-op when no .enc exists.
+        if: inputs.upstream_artifacts != ''
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          enc_found=0
+          for enc in upstream/*/stage-output.json.enc; do
+            enc_found=1
+            if [ -z "${SDLC_ARTIFACT_KEY:-}" ]; then
+              echo "::error::Encrypted upstream artifact ${enc} but SDLC_ARTIFACT_KEY is not in env. Add it to this agent's manifest \`secrets:\` list."
+              exit 1
+            fi
+            out="$(dirname "$enc")/stage-output.json"
+            openssl enc -d -aes-256-cbc -pbkdf2 -in "$enc" -out "$out" -pass env:SDLC_ARTIFACT_KEY
+            echo "Decrypted ${enc} -> ${out}"
+          done
+          if [ "$enc_found" = 0 ]; then echo "No encrypted upstream artifacts to decrypt."; fi
+
+      - name: Overlay analysis-ref source
+        # When a manifest declares `analysis_ref`, the agent must inspect THAT
+        # ref's code (e.g. snyk-triage validates findings against `development`,
+        # the branch the scanner ran on — not the sandbox base). We cannot
+        # `actions/checkout` that ref: the framework (composite action, prompts,
+        # schemas, skills) lives ONLY on the sandbox base, so a full checkout
+        # would strip it. Instead overlay the ref's source while preserving the
+        # framework paths (.github, .claude, agents). Also capture its sha/ref so
+        # an emit_sarif upload can be scoped to the scanned commit.
+        #
+        # `agents` is excluded alongside .github/.claude because the overlaid ref
+        # is untrusted under pull_request_target (a fork PR head). The base
+        # manifest — already read into step outputs before this step — must keep
+        # governing the run; letting the overlaid ref replace agents/<name>/agent.yml
+        # would expose tools.extra/secrets/allowed_tools to attacker control.
+        if: steps.manifest.outputs.analysis_ref != ''
+        env:
+          ANALYSIS_REF: ${{ steps.manifest.outputs.analysis_ref }}
+        run: |
+          set -euo pipefail
+          git fetch --depth=1 origin "$ANALYSIS_REF"
+          SHA="$(git rev-parse FETCH_HEAD)"
+          git checkout FETCH_HEAD -- . ':(exclude).github' ':(exclude).claude' ':(exclude)agents'
+          echo "ANALYSIS_SHA=${SHA}" >> "$GITHUB_ENV"
+          echo "ANALYSIS_REF_FULL=refs/heads/${ANALYSIS_REF}" >> "$GITHUB_ENV"
+          echo "Overlaid source from ${ANALYSIS_REF}@${SHA:0:7}; .github/.claude/agents preserved."
+
+      - id: stage
+        uses: ./.github/actions/run-claude-stage
+        with:
+          stage_name: ${{ inputs.agent_name }}
+          skill: ${{ steps.manifest.outputs.skill }}
+          allowed_tools: ${{ steps.manifest.outputs.allowed_tools }}
+          agent_version: ${{ steps.manifest.outputs.agent_version }}
+          model: ${{ steps.manifest.outputs.model }}
+          max_turns: ${{ steps.manifest.outputs.max_turns }}
+          upstream_artifacts: ${{ inputs.upstream_artifacts }}
+          private_output: ${{ steps.manifest.outputs.private_output }}
+          emit_sarif: ${{ steps.manifest.outputs.emit_sarif }}

--- a/agents/_template/agent.yml
+++ b/agents/_template/agent.yml
@@ -1,0 +1,68 @@
+# Agent manifest. An agent is a manifest + a skill reference.
+# All reusable agent logic lives in `.claude/skills/<skill>/SKILL.md` (or
+# `.claude/commands/<skill>.md`); the runtime wires CI and composes a
+# uniform prompt that invokes the skill. There is NO per-agent prompt.md.
+#
+# To add an agent: copy this directory, rename it, edit the required fields
+# below, point `skill:` at a local skill, commit. The dispatcher picks the
+# agent up on the next PR.
+
+contract_version: "0.1"               # required: pin schema version
+name: my-agent                         # required: kebab-case; surfaces in PR comments + kill-switch var
+
+# The local skill this agent wraps. Must be addressable as `/<skill>` in a
+# prompt (e.g. `code-review-and-quality`, `opsx:verify`, `feature-research`).
+# If your task needs custom orchestration, put it INSIDE the skill file —
+# the agent layer is just CI plumbing.
+skill: my-skill                        # required
+
+# When the agent runs.
+# Short form: triggers: [pull_request]
+# Long form with filters (branches + labels honored; paths reserved for v0.3):
+#   triggers:
+#     - on: pull_request
+#       filters:
+#         branches: [main, development-1.0]   # PR target branches
+#         labels: [review-me]                  # all must be present on PR
+triggers: [pull_request]               # required
+
+# Comma-separated Claude tool allowlist. Include the tools the wrapped
+# skill needs, plus `Skill` itself.
+# Tiers: read-only         = "Read,Grep,Glob,Skill"
+#        + git diff         = "Read,Grep,Glob,Bash(git diff:*),Skill"
+#        + MCP context      = append ",mcp__dial-context__*"
+allowed_tools: "Read,Grep,Glob,Skill"  # required
+
+# Optional metadata
+agent_version: "0.1.0"                 # appears in the output envelope
+description: "One-line description of what this agent does."
+model: claude-sonnet-4-6               # claude-opus-4-7 / claude-sonnet-4-6 / claude-haiku-4-5-20251001 / etc.
+phase: pilot                           # sandbox | pilot | production
+cost_class: light                      # light (<$0.50/run) | medium | heavy
+
+# Kill switch (optional override). Default derived from name: code-review → STAGE_CODE_REVIEW_ENABLED.
+# Set the corresponding repo or org variable to "false" to disable without a revert.
+# kill_switch_var: STAGE_MY_AGENT_ENABLED
+
+# Chaining (optional). List of upstream agents whose output this agent reads.
+# The platform downloads their stage-output.json files into upstream/{name}/
+# before running. Your skill reads upstream/<upstream-name>/stage-output.json.
+# Leave empty (or omit) if your agent runs independently — the common case.
+# needs: [scan-deps]
+
+# Per-agent timeout (optional, default 15 min, max 360).
+# timeout_minutes: 30
+
+# GHA permissions (optional). Validated against the platform-supported set:
+#   contents: read           — the default; you don't need to declare it
+#   pull-requests: write     — the default; you don't need to declare it
+#   checks: write            — opt-in: required only if you create check runs
+#   security-events: write   — opt-in: required only if you upload SARIF
+# Any value outside the supported set rejects the manifest at discovery.
+# permissions:
+#   checks: write
+
+# Concurrency override (optional). Default: dispatch-pr-<name>-<ref>.
+# concurrency:
+#   group: "${{ github.workflow }}-special-${{ github.ref }}"
+#   cancel_in_progress: true

--- a/agents/code-review/agent.yml
+++ b/agents/code-review/agent.yml
@@ -1,0 +1,10 @@
+contract_version: "0.1"
+name: code-review
+skill: code-review-and-quality
+agent_version: "0.1.0"
+description: "AI code review wrapping the local /code-review-and-quality skill."
+triggers: [pull_request]
+allowed_tools: "Read,Grep,Glob,Bash(git diff:*),Skill"
+model: claude-sonnet-4-6
+phase: pilot
+cost_class: light


### PR DESCRIPTION
## Summary

Port the SDLC code-review agent infrastructure to ai-dial-chat. Adds GitHub Actions workflows, agent scaffolding, and platform documentation to support running the code-review agent within the repository's CI/CD pipeline.

## Changes

- GitHub Actions: workflow dispatch, agent execution, and trust gate
- Agent manifest and reference documentation
- Platform setup and configuration guides
- Python utilities for findings aggregation, SARIF conversion, and output rendering
- Agent templates and code-review agent initial configuration

## Test plan

- [x] Branch builds without errors
- [x] All files staged and committed with proper Conventional Commits format
- [x] Ready for integration testing in CI/CD pipeline

🤖 Generated with Claude Code