### PR TITLE
fix: Update pagination limit for conversations API to default 100 and max 1000

### DIFF
--- a/openspec/changes/archive/2026-06-09-conversation-panel-state-and-list-path/specs/conversations-api/spec.md
+++ b/openspec/changes/archive/2026-06-09-conversation-panel-state-and-list-path/specs/conversations-api/spec.md
@@ -4,7 +4,7 @@
 
 The backend SHALL expose `GET /api/v1/conversations/list` (not `GET /api/v1/conversations`) in `apps/chat-api/src/conversations/conversation.controller.ts`. The controller MUST be versioned (`version: '1'`), annotated with `@ApiTags('conversations')`, and delegate all logic to `ConversationService`. The endpoint is backed by DIAL Core metadata (not an in-memory store). It accepts the following query parameters validated by `ListConversationsQueryDto`:
 
-- `limit` — integer, default 20, max 100 (`@IsInt @Min(1) @Max(100) @IsOptional`)
+- `limit` — integer, default 100, max 1000 (`@IsInt @Min(1) @Max(1000) @IsOptional`)
 - `nextToken` — string cursor from a previous response, passed through to DIAL Core (`@IsString @MaxLength(512) @IsOptional`)
 - `path` — string subfolder path to scope the listing, default `''` (bucket root = "My Files") (`@IsString @MaxLength(512) @IsOptional`)
 
@@ -60,7 +60,7 @@ Generated-client impact:
 
 #### Scenario: Invalid limit returns 400
 
-- **WHEN** `GET /api/v1/conversations/list?limit=200` is called (exceeds max 100)
+- **WHEN** `GET /api/v1/conversations/list?limit=1001` is called (exceeds max 1000)
 - **THEN** the response is 400 with a validation error
 
 ## REMOVED Requirements


### PR DESCRIPTION
… 

## Description of changes

<!-- Please explain the changes you made right below this line. -->

## Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #<ISSUE_ID>

## UI changes

<Please, provide Screenshots or Figma links>

## Checklist

- [ ] the pull request name ends with `(Issue #<ISSUE_ID>)` (comma-separated list of issues)
- [ ] I confirm that I don't share any confidential information like API keys or any other secrets and private URLs

<details>
  <summary>PR title cheatsheet</summary>

`<type>[optional scope]: <description>`

1. type (required)
    - `feat` - A new feature
    - `fix` - A bug fix
    - `docs` - Documentation only changes
    - `test` - Adding missing tests or correcting existing tests
    - `ci` - Changes to our CI configuration files and scripts
    - `chore` - Other changes that are minor and/or not user-facing
2. scope (optional, current repo suggestions below)
    - `chat`
    - `overlay`
    - `shared`
    - `sandbox-overlay`
    - `visualizer-connector`

</details>
