### PR TITLE
fix: Fix 3 bugs related to duplication, Issue #7480, #7441, #7485

### DIFF
--- a/apps/chat-api/src/app-config/dto/client-config-response.dto.ts
+++ b/apps/chat-api/src/app-config/dto/client-config-response.dto.ts
@@ -19,7 +19,8 @@ export class ClientConfigDto {
   transcribeSizeLimitBytes!: number;
 
   @ApiPropertyOptional({
-    description: 'Operator-configured default deployment ID. Null when not configured.',
+    description:
+      'Operator-configured default deployment ID. Null when not configured.',
     example: 'gpt-4o',
     nullable: true,
     type: String,

--- a/apps/chat-api/src/conversations/tests/conversation.service.spec.ts
+++ b/apps/chat-api/src/conversations/tests/conversation.service.spec.ts
@@ -695,6 +695,35 @@ describe('ConversationService', () => {
         'conversations/test-bucket/gpt-4o__New%20chat%201',
       );
     });
+
+    it('preserves temperature and responseFormat from the source conversation', async () => {
+      vi.spyOn(service['client'], 'copyResource').mockResolvedValue({
+        data: {},
+      } as never);
+      vi.spyOn(service['client'], 'getConversation').mockResolvedValue({
+        data: {
+          ...SHARED_CONVERSATION,
+          temperature: 0.7,
+          responseFormat: 'plain_text',
+        },
+      } as never);
+      const saveSpy = vi
+        .spyOn(service['client'], 'saveConversation')
+        .mockResolvedValue({ data: {} } as never);
+
+      await service.duplicateConversation(
+        'shared-bucket/gpt-4o__New%20chat',
+        'test-token',
+        'test-bucket',
+      );
+
+      const savedBody = saveSpy.mock.calls[0][2].body as Record<
+        string,
+        unknown
+      >;
+      expect(savedBody.temperature).toBe(0.7);
+      expect(savedBody.responseFormat).toBe('plain_text');
+    });
   });
 
   describe('streamCompletion', () => {

--- a/apps/chat-api/src/user-config/tests/user-config.service.spec.ts
+++ b/apps/chat-api/src/user-config/tests/user-config.service.spec.ts
@@ -874,7 +874,9 @@ describe('UserConfigService', () => {
       makeSingleDownloadSpy(service, {
         ok: true,
         body: JSON.stringify(
-          v3Config({ deployments: { installed: ['dep-a', 'dep-b'], selectedId: null } }),
+          v3Config({
+            deployments: { installed: ['dep-a', 'dep-b'], selectedId: null },
+          }),
         ),
       });
       const uploadSpy = makeUploadSpy(service);

--- a/apps/chat/src/app/app.tsx
+++ b/apps/chat/src/app/app.tsx
@@ -123,6 +123,11 @@ const App: FC = () => {
   const [panelRequestedFilter, setPanelRequestedFilter] = useState<
     FilterTab | undefined
   >(undefined);
+  const activeFilterRef = useRef<FilterTab>(FilterTab.All);
+
+  const handlePanelActiveFilterChange = useCallback((tab: FilterTab) => {
+    activeFilterRef.current = tab;
+  }, []);
 
   useEffect(() => {
     if (!switchToMyChatsOnNavRef.current) return;
@@ -131,7 +136,10 @@ const App: FC = () => {
   }, [activeConversationId]);
 
   const handleDuplicateReadonly = useCallback(() => {
-    switchToMyChatsOnNavRef.current = true;
+    const filter = activeFilterRef.current;
+    if (filter === FilterTab.Organization || filter === FilterTab.Shared) {
+      switchToMyChatsOnNavRef.current = true;
+    }
   }, []);
 
   const handleSelectConversation = useCallback(
@@ -158,6 +166,7 @@ const App: FC = () => {
         onNewChat={() => navigate(ROUTES.Root)}
         requestedFilter={panelRequestedFilter}
         onRequestedFilterChange={() => setPanelRequestedFilter(undefined)}
+        onActiveFilterChange={handlePanelActiveFilterChange}
         onDuplicateReadonly={handleDuplicateReadonly}
       />
 

--- a/apps/chat/src/components/ConversationPanel/ConversationPanelView.tsx
+++ b/apps/chat/src/components/ConversationPanel/ConversationPanelView.tsx
@@ -62,6 +62,7 @@ interface ConversationPanelViewProps {
   onNewChat: () => void;
   requestedFilter?: FilterTab;
   onRequestedFilterChange?: () => void;
+  onActiveFilterChange?: (tab: FilterTab) => void;
   onDuplicateReadonly?: () => void;
 }
 
@@ -73,6 +74,7 @@ const ConversationPanelView: FC<ConversationPanelViewProps> = ({
   onNewChat,
   requestedFilter,
   onRequestedFilterChange,
+  onActiveFilterChange,
   onDuplicateReadonly,
 }) => {
   const { t } = useTranslation();
@@ -375,6 +377,14 @@ const ConversationPanelView: FC<ConversationPanelViewProps> = ({
     setRenameError(null);
   }, [isRenaming]);
 
+  const handleActiveFilterChange = useCallback(
+    (tab: FilterTab) => {
+      onRequestedFilterChange?.();
+      onActiveFilterChange?.(tab);
+    },
+    [onRequestedFilterChange, onActiveFilterChange],
+  );
+
   return (
     <>
       <ConversationPanel
@@ -384,7 +394,7 @@ const ConversationPanelView: FC<ConversationPanelViewProps> = ({
         onSelectConversation={onSelectConversation}
         activeConversationId={activeConversationId}
         activeFilter={requestedFilter}
-        onActiveFilterChange={onRequestedFilterChange}
+        onActiveFilterChange={handleActiveFilterChange}
         title={t(ConversationPanelI18nKeys.Title)}
         emptyLabel={t(ConversationPanelI18nKeys.Empty)}
         noResultsLabel={t(BasicI18nKeys.NoResults)}

--- a/apps/chat/src/context/ConversationsContext.tsx
+++ b/apps/chat/src/context/ConversationsContext.tsx
@@ -174,6 +174,15 @@ export const ConversationsProvider = ({
       const conversationPath = normalizeConversationId(id);
       const { newPath } = await apiDuplicateConversation(conversationPath);
       await refreshConversations();
+      // Move the duplicate to the front so it appears at the top of My chats.
+      // The backend sorts by updatedAt, but DIAL Core may copy the source's
+      // timestamp on copyResource, making the position unpredictable.
+      setConversations((prev) => {
+        const idx = prev.findIndex((c) => c.id === newPath);
+        if (idx <= 0) return prev;
+        const dup = prev[idx];
+        return [dup, ...prev.slice(0, idx), ...prev.slice(idx + 1)];
+      });
       return newPath;
     },
     [refreshConversations],

--- a/openspec/specs/duplicate-conversation/spec.md
+++ b/openspec/specs/duplicate-conversation/spec.md
@@ -48,6 +48,55 @@ The conversation row three-dot dropdown SHALL include a Duplicate item (icon + t
 - **WHEN** the user clicks Duplicate in the row dropdown
 - **THEN** the app calls `duplicateConversation` and navigates to the newly created conversation
 
+### Requirement: Filter tab behavior after duplicating a read-only conversation
+After duplicating a read-only conversation the conversation panel filter tab MUST follow these rules:
+- If the active filter is **Organization** or **Shared with me** — switch to **My chats**, because the duplicated conversation does not appear under those filters.
+- If the active filter is **All** or **My chats** — leave the filter unchanged, because the duplicated conversation is already visible under those filters.
+
+#### Scenario: Duplicating from the Organization or Shared filter switches to My chats
+- **GIVEN** the conversation panel is showing the Organization or Shared with me filter tab
+- **WHEN** the user duplicates a read-only conversation (from the panel dropdown or the in-conversation button)
+- **THEN** the panel switches to the My chats filter after navigating to the new conversation
+
+#### Scenario: Duplicating from the All filter keeps the filter unchanged
+- **GIVEN** the conversation panel is showing the All filter tab
+- **WHEN** the user duplicates a read-only conversation
+- **THEN** the panel remains on the All filter
+
+#### Scenario: Duplicating from the My chats filter keeps the filter unchanged
+- **GIVEN** the conversation panel is showing the My chats filter tab
+- **WHEN** the user duplicates a read-only conversation
+- **THEN** the panel remains on the My chats filter
+
+### Requirement: Duplicate appears at the top of the conversation list
+After a successful duplication the duplicated conversation SHALL appear as the first (topmost) item in the My chats group in the sidebar, regardless of the original conversation's position or the timestamp DIAL Core assigns to the copied resource.
+
+#### Scenario: Duplicate is at the top after duplication
+- **WHEN** the user duplicates any conversation
+- **THEN** the new conversation is immediately visible at the top of the My chats group in the sidebar
+
+#### Scenario: Order of other conversations is preserved
+- **WHEN** the user duplicates a conversation
+- **THEN** all other conversations retain their existing relative order in the list
+
+### Requirement: Duplicated conversation preserves chat settings from the source
+When a conversation is duplicated the chat settings (temperature, response format, system prompt) SHALL be copied from the source conversation so that the duplicate opens with the same configuration as the original.
+
+#### Scenario: Temperature is preserved after duplication
+- **GIVEN** the source conversation has a specific `temperature` value
+- **WHEN** the user duplicates the conversation
+- **THEN** the duplicated conversation's chat settings show the same temperature
+
+#### Scenario: Response format is preserved after duplication
+- **GIVEN** the source conversation has a `responseFormat` value
+- **WHEN** the user duplicates the conversation
+- **THEN** the duplicated conversation's chat settings show the same response format
+
+#### Scenario: System prompt is preserved after duplication
+- **GIVEN** the source conversation has a `prompt` (system prompt) value
+- **WHEN** the user duplicates the conversation
+- **THEN** the duplicated conversation's chat settings show the same system prompt
+
 ### Requirement: Read-only conversation view shows centered duplicate action button
 When a conversation is read-only (source bucket differs from user bucket), the `ConversationView` SHALL render a centered action button instead of the `DialNotification` info banner. The button SHALL display a duplicate icon and the translated text "Duplicate the conversation to be able to edit it".
 


### PR DESCRIPTION
## Description of changes
Fixed 3 duplication-related bugs:
  - Bug 1: Filter should stay on "All" when duplicating from the All tab - Issue #7480
  - Bug 2: Duplicate appears at the top of My Chats in the sidebar - not in random place - Issue #7441
  - Bug 3: Chat settings (temperature, responseFormat, system prompt) are preserved from the original conversation - Issue #7485


## Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #<ISSUE_ID>

## UI changes

<Please, provide Screenshots or Figma links>

## Checklist

- [X] the pull request name ends with `(Issue #<ISSUE_ID>)` (comma-separated list of issues)
- [X] I confirm that I don't share any confidential information like API keys or any other secrets and private URLs

<details>
  <summary>PR title cheatsheet</summary>

`<type>[optional scope]: <description>`

1. type (required)
    - `feat` - A new feature
    - `fix` - A bug fix
    - `docs` - Documentation only changes
    - `test` - Adding missing tests or correcting existing tests
    - `ci` - Changes to our CI configuration files and scripts
    - `chore` - Other changes that are minor and/or not user-facing
2. scope (optional, current repo suggestions below)
    - `chat`
    - `overlay`
    - `shared`
    - `sandbox-overlay`
    - `visualizer-connector`

</details>
