### PR TITLE
fix(chat): fix organization auto collapse (Issue #3024)

### DIFF
--- a/apps/chat/src/components/Chat/ChangePathDialog.tsx
+++ b/apps/chat/src/components/Chat/ChangePathDialog.tsx
@@ -396,13 +396,22 @@ export const ChangePathDialog = ({
     gridEditingOptions,
   });
 
+  const publishedFolderIds = useMemo(
+    () => new Set(additionalOrganizationFolders.map((f) => f.id)),
+    [additionalOrganizationFolders],
+  );
+
   const isTempFolder = useCallback(
-    (id: string) =>
-      addedTempFolderIdsRef.current.has(id) ||
-      [...addedTempFolderIdsRef.current].some((rootId) =>
-        id.startsWith(`${rootId}/`),
-      ),
-    [],
+    (id: string) => {
+      if (publishedFolderIds.has(id)) return false;
+      return (
+        addedTempFolderIdsRef.current.has(id) ||
+        [...addedTempFolderIdsRef.current].some((rootId) =>
+          id.startsWith(`${rootId}/`),
+        )
+      );
+    },
+    [publishedFolderIds],
   );
 
   const handleOrganizationRenameValidation = useCallback(

--- a/apps/chat/src/components/Chat/ChangePathDialog.tsx
+++ b/apps/chat/src/components/Chat/ChangePathDialog.tsx
@@ -397,7 +397,12 @@ export const ChangePathDialog = ({
   });
 
   const publishedFolderIds = useMemo(
-    () => new Set(additionalOrganizationFolders.map((f) => f.id)),
+    () =>
+      new Set(
+        additionalOrganizationFolders
+          .filter((f) => !f.temporary)
+          .map((f) => f.id),
+      ),
     [additionalOrganizationFolders],
   );
 

--- a/apps/chat/src/components/Chat/Publish/PublicationHandler/PublicationHandler.tsx
+++ b/apps/chat/src/components/Chat/Publish/PublicationHandler/PublicationHandler.tsx
@@ -827,6 +827,7 @@ export function PublicationHandler({ publication, onSubmit }: Props) {
             areRulesChanged={hasUserChangedRules}
             initialState={initialState}
             isDraftRuleFilterOpen={isRulesSetterVisible}
+            isReview={isReview}
           />
         </div>
         {isCompareModalOpened && comparePath && (

--- a/apps/chat/src/components/Chat/Publish/PublicationHandler/PublicationHandlerFooter.tsx
+++ b/apps/chat/src/components/Chat/Publish/PublicationHandler/PublicationHandlerFooter.tsx
@@ -98,6 +98,7 @@ interface Props {
   isFormChanged: boolean;
   areRulesChanged: boolean;
   isDraftRuleFilterOpen: boolean;
+  isReview: boolean;
 }
 
 export const PublicationHandlerFooter = ({
@@ -106,6 +107,7 @@ export const PublicationHandlerFooter = ({
   isFormChanged,
   areRulesChanged,
   isDraftRuleFilterOpen,
+  isReview,
 }: Props) => {
   const router = useRouter();
   const { t } = useTranslation(Translation.Chat);
@@ -226,6 +228,8 @@ export const PublicationHandlerFooter = ({
       reviewed: ResourceToReview[],
       featureType: FeatureType,
     ) => {
+      if (isReview) return;
+
       const paths = uniq(
         [...toReview, ...reviewed].flatMap((resource) =>
           getParentFolderIdsFromEntityId(
@@ -243,7 +247,7 @@ export const PublicationHandlerFooter = ({
         );
       }
     },
-    [dispatch],
+    [dispatch, isReview],
   );
 
   const handlePublicationReview = useCallback(() => {


### PR DESCRIPTION
## Description of changes

When admin select publication request and view its content , the folders inside Organization should not be expanded or collapsed automatically

## Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #3024

## Checklist

- [x] the pull request name ends with `(Issue #<ISSUE_ID>)` (comma-separated list of issues)
- [x] I confirm that I don't share any confidential information like API keys or any other secrets and private URLs

<details>
  <summary>PR title cheatsheet</summary>

`<type>[optional scope]: <description>`

1. type (required)
    - `feat` - A new feature
    - `fix` - A bug fix
    - `docs` - Documentation only changes
    - `test` - Adding missing tests or correcting existing tests
    - `ci` - Changes to our CI configuration files and scripts
    - `chore` - Other changes that are minor and/or not user-facing
2. scope (optional, current repo suggestions below)
    - `chat`
    - `overlay`
    - `shared`
    - `sandbox-overlay`
    - `visualizer-connector`

</details>
