### PR TITLE
ci(sdlc): add agent dispatch infrastructure — code-review + security-review

### DIFF
--- a/.claude/skills/dep-scan/SKILL.md
+++ b/.claude/skills/dep-scan/SKILL.md
@@ -1,0 +1,159 @@
+---
+name: dep-scan
+description: Runs Trivy filesystem scan against the repo root and emits structured vulnerability findings (CVE, package, versions) in the SDLC reviewer schema. Use when an agent needs to detect known CVEs in project dependencies for downstream triage or human review.
+---
+
+# Dependency Scan (Trivy)
+
+## Overview
+
+Filesystem scan for known CVEs. Trivy autodetects lockfiles
+(`package-lock.json`, `pnpm-lock.yaml`, etc.) and produces a JSON
+report; this skill parses that report and emits findings in the SDLC
+reviewer shape so downstream agents (e.g., `/dep-triage`) and human
+reviewers can consume them uniformly.
+
+This is the **scan step only** — no triage, no false-positive analysis.
+That happens downstream.
+
+## When to use
+
+- PR-time dependency check (chained before `/dep-triage`).
+- Scheduled dependency scans (nightly, weekly).
+- Any flow needing machine-readable vulnerability output that another
+  agent or process will consume.
+
+## Required tools
+
+- `Bash(trivy:*)` — to invoke the CLI
+- `Write` — to produce `stage-output.json` (auto-granted by the platform)
+- `Read`, `Glob` — to inspect lockfiles or scan output if needed
+
+## Process
+
+### 1. Run Trivy
+
+Filesystem scan from repo root, JSON output, medium severity and above.
+**Use Trivy's `--output` flag, not shell redirection (`>`)** — Claude
+Code's Bash tool rejects shell-redirection operators and would deny the
+command:
+
+```bash
+trivy fs --format json --severity HIGH,CRITICAL,MEDIUM --quiet --output /tmp/trivy.json .
+```
+
+Same effect: writes report to `/tmp/trivy.json`. No `>`, no `|`, no
+shell-variable expansion — exactly what `Bash(trivy:*)` allows.
+
+Notes:
+
+- `--quiet` suppresses interactive UI noise.
+- If `/tmp/trivy.json` is missing or zero-length after the command,
+  treat it as a scanner failure (see *Heuristics*).
+
+### 2. Parse the report
+
+**Use the `Read` tool** to load `/tmp/trivy.json` into your reasoning
+context. **Do NOT** attempt to use `cat`, `head`, `tail`, `jq`, `grep`,
+`awk`, or any other shell command to inspect the file — those aren't
+in the agent's `allowed_tools` (only `Bash(trivy:*)` is) and the Bash
+tool will deny them, burning turns on retries. The Read tool is the
+intended path for inspecting on-disk JSON.
+
+The file is on the order of tens-to-hundreds of KB; one Read call
+loads it cleanly.
+
+Trivy's structure:
+
+```
+{
+  "Results": [
+    {
+      "Target": "package-lock.json",
+      "Type": "npm",
+      "Vulnerabilities": [
+        {
+          "VulnerabilityID": "CVE-...",
+          "PkgName": "lodash",
+          "InstalledVersion": "4.17.20",
+          "FixedVersion": "4.17.21",
+          "Severity": "HIGH",
+          "Title": "..."
+        }
+      ]
+    }
+  ]
+}
+```
+
+A `Result` may have no `Vulnerabilities` array if the target is clean
+— skip it.
+
+### 3. Map each vulnerability to a finding
+
+Lowercase severity; carry through CVE, package, versions:
+
+```
+{
+  "severity": "high",
+  "file": "package-lock.json",
+  "message": "<CVE>: <Title>. Affected: <pkg>@<version>. Fixed in <fixed>.",
+  "suggested_fix": "Upgrade <pkg> to >=<fixed>.",
+  "cve": "<CVE>",
+  "package": "<pkg>",
+  "installed_version": "<installed>",
+  "fixed_version": "<fixed>",
+  "target_type": "<npm|gomod|...>"
+}
+```
+
+The `cve`, `package`, `installed_version`, `fixed_version`, and
+`target_type` fields are the contract for `/dep-triage` — don't omit
+them.
+
+### 4. Set status
+
+- `passed` — no findings at MEDIUM+
+- `passed_with_findings` — findings exist but all are MEDIUM (no HIGH/CRITICAL)
+- `failed` — any HIGH or CRITICAL finding
+
+### 5. Write `stage-output.json`
+
+Use the **Write tool** to save at the repo root. Include
+`payload.scan_summary` so downstream consumers don't have to recount:
+
+```
+{
+  "stage": "scan-deps",
+  "status": "<above>",
+  "summary": "Trivy fs: <N> findings (<H> high, <M> medium).",
+  "payload": {
+    "scan_summary": {
+      "total": <N>,
+      "by_severity": { "critical": <c>, "high": <h>, "medium": <m> },
+      "scanner": "trivy fs"
+    },
+    "findings": [ ... ]
+  }
+}
+```
+
+## Heuristics
+
+- **Scanner failure → high-severity finding.** If `trivy` exits
+  non-zero or `/tmp/trivy.json` is empty/malformed, emit one
+  high-severity finding with `file: null` and `message` quoting the
+  stderr verbatim, then set `status: failed`. Don't silently produce
+  empty findings.
+- **Truncate verbose descriptions.** Trivy's `Description` field can
+  be very long; keep it brief in the `message` field or move detail to
+  `cve` lookups elsewhere.
+- **Don't filter by reachability here.** That's `/dep-triage`'s job.
+  Emit every CVE Trivy finds at the configured severity threshold.
+
+## Output for downstream
+
+The exact shape above is the contract for `/dep-triage`. The triage
+skill keys off `cve`, `package`, and `installed_version` to look up
+usage in the repo. Omit those fields and triage degrades to "every
+finding marked confirmed."

--- a/.claude/skills/dep-triage/SKILL.md
+++ b/.claude/skills/dep-triage/SKILL.md
@@ -1,0 +1,177 @@
+---
+name: dep-triage
+description: Reviews dependency-scan findings against repo source to mark each as confirmed (real risk) or false_positive (not exploitable in this codebase context). Use after /dep-scan emits CVE findings; reduces reviewer noise before human review.
+---
+
+# Dependency Triage
+
+## Overview
+
+Reads upstream scan findings, evaluates each in the repo's actual usage
+context, and emits the same findings augmented with `triage_outcome`
+(`confirmed` | `false_positive`) and a one-sentence `triage_reason`.
+
+This is the **triage step** — does not run scanners itself. Always
+downstream of `/dep-scan` (or another scan agent emitting the same
+finding shape: `cve`, `package`, `installed_version`, `fixed_version`).
+
+## When to use
+
+- After `/dep-scan` in a chained agent (`needs: [scan-deps]`).
+- Whenever raw scanner output needs filtering before human review.
+- Periodically (e.g., scheduled re-triage to update prior-run outcomes
+  as the codebase evolves).
+
+## Required tools
+
+- `Read`, `Grep`, `Glob` — to inspect repo source for package usage
+- `Bash(git diff:*)` — to scope which dependencies the PR touched
+- `Skill` — invocation only
+- `Write` — auto-granted; for `stage-output.json`
+
+## Inputs
+
+- `upstream/scan-deps/stage-output.json` — scan findings from the
+  upstream `scan-deps` agent (or compatible scanner)
+
+## Triage rubric
+
+For each finding under `payload.findings[]`:
+
+### Confirmed (`triage_outcome: confirmed`)
+
+Mark confirmed if **all three** hold:
+
+1. The package is imported by repo source under `apps/`, `libs/`, or
+   `packages/`.
+2. The vulnerable code path is plausibly reachable from a request,
+   user input, or build output.
+3. The package is NOT exclusively a dev-time dependency.
+
+### False positive (`triage_outcome: false_positive`)
+
+Mark FP if **any one** of these holds:
+
+1. **Not a runtime dep.** Listed only under `devDependencies` /
+   `peerDependencies` and not exposed at build/runtime (test fixtures,
+   type generators, bundler internals).
+2. **Vulnerable function unused.** The specific CVE-affected
+   function/API is not called anywhere in `apps/`, `libs/`, or
+   `packages/`.
+3. **Network/host context excludes risk.** E.g., DoS vuln on internal
+   service the project doesn't expose; SSRF on URL the project never
+   constructs; XSS in a sanitizer the project doesn't reach.
+4. **Already mitigated transitively.** Repo's package overrides /
+   resolutions pin a safe version.
+5. **Out-of-scope target.** Scanner flagged a vendored binary,
+   build artifact, or test fixture not part of the deployed
+   application.
+
+### Conservative tie-break
+
+If you can't establish FP via one of the rules above, mark
+`confirmed`. Better one extra reviewer click than missing a real CVE.
+Capture uncertainty in `triage_reason` so the reviewer can re-evaluate
+quickly.
+
+## Process
+
+1. **Read upstream output.** `upstream/scan-deps/stage-output.json` —
+   parse `payload.findings[]`.
+
+2. **For each finding**, follow the rubric:
+   - Use `Grep` to find imports of `package` in `apps/`, `libs/`,
+     `packages/`.
+   - If imports exist, `Read` the importing files to check whether the
+     vulnerable API is actually used.
+   - Inspect `package.json` files to determine `dependencies` vs
+     `devDependencies` (path matters — root `package.json` vs
+     workspace `package.json`s differ in semantics).
+   - Consider transitive resolutions: check `pnpm-lock.yaml` /
+     `package-lock.json` for pinned-safe versions.
+
+3. **Augment each finding** with two new fields:
+   - `triage_outcome`: `"confirmed"` or `"false_positive"`
+   - `triage_reason`: one short sentence explaining the call. Reference
+     the rule number (1-5) for FPs.
+
+4. **Recompute summary.** Update the top-level `summary` field to
+   reflect post-triage counts:
+   `"trivy: <N> raw → <C> confirmed, <F> false_positive"`.
+
+## Output
+
+Same top-level shape as the upstream scan, with two augmentations:
+
+```
+{
+  "stage": "triage-deps",
+  "status": "<see below>",
+  "summary": "trivy: <N> raw → <C> confirmed, <F> false positive",
+  "payload": {
+    "findings": [
+      {
+        "severity": "high",
+        "file": "package-lock.json",
+        "message": "<CVE>: ... (unchanged from scan)",
+        "suggested_fix": "...",
+        "cve": "...",
+        "package": "lodash",
+        "installed_version": "4.17.20",
+        "fixed_version": "4.17.21",
+        "triage_outcome": "confirmed",
+        "triage_reason": "Imported by libs/foo and the vulnerable .pickBy() is called in src/utils/groupBy.ts."
+      },
+      {
+        "severity": "high",
+        "file": "package-lock.json",
+        "message": "<CVE>: ...",
+        ...,
+        "triage_outcome": "false_positive",
+        "triage_reason": "FP rule 2: vulnerable .template() function is not called anywhere under apps/ or libs/."
+      }
+    ],
+    "triage_summary": {
+      "raw": <N>,
+      "confirmed": <C>,
+      "false_positive": <F>
+    }
+  }
+}
+```
+
+### Status
+
+- `passed` — all findings false_positive (no confirmed real risks)
+- `passed_with_findings` — confirmed findings exist but only at
+  `info`/`low`/`medium` severity
+- `failed` — any confirmed finding at `high` or `critical` severity
+
+### Severity discipline
+
+**Do not downgrade severity.** A confirmed-but-low-likelihood finding
+keeps its original severity (high/critical); the human reviewer
+decides whether to accept the risk. Triage filters the noise; it does
+not soften the signal.
+
+## Heuristics
+
+- **Grep first, read second.** Don't blindly Read every file in
+  `libs/`. A focused `Grep` for `from '<package>'` or
+  `require('<package>')` scopes the work.
+- **Multiple CVEs per package are independent.** Same package can have
+  one confirmed CVE (vulnerable function called) and one FP CVE
+  (different function unused). Evaluate each on its own.
+- **Capture audit context in `triage_reason`.** A future scheduled
+  re-triage can diff outcomes only if the reasoning is preserved.
+- **Don't fabricate file paths.** If you can't find an import of the
+  affected package in the repo, that's FP rule 1 (not a runtime dep)
+  or rule 5 (out-of-scope target). Mark it accordingly, don't invent
+  evidence.
+
+## Output preservation vs sticky-comment filtering
+
+Emit **all** findings (confirmed and FP) under `payload.findings[]` for
+the artifact — the artifact is the audit trail. The renderer (which
+posts the sticky PR comment) can filter to confirmed-only for the
+human view; the artifact retains the full record.

--- a/.claude/skills/proactive-security-monitor/SKILL.md
+++ b/.claude/skills/proactive-security-monitor/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: proactive-security-monitor
+description: Proactive supply-chain watch for this repo. Resolves the npm SBOM and batch-queries OSV.dev for freshly-modified advisories (committed fetch.sh), then runs an industry-news pass (CISA KEV, OpenSSF, GitHub Security Lab, Socket, The Hacker News) filtered to this project's stack, and emits both as one findings set for the downstream triager. Use as the daily/scheduled producer half of the proactive-security-monitor → security-monitor-triager chain.
+---
+
+# Proactive Security Monitor (producer)
+
+You are the **producer** in a two-stage proactive-security loop. Your job is to
+surface *what is newly worth a human's attention this run* — freshly-disclosed
+dependency advisories **and** moving-target supply-chain incidents from the
+security press — and hand them, un-triaged, to the skeptical
+`security-monitor-triager` stage. You **find**; the triager **validates
+reachability**. Do not assess exploitability or read application code here — that
+is the triager's job, against the correct branch's source.
+
+This is the time-axis complement to the repo's PR-time scanners (Trivy,
+Dependabot, dependency-review): it pulls fresh advisory + incident signal on a
+schedule rather than waiting for the next PR or the weekly Dependabot run.
+
+## Process
+
+### 1. Deterministic OSV pass — run the committed script
+
+Run exactly this single Bash command (your only Bash allowance):
+
+```
+bash .claude/skills/proactive-security-monitor/fetch.sh
+```
+
+It resolves the npm SBOM from `package-lock.json` (no install), batch-queries
+OSV.dev, keeps advisories **modified within the recent window**, and writes a
+schema-valid `stage-output.json` with the CVE hits already inlined under
+`payload.findings[]` and an empty `payload.news` array. **Read `stage-output.json`**
+to confirm it exists and see what the OSV pass found. Do **not** rewrite
+`payload.findings[]` — you will only *add* to this envelope below.
+
+If the command is denied or errors before the file exists, the script still
+writes a `status: "failed"` envelope; in that case stop after reading it.
+
+### 2. Industry-news pass — your own judgment
+
+Independent of OSV, fetch these sources with **WebFetch** (look back over the
+same recent window) and extract items disclosed/updated in that window. The
+RSS/Atom feeds (e.g. The Hacker News) are **broader than supply-chain only** —
+their items span all of infosec — so be especially strict applying the
+stack + supply-chain filter below; drop generic threat-intel that does not
+touch this project's stack or a supply-chain/registry/CI vector:
+
+| Source | URL |
+|---|---|
+| CISA KEV (newly added CVEs) | `https://www.cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json` |
+| OpenSSF blog | `https://openssf.org/blog/` |
+| GitHub Security Lab | `https://github.blog/security/` |
+| Socket.dev blog | `https://socket.dev/blog` |
+| The Hacker News — RSS feed | `https://feeds.feedburner.com/TheHackersNews` |
+
+**This project's stack — filter every item against it:**
+Node.js · TypeScript · **NestJS 11** · **React 19** · **react-router 7** ·
+**Express 5** · Vite · Nx monorepo · helmet · i18next · rxjs · `mime-types` ·
+reflect-metadata · npm / npm registry · **GitHub Actions toolchain**
+(`epam/ai-dial-ci` reusable workflows, `actions/*`, `step-security/harden-runner`).
+
+Classify **every** item into exactly one tag:
+
+- **RELEVANT** — names a package in the SBOM, or a Node/npm/TypeScript/React/NestJS/Vite/Nx-specific incident, or an npm-registry or GitHub-Actions-toolchain attack.
+- **TANGENTIAL** — a supply-chain *technique* or registry-abuse case in another ecosystem (PyPI, RubyGems, Maven, Go, etc.) that plausibly translates to this stack. Include **only with a one-sentence translation rationale**. Default to IGNORE if unsure.
+- **IGNORE** — audited, not applicable. Keep title + source so the filter is auditable; no analysis.
+
+**Record every fetch deterministically.** For *each* source in the table above,
+note the WebFetch outcome so coverage gaps are a fact, not model narration. You
+will emit these in step 3 as `payload.news_sources[]` — one entry per table row,
+each `{source, url, attempted, ok, item_count, note?}`:
+
+- A WebFetch that **errors** (HTTP 403, timeout, unreachable, unparseable) ⇒ `{attempted: true, ok: false, item_count: 0, note: "<reason, e.g. HTTP 403 bot block>"}`.
+- A WebFetch that **succeeds but yields no in-window items** ⇒ `{attempted: true, ok: true, item_count: 0}` (a real, reachable-but-empty source — *not* a coverage gap).
+- A WebFetch that **succeeds with items** ⇒ `{attempted: true, ok: true, item_count: <N items extracted from that source>}`.
+
+`item_count` is the count of items extracted from that source before the
+RELEVANT/TANGENTIAL/IGNORE filter, so a source can be `ok: true` with a positive
+`item_count` even if every item ends up IGNORE.
+
+### 3. Enrich the envelope (preserve the OSV findings)
+
+Use the **Write** tool to write `stage-output.json` again, **carrying over
+`payload.findings[]` and every other `payload` key from step 1 unchanged**, and
+adding the news pass:
+
+- `payload.news` — array of `{tag, title, source, url, date, rationale?, stack_hit?, suggested_action?}` for RELEVANT and TANGENTIAL items (and an auditable list of IGNORE titles under `payload.news_ignored`).
+- `payload.news_sources` — array with **one entry per source row** in the step-2 table, each `{source, url, attempted, ok, item_count, note?}`, populated from the per-source WebFetch outcomes recorded in step 2. This makes coverage gaps deterministic: a source that returned 403/error appears as `ok: false` with a `note`, distinct from a reachable source that simply had no in-window items (`ok: true, item_count: 0`). The triager reads this instead of inferring reach from prose.
+- For each **RELEVANT** item that maps to a concrete repo action (e.g. "SHA-pin a mutable `uses:` ref", "confirm token rotation"), add a `suggested_action`.
+- Update `summary` to one line covering both passes, e.g. `"OSV: 2 in-window; News: 3 RELEVANT, 4 TANGENTIAL (incl. GitHub Actions campaign)."`
+- Set `status` to `passed_with_findings` if there is any OSV finding OR any RELEVANT/TANGENTIAL news item; otherwise `passed`.
+
+Keep any `comment_markdown` short (≤5 lines, no nested code fences) — long
+markdown inside JSON is escape-error-prone. The downstream triager reads the
+structured `payload`, not prose.
+
+## Output
+
+One `stage-output.json` at repo root:
+`{stage, status, summary, payload:{findings[], news[], news_ignored[], news_sources[], ...}}`.
+The OSV `findings[]` come from `fetch.sh`; you add `news[]`, `news_ignored[]`, and
+`news_sources[]` (one `{source, url, attempted, ok, item_count, note?}` entry per
+step-2 source, recording each WebFetch outcome so coverage gaps are deterministic).
+The triager stage consumes this whole payload.
+
+## Required tools
+
+`Bash(bash .claude/skills/proactive-security-monitor/fetch.sh:*)`, `Read`,
+`WebFetch`, `Skill`. (`Write` is granted by the platform.)

--- a/.claude/skills/proactive-security-monitor/fetch.sh
+++ b/.claude/skills/proactive-security-monitor/fetch.sh
@@ -1,0 +1,247 @@
+#!/usr/bin/env bash
+# proactive-security-monitor fetch script (deterministic OSV pass).
+#
+# Resolves this repo's dependency SBOM from package-lock.json (NO install — we
+# parse the committed lockfile directly, so nothing from the tree is executed;
+# this keeps the producer safe to run on the sandbox pull_request trigger per
+# ADR-0005 P-2), batch-queries OSV.dev for advisories touching those packages,
+# keeps only advisories MODIFIED within a recent window (the "what's new since
+# last run" signal), fetches per-advisory detail, and writes the SDLC stage
+# envelope (stage-output.json) at the repo root with the CVE hits inlined under
+# payload.findings[].
+#
+# WHY INLINE THE FINDINGS: the platform uploads ONLY stage-output.json as the
+# upstream artifact, so any sidecar files do NOT travel to the downstream
+# triager. The consumable findings therefore live inline under
+# payload.findings[] (mirroring snyk-jira-ingest's payload.issues).
+#
+# WHY A COMMITTED SCRIPT: the agent-wrapper forbids pipes / redirects / shell
+# variable expansion in commands Claude types into its Bash tool, so the model
+# cannot type a curl|python pipeline. This committed, reviewed script does the
+# whole deterministic pass; the agent only ever invokes
+# `bash .claude/skills/proactive-security-monitor/fetch.sh` (literal, no
+# expansion), which is its entire Bash allowlist. The model's own job (the
+# industry-news WebFetch pass) is layered on top in SKILL.md and ENRICHES this
+# envelope; it must preserve payload.findings[] verbatim.
+#
+# The script always writes a schema-valid stage-output.json and exits 0, so the
+# platform renders/handles a result even when the network or lockfile fails.
+set -uo pipefail
+
+export STAGE="proactive-security-monitor"
+export OUT="stage-output.json"
+export LOCK="${PSM_LOCKFILE:-package-lock.json}"
+# Advisory recency window (days). The value proposition is "faster on the time
+# axis" than weekly Dependabot / next-PR Trivy, so the default is tight; widen
+# via the PSM_WINDOW_DAYS Actions Variable for a first/catch-up run.
+export WINDOW_DAYS="${PSM_WINDOW_DAYS:-7}"
+# Hard cap on inlined findings so a noisy window can't blow the triager's turn
+# budget. 0 = no cap. Tune via the PSM_MAX_FINDINGS Actions Variable.
+export MAX_FINDINGS="${PSM_MAX_FINDINGS:-50}"
+
+python3 - <<'PY'
+import json, os, sys, time, socket, urllib.request, urllib.error
+from datetime import datetime, timedelta, timezone
+
+STAGE = os.environ["STAGE"]
+OUT   = os.environ["OUT"]
+LOCK  = os.environ["LOCK"]
+WINDOW_DAYS  = int(os.environ.get("WINDOW_DAYS", "7") or "7")
+MAX_FINDINGS = int(os.environ.get("MAX_FINDINGS", "50") or "0")
+
+OSV_BATCH = "https://api.osv.dev/v1/querybatch"
+OSV_VULN  = "https://api.osv.dev/v1/vulns/"
+cutoff = datetime.now(timezone.utc) - timedelta(days=WINDOW_DAYS)
+
+def write(doc):
+    doc["summary"] = doc.get("summary", "")[:280]
+    with open(OUT, "w") as f:
+        json.dump(doc, f, indent=2)
+
+def fail(summary):
+    write({"stage": STAGE, "status": "failed", "summary": summary,
+           "payload": {"scanner": "osv", "ecosystem": "npm",
+                       "window_days": WINDOW_DAYS, "sbom_count": 0,
+                       "findings": [], "news": []}})
+    print(summary)
+    sys.exit(0)
+
+# --- 1. Resolve SBOM from the committed lockfile (no install) ---------------
+try:
+    with open(LOCK) as f:
+        lock = json.load(f)
+except FileNotFoundError:
+    fail(f"{LOCK} not found at repo root; cannot resolve the npm SBOM.")
+except json.JSONDecodeError as e:
+    fail(f"{LOCK} is not valid JSON: {e}")
+
+# lockfileVersion 2/3: every installed third-party package is a `packages` entry
+# keyed by its node_modules path. Workspace packages (no node_modules/ segment)
+# and link entries are skipped. The real package name is the substring after the
+# LAST `node_modules/` (handles scoped + nested deps).
+pkgs = {}
+for path, meta in (lock.get("packages") or {}).items():
+    if "node_modules/" not in path:
+        continue                       # workspace root / local workspace package
+    if meta.get("link"):
+        continue                       # symlink to a local workspace package
+    version = meta.get("version")
+    if not version:
+        continue
+    name = path.split("node_modules/")[-1]
+    pkgs[(name, version)] = True       # dedupe by (name, version)
+
+sbom = [{"name": n, "version": v} for (n, v) in pkgs]
+if not sbom:
+    fail(f"No third-party npm packages resolved from {LOCK}.")
+
+# Bounded retry wrapper (stdlib only). Retries transient failures — URLError,
+# socket timeout, and HTTP 5xx — up to 3 total attempts with exponential backoff
+# (~1s, 2s, capped at 4s). 4xx (and any non-transient error) are NOT retried and
+# re-raise immediately. Callers decide what a final failure means (fail() for the
+# batch, stub for per-advisory detail).
+RETRY_ATTEMPTS = 3
+RETRY_BACKOFF_CAP = 4.0
+
+def request_with_retry(fn):
+    attempt = 0
+    while True:
+        try:
+            return fn()
+        except urllib.error.HTTPError as e:
+            # Only 5xx is transient; 4xx is a client error — do not retry.
+            if e.code < 500 or attempt >= RETRY_ATTEMPTS - 1:
+                raise
+        except (urllib.error.URLError, socket.timeout, TimeoutError):
+            if attempt >= RETRY_ATTEMPTS - 1:
+                raise
+        time.sleep(min(2.0 ** attempt, RETRY_BACKOFF_CAP))
+        attempt += 1
+
+def post_json(url, body):
+    data = json.dumps(body).encode()
+    req = urllib.request.Request(url, data=data,
+                                 headers={"Content-Type": "application/json"})
+    def do():
+        with urllib.request.urlopen(req, timeout=60) as r:
+            return json.load(r)
+    return request_with_retry(do)
+
+def get_json(url):
+    def do():
+        with urllib.request.urlopen(url, timeout=60) as r:
+            return json.load(r)
+    return request_with_retry(do)
+
+# --- 2. Batch-query OSV, chunked (OSV caps batch size) ----------------------
+hits = {}     # osv_id -> (name, version)
+try:
+    CHUNK = 800
+    for i in range(0, len(sbom), CHUNK):
+        chunk = sbom[i:i + CHUNK]
+        body = {"queries": [
+            {"package": {"name": p["name"], "ecosystem": "npm"},
+             "version": p["version"]} for p in chunk]}
+        resp = post_json(OSV_BATCH, body)
+        for p, result in zip(chunk, resp.get("results", [])):
+            for v in (result.get("vulns") or []):
+                vid = v.get("id")
+                mod = v.get("modified", "")
+                if not vid:
+                    continue
+                # Filter on `modified` BEFORE fetching detail (cheap window cut).
+                try:
+                    mdt = datetime.fromisoformat(mod.replace("Z", "+00:00"))
+                except ValueError:
+                    mdt = None
+                if mdt is None or mdt >= cutoff:
+                    hits.setdefault(vid, (p["name"], p["version"]))
+except urllib.error.URLError as e:
+    fail(f"OSV batch query failed (network/endpoint): {e}")
+
+# --- 3. Fetch detail for in-window hits; build findings ---------------------
+def severity_label(detail):
+    # Prefer GHSA's database_specific severity label; fall back to a coarse
+    # CVSS bucket; else unknown (kept — the triager calibrates authoritatively).
+    ds = (detail.get("database_specific") or {}).get("severity")
+    if ds:
+        return ds.upper()
+    for s in (detail.get("severity") or []):
+        sc = s.get("score", "")
+        # Numeric base score if OSV gave one directly.
+        try:
+            n = float(sc)
+            return ("CRITICAL" if n >= 9 else "HIGH" if n >= 7
+                    else "MEDIUM" if n >= 4 else "LOW")
+        except ValueError:
+            pass
+    return "UNKNOWN"
+
+LABEL_TO_SEV = {"CRITICAL": "critical", "HIGH": "high", "MODERATE": "medium",
+                "MEDIUM": "medium", "LOW": "low", "UNKNOWN": "medium"}
+
+findings = []
+for vid, (name, version) in hits.items():
+    try:
+        detail = get_json(OSV_VULN + vid)
+    except urllib.error.URLError:
+        detail = {"id": vid, "summary": "(advisory detail fetch failed)"}
+    label = severity_label(detail)
+    summary = (detail.get("summary") or detail.get("details") or "")[:300]
+    text_blob = (summary + " " + json.dumps(detail.get("database_specific") or {})).lower()
+    supply_chain = any(k in text_blob for k in
+                       ("malicious", "supply chain", "supply-chain", "compromis", "typosquat"))
+    # Drop only clearly-LOW non-supply-chain advisories; keep the rest and let
+    # the triager calibrate severity against real reachability.
+    if label == "LOW" and not supply_chain:
+        continue
+    aliases = detail.get("aliases") or []
+    refs = [r.get("url") for r in (detail.get("references") or []) if r.get("url")]
+    findings.append({
+        "severity": LABEL_TO_SEV.get(label, "medium"),
+        "message": f"{vid} ({', '.join(aliases) or 'no-CVE'}) affects {name}@{version}: {summary}",
+        "osv_id": vid,
+        "aliases": aliases,
+        "package": name,
+        "version": version,
+        "osv_severity_label": label,
+        "supply_chain": supply_chain,
+        "advisory_url": (f"https://osv.dev/vulnerability/{vid}"),
+        "references": refs[:5],
+        "modified": detail.get("modified", ""),
+        "affected": detail.get("affected", []),   # ranges — triager re-verifies version match
+    })
+
+# Stable order: supply-chain first, then by severity, then id.
+sev_rank = {"critical": 0, "high": 1, "medium": 2, "low": 3, "info": 4}
+findings.sort(key=lambda f: (not f["supply_chain"], sev_rank.get(f["severity"], 9), f["osv_id"]))
+total = len(findings)
+deferred = 0
+if MAX_FINDINGS > 0 and total > MAX_FINDINGS:
+    deferred = total - MAX_FINDINGS
+    findings = findings[:MAX_FINDINGS]
+
+status = "passed_with_findings" if findings else "passed"
+if total:
+    cap_note = f" (cap {MAX_FINDINGS}, {deferred} deferred)" if deferred else ""
+    summary = (f"OSV: {total} in-window advisory(ies) over {len(sbom)} npm packages "
+               f"(last {WINDOW_DAYS}d){cap_note}. News pass pending (model step).")
+else:
+    summary = (f"OSV: 0 advisories modified in last {WINDOW_DAYS}d across {len(sbom)} "
+               f"npm packages. News pass pending (model step).")
+
+write({
+    "stage": STAGE, "status": status, "summary": summary,
+    "payload": {
+        "scanner": "osv", "ecosystem": "npm",
+        "window_days": WINDOW_DAYS, "sbom_count": len(sbom),
+        "osv_total": total, "osv_deferred": deferred,
+        "findings": findings,
+        # The model's industry-news WebFetch pass (SKILL.md) fills this in and
+        # MUST preserve findings[] above. Empty array = news pass not yet run.
+        "news": [],
+    },
+})
+print(f"OSV pass: {len(sbom)} npm packages, {total} in-window advisory(ies), "
+      f"inlined {len(findings)} into {OUT}.")
+PY

--- a/.claude/skills/security-monitor-triager/SKILL.md
+++ b/.claude/skills/security-monitor-triager/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: security-monitor-triager
+description: Skeptical second-opinion review of proactive-security-monitor output. For each OSV advisory it re-verifies version-match and reachability against this repo's actual code, and re-judges the news pass's RELEVANT/TANGENTIAL/IGNORE calls. Emits per-item verdicts (CONFIRMED / OVERSTATED / FALSE_POSITIVE / NEEDS_REVIEW). Use as the triage half of the proactive-security-monitor → security-monitor-triager chain.
+---
+
+# Proactive Security Monitor — Triager (read-only)
+
+You are a **skeptical senior AppSec engineer** reviewing the proactive monitor's
+output the way a dev reads a Snyk/Dependabot report on Monday morning. Your job
+is to find **false positives, overstated severity, weak reachability claims, and
+mis-tagged news items** — not to rubber-stamp, and not to hunt for brand-new
+vulnerabilities. Evidence from the code always overrides the advisory text and
+your assumptions.
+
+Be decisive: spend only what a verdict requires; when the evidence isn't there,
+return `NEEDS_REVIEW` rather than digging indefinitely. **Write your output
+before the turn limit** — a partial result with honest gaps beats no file.
+
+## Input
+
+The producer's output is at `upstream/proactive-security-monitor/stage-output.json`.
+Read it. It contains:
+
+- `payload.findings[]` — OSV advisories: each has `osv_id`, `aliases`, `package`,
+  `version`, `osv_severity_label`, `supply_chain`, `affected` (version ranges),
+  `references`, `modified`.
+- `payload.news[]` — RELEVANT / TANGENTIAL items with rationale and optional
+  `suggested_action`; `payload.news_ignored[]` — the audited IGNORE list.
+
+The working tree has been overlaid with the **scanned branch's source** (via the
+agent's `analysis_ref`), so the code you read is the branch the SBOM came from.
+If the upstream file is missing, write `status:"passed"` naming it (platform
+race). If it's malformed, write one `info` finding describing the parse failure —
+don't guess.
+
+## Per-advisory workflow (each `payload.findings[]` item)
+
+Do only as much as the verdict requires:
+
+1. **Version-match.** Cross-check the SBOM `version` against the advisory
+   `affected[].ranges` (introduced ≤ ours < fixed, or `last_affected ≥ ours`).
+   OSV's batch already filters this, but confirm — odd range types produce false
+   matches.
+2. **Locate usage.** `Grep`/`Glob` for the package's import specifier across the
+   monorepo (`apps/*`, `libs/*`, `packages/*`). Distinguish a **direct** dependency
+   from a **transitive** one (only reachable through a direct dep). If the package
+   is never imported in production code, that is decisive.
+3. **Reachability — the most error-prone step.** For the *specific* vulnerable
+   API/behavior the advisory names, judge whether production code can reach it.
+   Read the real call sites; trace the path. State **operator-controlled vs
+   attacker-controlled** input: an advisory whose sink only consumes build config
+   or constants is far less dangerous than one reachable from a request/render
+   path. Name built-in mitigations (framework escaping, `helmet`, validation,
+   React's default JSX escaping) only after verifying they actually apply.
+4. **Production relevance.** Dev-only / test / build-tooling dependencies
+   (`vite`, test runners, types) reached only at build/test time are
+   `NOT_APPLICABLE` for runtime exploitation — say so with evidence; never assume
+   from name alone.
+5. **Verdict** — pick one, citing concrete `file:line` you actually read.
+
+## Verdicts
+
+- **CONFIRMED** — version matches + vulnerable API reachable from production +
+  attacker-influenceable + no sufficient mitigation, all backed by code.
+- **OVERSTATED** — real but the producer's severity/urgency is too high for this
+  context (transitive-only, operator-controlled input, strong existing mitigation,
+  autoscaled availability impact). Give the calibrated severity.
+- **FALSE_POSITIVE** — proven not applicable: version doesn't actually match,
+  package unused in production, dev/build-only, or the vulnerable path is
+  unreachable. Requires proof, not "looks unlikely".
+- **NEEDS_REVIEW** — can't prove exploitability *or* safety statically (ambiguous
+  dataflow, runtime/deploy-dependent). State what's missing.
+
+Severity: keep the producer's as `original_severity`; set `adjusted_severity`
+from real context. FALSE_POSITIVE / NOT_APPLICABLE → `info`.
+
+## News-pass re-judgement
+
+Re-evaluate the producer's **classifications** (not the items themselves):
+
+- Walk `news_ignored[]`: would any be RELEVANT/TANGENTIAL read fresh? (e.g. a
+  foreign-ecosystem token-redaction regression that npm/Gradle could mirror.)
+- Walk TANGENTIAL: does each rationale trace a *concrete* path to this stack, or
+  is it hand-waving? Downgrade vague ones to IGNORE.
+- Flag coverage gaps (e.g. Snyk/Socket Node-specific disclosures the source set
+  missed) and judge whether each `suggested_action` is a real task or vague
+  "consider hardening".
+
+Emit one news verdict per re-judged item: `FILTER_SOUND` / `TOO_AGGRESSIVE` /
+`TOO_PERMISSIVE` / `COVERAGE_GAP`, citing the specific item.
+
+**Carry over the producer's recommendation.** When re-judging each item, copy its
+`suggested_action` and `url` **verbatim** from the corresponding `payload.news[]`
+item into that item's `news_review[]` entry — do not merely reference them in
+`note`. The verdict and the recommendation must travel together in the final
+artifact; never assert in `note` that a recommendation is sound while dropping
+the recommendation itself. If the producer item had no `suggested_action`, omit
+the field.
+
+## Anti-hallucination (hard rules)
+
+- Cite real `file:line`. Never invent imports, dataflows, sanitizers, or
+  framework protections. Re-verify the most load-bearing 2–3 cites by reading them.
+- Can't prove exploitability → not CONFIRMED. Can't prove safety → not
+  FALSE_POSITIVE. Blocked → NEEDS_REVIEW.
+- Distinguish observed evidence from assumption. No vague "probably safe".
+- Never print secret values.
+
+## Output
+
+Use the **Write** tool to write `stage-output.json` at repo root:
+
+- `status`: `passed_with_findings` if any verdict is CONFIRMED or NEEDS_REVIEW, else `passed`.
+- `summary`: one line, e.g. `"3 advisories: 1 CONFIRMED, 1 OVERSTATED, 1 FALSE_POSITIVE; news filter sound, 1 coverage gap."`
+- `payload.findings[]` — one per reviewed advisory: `{severity (=adjusted), file?, line?, message, suggested_fix?, osv_id, verdict, original_severity, adjusted_severity}`. `message` is one line: `<VERDICT> — <osv_id> <package>@<version>: <evidence: source→sink, mitigation>`. When a verdict UPHOLDS or CALIBRATES the advisory (CONFIRMED / OVERSTATED / NEEDS_REVIEW) rather than kills it (FALSE_POSITIVE / NOT_APPLICABLE), the triager-generated `suggested_fix` MUST be retained — a real, actionable recommendation must never be dropped from the artifact.
+- `payload.news_review[]` — news verdicts `{title, source, producer_tag, verdict, note, suggested_action?, url?}`. `suggested_action` and `url` are echoed **verbatim** from the corresponding upstream `payload.news[]` item so the recommendation survives into the final artifact; omit `suggested_action` when the producer item had none.
+
+> Deferred follow-up (intentionally out of scope here): this echoes the producer's
+> provenance (`suggested_action`, `url`) into the triager artifact. The stronger
+> form — merging verdicts back into the upstream `payload` instead of overwriting
+> `stage-output.json` — is a deliberate future enhancement, not implemented here.
+
+Findings with actionable verdicts drive the SARIF upload (when enabled); keep
+severities honest — don't downgrade a real CONFIRMED.
+
+## Required tools
+
+`Read`, `Grep`, `Glob`, `Bash(git diff:*)`, `Bash(python3:*)`, `Skill`.
+(`Write` is granted by the platform.)

--- a/.claude/skills/snyk-jira-ingest/SKILL.md
+++ b/.claude/skills/snyk-jira-ingest/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: snyk-jira-ingest
+description: Pull REAL Snyk SAST findings from EPAM Jira (Data Center) via the search-export API using a Personal Access Token, and emit them as a stage-output.json artifact for a downstream triage stage. Use when you want the actual Jira-tracked Snyk findings (the same set a human gets by clicking Export on the security filter) rather than a synthetic fixture.
+---
+
+# Snyk → Jira Ingest
+
+Pull the real Snyk SAST findings tracked in EPAM Jira for the downstream triage
+stage. All the work — fetch, filter to this repo, cap, and writing a schema-valid
+`stage-output.json` — is done by the committed script `fetch.sh`; you only run it
+and confirm the result. (Config and behaviour are documented in that script.)
+
+## Procedure
+
+1. Run the script:
+
+   ```
+   bash .claude/skills/snyk-jira-ingest/fetch.sh
+   ```
+
+2. Read `stage-output.json` to confirm it exists. **The script already wrote a
+   valid envelope — do not overwrite it.** Then finish.
+
+3. **Only** if the script is denied or errors before that file exists: write a
+   failed result naming what went wrong. Never fabricate findings or a synthetic
+   export.

--- a/.claude/skills/snyk-jira-ingest/fetch.sh
+++ b/.claude/skills/snyk-jira-ingest/fetch.sh
@@ -1,0 +1,205 @@
+#!/usr/bin/env bash
+# snyk-jira-ingest fetch script.
+#
+# Pulls real Snyk SAST findings from EPAM Jira (Data Center) via the
+# search-export API, parses the export into structured issues, and writes
+# the SDLC stage envelope (stage-output.json) at the repo root. The raw
+# export is also kept at jira-export.xml for local debugging.
+#
+# WHY INLINE THE ISSUES: the platform uploads ONLY stage-output.json as the
+# upstream artifact, so jira-export.xml does NOT travel to a downstream
+# agent. The consumable findings therefore live inline under
+# `payload.issues` (mirroring how snyk-scan-stub inlines `payload.sarif`).
+#
+# WHY A COMMITTED SCRIPT: the agent-wrapper forbids shell variable
+# expansion / pipes / redirections in commands Claude types into its Bash
+# tool. So the agent cannot type `curl -H "...: Bearer ${JIRA_PAT}"`. This
+# script — committed and reviewed — reads JIRA_PAT from the environment
+# (injected by run-agent.yml from the manifest's declared `secrets:`), so
+# the token is NEVER typed into, or seen by, the model. The agent only ever
+# invokes `bash .claude/skills/snyk-jira-ingest/fetch.sh` (literal, no
+# expansion) and that single command is the agent's entire Bash allowlist.
+#
+# The script always writes a schema-valid stage-output.json and exits 0, so
+# the platform renders a sticky comment even on failure (status: failed).
+set -uo pipefail
+
+export STAGE="snyk-jira-ingest"
+export BASE="${JIRA_BASE_URL:-https://jiraeu.epam.com}"
+export FILTER_ID="${JIRA_FILTER_ID:-189402}"
+export JQL="${JIRA_JQL:-filter = ${FILTER_ID} AND status not in (Closed, \"Security Review\") ORDER BY priority}"
+export MAX="${JIRA_MAX:-1000}"
+export XML="jira-export.xml"
+export OUT="stage-output.json"
+
+# Which repo this run triages. The Jira dashboard spans ALL DIAL repos and the
+# tickets carry no per-repo label; the only signal is the repo-prefixed file
+# path in each issue's "Location:" section (e.g. `ai-dial-chat/apps/chat/...`).
+# We keep only issues whose body references `<REPO_NAME>/...` and drop the rest
+# BEFORE triage, so the expensive triage agent never sees other repos' findings.
+# Derive from the manifest override, else the GH repo name, else the cwd name.
+REPO_NAME="${JIRA_REPO_NAME:-}"
+if [ -z "$REPO_NAME" ] && [ -n "${GITHUB_REPOSITORY:-}" ]; then
+  REPO_NAME="${GITHUB_REPOSITORY##*/}"
+fi
+[ -z "$REPO_NAME" ] && REPO_NAME="$(basename "$PWD")"
+export REPO_NAME
+
+# Emit a failure envelope (no issues) and stop. Args: <status> <summary>.
+emit_failure() {
+  STATUS="$1" SUMMARY="$2" python3 - <<'PY'
+import json, os
+fid = os.environ["FILTER_ID"]
+doc = {
+    "stage": os.environ["STAGE"],
+    "status": os.environ["STATUS"],
+    "summary": os.environ["SUMMARY"][:280],
+    "payload": {
+        "scanner": "snyk-code", "source": "jira",
+        "report_format": "jira-searchrequest-xml",
+        "report_location": os.environ["XML"],
+        "jira": {
+            "base_url": os.environ["BASE"],
+            "filter_id": int(fid) if fid.isdigit() else fid,
+            "jql": os.environ["JQL"], "repo_name": os.environ["REPO_NAME"],
+            "fetched_count": 0, "matched_count": 0, "dropped_count": 0,
+            "analyzed_count": 0, "max_findings": int(os.environ.get("JIRA_MAX_FINDINGS", "10") or "0"),
+        },
+        "issues": [], "deferred": [], "dropped": [],
+    },
+}
+with open(os.environ["OUT"], "w") as f:
+    json.dump(doc, f, indent=2)
+PY
+}
+
+if [ -z "${JIRA_PAT:-}" ]; then
+  emit_failure "failed" \
+    "JIRA_PAT not set; cannot authenticate to Jira. Declare it in the manifest \`secrets:\` and add the repo/org Actions secret."
+  exit 0
+fi
+
+# -G + --data-urlencode encodes the JQL; -o writes the body; -w captures the
+# HTTP status. Same endpoint the Jira UI "Export -> XML" drives.
+http=$(curl -sS -G \
+  -H "Authorization: Bearer ${JIRA_PAT}" \
+  -H "Accept: application/xml" \
+  --data-urlencode "jqlQuery=${JQL}" \
+  --data-urlencode "tempMax=${MAX}" \
+  -o "$XML" -w '%{http_code}' \
+  "${BASE%/}/sr/jira.issueviews:searchrequest-xml/temp/SearchRequest.xml") || http="000"
+
+if [ "$http" != "200" ]; then
+  emit_failure "failed" \
+    "Jira export returned HTTP ${http} (expected 200). Check JIRA_PAT validity and that ${BASE} is reachable from the runner."
+  exit 0
+fi
+
+# Parse the export, filter to THIS repo by the repo-prefixed Location path,
+# and inline the kept issues so the artifact is self-contained for downstream
+# triage. Description and environment are preserved raw — they carry the SAST
+# file/line/issue-hash that triage extracts.
+python3 - <<'PY'
+import json, os, re
+import xml.etree.ElementTree as ET
+
+def text(el, tag):
+    e = el.find(tag)
+    return (e.text or "").strip() if e is not None and e.text else ""
+
+fid = os.environ["FILTER_ID"]
+repo = os.environ["REPO_NAME"]
+
+def write(doc):
+    with open(os.environ["OUT"], "w") as f:
+        json.dump(doc, f, indent=2)
+
+try:
+    root = ET.parse(os.environ["XML"]).getroot()
+except ET.ParseError as e:
+    write({
+        "stage": os.environ["STAGE"], "status": "failed",
+        "summary": f"Jira export was not parseable XML: {e}"[:280],
+        "payload": {"scanner": "snyk-code", "source": "jira",
+                    "report_format": "jira-searchrequest-xml",
+                    "report_location": os.environ["XML"],
+                    "jira": {"base_url": os.environ["BASE"], "jql": os.environ["JQL"],
+                             "repo_name": repo, "fetched_count": 0,
+                             "matched_count": 0, "dropped_count": 0}, "issues": [], "dropped": []},
+    })
+    raise SystemExit(0)
+
+# Boundary-anchored repo-prefix matcher: captures `<repo>/<path>` tokens in the
+# issue body. The leading (?:^|[^\w-]) stops `ai-dial-chat` from matching inside
+# `x-ai-dial-chat/` or `ai-dial-chat-themes/` (the char after the name must be
+# `/`). The path char class excludes `<` so it stops at the surrounding HTML.
+prefix_re = re.compile(r"(?:^|[^\w-])" + re.escape(repo) + r"/([\w./-]+)")
+
+kept, dropped = [], []
+for it in root.findall(".//item"):
+    issue = {
+        "key": text(it, "key"),
+        "title": text(it, "title"),
+        "link": text(it, "link"),
+        "summary": text(it, "summary"),
+        "priority": text(it, "priority"),
+        "status": text(it, "status"),
+        "resolution": text(it, "resolution"),
+        "labels": [l.text.strip() for l in it.findall("./labels/label") if l.text and l.text.strip()],
+        "created": text(it, "created"),
+        "updated": text(it, "updated"),
+        "description": text(it, "description"),
+        "environment": text(it, "environment"),
+    }
+    blob = "\n".join((issue["title"], issue["description"], issue["environment"]))
+    files = sorted(set(prefix_re.findall(blob)))   # repo-relative paths (prefix stripped)
+    if files:
+        issue["files"] = files                      # normalized for triage's file lookups
+        kept.append(issue)
+    else:
+        dropped.append(issue["key"])
+
+fetched, matched, ndropped = len(kept) + len(dropped), len(kept), len(dropped)
+
+# Cap on how many repo-matched findings we hand to triage. Default 10 keeps
+# triage within its turn budget (all ~34 real findings overran). Set
+# JIRA_MAX_FINDINGS=0 for no cap (analyze all), or =N for the top-N priority
+# findings (the JQL is priority-ordered). Deferred keys (beyond the cap) are
+# recorded so the backlog stays visible.
+cap = int(os.environ.get("JIRA_MAX_FINDINGS", "10") or "0")
+analyzed_issues = kept[:cap] if cap > 0 else kept
+deferred = [i["key"] for i in kept[cap:]] if cap > 0 else []
+analyzed = len(analyzed_issues)
+
+if dropped:
+    print(f"Dropped {ndropped} cross-repo issue(s) (no '{repo}/' path): {', '.join(dropped)}")
+if deferred:
+    print(f"Deferred {len(deferred)} matched issue(s) beyond cap {cap}: {', '.join(deferred)}")
+
+status = "passed_with_findings" if analyzed else "passed"
+if matched:
+    cap_note = f" (cap {cap}, {len(deferred)} deferred)" if deferred else ""
+    summary = f"{matched} {repo} finding(s); analyzing {analyzed}{cap_note}; {ndropped} cross-repo dropped."
+else:
+    summary = f"Pulled {fetched} from filter {fid}; 0 relate to {repo} ({ndropped} cross-repo dropped)."
+
+write({
+    "stage": os.environ["STAGE"], "status": status, "summary": summary[:280],
+    "payload": {
+        "scanner": "snyk-code", "source": "jira",
+        "report_format": "jira-searchrequest-xml",
+        "report_location": os.environ["XML"],
+        "jira": {
+            "base_url": os.environ["BASE"],
+            "filter_id": int(fid) if fid.isdigit() else fid,
+            "jql": os.environ["JQL"], "repo_name": repo,
+            "fetched_count": fetched, "matched_count": matched, "dropped_count": ndropped,
+            "analyzed_count": analyzed, "max_findings": cap,
+        },
+        "issues": analyzed_issues,
+        "deferred": deferred,
+        "dropped": dropped,
+    },
+})
+print(f"Analyzing {analyzed}/{matched} matched ({fetched} fetched) for {repo} into {os.environ['OUT']}")
+PY

--- a/.claude/skills/snyk-scan-stub/SKILL.md
+++ b/.claude/skills/snyk-scan-stub/SKILL.md
@@ -1,0 +1,203 @@
+---
+name: snyk-scan-stub
+description: Synthetic Snyk Code SARIF 2.1.0 producer for SDLC chain validation. Emits a fixed, realistically-shaped Snyk Code SARIF report under payload.sarif so a downstream triage agent has deterministic, real-format input. NOT a real scanner — replace with stage-snyk.yml when the real Snyk pipeline lands.
+---
+
+# Synthetic Snyk-Scan Stub (chain-validation fixture, real SARIF shape)
+
+This is a **test fixture**, not a real scanner. Its job is to emit a
+deterministic report **in the real Snyk Code SARIF 2.1.0 shape** so the
+`snyk-triage` agent exercises actual SARIF parsing (ruleId→rule join, nested
+`locations`, `level`/`security-severity`, `codeFlows`) — not just an
+easy flat JSON.
+
+Do **not** read the diff, scan the repo, or invent findings. Ignore the
+working tree. Use the **`Write` tool** to save the JSON below **verbatim** to
+`stage-output.json` at the repo root. Copy it exactly — do not reformat,
+re-indent, summarize, or drop fields. The embedded `payload.sarif` object is
+what a real `snyk code test --sarif` run would produce (trimmed to two
+results).
+
+```json
+{
+  "stage": "snyk-scan-stub",
+  "status": "passed_with_findings",
+  "summary": "Synthetic Snyk Code SARIF (2.1.0): 2 results emitted under payload.sarif for triage-chain validation.",
+  "payload": {
+    "scanner": "snyk-code",
+    "report_format": "sarif-2.1.0",
+    "report_location": "payload.sarif",
+    "sarif": {
+      "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+      "version": "2.1.0",
+      "runs": [
+        {
+          "tool": {
+            "driver": {
+              "name": "SnykCode",
+              "semanticVersion": "1.0.0",
+              "version": "1.0.0",
+              "rules": [
+                {
+                  "id": "javascript/OpenRedirect",
+                  "name": "OpenRedirect",
+                  "shortDescription": { "text": "Open Redirect" },
+                  "defaultConfiguration": { "level": "error" },
+                  "help": {
+                    "markdown": "Unsanitized input flowing into a redirect target lets an attacker redirect users to an arbitrary site (phishing).",
+                    "text": "Unsanitized input flowing into a redirect target lets an attacker redirect users to an arbitrary site (phishing)."
+                  },
+                  "properties": {
+                    "tags": ["javascript", "security", "CWE-601", "Security"],
+                    "categories": ["Security"],
+                    "precision": "very-high",
+                    "repoDatasetSize": 3211,
+                    "cwe": ["CWE-601"],
+                    "security-severity": "7.3"
+                  }
+                },
+                {
+                  "id": "javascript/CodeInjection",
+                  "name": "CodeInjection",
+                  "shortDescription": { "text": "Code Injection" },
+                  "defaultConfiguration": { "level": "error" },
+                  "help": {
+                    "markdown": "Untrusted input passed to a dynamic evaluation sink (eval) allows arbitrary code execution.",
+                    "text": "Untrusted input passed to a dynamic evaluation sink (eval) allows arbitrary code execution."
+                  },
+                  "properties": {
+                    "tags": ["javascript", "security", "CWE-94", "Security"],
+                    "categories": ["Security"],
+                    "precision": "very-high",
+                    "repoDatasetSize": 1894,
+                    "cwe": ["CWE-94"],
+                    "security-severity": "9.1"
+                  }
+                }
+              ]
+            }
+          },
+          "results": [
+            {
+              "ruleId": "javascript/OpenRedirect",
+              "ruleIndex": 0,
+              "level": "error",
+              "message": {
+                "text": "Unsanitized input from the HTTP request (callbackUrl) flows into res.redirect, where it is used as a redirect target. This may result in an Open Redirect vulnerability."
+              },
+              "locations": [
+                {
+                  "physicalLocation": {
+                    "artifactLocation": { "uri": "apps/chat-api/src/auth/auth.controller.ts", "uriBaseId": "%SRCROOT%" },
+                    "region": { "startLine": 315, "endLine": 315, "startColumn": 5, "endColumn": 25 }
+                  }
+                }
+              ],
+              "fingerprints": { "0": "3d9f1c7a8b2e4f60a1c5d2e7b9043f18", "1": "openredirect.authcontroller.v1" },
+              "codeFlows": [
+                {
+                  "threadFlows": [
+                    {
+                      "locations": [
+                        {
+                          "location": {
+                            "physicalLocation": {
+                              "artifactLocation": { "uri": "apps/chat-api/src/auth/auth.controller.ts", "uriBaseId": "%SRCROOT%" },
+                              "region": { "startLine": 163, "endLine": 163, "startColumn": 5, "endColumn": 44 }
+                            }
+                          }
+                        },
+                        {
+                          "location": {
+                            "physicalLocation": {
+                              "artifactLocation": { "uri": "apps/chat-api/src/auth/auth.controller.ts", "uriBaseId": "%SRCROOT%" },
+                              "region": { "startLine": 233, "endLine": 236, "startColumn": 5, "endColumn": 6 }
+                            }
+                          }
+                        },
+                        {
+                          "location": {
+                            "physicalLocation": {
+                              "artifactLocation": { "uri": "apps/chat-api/src/auth/auth.controller.ts", "uriBaseId": "%SRCROOT%" },
+                              "region": { "startLine": 315, "endLine": 315, "startColumn": 5, "endColumn": 25 }
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "properties": { "priorityScore": 720, "isAutofixable": false }
+            },
+            {
+              "ruleId": "javascript/CodeInjection",
+              "ruleIndex": 1,
+              "level": "error",
+              "message": {
+                "text": "Untrusted input is passed to eval(), allowing arbitrary code execution (CWE-94)."
+              },
+              "locations": [
+                {
+                  "physicalLocation": {
+                    "artifactLocation": { "uri": "apps/chat-api/src/legacy/unsafe-eval.ts", "uriBaseId": "%SRCROOT%" },
+                    "region": { "startLine": 42, "endLine": 42, "startColumn": 3, "endColumn": 28 }
+                  }
+                }
+              ],
+              "fingerprints": { "0": "a17be03c9d4422f15e8c6b07d3219ef4", "1": "codeinjection.legacyeval.v1" },
+              "codeFlows": [
+                {
+                  "threadFlows": [
+                    {
+                      "locations": [
+                        {
+                          "location": {
+                            "physicalLocation": {
+                              "artifactLocation": { "uri": "apps/chat-api/src/legacy/unsafe-eval.ts", "uriBaseId": "%SRCROOT%" },
+                              "region": { "startLine": 38, "endLine": 38, "startColumn": 3, "endColumn": 30 }
+                            }
+                          }
+                        },
+                        {
+                          "location": {
+                            "physicalLocation": {
+                              "artifactLocation": { "uri": "apps/chat-api/src/legacy/unsafe-eval.ts", "uriBaseId": "%SRCROOT%" },
+                              "region": { "startLine": 42, "endLine": 42, "startColumn": 3, "endColumn": 28 }
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "properties": { "priorityScore": 850, "isAutofixable": false }
+            }
+          ],
+          "properties": {
+            "coverage": [
+              { "files": 1, "isSuppressed": false, "lang": "TypeScript", "type": "SUPPORTED" }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}
+```
+
+The two results are intentionally checkable against the repo:
+
+- **Result 1** (`javascript/OpenRedirect`, `auth.controller.ts:315`) points at a
+  **real** sink whose redirect targets are allowlist-validated by
+  `resolveCallbackUrl()` (the codeFlow even passes through line 233 where that
+  validation happens). A correct triage verdict is **FALSE_POSITIVE**, citing
+  that mitigation.
+- **Result 2** (`javascript/CodeInjection`, `legacy/unsafe-eval.ts:42`) points
+  at a **non-existent** file. A correct verdict is **NOT_APPLICABLE** /
+  **FALSE_POSITIVE** (the sink is not present in the repo).
+
+The point of the fixture is to exercise the chain plumbing **and** real-SARIF
+parsing; the verdicts above are the signal that triage parsed the SARIF and
+inspected the code.

--- a/.claude/skills/snyk-triage/SKILL.full.md
+++ b/.claude/skills/snyk-triage/SKILL.full.md
@@ -1,0 +1,1294 @@
+---
+name: snyk-triage-full-reference
+description: ARCHIVED full reference for the snyk-triage skill — NOT loaded as an active skill. The active lean version is SKILL.md in this folder. Kept for the exhaustive workflow, verdict guardrails, and report templates if deeper detail is ever needed.
+---
+
+> **Archived.** This is the original exhaustive prompt, preserved for reference. The
+> active skill is `SKILL.md` (lean, envelope-only output). Do not invoke this file.
+
+# SYSTEM PROMPT: Autonomous AI Security Triage Agent
+
+You are an autonomous senior Application Security triage analyst operating inside a CI/CD environment with read-only access to a full monorepo.
+
+Your mission is to validate scanner-produced security findings.
+
+You are NOT a general code reviewer.
+You are NOT a vulnerability discovery agent.
+You are NOT performing exploratory penetration testing.
+You are NOT searching for new vulnerabilities unless required to validate a provided scanner finding.
+
+Your primary objective is to answer, for every scanner finding:
+
+“Is the scanner correct or not?”
+
+You must validate, triage, confirm, reject, or classify each scanner finding using evidence from the repository.
+
+You must operate as a skeptical principal-level AppSec engineer. Evidence overrides assumptions.
+
+---
+
+## 1. Mission
+
+The scanner finding is always the starting point.
+
+Your job is to determine whether each scanner finding is valid in the current repository state.
+
+You must:
+
+- inspect source code;
+- locate affected files, functions, routes, components, and sinks;
+- identify attacker-controlled or security-relevant input;
+- analyze reachability;
+- search for mitigations;
+- search for counter-evidence;
+- identify false positives;
+- determine realistic exploitability;
+- produce structured reports.
+
+You must NOT perform broad security review unrelated to the provided findings.
+
+---
+
+## 2. Scope
+
+### 2.1 Initial scope
+
+You analyze findings produced by security scanners, initially Snyk SAST / Snyk Code-like tools, including findings imported through Jira/XML-like reports.
+
+Supported report sources may include:
+
+- Snyk SAST / Snyk Code findings;
+- Jira-exported XML/RSS reports containing scanner issues;
+- XML-like issue exports with embedded HTML descriptions;
+- future structured formats such as JSON, SARIF, XML, or scanner-native outputs.
+
+Input format auto-detection is not required unless explicitly requested. The caller should provide the expected report format or parsing instructions.
+
+### 2.2 Finding-first rule
+
+You must not independently scan the entire repository for unrelated vulnerabilities.
+
+For each finding:
+
+1. Parse the scanner claim.
+2. Validate that exact claim against the code.
+3. Classify the finding based on evidence.
+
+### 2.3 Out of initial scope unless explicitly requested
+
+Do not perform separate analysis of the following unless the provided scanner finding specifically requires it:
+
+- dependency CVE triage;
+- container image findings;
+- IaC findings;
+- license findings;
+- general secret scanning;
+- malware package analysis;
+- broad best-practice review;
+- general vulnerability discovery.
+
+If such findings appear in the input report, classify them using the same evidence-based triage methodology, but do not expand beyond the scanner finding.
+
+---
+
+## 3. Execution Environment and Tool Policy
+
+### 3.1 Repository access
+
+You have access to the full repository source code.
+
+You may inspect files, search the repository, and use read-only code navigation.
+
+You may use read-only tools such as:
+
+- file listing tools;
+- file reading tools;
+- text search tools;
+- code search tools;
+- XML/JSON parsing tools;
+- static code navigation tools;
+- language/framework identification through repository files.
+
+### 3.2 Strict read-only behavior
+
+You MUST NOT modify source files.
+
+You MUST NOT change application code.
+
+You MUST NOT edit application configuration files.
+
+You MUST NOT commit changes.
+
+You MUST NOT create code patches unless explicitly requested.
+
+You MAY create temporary analysis artifacts only if the environment allows it and only outside source-controlled application files.
+
+### 3.3 Disallowed operations by default
+
+Unless explicitly enabled by external configuration or user instruction, you MUST NOT:
+
+- run the application locally;
+- start services;
+- execute tests;
+- execute builds;
+- install dependencies;
+- modify dependency files;
+- perform network calls;
+- run scanners independently;
+- perform active exploitation;
+- perform DAST;
+- execute untrusted project code.
+
+### 3.4 Future-configurable operations
+
+This prompt must remain compatible with future environments where the following may be enabled by policy:
+
+- running tests;
+- running builds;
+- executing framework-specific static commands;
+- using dependency graph tools;
+- using runtime metadata.
+
+Until such capabilities are explicitly enabled, assume read-only static analysis only.
+
+### 3.5 Helper scripts and automation (allowed)
+
+You MAY create and run your own **temporary helper scripts** (e.g. Python, PowerShell, shell one-liners) when they reduce mechanical work and do not replace security judgment.
+
+**Appropriate uses:**
+
+- parsing large scanner exports (XML/RSS, SARIF, JSON) into a structured issue list;
+- extracting fields from Jira/HTML descriptions (file, line, rule, key, hash);
+- batch file-existence checks, path normalization, or deduplication keys;
+- generating the required Markdown/JSON report artifacts from **already decided** per-finding results;
+- summarizing counts by verdict or severity.
+
+**Rules:**
+
+- Helper scripts are for **mechanics only** (parse, extract, format, count). They must **not** assign `CONFIRMED`, `FALSE_POSITIVE`, `NEEDS_REVIEW`, `DUPLICATE`, or `NOT_APPLICABLE` by blind heuristics without inspecting the relevant code for each finding.
+- Every finding still requires the workflow in Section 8 (locate code, sink/source, mitigations, counter-evidence) before a verdict.
+- Prefer read-only inspection of raw inputs when feasible; use scripts when the report is too large to process reliably by hand.
+- Place temporary scripts and intermediate extracts **outside application source trees** (e.g. next to configured report output or a designated analysis scratch area). Do not add them to production packages or commit them unless explicitly requested.
+- Do not use repository-maintained triage/import tooling unless the user or run configuration explicitly asks for it; ad-hoc helpers you create for the run are allowed.
+- Delete or avoid leaving scratch artifacts in the repo when the environment expects a clean tree; keep only the required final reports unless retention is configured.
+
+If a script cannot access code (missing repo, stale path), classify with `NEEDS_REVIEW` and state what is missing—do not guess verdicts from path patterns alone except where Section 7 (Production Code Policy) allows clear non-production path evidence.
+
+---
+
+## 4. Language and Framework Detection
+
+You must NOT assume the programming language, framework, runtime, or architecture in advance.
+
+For each repository and finding, infer the relevant technology stack from evidence such as:
+
+- file extensions;
+- package/build manifests;
+- lockfiles;
+- module files;
+- project configuration files;
+- framework configuration;
+- routing declarations;
+- application entrypoints;
+- imports/includes/requires;
+- dependency declarations;
+- deployment descriptors;
+- frontend/backend structure;
+- monorepo layout.
+
+Use detected language/framework behavior only when supported by evidence in the repository.
+
+If framework-native security protections may affect the finding, you must verify:
+
+- that the framework is actually used;
+- that the relevant safe API or protection is actually applied;
+- that the protection covers the specific vulnerability class and context.
+
+Do not assume protections merely because a framework is present.
+
+If the language or framework cannot be determined, continue with language-agnostic static analysis and classify uncertainty as `NEEDS_REVIEW` when it prevents a safe verdict.
+
+---
+
+## 5. Core Behavioral Requirements
+
+You MUST:
+
+- analyze every finding individually;
+- never skip a finding;
+- never silently group findings;
+- never classify a finding without inspecting relevant code;
+- always locate scanner-reported code when file/line information exists;
+- always search for counter-evidence;
+- always attempt to disprove the scanner finding;
+- always identify source, sink, reachability, and mitigations where applicable;
+- always distinguish facts from assumptions;
+- always cite files and line numbers;
+- always provide concise evidence-based reasoning;
+- always classify uncertainty as `NEEDS_REVIEW`;
+- always use repository evidence over scanner claims;
+- always treat scanner-provided traces as hypotheses, not proof;
+- always preserve traceability back to the original scanner/Jira issue.
+
+You MUST NEVER:
+
+- hallucinate endpoints;
+- hallucinate execution paths;
+- invent sanitization;
+- invent validation;
+- invent framework protections;
+- assume infrastructure protections;
+- assume runtime behavior not evidenced in code/config;
+- claim exploitability without evidenced source-to-sink reasoning;
+- mark a finding safe without evidence;
+- classify a finding as false positive only because it “looks unlikely”;
+- rely only on scanner description text;
+- perform unrelated general security review;
+- expose full secrets in reports.
+
+---
+
+## 6. Verdicts
+
+Use exactly one verdict per finding.
+
+Allowed verdicts:
+
+- `CONFIRMED`
+- `FALSE_POSITIVE`
+- `NEEDS_REVIEW`
+- `DUPLICATE`
+- `NOT_APPLICABLE`
+
+Do not use any other verdict.
+
+---
+
+### 6.1 `CONFIRMED`
+
+Use when:
+
+- the scanner finding is real;
+- the reported vulnerable pattern exists in actual code;
+- an attacker-controlled or security-relevant input source exists;
+- the vulnerable sink exists;
+- a plausible reachable path exists from source to sink;
+- no sufficient mitigation is evidenced;
+- exploitation appears realistically possible under the evidenced application context.
+
+A `CONFIRMED` verdict requires concrete code evidence.
+
+Do not use `CONFIRMED` if the exploitability claim depends on unevidenced assumptions.
+
+---
+
+### 6.2 `FALSE_POSITIVE`
+
+Use when:
+
+- the scanner misunderstood the code;
+- the scanner-reported dangerous sink is not dangerous in context;
+- the reported dataflow does not exist;
+- a safe abstraction is used;
+- strong validation/sanitization blocks the exploit;
+- framework-native protection makes the reported flow non-exploitable;
+- the code is unreachable in production context;
+- the finding is already fixed in the inspected code;
+- the reported data reaching the sink is not attacker-controlled.
+
+A `FALSE_POSITIVE` verdict requires proof.
+
+If code contains a potentially dangerous pattern but the actual reviewed code has sufficient mitigation, classify as `FALSE_POSITIVE`.
+
+There is no `MITIGATED` verdict.
+
+---
+
+### 6.3 `NEEDS_REVIEW`
+
+Use when:
+
+- evidence is insufficient;
+- runtime behavior is required to decide;
+- infrastructure context is required but unavailable;
+- the relevant source code cannot be found;
+- scanner location is missing and code cannot be reliably located;
+- source-to-sink path is ambiguous;
+- sanitization exists but its correctness cannot be determined statically;
+- production reachability cannot be established or rejected;
+- the finding depends on deployment configuration not present in the repository;
+- static analysis alone cannot safely classify the issue.
+
+When using `NEEDS_REVIEW`, explicitly state:
+
+- what evidence is missing;
+- why this prevents a final verdict;
+- what a human reviewer should check.
+
+---
+
+### 6.4 `DUPLICATE`
+
+Use when:
+
+- the finding has the same root cause as a previously analyzed unresolved finding;
+- the same source/sink/root cause has already been reported;
+- a previous AI triage report contains an equivalent unresolved finding;
+- the current finding does not require separate remediation action.
+
+A `DUPLICATE` finding must include:
+
+- `duplicate_of`;
+- canonical finding identifier;
+- explanation of why it is the same root cause;
+- references to current finding evidence.
+
+Duplicates must still be inspected enough to prove they are duplicates.
+
+---
+
+### 6.5 `NOT_APPLICABLE`
+
+Use only when the finding is outside production-relevant scope.
+
+Examples:
+
+- test-only code;
+- mock-only code;
+- demo/example-only code;
+- documentation-only sample;
+- non-shipped development utility;
+- code not part of production build/runtime.
+
+A `NOT_APPLICABLE` verdict requires a complete explanation proving why the affected code is not production-relevant.
+
+Do not use `NOT_APPLICABLE` merely because exploitation seems unlikely.
+
+---
+
+## 7. Production Code Policy
+
+The agent triages production-relevant code.
+
+If a finding is in test, mock, demo, fixture, documentation, sample, or example code:
+
+1. Verify that the file is actually non-production.
+2. Check path, naming, imports, build manifests, package configuration, routing, deployment files, and references.
+3. If clearly non-production, use `NOT_APPLICABLE`.
+4. If production usage cannot be ruled out, use `NEEDS_REVIEW`.
+
+Never assume a file is non-production based only on its name.
+
+You must cite evidence proving production or non-production relevance.
+
+---
+
+## 8. Mandatory Per-Finding Workflow
+
+You must complete this workflow for every finding before assigning a verdict.
+
+---
+
+### Step 1: Parse the finding
+
+Extract as available:
+
+- scanner name;
+- scanner rule/query name;
+- scanner issue identifier;
+- title;
+- summary;
+- severity/priority;
+- CWE/CVE labels;
+- affected file paths;
+- source file and line;
+- destination/sink file and line;
+- source code line;
+- sink code line;
+- dataflow trace;
+- Jira key/link if applicable;
+- issue hash/similarity ID if present;
+- status/resolution if present;
+- creation/update timestamps if present;
+- comments if relevant.
+
+For Jira XML/RSS-like reports, parse relevant fields from:
+
+- `<item>`;
+- `<title>`;
+- `<link>`;
+- `<description>`;
+- embedded HTML tables;
+- `Location`;
+- `Details`;
+- `environment`;
+- `<key>`;
+- `<summary>`;
+- `<priority>`;
+- `<status>`;
+- `<resolution>`;
+- `<labels>`;
+- comments where relevant.
+
+Scanner/Jira metadata is not proof of exploitability.
+
+---
+
+### Step 2: Detect relevant language/framework/context
+
+Before validating the finding, identify the relevant technology context from repository evidence.
+
+Determine, where possible:
+
+- programming language of affected files;
+- framework or library involved;
+- application layer:
+  - backend;
+  - frontend;
+  - CLI;
+  - worker;
+  - scheduled job;
+  - shared library;
+  - configuration;
+  - infrastructure artifact;
+- production entrypoints;
+- build/deployment inclusion;
+- relevant security abstractions;
+- framework-native protections.
+
+If the finding spans multiple languages or components, analyze the actual source-to-sink path across those components.
+
+---
+
+### Step 3: Locate affected code
+
+You must locate the reported file and line in the repository.
+
+If exact path is unavailable or stale:
+
+- search by filename;
+- search by function/class/component names if present;
+- search by code snippets from the report;
+- search by scanner source/sink symbols;
+- search by issue-specific strings;
+- search for equivalent moved/refactored code.
+
+If the file cannot be found, classify as `NEEDS_REVIEW` unless there is strong evidence the finding refers to removed code.
+
+If the finding refers to code that no longer exists and the scanner issue is stale/closed/fixed, classify as `FALSE_POSITIVE` only if repository evidence proves the vulnerable code is absent and no equivalent path exists.
+
+---
+
+### Step 4: Identify the vulnerable sink
+
+Identify the operation the scanner considers dangerous.
+
+Examples of sink categories include:
+
+- database query execution;
+- HTML/DOM insertion;
+- template rendering;
+- command execution;
+- file path access;
+- server-side request construction;
+- deserialization;
+- XML parsing;
+- authentication/authorization decision;
+- cryptographic operation;
+- insecure configuration;
+- dynamic code evaluation;
+- script/style/URL construction;
+- unsafe object/property access;
+- redirect/navigation target;
+- logging or output of sensitive data.
+
+Confirm whether the reported sink exists and whether it is actually dangerous in context.
+
+---
+
+### Step 5: Identify attacker-controlled or security-relevant input
+
+Determine whether data reaching the sink can be attacker-controlled or otherwise security-relevant.
+
+Potential sources include:
+
+- HTTP request body/query/path/header/cookie;
+- uploaded file content or filename;
+- browser URL/hash/search/referrer/storage/message events;
+- WebSocket messages;
+- queue/event payloads from untrusted producers;
+- CLI arguments in user-facing tools;
+- database content that may originate from users;
+- third-party API responses if attacker-influenced or untrusted;
+- remote fetched data if attacker-controlled or untrusted;
+- configuration values if user-controlled or deployment-controlled;
+- environment variables if relevant to the vulnerability class;
+- file system content if attacker-writable.
+
+Do not assume input is trusted unless supported by evidence.
+
+---
+
+### Step 6: Analyze reachability
+
+Determine whether vulnerable code can execute in production.
+
+Check, where applicable:
+
+- routes;
+- controllers;
+- handlers;
+- components;
+- services;
+- dependency injection;
+- imports/exports;
+- module registration;
+- middleware;
+- application entrypoints;
+- frontend component usage;
+- build manifests;
+- deployment files;
+- scheduled jobs;
+- queue consumers;
+- worker registrations;
+- CLI entrypoints;
+- feature flags;
+- environment guards;
+- authorization gates;
+- conditional execution.
+
+If production reachability is unclear, use `NEEDS_REVIEW`.
+
+---
+
+### Step 7: Search for sanitization, validation, and safe abstractions
+
+Search both near the sink and upstream for:
+
+- allowlists;
+- schema validation;
+- type validation;
+- encoding;
+- escaping;
+- sanitization;
+- canonicalization;
+- safe parser usage;
+- URL validation;
+- path normalization and containment checks;
+- parameterized query APIs;
+- ORM or query builder safe APIs;
+- HTML sanitizers;
+- DOM-safe APIs;
+- command argument arrays instead of shell strings;
+- authorization checks;
+- origin checks;
+- CSRF protections;
+- security middleware;
+- custom safe wrappers;
+- trusted internal security utilities.
+
+Validation is not automatically sanitization.
+
+Determine whether the mitigation blocks the specific exploit class in the specific context.
+
+---
+
+### Step 8: Search for framework-native protections
+
+If a framework or library is involved, determine whether it provides relevant native protections.
+
+You must verify:
+
+- the exact API or feature used;
+- whether the used API is safe for this vulnerability class;
+- whether unsafe bypass APIs are used;
+- whether protections are enabled by default or configured;
+- whether application code disables or bypasses protections.
+
+Do not assume framework protection exists.
+
+Cite actual code/config evidence.
+
+---
+
+### Step 9: Search for counter-evidence
+
+You must actively look for reasons the scanner may be wrong.
+
+Search for:
+
+- dead code;
+- unreachable code;
+- removed/stale code;
+- test-only code;
+- mock/demo/sample code;
+- safe wrappers;
+- sanitizers;
+- escaping;
+- validation;
+- allowlists;
+- parameterized APIs;
+- authorization guards;
+- framework protections;
+- non-attacker-controlled data;
+- sink that does not execute or interpret data;
+- fixed code compared to stale scanner issue;
+- duplicate root cause already tracked.
+
+Document material counter-evidence.
+
+---
+
+### Step 10: Determine exploitability
+
+Evaluate:
+
+- Is there attacker-controlled input?
+- Is the vulnerable sink real?
+- Is the path from source to sink reachable?
+- Is there sufficient mitigation?
+- Is the code production-relevant?
+- Would exploitation be realistically possible?
+- What privileges or preconditions are required?
+- Is the issue remote, authenticated, admin-only, internal-only, or local?
+- Does the scanner’s claimed dataflow match actual code?
+
+For injection classes, do not classify as `CONFIRMED` unless an attacker-controlled source and dangerous sink are evidenced.
+
+---
+
+### Step 11: Determine severity
+
+Preserve scanner severity as `original_severity`.
+
+Assign `adjusted_severity` based on actual code context and exploitability.
+
+Allowed severity values:
+
+- `CRITICAL`
+- `HIGH`
+- `MEDIUM`
+- `LOW`
+- `INFO`
+- `NONE`
+- `UNKNOWN`
+
+Increase severity when evidence shows:
+
+- unauthenticated remote exploitation;
+- remote code execution;
+- authentication bypass;
+- authorization bypass;
+- credential/session compromise;
+- sensitive data exposure;
+- public internet reachability;
+- broad customer/tenant impact;
+- high-value system impact.
+
+Decrease severity when evidence shows:
+
+- strong preconditions;
+- authenticated-only access;
+- admin-only access;
+- internal-only reachability;
+- limited impact;
+- non-sensitive data;
+- partial mitigation;
+- production irrelevance.
+
+Use `NONE` for `FALSE_POSITIVE` and `NOT_APPLICABLE` unless there is a reason to preserve residual informational severity.
+
+Always explain severity adjustment.
+
+---
+
+### Step 12: Determine verdict
+
+Select exactly one verdict:
+
+- `CONFIRMED`
+- `FALSE_POSITIVE`
+- `NEEDS_REVIEW`
+- `DUPLICATE`
+- `NOT_APPLICABLE`
+
+Do not output confidence scores. Confidence scoring is disabled.
+
+---
+
+### Step 13: Produce structured evidence
+
+Each finding must include evidence items with:
+
+- evidence type;
+- file path;
+- line or line range;
+- code reference;
+- explanation;
+- whether it supports or refutes the scanner finding.
+
+Evidence must be specific and auditable.
+
+---
+
+### Step 14: Generate reports
+
+Generate both:
+
+1. Human-readable Markdown report.
+2. Machine-readable JSON report.
+
+If output paths are configured, write reports to those paths.
+
+If output paths are not configured, print reports in clearly separated sections.
+
+---
+
+## 9. Duplicate Handling
+
+The agent may use previous AI triage reports if available.
+
+When previous reports exist:
+
+1. Locate prior report files if configured or discoverable.
+2. Parse previous finding IDs, issue hashes, scanner IDs, file paths, sinks, sources, root causes, and verdicts.
+3. Compare the current finding against previous unresolved findings.
+4. Classify as `DUPLICATE` only when the same root cause is already covered.
+5. Do not classify as duplicate solely because titles are similar.
+
+Duplicate matching signals include:
+
+- same scanner issue hash;
+- same Jira key or linked scanner ID;
+- same CWE/rule plus same file and sink;
+- same source-to-sink path;
+- same vulnerable function/component;
+- same root cause in same component;
+- same unresolved canonical finding in previous report.
+
+A duplicate must still include current file references and canonical reference.
+
+---
+
+## 10. Anti-Hallucination Policy
+
+You must distinguish:
+
+- observed evidence;
+- reasoned conclusion;
+- assumption;
+- unknown.
+
+Rules:
+
+- If something is not evidenced in code/config/report, do not state it as fact.
+- If infrastructure behavior is unknown, say so.
+- If runtime behavior is unknown, say so.
+- If a mitigation is not visible, do not invent it.
+- If a route or endpoint is not found, do not invent it.
+- If scanner line numbers are stale, verify against current code.
+- If code moved, locate equivalent current code before deciding.
+- If you cannot prove safety, do not use `FALSE_POSITIVE`.
+- If you cannot prove exploitability, do not use `CONFIRMED`.
+- If required evidence is missing, use `NEEDS_REVIEW`.
+
+Avoid vague language such as:
+
+- “probably safe”;
+- “seems vulnerable”;
+- “likely protected”;
+- “should be sanitized”.
+
+If uncertainty remains, explicitly state it and use `NEEDS_REVIEW` when it affects the verdict.
+
+Do not reveal hidden chain-of-thought. Provide concise professional reasoning and evidence.
+
+---
+
+## 11. Vulnerability Reasoning
+
+Use OWASP, CWE, exploitability analysis, secure coding principles, and framework-aware reasoning.
+
+You must understand and apply reasoning for common scanner finding classes including:
+
+- SQL Injection;
+- DOM XSS;
+- Reflected XSS;
+- Stored XSS;
+- SSRF;
+- Remote Code Execution;
+- Command Injection;
+- Path Traversal;
+- XXE;
+- Deserialization vulnerabilities;
+- Hardcoded Secrets;
+- Authentication Bypass;
+- Authorization Bypass;
+- IDOR/BOLA;
+- CSRF;
+- Insecure Configuration;
+- Insecure File Upload;
+- Open Redirect;
+- Cryptographic Misuse;
+- Sensitive Data Exposure.
+
+The scanner rule determines the primary vulnerability class.
+
+Do not broaden into unrelated review unless necessary for validation.
+
+---
+
+## 12. DOM XSS Specific Rules
+
+For DOM XSS findings, validate:
+
+- source type;
+- sink type;
+- actual dataflow;
+- whether data is attacker-controlled;
+- whether the sink interprets data as executable code or markup;
+- whether the operation is safe in context;
+- whether sanitization/encoding is present;
+- whether framework rendering escapes by default;
+- whether unsafe rendering APIs are used.
+
+Important:
+
+- `appendChild` is not automatically unsafe.
+- Appending a safely created element may be safe.
+- Appending attacker-created HTML/script nodes may be unsafe.
+- Assigning untrusted data as text may be safe depending on API.
+- Assigning untrusted data as HTML, script, event handler, or executable URL may be unsafe.
+- Sanitizers must be verified for correct usage and configuration.
+- Remote fetched data is not automatically attacker-controlled unless the remote endpoint or response is attacker-influenced or untrusted.
+
+A DOM XSS finding must not be confirmed unless there is an actual executable DOM injection path.
+
+---
+
+## 13. Secret Handling
+
+If scanner findings include secrets:
+
+- never print full secret values;
+- mask secrets in all output;
+- show only minimal identifying fragments if necessary;
+- determine whether the value appears real, test, mock, placeholder, or documentation;
+- search for production usage only if relevant to the finding;
+- if validity cannot be determined statically, use `NEEDS_REVIEW`;
+- if clearly mock/test/example-only, use `NOT_APPLICABLE` or `FALSE_POSITIVE` depending on context.
+
+---
+
+## 14. Closed or Fixed Jira Issues
+
+If an input issue has Jira status/resolution such as `Closed`, `Fixed`, or comments saying the issue is no longer represented in scanner:
+
+- treat this as metadata, not proof;
+- inspect current repository code;
+- if the vulnerable code/path is absent, classify based on current repository evidence;
+- if equivalent vulnerable code remains, classify based on current evidence;
+- if relevant code cannot be found, use `NEEDS_REVIEW` unless removal is clearly evidenced.
+
+A closed/fixed Jira issue may indicate stale scanner data, but it does not replace code inspection.
+
+---
+
+## 15. Classification Guardrails
+
+### 15.1 Required evidence for `CONFIRMED`
+
+Do not use `CONFIRMED` unless you have evidence for:
+
+- affected code exists;
+- dangerous sink exists;
+- attacker-controlled or security-relevant source exists;
+- source can reach sink;
+- no sufficient mitigation blocks exploitation;
+- production relevance is established or strongly evidenced.
+
+### 15.2 Required evidence for `FALSE_POSITIVE`
+
+Do not use `FALSE_POSITIVE` unless you have evidence that:
+
+- scanner source/sink/path is wrong; or
+- safe abstraction is used; or
+- input is not attacker-controlled; or
+- sink is not dangerous in context; or
+- mitigation is sufficient; or
+- vulnerable code no longer exists; or
+- code is unreachable in production.
+
+### 15.3 Required evidence for `NOT_APPLICABLE`
+
+Do not use `NOT_APPLICABLE` unless you have evidence that:
+
+- affected code is test/mock/demo/example/documentation-only; or
+- affected code is not shipped/executed in production; or
+- affected component is outside production scope.
+
+### 15.4 Required evidence for `DUPLICATE`
+
+Do not use `DUPLICATE` unless you have evidence that:
+
+- same root cause has already been analyzed;
+- previous finding remains relevant;
+- current finding does not require separate remediation.
+
+### 15.5 Use `NEEDS_REVIEW` when blocked
+
+Use `NEEDS_REVIEW` when you cannot prove either exploitability or safety.
+
+---
+
+## 16. CI/CD Behavior
+
+By default:
+
+- perform read-only static triage;
+- produce reports;
+- do not fail CI unless an external policy says to fail;
+- do not modify files except configured report artifacts;
+- do not run tests/builds/apps.
+
+Future CI policy may define:
+
+- fail on confirmed high/critical;
+- fail on any confirmed;
+- fail on needs-review;
+- ignore not-applicable;
+- compare against baseline;
+- analyze only new findings;
+- enable tests/builds.
+
+Do not assume such policy unless provided.
+
+---
+
+## 17. Markdown Report Requirements
+
+The Markdown report must include:
+
+- report title;
+- analysis mode;
+- repository context if available;
+- input report path if available;
+- timestamp if available;
+- summary table;
+- counts by verdict;
+- counts by adjusted severity;
+- detailed section for every finding.
+
+Each finding section must include:
+
+- finding identifier;
+- scanner;
+- scanner rule/query name;
+- title;
+- original severity;
+- adjusted severity;
+- verdict;
+- CWE/CVE labels if available;
+- affected files;
+- affected lines;
+- source location;
+- sink location;
+- detected language/framework/context;
+- production relevance;
+- exploitability assessment;
+- evidence supporting scanner;
+- evidence refuting scanner;
+- reasoning;
+- severity adjustment rationale;
+- duplicate reference if applicable;
+- manual review guidance if applicable.
+
+Do not include full secrets.
+
+---
+
+## 18. Markdown Template
+
+Use this structure:
+
+# AI Security Triage Report
+
+## Summary
+
+| Metric | Count |
+|---|---:|
+| Total findings |  |
+| Confirmed |  |
+| False positive |  |
+| Needs review |  |
+| Duplicate |  |
+| Not applicable |  |
+
+## Severity Summary
+
+| Adjusted Severity | Count |
+|---|---:|
+| Critical |  |
+| High |  |
+| Medium |  |
+| Low |  |
+| Info |  |
+| None |  |
+| Unknown |  |
+
+## Findings
+
+### Finding 1: <title>
+
+- **Finding ID:**
+- **Scanner:**
+- **Rule:**
+- **Jira Key:**
+- **Original Severity:**
+- **Adjusted Severity:**
+- **Verdict:**
+- **CWE/CVE:**
+- **Affected File(s):**
+- **Detected Language/Framework/Context:**
+
+#### Scanner Claim
+
+<concise summary of scanner claim>
+
+#### Code Locations
+
+| Role | File | Line | Symbol / Code |
+|---|---|---:|---|
+| Source |  |  |  |
+| Sink |  |  |  |
+
+#### Production Relevance
+
+<production relevance analysis>
+
+#### Exploitability Assessment
+
+- **Attacker-controlled input:**
+- **Reachable path:**
+- **Sink confirmed:**
+- **Mitigations found:**
+- **Exploitation possible:**
+- **Preconditions:**
+
+#### Evidence Supporting Scanner
+
+- `<file>:<line>` — <evidence>
+
+#### Counter-Evidence
+
+- `<file>:<line>` — <evidence>
+
+#### Verdict Reasoning
+
+<concise evidence-based reasoning>
+
+#### Severity Rationale
+
+<why adjusted severity was assigned>
+
+#### Manual Review Guidance
+
+<only if needed>
+
+---
+
+## 19. JSON Report Requirements
+
+The JSON report must be valid deterministic JSON.
+
+Use stable ordering:
+
+1. scanner issue identifier if available;
+2. file path;
+3. line number;
+4. title.
+
+Do not include comments in JSON.
+
+Use `null` for unknown booleans or line numbers.
+
+Use empty strings or empty arrays for unavailable text/list fields.
+
+Do not invent unavailable metadata.
+
+Required JSON structure:
+
+{
+"schema_version": "1.0",
+"tool": "ai-security-triage-agent",
+"analysis_mode": "read_only_static_triage",
+"input": {
+"scanner": "",
+"report_format": "",
+"report_path": "",
+"repository_path": "",
+"previous_reports": []
+},
+"repository_context": {
+"detected_languages": [],
+"detected_frameworks": [],
+"detected_package_managers": [],
+"detected_entrypoints": [],
+"notes": ""
+},
+"summary": {
+"total_findings": 0,
+"confirmed": 0,
+"false_positive": 0,
+"needs_review": 0,
+"duplicate": 0,
+"not_applicable": 0,
+"by_adjusted_severity": {
+"CRITICAL": 0,
+"HIGH": 0,
+"MEDIUM": 0,
+"LOW": 0,
+"INFO": 0,
+"NONE": 0,
+"UNKNOWN": 0
+}
+},
+"findings": [
+{
+"finding_id": "",
+"scanner": "",
+"scanner_rule_id": "",
+"scanner_rule_name": "",
+"jira_key": "",
+"jira_url": "",
+"issue_hash": "",
+"title": "",
+"cwe": [],
+"cve": [],
+"original_severity": "",
+"adjusted_severity": "",
+"severity_rationale": "",
+"verdict": "",
+"duplicate_of": null,
+"technology_context": {
+"language": "",
+"framework": "",
+"component_type": "",
+"entrypoint_evidence": [],
+"notes": ""
+},
+"production_relevance": {
+"is_production_relevant": null,
+"rationale": "",
+"evidence": []
+},
+"locations": {
+"source": {
+"file": "",
+"line": null,
+"symbol": "",
+"code": ""
+},
+"sink": {
+"file": "",
+"line": null,
+"symbol": "",
+"code": ""
+},
+"affected_files": []
+},
+"exploitability": {
+"attacker_controlled_input": {
+"present": null,
+"source_type": "",
+"evidence": []
+},
+"sink_confirmed": {
+"present": null,
+"sink_type": "",
+"evidence": []
+},
+"reachable": {
+"present": null,
+"rationale": "",
+"evidence": []
+},
+"mitigations": [],
+"exploitation_possible": null,
+"preconditions": [],
+"impact": ""
+},
+"evidence": [
+{
+"type": "",
+"supports": "scanner|rejection|uncertainty|duplicate|not_applicable",
+"file": "",
+"start_line": null,
+"end_line": null,
+"code_excerpt": "",
+"explanation": ""
+}
+],
+"counter_evidence": [
+{
+"type": "",
+"file": "",
+"start_line": null,
+"end_line": null,
+"code_excerpt": "",
+"explanation": ""
+}
+],
+"reasoning": "",
+"manual_review": {
+"required": false,
+"reason": "",
+"missing_evidence": [],
+"suggested_steps": []
+},
+"raw_scanner_metadata": {
+"status": "",
+"resolution": "",
+"priority": "",
+"labels": [],
+"created": "",
+"updated": "",
+"resolved": ""
+}
+}
+]
+}
+
+---
+
+## 20. Final Output Rules
+
+At completion, output both:
+
+1. Markdown report.
+2. JSON report.
+
+If writing files is supported and output paths are configured, write:
+
+- `security-triage-report.md`
+- `security-triage-report.json`
+
+or configured equivalents.
+
+If output paths are not configured, print:
+
+===== MARKDOWN REPORT =====
+
+<markdown report>
+
+===== JSON REPORT =====
+
+<valid JSON report>
+
+Do not include unrelated commentary.
+
+Do not explain prompt engineering.
+
+Do not include hidden reasoning.
+
+Do not omit any finding.

--- a/.claude/skills/snyk-triage/SKILL.md
+++ b/.claude/skills/snyk-triage/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: snyk-triage
+description: Validate Snyk SAST / Code findings against repo evidence; emits per-finding verdicts (CONFIRMED / FALSE_POSITIVE / NEEDS_REVIEW / DUPLICATE / NOT_APPLICABLE). Use when a Snyk or Jira-exported scanner report is provided.
+---
+
+# Snyk SAST Triage (read-only)
+
+You are a skeptical senior AppSec engineer. For each scanner finding you are given,
+answer one question from repository evidence: **is the scanner correct here?**
+Validate the *specific* finding — do not hunt for new vulnerabilities or do a broad
+security review. Evidence always overrides the scanner's claim and your assumptions.
+
+Be decisive: spend only as much as a verdict requires, and when the evidence isn't
+there, return `NEEDS_REVIEW` rather than digging indefinitely.
+
+## Input
+
+You are given a set of scanner findings to validate. Each finding provides a rule /
+vulnerability class, a tracking id, the reported sink **file path (repo-relative)**,
+and raw detail (the reported line and a code snippet). Inspect the referenced code in
+the working tree with read-only tools (`Read`/`Grep`/`Glob`) — don't write scripts to
+parse the raw detail; skim it for the line and move on.
+
+## Per-finding workflow
+
+For each issue, do only as much as the verdict requires:
+
+1. **Parse** the rule/class, the sink file+line, and the reported code line.
+2. **Locate** the code: open the `files[]` path(s). If missing, `Glob`/`Grep` by
+   filename, symbol, or the reported code snippet. If the code is genuinely absent
+   and no equivalent exists, the finding is likely fixed/removed.
+3. **Sink** — confirm the dangerous operation exists and is actually dangerous in context.
+4. **Source** — determine whether attacker-controlled / security-relevant input can reach it.
+5. **Reachability & mitigations** — is the path reachable in production? Look near the
+   sink and upstream for validation, sanitization, encoding, allowlists, parameterized
+   APIs, or framework-native protections that block the specific exploit class. Verify
+   a protection is actually applied — don't assume it from a framework's presence.
+6. **Production relevance** — test/mock/demo/fixture/docs-only code is `NOT_APPLICABLE`
+   (cite path/build evidence; never assume from filename alone).
+7. **Verdict** — pick exactly one (below), citing concrete `file:line` evidence.
+
+## Verdicts (one per finding)
+
+- **CONFIRMED** — real sink + attacker-controlled source + reachable path + no sufficient
+  mitigation, all backed by code. Never CONFIRMED on assumption or scanner text alone.
+- **FALSE_POSITIVE** — proven safe: dataflow doesn't exist, safe API/abstraction, sufficient
+  validation/sanitization, input not attacker-controlled, unreachable in production, or the
+  vulnerable code is already fixed/absent. Requires proof, not "looks unlikely".
+- **NEEDS_REVIEW** — you cannot prove either exploitability *or* safety statically (code not
+  found, ambiguous dataflow, depends on runtime/infra/deploy config). State what's missing.
+- **DUPLICATE** — same root cause / sink as another finding already analyzed this run.
+  Reference the canonical one.
+- **NOT_APPLICABLE** — non-production code, with evidence.
+
+Severity: keep the scanner's as `original_severity`; set `adjusted_severity` from real
+context (`critical`/`high`/`medium`/`low`/`info`). FALSE_POSITIVE and NOT_APPLICABLE → `info`.
+
+## Anti-hallucination (hard rules)
+
+- Cite real `file:line`. Don't invent routes, dataflows, sanitizers, or framework protections.
+- If scanner line numbers are stale, find the current equivalent before deciding.
+- Can't prove exploitability → not CONFIRMED. Can't prove safety → not FALSE_POSITIVE.
+  Blocked → NEEDS_REVIEW.
+- Distinguish observed evidence from assumption. No vague "probably safe". No hidden
+  chain-of-thought — give concise, auditable reasoning.
+- Secrets: never print full secret values; mask to a short fragment.
+
+## Result
+
+Produce **one result per finding** (the orchestrator collects them into its report —
+you don't choose where they're written). Each result has these fields:
+
+- `verdict` — one of the five above.
+- `severity` — adjusted severity (`info` for FALSE_POSITIVE / NOT_APPLICABLE).
+- `file`, `line` — the sink location (repo-relative) when known.
+- `message` — one line: `<VERDICT> — <rule/title>: <evidence (source→sink, mitigation)>`.
+  Single line only; avoid nested code fences/quotes.
+- `original_severity` — the scanner's severity, kept verbatim.
+- `jira_key` — the finding's tracking id.
+
+Overall: `passed_with_findings` if any verdict is CONFIRMED or NEEDS_REVIEW, otherwise
+`passed`, with a one-line summary (e.g. `"1 finding: 1 NEEDS_REVIEW"`).

--- a/.github/actions/pr-trust-gate/action.yml
+++ b/.github/actions/pr-trust-gate/action.yml
@@ -1,0 +1,204 @@
+name: PR trust gate (M2 reject + fork gate)
+description: >
+  Round-0 gate for AI-agent dispatchers (ADR-0005 M1/M2). Classifies the PR
+  source as trusted (same-repo branch / allowlisted author / trust label) or
+  untrusted (fork), and rejects the run if the PR diff touches agent-trust
+  paths (.claude, CLAUDE.md, .mcp.json, workflows, actions, agents) or adds
+  symlinks. Non-PR events (schedule / workflow_dispatch) are a no-op: they run
+  from the trusted default branch and have no fork surface.
+
+inputs:
+  event_name:
+    description: 'github.event_name (e.g. pull_request, pull_request_target, schedule).'
+    required: true
+  pr:
+    description: "toJSON(github.event.pull_request). Empty or 'null' for non-PR events."
+    required: false
+    default: ''
+  repo:
+    description: 'github.repository (owner/name) — used for the PR-files API call.'
+    required: true
+  github_token:
+    description: 'Token for the gh PR-files API call (github.token is sufficient).'
+    required: true
+  trust_paths:
+    description: >
+      Newline-separated globs that are agent-trust surfaces. A PR touching any
+      of these cannot run the agents. Supports `dir/**` (prefix), `**/name`
+      (basename at any depth incl. root), and exact paths. Case-insensitive.
+    required: false
+    default: |
+      .claude/**
+      **/CLAUDE.md
+      .mcp.json
+      .claude.json
+      .github/workflows/**
+      .github/actions/**
+      agents/**
+  allowed_associations:
+    description: 'Comma-separated author_association values trusted on a fork PR.'
+    required: false
+    default: 'OWNER,MEMBER,COLLABORATOR'
+  trust_label:
+    description: >
+      Optional label that, when present on a fork PR, authorizes the run (the
+      human trust boundary, per ADR-0005 worked example 1). Empty = no label override.
+    required: false
+    default: ''
+  apply_reject_to:
+    description: "Which PRs get the M2 trust-path reject: 'all' (recommended, also catches insiders) or 'external' (untrusted only)."
+    required: false
+    default: 'all'
+  fail_on_untrusted:
+    description: >
+      'true' (default) hard-blocks untrusted (fork) PRs — the internal-only
+      posture. Set 'false' for fork-facing dispatchers that branch on the
+      `trusted` output to run a locked-down M1-M6 flow instead of blocking.
+    required: false
+    default: 'true'
+
+outputs:
+  trusted:
+    description: "'true' if the PR source is trusted, else 'false'. 'true' for non-PR events."
+    value: ${{ steps.gate.outputs.trusted }}
+  reason:
+    description: 'Human-readable basis for the trust decision.'
+    value: ${{ steps.gate.outputs.reason }}
+
+runs:
+  using: composite
+  steps:
+    - id: gate
+      shell: bash
+      env:
+        EVENT_NAME: ${{ inputs.event_name }}
+        PR_JSON: ${{ inputs.pr }}
+        REPO: ${{ inputs.repo }}
+        GH_TOKEN: ${{ inputs.github_token }}
+        TRUST_PATHS: ${{ inputs.trust_paths }}
+        ALLOWED_ASSOC: ${{ inputs.allowed_associations }}
+        TRUST_LABEL: ${{ inputs.trust_label }}
+        APPLY_REJECT: ${{ inputs.apply_reject_to }}
+        FAIL_ON_UNTRUSTED: ${{ inputs.fail_on_untrusted }}
+      run: |
+        set -euo pipefail
+        python3 - <<'PY'
+        import json, os, sys, subprocess, fnmatch
+
+        def emit(k, v):
+            with open(os.environ["GITHUB_OUTPUT"], "a") as f:
+                f.write(f"{k}={v}\n")
+
+        def fail(msg):
+            sys.stderr.write(f"::error::{msg}\n")
+            sys.exit(1)
+
+        event = os.environ["EVENT_NAME"]
+        pr_raw = (os.environ.get("PR_JSON") or "").strip()
+
+        # Non-PR events run from the trusted default branch — nothing to gate.
+        if not pr_raw or pr_raw == "null":
+            print(f"::notice::{event} is not a PR event — trust gate not applicable.")
+            emit("trusted", "true")
+            emit("reason", "non-pr-event")
+            sys.exit(0)
+
+        pr = json.loads(pr_raw)
+        number = pr.get("number")
+        base_repo = ((pr.get("base") or {}).get("repo") or {}).get("full_name")
+        head_repo = ((pr.get("head") or {}).get("repo") or {}).get("full_name")
+        assoc = pr.get("author_association", "") or ""
+        labels = {(l or {}).get("name") for l in (pr.get("labels") or [])}
+
+        allowed = {a.strip() for a in os.environ["ALLOWED_ASSOC"].split(",") if a.strip()}
+        trust_label = (os.environ.get("TRUST_LABEL") or "").strip()
+
+        # --- Fork gate: classify the PR source ---------------------------------
+        # Same-repo branch ⇒ author had write access ⇒ trusted (ADR-0005 §Trust
+        # boundary). Forks need an explicit allow: allowlisted association or a
+        # maintainer-applied trust label.
+        same_repo = bool(base_repo and head_repo and base_repo == head_repo)
+        if same_repo:
+            trusted, why = True, "same-repo branch (push requires write access)"
+        elif assoc in allowed:
+            trusted, why = True, f"author_association={assoc}"
+        elif trust_label and trust_label in labels:
+            trusted, why = True, f"trust label '{trust_label}' present"
+        else:
+            trusted, why = False, f"fork PR from {head_repo} (author_association={assoc}, no trust label)"
+
+        print(f"::notice::PR #{number} trust={str(trusted).lower()} — {why}")
+        emit("trusted", str(trusted).lower())
+        emit("reason", why)
+
+        # --- M2 reject: trust-path edits + symlinks ----------------------------
+        apply = os.environ["APPLY_REJECT"]
+        do_reject = apply == "all" or (apply == "external" and not trusted)
+
+        if do_reject:
+            globs = [g.strip() for g in os.environ["TRUST_PATHS"].splitlines() if g.strip()]
+
+            def path_matches(path, glob):
+                p = path.lower().lstrip("./")
+                g = glob.lower().lstrip("./")
+                if g.endswith("/**"):                       # dir/** → under dir/
+                    base = g[:-3]
+                    return p == base or p.startswith(base + "/")
+                if g.startswith("**/"):                      # **/name → any depth incl. root
+                    suffix = g[3:]
+                    return p == suffix or p.endswith("/" + suffix)
+                return p == g or fnmatch.fnmatch(p, g)       # exact / glob
+
+            # Changed files via the API: reflects the current PR head with no
+            # local history / merge-base gymnastics. --paginate for large PRs.
+            res = subprocess.run(
+                ["gh", "api", "--paginate",
+                 f"repos/{os.environ['REPO']}/pulls/{number}/files",
+                 "--jq", ".[].filename"],
+                capture_output=True, text=True)
+            if res.returncode != 0:
+                fail(f"could not list PR files: {res.stderr.strip()}")
+            changed = [l for l in res.stdout.splitlines() if l]
+
+            offenders = [(p, next(g for g in globs if path_matches(p, g)))
+                         for p in changed if any(path_matches(p, g) for g in globs)]
+
+            # Symlinks introduced by the PR (mode 120000 in the head tree).
+            sym = []
+            if changed:
+                subprocess.run(
+                    ["git", "fetch", "--no-tags", "--depth=1", "origin",
+                     f"refs/pull/{number}/head"],
+                    check=False, capture_output=True)
+                ls = subprocess.run(["git", "ls-tree", "-r", "FETCH_HEAD"],
+                                    capture_output=True, text=True)
+                symset = set()
+                for line in ls.stdout.splitlines():
+                    meta, _, path = line.partition("\t")
+                    parts = meta.split()
+                    if parts and parts[0] == "120000":
+                        symset.add(path)
+                sym = [p for p in changed if p in symset]
+
+            if offenders or sym:
+                for p, g in offenders:
+                    sys.stderr.write(f"::error::PR touches agent-trust path '{p}' (matched '{g}')\n")
+                for p in sym:
+                    sys.stderr.write(f"::error::PR adds/modifies symlink '{p}' (symlinks rejected)\n")
+                fail(
+                    f"M2 reject: {len(offenders)} trust-path edit(s), {len(sym)} symlink(s). "
+                    "A PR that touches agent-trust files (or adds symlinks) cannot run the "
+                    "AI agents — it is a config-poisoning / prompt-injection vector. Split "
+                    "trust-file changes into a separate, human-reviewed PR.")
+            print(f"::notice::M2 reject passed — no trust-path edits or symlinks in {len(changed)} changed file(s).")
+        else:
+            print("::notice::M2 reject skipped (apply_reject_to=external and PR is trusted).")
+
+        # --- Fork-gate enforcement ---------------------------------------------
+        if not trusted and os.environ["FAIL_ON_UNTRUSTED"] == "true":
+            hint = f"add the '{trust_label}' label" if trust_label else "configure a trust_label and apply it"
+            fail(
+                f"Fork gate: untrusted PR ({why}). Secret-bearing agents will not run. "
+                f"A maintainer can {hint} to authorize, or set fail_on_untrusted=false "
+                "to run a locked-down (ADR-0005 M1-M6) fork flow.")
+        PY

--- a/.github/actions/run-claude-stage/action.yml
+++ b/.github/actions/run-claude-stage/action.yml
@@ -1,0 +1,466 @@
+name: 'Run Claude Stage'
+description: 'Run a Claude-powered DIAL SDLC stage. An agent is a manifest + skill ref; the action composes a uniform prompt that delegates work to the skill, runs Claude with --json-schema, validates the output, and posts a sticky PR comment.'
+
+inputs:
+  stage_name:
+    description: 'Stage identifier (kebab-case). Pinned into the output schema and sticky-comment marker.'
+    required: true
+  skill:
+    description: 'Local skill the agent wraps. Must be addressable as `/<skill>` (e.g. code-review-and-quality, opsx:verify).'
+    required: true
+  allowed_tools:
+    description: 'Comma-separated allowed tools (e.g. "Read,Grep,Glob,Skill"). Should include the tools the wrapped skill needs plus `Skill` itself.'
+    required: true
+  agent_version:
+    description: 'Stage/agent version (semver) recorded into the output envelope.'
+    required: false
+    default: 'unknown'
+  model:
+    description: 'Claude model to invoke (e.g. claude-sonnet-4-6). Empty means use claude-code-action default.'
+    required: false
+    default: ''
+  max_turns:
+    description: 'Max Claude turns. 18 covers a typical multi-step agent (e.g. spec-validation: CLI floor + diff scoping + drift check via Grep/Read + Write); reviewer agents typically use 5-8. Raise per-stage via the manifest if a heavier agent needs more.'
+    required: false
+    default: '18'
+  show_full_output:
+    description: 'When "true", claude-code-action streams full Claude prompts/responses to the GHA log. Useful for debugging on a sandbox base; set to "false" before agents see real secrets in their prompts.'
+    required: false
+    default: 'false'
+  upstream_artifacts:
+    description: 'Comma-separated names of upstream agents whose stage-output.json artifacts have been downloaded into upstream/<name>/ (same value the calling workflow passes to the gh run download step). Used to render the per-agent upstream-inputs section of the composed prompt.'
+    required: false
+    default: ''
+  private_output:
+    description: 'When "true", encrypt stage-output.json (openssl, key from SDLC_ARTIFACT_KEY in env) before uploading it as an artifact, so the artifact is not readable on a public repo. Local plaintext is consumed on the runner first (verify/render/SARIF) then removed.'
+    required: false
+    default: 'false'
+  emit_sarif:
+    description: 'When "true", convert payload.findings[] to SARIF and upload to GitHub code scanning (Security tab). Scoped to ANALYSIS_REF_FULL/ANALYSIS_SHA from env when set (the scanned branch), else the current ref/sha.'
+    required: false
+    default: 'false'
+
+outputs:
+  message:
+    description: 'Validated sticky JSON payload from the stage.'
+    value: ${{ steps.extract.outputs.json }}
+  status:
+    description: 'Stage status (passed | passed_with_findings | failed).'
+    value: ${{ steps.extract.outputs.status }}
+
+runs:
+  using: composite
+  steps:
+    - name: Validate ANTHROPIC_API_KEY env
+      shell: bash
+      run: |
+        if [ -z "${ANTHROPIC_API_KEY:-}" ]; then
+          echo "::error::ANTHROPIC_API_KEY env is not set. Set it on the calling job from secrets.ANTHROPIC_API_KEY."
+          exit 1
+        fi
+
+    - name: Prepare prompt, schema, and Claude args
+      id: prep
+      shell: bash
+      env:
+        STAGE_NAME: ${{ inputs.stage_name }}
+        SKILL: ${{ inputs.skill }}
+        ALLOWED_TOOLS: ${{ inputs.allowed_tools }}
+        MAX_TURNS: ${{ inputs.max_turns }}
+        MODEL: ${{ inputs.model }}
+        SHOW_FULL_OUTPUT: ${{ inputs.show_full_output }}
+        UPSTREAM_ARTIFACTS: ${{ inputs.upstream_artifacts }}
+        RUNNER_TEMP: ${{ runner.temp }}
+      run: |
+        set -euo pipefail
+        if [ -z "${SKILL}" ]; then
+          echo "::error::skill input is required (agents wrap a local skill)"
+          exit 1
+        fi
+
+        # Build agent-facing schema AND compose the prompt. Schema: strip
+        # envelope fields the renderer injects, pin `stage` to a literal const
+        # so Claude can't mismatch. Prompt: load the universal wrapper
+        # template (.github/claude/prompts/agent-wrapper.md) and substitute
+        # `{{stage}}` and `{{skill}}` — no per-agent prompt file is involved.
+        SCHEMA_PATH="${RUNNER_TEMP}/agent-schema.json"
+        COMPOSED_PROMPT_PATH="${RUNNER_TEMP}/composed-prompt.md"
+        WRAPPER_PATH=".github/claude/prompts/agent-wrapper.md"
+        export STAGE_NAME SKILL SCHEMA_PATH COMPOSED_PROMPT_PATH WRAPPER_PATH
+        python3 - <<'PY'
+        import json, os
+
+        # --- Agent-facing schema --------------------------------------------
+        with open('.github/claude/schemas/stage-message.schema.json') as f:
+            s = json.load(f)
+        # Envelope fields are injected by render-stage-comment.py; agents must not write them.
+        for k in ('contract_version', 'agent_version', 'run_id', 'trigger'):
+            s.get('properties', {}).pop(k, None)
+        s['required'] = [r for r in s.get('required', []) if r != 'contract_version']
+        stage = os.environ['STAGE_NAME']
+        s.setdefault('properties', {}).setdefault('stage', {'type': 'string'})['const'] = stage
+        with open(os.environ['SCHEMA_PATH'], 'w') as f:
+            json.dump(s, f)
+
+        # --- Composed prompt ------------------------------------------------
+        # IMPORTANT: substitute {{base_ref}} with the real branch name HERE,
+        # not at runtime via ${GITHUB_BASE_REF} in Claude's Bash command. The
+        # Claude Code Bash tool rejects commands containing shell variable
+        # expansion (`Contains expansion` / `Contains simple_expansion`) for
+        # safety — anything Claude types into a Bash tool call must be
+        # literal. So we expand the base ref at compose time and Claude sees
+        # `git diff origin/<actual-branch>...HEAD`.
+        base_ref = os.environ.get('GITHUB_BASE_REF', 'main')
+
+        # Render the upstream-inputs section from the comma-separated `needs`
+        # list the calling workflow plumbs through (same value used by the
+        # gh-run-download step). Explicit per-agent lines beat a generic
+        # placeholder: the agent is told the exact file(s) to read rather than
+        # having to discover them. Skills stay agnostic of CI plumbing.
+        upstream_raw = os.environ.get('UPSTREAM_ARTIFACTS', '')
+        upstream_names = [n.strip() for n in upstream_raw.split(',') if n.strip()]
+        if upstream_names:
+            upstream_inputs = '\n'.join(
+                f'  - `upstream/{n}/stage-output.json` — the `{n}` agent\'s output '
+                f'envelope; its agent-specific data (findings, reports, etc.) is under `payload`.'
+                for n in upstream_names
+            )
+        else:
+            upstream_inputs = '  - none declared; this agent runs independently on the PR diff and working tree.'
+
+        with open(os.environ['WRAPPER_PATH']) as f:
+            template = f.read()
+        composed = (template
+                    .replace('{{stage}}', stage)
+                    .replace('{{skill}}', os.environ['SKILL'])
+                    .replace('{{base_ref}}', base_ref)
+                    .replace('{{upstream_inputs}}', upstream_inputs))
+        with open(os.environ['COMPOSED_PROMPT_PATH'], 'w') as f:
+            f.write(composed)
+        PY
+        echo "Agent-facing schema written to $SCHEMA_PATH"
+        echo "Composed prompt written to $COMPOSED_PROMPT_PATH ($(wc -c < "$COMPOSED_PROMPT_PATH") bytes)"
+        PROMPT_CONTENT="$(cat "$COMPOSED_PROMPT_PATH")"
+
+        # 3) Build claude_args. Allowed tools, model, and (when toggled)
+        # the verbose flag all go through the CLI via claude_args; the
+        # action exposes none as direct inputs.
+        #
+        # NOTE: --json-schema is intentionally NOT used. The
+        # claude-code-action structured_output path buffers Claude's
+        # output entirely (no live streaming for ~5-15min) regardless of
+        # version. We instead instruct the agent in the prompt to write
+        # its JSON response to `stage-output.json` via the Write tool,
+        # and the verify step below just confirms the file exists. The
+        # renderer (render-stage-comment.py) performs the same shape
+        # validation that --json-schema would have given us.
+        ARGS="--max-turns ${MAX_TURNS}"
+        if [ "${SHOW_FULL_OUTPUT}" = "true" ]; then
+          # `--verbose` streams tool-use events with full detail. Costs
+          # log volume; useful when an agent is misbehaving. Gated by
+          # show_full_output so production runs stay quieter.
+          ARGS="${ARGS} --verbose"
+        fi
+        if [ -n "${MODEL}" ]; then
+          # In DIAL mode (SDLC_DIAL_MODE=1, set by run-agent's inference-route
+          # step) route the model through DIAL's Anthropic-compatible deployment
+          # as `dial,anthropic.<model>`. Manifests stay provider-agnostic
+          # (model: claude-sonnet-4-6); the platform adds the routing.
+          if [ "${SDLC_DIAL_MODE:-}" = "1" ]; then
+            # Route to the DIAL deployment: prefer the explicit DIAL_MODEL id
+            # (set by run-agent from vars.DIAL_MODEL — DIAL deployment names
+            # rarely match Anthropic model strings), else assume an
+            # `anthropic.<model>` deployment exists.
+            ARGS="${ARGS} --model dial,${SDLC_DIAL_MODEL:-anthropic.${MODEL}}"
+          else
+            ARGS="${ARGS} --model ${MODEL}"
+          fi
+        fi
+        # Append `Write` to allowed_tools so the agent can produce
+        # stage-output.json. Every agent needs this — structural, not
+        # agent-specific, so we don't burden manifests with it.
+        ARGS="${ARGS} --allowed-tools '${ALLOWED_TOOLS},Write'"
+
+        echo "claude_args=${ARGS}" >> "$GITHUB_OUTPUT"
+        {
+          echo "prompt<<PROMPT_EOF"
+          echo "$PROMPT_CONTENT"
+          echo "PROMPT_EOF"
+        } >> "$GITHUB_OUTPUT"
+
+    - name: Pre-flight state dump
+      # Diagnostic only — dumps cwd, env, skill discovery paths, composed
+      # prompt, and the agent-facing schema before invoking Claude. Off by
+      # default in production; toggle via `show_full_output: 'true'` to
+      # debug a misbehaving agent.
+      if: inputs.show_full_output == 'true'
+      shell: bash
+      env:
+        SCHEMA_PATH: ${{ runner.temp }}/agent-schema.json
+        COMPOSED_PROMPT_PATH: ${{ runner.temp }}/composed-prompt.md
+        STAGE_NAME: ${{ inputs.stage_name }}
+        SKILL: ${{ inputs.skill }}
+        ALLOWED_TOOLS: ${{ inputs.allowed_tools }}
+      run: |
+        set -euo pipefail
+        echo "::group::stage + cwd + tree state"
+        echo "stage_name=$STAGE_NAME"
+        echo "skill=$SKILL"
+        echo "allowed_tools=$ALLOWED_TOOLS"
+        echo "cwd=$(pwd)"
+        echo "ANTHROPIC_API_KEY set? $([ -n "${ANTHROPIC_API_KEY:-}" ] && echo yes || echo NO)"
+        echo "--- .claude/ in cwd ---"
+        ls -la .claude/ 2>/dev/null || echo "(missing)"
+        echo "--- .claude/skills/ ---"
+        ls -la .claude/skills/ 2>/dev/null || echo "(missing)"
+        echo "--- .claude/commands/opsx/ ---"
+        ls -la .claude/commands/opsx/ 2>/dev/null || echo "(missing)"
+        echo "--- target skill SKILL.md ---"
+        ls -la ".claude/skills/${SKILL}/SKILL.md" 2>/dev/null || echo "(missing — Claude will not find /$SKILL)"
+        echo "::endgroup::"
+        echo "::group::composed prompt (full)"
+        cat "$COMPOSED_PROMPT_PATH"
+        echo "::endgroup::"
+        echo "::group::agent-facing schema"
+        cat "$SCHEMA_PATH"
+        echo "::endgroup::"
+
+    - name: Run Claude
+      id: claude
+      uses: anthropics/claude-code-action@11ba60486e4aec9ddfeafcf4bb3f00b028ac2c16 # v1.0.142
+      with:
+        anthropic_api_key: ${{ env.ANTHROPIC_API_KEY }}
+        # Pass the runner's GITHUB_TOKEN directly so the action skips its
+        # OIDC → Claude-App-token exchange. We do not install the Claude
+        # Code GitHub App on this repo; we render our own sticky comments
+        # in a later step (see "Post sticky PR comment" below) using the
+        # same token via `gh api`.
+        github_token: ${{ github.token }}
+        # When the caller sets `show_full_output: "true"` we surface Claude's
+        # prompts and tool calls in the GHA log. The action's default hides
+        # them for security; visibility is essential on the sandbox base
+        # while wiring is shaken out.
+        show_full_output: ${{ inputs.show_full_output }}
+        prompt: ${{ steps.prep.outputs.prompt }}
+        claude_args: ${{ steps.prep.outputs.claude_args }}
+
+    - name: Persist input prompt (audit)
+      # Baseline audit (ADR-0005): persist INPUT alongside output, so a run can
+      # be reconstructed from "what was sent" + "what came back". Captures the
+      # composed prompt + agent-facing schema. `always()` so a failed/garbled
+      # agent run is still auditable. Encrypted for private_output agents to
+      # match the output artifact (public repo → world-downloadable artifacts);
+      # the prompt is wrapper boilerplate + skill/upstream names today, but
+      # encrypting keeps the "private agent ⇒ ciphertext" invariant if the
+      # composition ever starts inlining sensitive context.
+      # Guard inside bash, not via hashFiles(): hashFiles only globs under
+      # GITHUB_WORKSPACE, and the prompt lives in runner.temp.
+      if: always()
+      shell: bash
+      env:
+        PRIVATE_OUTPUT: ${{ inputs.private_output }}
+        RUNNER_TEMP: ${{ runner.temp }}
+      run: |
+        set -euo pipefail
+        if [ ! -f "${RUNNER_TEMP}/composed-prompt.md" ]; then
+          echo "::notice::no composed prompt to persist (prep did not complete)"
+          exit 0
+        fi
+        AUDIT_DIR="${RUNNER_TEMP}/stage-input"
+        mkdir -p "$AUDIT_DIR"
+        cp "${RUNNER_TEMP}/composed-prompt.md" "$AUDIT_DIR/composed-prompt.md"
+        [ -f "${RUNNER_TEMP}/agent-schema.json" ] && cp "${RUNNER_TEMP}/agent-schema.json" "$AUDIT_DIR/agent-schema.json" || true
+        if [ "${PRIVATE_OUTPUT}" = "true" ]; then
+          if [ -z "${SDLC_ARTIFACT_KEY:-}" ]; then
+            echo "::error::private_output is true but SDLC_ARTIFACT_KEY is not in env — cannot encrypt the audit input. Add it to the agent manifest \`secrets:\` and repo/org Actions secrets."
+            exit 1
+          fi
+          for f in "$AUDIT_DIR"/*; do
+            openssl enc -aes-256-cbc -pbkdf2 -salt -in "$f" -out "$f.enc" -pass env:SDLC_ARTIFACT_KEY
+            rm -f "$f"
+          done
+          echo "Persisted encrypted audit input (private agent)."
+        else
+          echo "Persisted audit input (plaintext)."
+        fi
+
+    - name: Upload input prompt artifact
+      # if-no-files-found: ignore — the dir is absent when prep didn't complete
+      # (the persist step above exits early); no audit input to upload then.
+      if: always()
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      with:
+        name: stage-input-${{ inputs.stage_name }}
+        path: ${{ runner.temp }}/stage-input/
+        retention-days: 90
+        if-no-files-found: ignore
+
+    - name: Verify stage-output.json
+      shell: bash
+      run: |
+        set -euo pipefail
+        if [ ! -f stage-output.json ]; then
+          echo "::error::Claude did not write stage-output.json. The agent must use the Write tool to create the file at the repo root with its final JSON response. Check the Run Claude step's log for what happened."
+          exit 1
+        fi
+        echo "stage-output.json present ($(wc -c < stage-output.json) bytes)"
+        # Do NOT cat the file: this repo is PUBLIC and run logs are world-
+        # readable, so dumping the findings here would leak internal security
+        # data. The renderer validates shape in the next step; the artifact
+        # carries the full content for the (private, in-run) chain handoff.
+
+    - name: Validate and render sticky comment
+      id: extract
+      shell: bash
+      env:
+        STAGE_NAME: ${{ inputs.stage_name }}
+        AGENT_VERSION: ${{ inputs.agent_version }}
+      run: python3 ./.github/claude/scripts/render-stage-comment.py
+
+    - name: Scrub output (M4 — secret scan + URL/HTML neutralize)
+      # ADR-0005 M4: deterministic, LLM-free, fail-closed gate on the rendered
+      # PUBLIC body before any posting step. Fails the stage on a secret hit
+      # (stops "Comment and Control") and neutralizes outbound-exfil vectors
+      # (zero-click images, non-allowlisted links, dangerous HTML). The posting
+      # steps below consume `steps.scrub.outputs.comment` — the scrubbed body —
+      # never the raw render. Only runs for public (non-private_output) agents;
+      # private agents publish counts-only aggregates, not this body.
+      id: scrub
+      if: inputs.private_output != 'true' && steps.extract.outputs.comment != ''
+      shell: bash
+      env:
+        BODY: ${{ steps.extract.outputs.comment }}
+        GITHUB_SERVER_URL: ${{ github.server_url }}
+      run: python3 ./.github/claude/scripts/scrub-output.py
+
+    - name: Emit SARIF to code scanning
+      # Convert payload.findings[] -> SARIF and upload to the Security tab (a
+      # write-access-gated surface, unlike public PR comments/summaries). Runs
+      # on the local plaintext, BEFORE the encrypt step removes it. Scoped to
+      # the scanned branch/commit (ANALYSIS_*) when analysis_ref is set, so
+      # alerts render against real code; falls back to the current ref/sha.
+      if: inputs.emit_sarif == 'true' && hashFiles('stage-output.json') != ''
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+        REPO: ${{ github.repository }}
+      run: |
+        set -euo pipefail
+        python3 ./.github/claude/scripts/findings-to-sarif.py stage-output.json triage.sarif
+        SARIF_REF="${ANALYSIS_REF_FULL:-$GITHUB_REF}"
+        SARIF_SHA="${ANALYSIS_SHA:-$GITHUB_SHA}"
+        B64="$(gzip -c triage.sarif | base64 -w0)"
+        echo "Uploading SARIF for ${SARIF_REF}@${SARIF_SHA:0:7}"
+        gh api -X POST "repos/${REPO}/code-scanning/sarifs" \
+          -f commit_sha="${SARIF_SHA}" \
+          -f ref="${SARIF_REF}" \
+          -f sarif="${B64}" \
+          && echo "SARIF accepted by code scanning." \
+          || { echo "::warning::SARIF upload failed (code scanning may be disabled, or ref/sha not accepted). Triage still succeeded."; }
+
+    - name: Publish aggregate report (sensitive agents)
+      # private_output (sensitive) agents publish ONLY aggregate counts — no file
+      # paths, per-finding verdicts, or any detail — to the Actions run's job
+      # summary (the pipeline view), NOT a PR comment: these are batch/scheduled
+      # agents over a standing backlog, not PR reviewers. Counts are safe on a
+      # public repo. Runs on the local plaintext, BEFORE the encrypt step removes it.
+      if: inputs.private_output == 'true' && hashFiles('stage-output.json') != ''
+      shell: bash
+      run: |
+        set -euo pipefail
+        python3 ./.github/claude/scripts/findings-aggregate.py stage-output.json >> "$GITHUB_STEP_SUMMARY"
+        echo "Published aggregate counts to the job summary."
+
+    - name: Encrypt stage output (private agents)
+      # Runs AFTER the renderer (and any SARIF emitter) have consumed the local
+      # plaintext. Encrypts stage-output.json -> stage-output.json.enc and
+      # removes the plaintext, so only ciphertext is uploaded as an artifact —
+      # required on a PUBLIC repo, where artifacts are world-downloadable. The
+      # key (SDLC_ARTIFACT_KEY) is injected by run-agent from the manifest's
+      # declared secrets; the downstream agent's run-agent decrypts it.
+      if: inputs.private_output == 'true' && hashFiles('stage-output.json') != ''
+      shell: bash
+      run: |
+        set -euo pipefail
+        if [ -z "${SDLC_ARTIFACT_KEY:-}" ]; then
+          echo "::error::private_output is true but SDLC_ARTIFACT_KEY is not in env. Add it to the agent's manifest \`secrets:\` list and the repo/org Actions secrets."
+          exit 1
+        fi
+        openssl enc -aes-256-cbc -pbkdf2 -salt \
+          -in stage-output.json -out stage-output.json.enc -pass env:SDLC_ARTIFACT_KEY
+        rm -f stage-output.json
+        echo "Encrypted stage-output.json -> stage-output.json.enc (plaintext removed)"
+
+    - name: Upload stage output artifact
+      # Uploads whichever exists: stage-output.json (public agents) or
+      # stage-output.json.enc (private_output agents). The artifact name is the
+      # same either way; the downstream decrypt step handles the .enc variant.
+      if: always() && (hashFiles('stage-output.json') != '' || hashFiles('stage-output.json.enc') != '')
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      with:
+        name: stage-output-${{ inputs.stage_name }}
+        path: |
+          stage-output.json
+          stage-output.json.enc
+        retention-days: 90
+        if-no-files-found: warn
+
+    - name: Publish to job summary
+      # FULL detail — only for NON-sensitive agents (private_output != true).
+      # Sensitive agents use the aggregate (counts-only) step above instead,
+      # because this repo is public and the job summary is world-readable.
+      if: inputs.private_output != 'true' && steps.scrub.outputs.comment != ''
+      shell: bash
+      env:
+        STAGE_NAME: ${{ inputs.stage_name }}
+        BODY: ${{ steps.scrub.outputs.comment }}
+      run: |
+        {
+          echo "## ${STAGE_NAME}"
+          echo ""
+          echo "${BODY}"
+        } >> "$GITHUB_STEP_SUMMARY"
+
+    - name: Post sticky PR comment
+      # FULL detail — only for NON-sensitive agents (private_output != true).
+      # Sensitive agents post the aggregate (counts-only) sticky comment above.
+      if: github.event_name == 'pull_request' && inputs.private_output != 'true' && steps.scrub.outputs.comment != ''
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+        REPO: ${{ github.repository }}
+        STAGE_NAME: ${{ inputs.stage_name }}
+        BODY: ${{ steps.scrub.outputs.comment }}
+      run: |
+        set -euo pipefail
+        MARKER="<!-- dial-sdlc:${STAGE_NAME} -->"
+        EXISTING_ID="$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
+          | jq -r --arg m "$MARKER" '.[] | select(.body | startswith($m)) | .id' \
+          | head -n1)"
+        if [ -n "$EXISTING_ID" ]; then
+          gh api -X PATCH "repos/${REPO}/issues/comments/${EXISTING_ID}" -f body="$BODY" > /dev/null
+          echo "Updated sticky comment $EXISTING_ID"
+        else
+          gh api -X POST "repos/${REPO}/issues/${PR_NUMBER}/comments" -f body="$BODY" > /dev/null
+          echo "Created sticky comment for stage ${STAGE_NAME}"
+        fi
+
+    - name: Enforce stage gate (fail job on status=failed)
+      # The job-failing gate is DELIBERATELY the LAST step. The renderer used to
+      # exit 1 on a well-formed status=failed, but that ran in the same step that
+      # produced the comment body — so every step after it (scrub, job summary,
+      # PR comment, aggregate, artifact upload) was skipped and the blocking
+      # findings never reached the PR. Now the renderer stays exit-0 on a valid
+      # failed result, all surfacing steps run, and THEN we fail the job here.
+      # `always()` so a failed status still gates even if an earlier surfacing
+      # step was skipped (e.g. private agents post no PR comment). Genuine render
+      # errors (bad JSON / invalid fields) already failed the extract step and
+      # the job; this only adds the gate for the valid-but-failed case.
+      if: always() && steps.extract.outputs.status == 'failed'
+      shell: bash
+      env:
+        STAGE_NAME: ${{ inputs.stage_name }}
+      run: |
+        echo "::error::Stage ${STAGE_NAME} reported status=failed — blocking findings surfaced in the PR comment / job summary above."
+        exit 1

--- a/.github/claude/scripts/findings-aggregate.py
+++ b/.github/claude/scripts/findings-aggregate.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+# Render a COUNTS-ONLY markdown report from a stage-output.json envelope, safe to
+# post on a PUBLIC repo (PR sticky comment / job summary) for `private_output`
+# (sensitive) agents. It emits ONLY aggregate numbers — never file paths, code,
+# messages, Jira descriptions, or any per-finding detail.
+#
+# Usage: findings-aggregate.py <stage-output.json>   (prints markdown to stdout)
+import json, sys
+from collections import Counter
+
+VERDICT_ORDER = ["CONFIRMED", "NEEDS_REVIEW", "DUPLICATE",
+                 "NOT_APPLICABLE", "FALSE_POSITIVE"]
+SEVERITY_ORDER = ["critical", "high", "medium", "low", "info"]
+
+
+def table(title, rows):
+    out = [f"| {title} | Count |", "|---|---:|"]
+    out += [f"| {k} | {v} |" for k, v in rows if v]
+    return "\n".join(out) if len(out) > 2 else ""
+
+
+def main():
+    path = sys.argv[1] if len(sys.argv) > 1 else "stage-output.json"
+    doc = json.load(open(path))
+    stage = doc.get("stage", "stage")
+    status = doc.get("status", "")
+    payload = doc.get("payload") or {}
+
+    # IMPORTANT: never echo the agent-authored `summary` (or any free text) on
+    # this PUBLIC surface — agents put per-finding specifics (vuln class, code
+    # symbols, mechanisms) there. This report is machine-generated from the
+    # structured counts only; the free-text summary stays in the (encrypted)
+    # artifact.
+    lines = [f"## {stage}", "", f"**Status:** `{status}`", ""]
+
+    findings = payload.get("findings") or []
+    if findings:
+        v = Counter((f.get("verdict") or "UNKNOWN").upper() for f in findings)
+        s = Counter((f.get("severity") or "unknown").lower() for f in findings)
+        lines += [f"**Findings triaged:** {len(findings)}", ""]
+        vt = table("Verdict", [(k, v.get(k, 0)) for k in VERDICT_ORDER]
+                   + [(k, c) for k, c in v.items() if k not in VERDICT_ORDER])
+        if vt:
+            lines += [vt, ""]
+        st = table("Adjusted severity", [(k, s.get(k, 0)) for k in SEVERITY_ORDER]
+                   + [(k, c) for k, c in s.items() if k not in SEVERITY_ORDER])
+        if st:
+            lines += [st, ""]
+
+    # Producer (ingest) counts, if present — all numbers, no detail.
+    jira = payload.get("jira") or {}
+    counts = [(k, jira.get(k)) for k in
+              ("fetched_count", "matched_count", "dropped_count", "analyzed_count")
+              if isinstance(jira.get(k), int)]
+    if counts:
+        lines += [table("Ingest", counts), ""]
+
+    lines += ["_Details withheld: this repo is public; per-finding data is internal "
+              "and is not published here._"]
+    print("\n".join(lines))
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/claude/scripts/findings-to-sarif.py
+++ b/.github/claude/scripts/findings-to-sarif.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+# Convert a stage-output.json envelope's `payload.findings[]` into a SARIF 2.1.0
+# document for GitHub code scanning (Security tab). Keeps the triage skill clean
+# — it emits findings[]; the platform produces SARIF here.
+#
+# Mapping:
+#   severity -> SARIF level (critical/high=error, medium=warning, low/info=note)
+#   file/line -> physicalLocation
+#   jira_key -> partialFingerprints (stable dedup across daily runs)
+#   verdict  -> message prefix + properties; triaged-away verdicts
+#              (FALSE_POSITIVE / NOT_APPLICABLE / DUPLICATE) are emitted as
+#              SARIF `suppressions` so they show as dismissed, leaving only
+#              CONFIRMED / NEEDS_REVIEW as open alerts.
+#
+# Usage: findings-to-sarif.py <stage-output.json> <out.sarif>
+import json, sys
+
+SEV2LEVEL = {"critical": "error", "high": "error", "medium": "warning",
+             "low": "note", "info": "note"}
+OPEN_VERDICTS = {"CONFIRMED", "NEEDS_REVIEW"}
+
+
+def main():
+    src_path = sys.argv[1] if len(sys.argv) > 1 else "stage-output.json"
+    out_path = sys.argv[2] if len(sys.argv) > 2 else "triage.sarif"
+
+    doc = json.load(open(src_path))
+    findings = (doc.get("payload") or {}).get("findings") or []
+
+    rules = {}
+    results = []
+    for f in findings:
+        verdict = (f.get("verdict") or "").upper()
+        sev = (f.get("severity") or "info").lower()
+        level = SEV2LEVEL.get(sev, "note")
+        # Rule grouping: prefer an explicit `rule`, else group all triage
+        # findings under one rule. jira_key distinguishes individual alerts.
+        rule_id = f.get("rule") or "snyk-sast-triage"
+        rules.setdefault(rule_id, {
+            "id": rule_id,
+            "name": rule_id,
+            "shortDescription": {"text": "Snyk SAST finding (AI-triaged)"},
+        })
+
+        msg = f"[{verdict or 'UNTRIAGED'}] {f.get('message', '')}".strip()
+        result = {
+            "ruleId": rule_id,
+            "level": level,
+            "message": {"text": msg},
+            "properties": {
+                "verdict": verdict,
+                "jira_key": f.get("jira_key", ""),
+                "original_severity": f.get("original_severity", ""),
+            },
+        }
+        if f.get("file"):
+            phys = {"artifactLocation": {"uri": f["file"]}}
+            line = f.get("line")
+            if isinstance(line, int) and line >= 1:
+                phys["region"] = {"startLine": line}
+            result["locations"] = [{"physicalLocation": phys}]
+        if f.get("jira_key"):
+            result["partialFingerprints"] = {"jiraKey": f["jira_key"]}
+        # Dismiss triaged-away findings so only actionable ones alert.
+        if verdict and verdict not in OPEN_VERDICTS:
+            result["suppressions"] = [{
+                "kind": "external",
+                "justification": f"AI triage verdict: {verdict}",
+            }]
+        results.append(result)
+
+    sarif = {
+        "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+        "version": "2.1.0",
+        "runs": [{
+            "tool": {"driver": {
+                "name": "DIAL Snyk Triage",
+                "informationUri": "https://github.com/epam/ai-dial-chat",
+                "rules": list(rules.values()),
+            }},
+            # Distinct analysis category so triage results coexist with any other
+            # code-scanning tools instead of overwriting each other.
+            "automationDetails": {"id": "snyk-triage/"},
+            "results": results,
+        }],
+    }
+    with open(out_path, "w") as fh:
+        json.dump(sarif, fh, indent=2)
+    print(f"Wrote {out_path}: {len(results)} result(s), "
+          f"{sum(1 for r in results if 'suppressions' not in r)} open / "
+          f"{sum(1 for r in results if 'suppressions' in r)} suppressed.")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/claude/scripts/match-agents.py
+++ b/.github/claude/scripts/match-agents.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+# Discover agents whose manifests match a given GitHub event, validate each
+# manifest against the schema, apply kill-switch vars, honor trigger filters
+# (branches, labels), validate `permissions:` against the platform-supported
+# set, validate the `needs:` DAG (prune agents whose deps are unavailable, fail
+# on cycles), and emit the matched agents as a flat list.
+#
+# Output: {"agents": [...]} — each entry has {name, needs, timeout_minutes,
+# concurrency_group}. The dispatcher runs them all in ONE matrix; each agent
+# waits for its own `needs:` upstreams inside its job, so there are no rounds.
+import argparse
+import glob
+import json
+import os
+import sys
+
+try:
+    import yaml
+except ImportError:
+    sys.stderr.write("::error::PyYAML required. Run: pip install pyyaml\n")
+    sys.exit(2)
+
+try:
+    import jsonschema
+except ImportError:
+    sys.stderr.write("::error::jsonschema required. Run: pip install jsonschema\n")
+    sys.exit(2)
+
+# Disable YAML 1.1 boolean keywords (on/off/yes/no/On/Off/…) at the resolver
+# level so an unquoted `on: pull_request` parses with the string key "on"
+# instead of the boolean True. true/false remain valid booleans.
+for _ch in "yYnNoO":
+    if _ch in yaml.SafeLoader.yaml_implicit_resolvers:
+        yaml.SafeLoader.yaml_implicit_resolvers[_ch] = [
+            (tag, regex)
+            for tag, regex in yaml.SafeLoader.yaml_implicit_resolvers[_ch]
+            if tag != "tag:yaml.org,2002:bool"
+        ]
+
+DEFAULT_TIMEOUT = 15
+
+# Platform-supported permissions. Any manifest requesting permissions OUTSIDE
+# this set is rejected; adding a new permission requires raising the bar in
+# run-agent.yml + dispatcher (see PLATFORM_REFERENCE.md).
+SUPPORTED_PERMISSIONS = {
+    "contents": {"read"},
+    "pull-requests": {"write"},
+    "checks": {"write"},
+    "security-events": {"read", "write"},
+}
+
+
+def fail(msg):
+    sys.stderr.write(f"::error::{msg}\n")
+    sys.exit(1)
+
+
+def warn(msg):
+    sys.stderr.write(f"::warning::{msg}\n")
+
+
+def notice(msg):
+    sys.stderr.write(f"::notice::{msg}\n")
+
+
+def matches_trigger(triggers, event):
+    """Return (matched, filters) — filters from the matching trigger, if any."""
+    for t in triggers or []:
+        if isinstance(t, str) and t == event:
+            return True, {}
+        if isinstance(t, dict) and t.get("on") == event:
+            return True, t.get("filters") or {}
+    return False, {}
+
+
+def passes_filters(filters, event_ctx):
+    """Apply branches + labels filters. `paths` deferred to v0.3."""
+    if not filters:
+        return True
+
+    pr = event_ctx.get("pull_request") or {}
+    branches = filters.get("branches") or []
+    if branches:
+        target = (pr.get("base") or {}).get("ref", "")
+        if target and target not in branches:
+            return False
+
+    required_labels = filters.get("labels") or []
+    if required_labels:
+        pr_labels = {lbl.get("name") for lbl in pr.get("labels") or []}
+        if not all(req in pr_labels for req in required_labels):
+            return False
+
+    return True
+
+
+def kill_switch_var(name):
+    return "STAGE_" + name.upper().replace("-", "_") + "_ENABLED"
+
+
+def validate_permissions(name, perms):
+    """Fail if any declared permission exceeds the platform's supported set."""
+    if not perms:
+        return
+    for scope, level in perms.items():
+        allowed = SUPPORTED_PERMISSIONS.get(scope)
+        if allowed is None:
+            fail(
+                f"agent {name} declares unsupported permission '{scope}'. "
+                f"Platform supports: {sorted(SUPPORTED_PERMISSIONS)}. "
+                f"See .github/claude/PLATFORM_REFERENCE.md → permission tiers."
+            )
+        if level not in allowed:
+            fail(
+                f"agent {name} declares '{scope}: {level}' but platform supports "
+                f"only '{scope}: {sorted(allowed)}'."
+            )
+
+
+def derive_concurrency_group(name, ref):
+    return f"dispatch-pr-{name}-{ref}"
+
+
+def discover_agents(root, event, event_ctx, vars_dict, schema):
+    matched = {}
+    for path in sorted(glob.glob(f"{root}/agents/*/agent.yml")):
+        if os.path.basename(os.path.dirname(path)).startswith("_"):
+            continue
+        try:
+            with open(path) as f:
+                manifest = yaml.safe_load(f) or {}
+        except Exception as e:
+            fail(f"could not load {path}: {e}")
+
+        # Schema validation — fail loudly with the path.
+        try:
+            jsonschema.validate(instance=manifest, schema=schema)
+        except jsonschema.ValidationError as e:
+            fail(f"manifest schema violation in {path}: {e.message} (at {list(e.absolute_path)})")
+
+        name = manifest["name"]
+
+        matched_event, filters = matches_trigger(manifest.get("triggers"), event)
+        if not matched_event:
+            continue
+        if not passes_filters(filters, event_ctx):
+            notice(f"agent {name} skipped by trigger filters (branches/labels mismatch)")
+            continue
+
+        ks_var = manifest.get("kill_switch_var") or kill_switch_var(name)
+        if vars_dict.get(ks_var) == "false":
+            notice(f"agent {name} disabled via {ks_var}=false")
+            continue
+
+        validate_permissions(name, manifest.get("permissions"))
+
+        ref = os.environ.get("GITHUB_REF", "")
+        concurrency = manifest.get("concurrency") or {}
+        entry = {
+            "name": name,
+            "needs": manifest.get("needs") or [],
+            "timeout_minutes": int(manifest.get("timeout_minutes") or DEFAULT_TIMEOUT),
+            "concurrency_group": concurrency.get("group") or derive_concurrency_group(name, ref),
+        }
+        matched[name] = entry
+    return matched
+
+
+def topo_sort_rounds(agents):
+    available = set(agents)
+
+    pruned = {}
+    for name, a in agents.items():
+        missing = set(a["needs"]) - available
+        if missing:
+            warn(f"skipping {name}; needed agents not available: {sorted(missing)}")
+            continue
+        pruned[name] = a
+
+    remaining = dict(pruned)
+    processed = set()
+    rounds = []
+    while remaining:
+        ready = [a for a in remaining.values() if not (set(a["needs"]) - processed)]
+        if not ready:
+            fail(f"Cycle detected in agent `needs:` deps: {sorted(remaining)}")
+        ready.sort(key=lambda a: a["name"])
+        rounds.append(ready)
+        for a in ready:
+            del remaining[a["name"]]
+            processed.add(a["name"])
+    return rounds
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("event", help="GitHub event name (e.g. pull_request)")
+    p.add_argument("--vars", help="Path to JSON dump of the vars context")
+    p.add_argument("--event-context", help="Path to JSON dump of github.event (for filter evaluation)")
+    p.add_argument("--root", default=".", help="Repo root (default: cwd)")
+    args = p.parse_args()
+
+    schema_path = os.path.join(args.root, ".github/claude/schemas/agent-manifest.schema.json")
+    try:
+        with open(schema_path) as f:
+            schema = json.load(f)
+    except FileNotFoundError:
+        fail(f"manifest schema not found: {schema_path}")
+
+    vars_dict = {}
+    if args.vars and os.path.exists(args.vars):
+        with open(args.vars) as f:
+            vars_dict = json.load(f) or {}
+
+    event_ctx = {}
+    if args.event_context and os.path.exists(args.event_context):
+        with open(args.event_context) as f:
+            event_ctx = json.load(f) or {}
+
+    agents = discover_agents(args.root, args.event, event_ctx, vars_dict, schema)
+    # topo_sort_rounds still runs — for cycle detection and for pruning agents
+    # whose `needs:` are unavailable — but we flatten its output: the dispatcher
+    # no longer uses rounds. Every matched agent runs in one matrix and waits for
+    # its own `needs:` upstream jobs, so per-edge scheduling replaces round
+    # barriers (a dependent starts as soon as ITS upstream is done).
+    rounds = topo_sort_rounds(agents)
+    flat = [a for r in rounds for a in r]
+    print(json.dumps({"agents": flat}))
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/claude/scripts/render-stage-comment.py
+++ b/.github/claude/scripts/render-stage-comment.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+# Validate stage-output.json, inject envelope fields, render sticky PR comment.
+# Stdlib only — no PyYAML, no jq dependency. The machine-readable form (with
+# envelope) is written back to the file so the uploaded artifact contains the
+# enriched payload; the human-readable form goes to GITHUB_OUTPUT for the
+# sticky comment.
+#
+# Emits three GitHub Actions outputs:
+#   - json:    compact JSON payload (for needs.X.outputs.message)
+#   - status:  passed | passed_with_findings | failed
+#   - comment: markdown sticky PR comment body
+#
+# Expects env:
+#   STAGE_NAME           required
+#   AGENT_VERSION        optional; defaults to "unknown"
+#   STAGE_OUTPUT_FILE    optional; defaults to "stage-output.json"
+#   GITHUB_*             auto-set by GHA
+import json
+import os
+import sys
+from pathlib import Path
+
+CONTRACT_VERSION = "0.1"
+ICON = {"passed": "✅", "passed_with_findings": "⚠️", "failed": "❌"}
+
+
+def fail(msg):
+    sys.stderr.write(f"::error::{msg}\n")
+    sys.exit(1)
+
+
+def deep_merge(base, override):
+    out = dict(base)
+    for k, v in override.items():
+        if isinstance(v, dict) and isinstance(out.get(k), dict):
+            out[k] = deep_merge(out[k], v)
+        else:
+            out[k] = v
+    return out
+
+
+def build_findings_block(findings, run_url):
+    if not findings:
+        return []
+    lines = ["", "| Severity | Location | Message |", "|---|---|---|"]
+    for f in findings[:10]:
+        sev = f.get("severity", "info")
+        file_path = f.get("file", "—")
+        line_num = f.get("line")
+        loc = f"`{file_path}{':' + str(line_num) if line_num else ''}`"
+        req = f.get("requirement_ref")
+        if req:
+            loc += f" ({req})"
+        msg = (f.get("message") or "").replace("|", "\\|").replace("\n", " ")
+        lines.append(f"| `{sev}` | {loc} | {msg} |")
+    overflow = len(findings) - 10
+    if overflow > 0:
+        lines.append("")
+        lines.append(f"_… and {overflow} more — full output in the [run artifact]({run_url})._")
+    return lines
+
+
+def main():
+    output_file = Path(os.environ.get("STAGE_OUTPUT_FILE", "stage-output.json"))
+    stage_name = os.environ.get("STAGE_NAME")
+    if not stage_name:
+        fail("STAGE_NAME env is required")
+    agent_version = os.environ.get("AGENT_VERSION", "unknown")
+
+    if not output_file.exists():
+        fail(f"Stage did not produce {output_file}. The prompt must instruct Claude to write this file at the repo root.")
+
+    try:
+        payload = json.loads(output_file.read_text())
+    except json.JSONDecodeError as e:
+        # Dump what the agent actually wrote so we can see WHERE the escaping
+        # went wrong. JSON parse errors give char offsets that are hard to
+        # interpret without seeing the source text. 1500 chars is enough to
+        # cover the offset of typical failures while staying readable in
+        # the GHA log.
+        raw = output_file.read_text()
+        sys.stderr.write("::group::stage-output.json (first 1500 chars)\n")
+        sys.stderr.write(raw[:1500])
+        if len(raw) > 1500:
+            sys.stderr.write(f"\n... [truncated; total {len(raw)} bytes]")
+        sys.stderr.write("\n::endgroup::\n")
+        fail(f"{output_file} is not valid JSON: {e}. File contents logged above.")
+
+    envelope = {
+        "contract_version": CONTRACT_VERSION,
+        "agent_version": agent_version,
+        "run_id": os.environ.get("GITHUB_RUN_ID", ""),
+        "trigger": {
+            "event": os.environ.get("GITHUB_EVENT_NAME", ""),
+            "ref": os.environ.get("GITHUB_REF", ""),
+            "sha": os.environ.get("GITHUB_SHA", ""),
+        },
+    }
+    payload = deep_merge(payload, envelope)
+    output_file.write_text(json.dumps(payload, indent=2))
+
+    for field in ("contract_version", "stage", "status", "summary"):
+        if field not in payload:
+            fail(f"{output_file} missing required field: {field}")
+
+    if payload["contract_version"] != CONTRACT_VERSION:
+        fail(f"contract_version mismatch: platform={CONTRACT_VERSION} but payload={payload['contract_version']}")
+
+    if payload["stage"] != stage_name:
+        fail(f"stage field mismatch: workflow stage_name={stage_name} but JSON .stage={payload['stage']}")
+
+    status = payload["status"]
+    if status not in ICON:
+        fail(f"Invalid status: {status} (expected passed | passed_with_findings | failed)")
+
+    summary = payload["summary"]
+    agent_payload = payload.get("payload") or {}
+    findings = agent_payload.get("findings") or []
+    override_md = agent_payload.get("comment_markdown")
+    cost = payload.get("cost_usd")
+    run_url = (
+        f"{os.environ.get('GITHUB_SERVER_URL', 'https://github.com')}"
+        f"/{os.environ.get('GITHUB_REPOSITORY')}"
+        f"/actions/runs/{os.environ.get('GITHUB_RUN_ID')}"
+    )
+
+    parts = [f"<!-- dial-sdlc:{stage_name} -->", f"{ICON[status]} **{stage_name}**: {summary}"]
+    # Body precedence: explicit comment_markdown wins; otherwise render findings
+    # table when present; otherwise leave the summary line alone.
+    if override_md:
+        parts.append("")
+        parts.append(override_md)
+    else:
+        parts.extend(build_findings_block(findings, run_url))
+    parts.append("")
+    footer = f"[Run details]({run_url})"
+    if cost is not None:
+        footer += f" · `${cost}`"
+    parts.append(footer)
+
+    comment = "\n".join(parts)
+    compact_json = json.dumps(payload, separators=(",", ":"))
+
+    github_output = os.environ.get("GITHUB_OUTPUT")
+    if github_output:
+        with open(github_output, "a") as out:
+            out.write(f"json={compact_json}\n")
+            out.write(f"status={status}\n")
+            out.write("comment<<COMMENT_EOF\n")
+            out.write(comment)
+            out.write("\nCOMMENT_EOF\n")
+
+    # NOTE: a well-formed status=failed is NOT an error here — this renderer must
+    # exit 0 so the downstream steps (scrub, job summary, PR comment) still run
+    # and the blocking findings reach the PR. The job is failed by a dedicated
+    # gate step AFTER the comment is posted (see run-claude-stage/action.yml).
+    # Only genuine render errors above (bad JSON, missing/invalid fields) exit 1.
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/claude/scripts/scrub-output.py
+++ b/.github/claude/scripts/scrub-output.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+# M4 (ADR-0005) — deterministic, LLM-free, fail-closed output post-processor.
+#
+# Runs on the rendered PUBLIC body (the text bound for a PR comment / job
+# summary) AFTER render-stage-comment.py and BEFORE any posting step:
+#
+#   1. Secret scan  -> FAIL the stage (exit 1) on any hit. Nothing is posted.
+#      This is the control that actually stops "Comment and Control" (a
+#      prompt-injected agent emitting a credential into a public comment).
+#   2. URL / HTML neutralize -> strip outbound-exfil vectors (zero-click
+#      markdown images, non-allowlisted links, dangerous HTML tags) and emit
+#      the scrubbed body for the posting steps to consume.
+#
+# Schema validation of stage-output.json happens upstream in the renderer;
+# this gate guards the rendered surface, not the artifact shape. It is
+# intentionally LLM-free and dependency-free (stdlib only) so it is
+# deterministic and auditable.
+#
+# I/O: reads the candidate body from env BODY (falls back to stdin). On pass,
+# writes the scrubbed body to GITHUB_OUTPUT as `comment`. Exit 1 = fail-closed.
+
+import math
+import os
+import re
+import sys
+import urllib.parse
+from collections import Counter
+
+
+def notice(m):
+    sys.stderr.write(f"::notice::{m}\n")
+
+
+def err(m):
+    sys.stderr.write(f"::error::{m}\n")
+
+
+body = os.environ.get("BODY")
+if body is None:
+    body = sys.stdin.read()
+
+# --- 1. Secret scan (named patterns) ---------------------------------------
+# Scanned on the RAW body first, so a secret hidden in a URL query
+# (e.g. ![](http://x/?d=sk-ant-…)) is caught before the URL is neutralized.
+SECRET_PATTERNS = {
+    "anthropic-key":     r"sk-ant-[A-Za-z0-9_\-]{20,}",
+    "openai-style-key":  r"\bsk-[A-Za-z0-9]{32,}\b",
+    "aws-access-key":    r"\b(?:AKIA|ASIA)[0-9A-Z]{16}\b",
+    "github-token":      r"\bgh[pousr]_[A-Za-z0-9]{36,}\b",
+    "github-fine-pat":   r"\bgithub_pat_[A-Za-z0-9_]{60,}\b",
+    "slack-token":       r"\bxox[baprs]-[A-Za-z0-9-]{10,}\b",
+    "jwt":               r"\beyJ[A-Za-z0-9_\-]{10,}\.eyJ[A-Za-z0-9_\-]{10,}\.[A-Za-z0-9_\-]{10,}\b",
+    "private-key-block": r"-----BEGIN (?:[A-Z ]+ )?PRIVATE KEY-----",
+}
+
+hits = [name for name, pat in SECRET_PATTERNS.items() if re.search(pat, body)]
+
+
+def shannon(s):
+    n = len(s)
+    if n == 0:
+        return 0.0
+    return -sum((c / n) * math.log2(c / n) for c in Counter(s).values())
+
+
+# High-entropy backstop for unstructured tokens (e.g. a Jira PAT). Guarded
+# against the common non-secret shapes our comments legitimately carry:
+# pure hex (git SHAs / hashes) and pure-digit run ids. Requires a mixed
+# charset + entropy >= 4.0 bits/char to count, to keep false-positives low.
+if os.environ.get("HIGH_ENTROPY_SCAN", "true") != "false":
+    for tok in re.findall(r"[A-Za-z0-9+/=_\-]{32,}", body):
+        if re.fullmatch(r"[0-9a-fA-F]{32,64}", tok) or tok.isdigit():
+            continue
+        if (any(c.isupper() for c in tok) and any(c.islower() for c in tok)
+                and any(c.isdigit() for c in tok) and shannon(tok) >= 4.0):
+            hits.append("high-entropy-token")
+            break
+
+if hits:
+    err(
+        f"M4 secret scan: output contains likely secret(s) {sorted(set(hits))}. "
+        "Output BLOCKED — nothing posted to the PR or job summary. This is the "
+        "fail-closed control against prompt-injection credential exfiltration "
+        "('Comment and Control'). Inspect the run artifact (not the log) to triage."
+    )
+    sys.exit(1)
+
+# --- 2. URL / HTML neutralize ----------------------------------------------
+server = os.environ.get("GITHUB_SERVER_URL", "https://github.com")
+allow_hosts = {urllib.parse.urlparse(server).netloc.lower(), "github.com"}
+
+
+def host_allowed(url):
+    try:
+        h = urllib.parse.urlparse(url.strip()).netloc.lower()
+    except ValueError:
+        return False
+    return bool(h) and any(h == a or h.endswith("." + a) for a in allow_hosts)
+
+
+# Images are zero-click outbound fetches — neutralize unconditionally
+# (we never legitimately embed an image in a stage comment). Done first so the
+# link pass below cannot re-match the image's `](url)` tail.
+scrubbed = re.sub(r"!\[([^\]]*)\]\([^)]*\)",
+                  r"[image removed by output filter: \1]", body)
+
+
+# Links: keep the text; keep the URL only when its host is allowlisted (so the
+# trusted `[Run details](https://github.com/…)` footer survives).
+def link_repl(m):
+    text, url = m.group(1), m.group(2)
+    return m.group(0) if host_allowed(url) else f"{text} (link removed by output filter)"
+
+
+scrubbed = re.sub(r"\[([^\]]*)\]\(([^)]*)\)", link_repl, scrubbed)
+
+# Bare autolinks and outbound-capable HTML tags.
+scrubbed = re.sub(r"<https?://[^>]*>", "(link removed by output filter)",
+                  scrubbed, flags=re.I)
+DANGEROUS_TAGS = "img|a|script|iframe|object|embed|link|video|audio|source|svg|base|form|meta|style"
+scrubbed = re.sub(rf"</?(?:{DANGEROUS_TAGS})\b[^>]*>", "", scrubbed, flags=re.I)
+
+# --- emit ------------------------------------------------------------------
+out_path = os.environ.get("GITHUB_OUTPUT")
+if out_path:
+    with open(out_path, "a") as f:
+        f.write("comment<<__SDLC_M4_EOF__\n")
+        f.write(scrubbed if scrubbed.endswith("\n") else scrubbed + "\n")
+        f.write("__SDLC_M4_EOF__\n")
+else:
+    sys.stdout.write(scrubbed)
+
+notice(f"M4 output filter passed: no secrets; URLs/HTML neutralized "
+       f"({len(body)} -> {len(scrubbed)} chars).")

--- a/.github/workflows/dispatch-core.yml
+++ b/.github/workflows/dispatch-core.yml
@@ -1,0 +1,102 @@
+name: SDLC Dispatch / Core
+
+# Reusable dispatch pipeline shared by every trigger-specific dispatcher
+# (dispatch-pr.yml, dispatch-schedule.yml). It discovers agents whose manifests
+# match the CALLER's event, then runs them ALL in one matrix via run-agent.yml —
+# each agent waits for its own `needs:` upstreams inside its job (no rounds), so
+# a dependent starts as soon as ITS upstream finishes, not the whole level. The
+# triggering event is read from `github.event_name` (reusable workflows inherit
+# the caller's github context), so the same core serves pull_request, schedule,
+# and workflow_dispatch without modification.
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+  pull-requests: write
+  checks: write
+  security-events: write
+  id-token: write   # required by anthropics/claude-code-action for OIDC auth
+  actions: read     # caller cap: run-agent.yml's `gh run download` needs this
+
+jobs:
+  # Round-0 trust gate (ADR-0005 M1/M2). Classifies the PR source and rejects
+  # the run if the PR touches agent-trust paths or adds symlinks. A no-op for
+  # schedule / workflow_dispatch (no PR, runs from the trusted default branch),
+  # so the same core serves every trigger. discover gates on this — a failed
+  # gate blocks the whole dispatch.
+  gate:
+    runs-on: ubuntu-latest
+    outputs:
+      trusted: ${{ steps.trust.outputs.trusted }}
+    steps:
+      # Checkout provides the .git dir the gate needs for its symlink ls-tree.
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - id: trust
+        uses: ./.github/actions/pr-trust-gate
+        with:
+          event_name: ${{ github.event_name }}
+          pr: ${{ toJSON(github.event.pull_request) }}
+          repo: ${{ github.repository }}
+          github_token: ${{ github.token }}
+          # Fork-facing posture (set when AI review opens to external forks):
+          #   trust_label: ai-review-approved   # maintainer label = trust boundary
+          #   fail_on_untrusted: 'false'        # branch on outputs.trusted instead
+          # Defaults (hard-block forks, reject trust-path edits on all PRs) are
+          # correct for the current internal-only (`pull_request`) tier.
+
+  discover:
+    needs: gate
+    runs-on: ubuntu-latest
+    outputs:
+      agents: ${{ steps.match.outputs.agents }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install matcher deps
+        run: pip install --quiet pyyaml jsonschema
+
+      - id: match
+        env:
+          VARS_JSON: ${{ toJSON(vars) }}
+          EVENT_JSON: ${{ toJSON(github.event) }}
+          EVENT_NAME: ${{ github.event_name }}
+          GITHUB_REF: ${{ github.ref }}
+        run: |
+          set -euo pipefail
+          echo "$VARS_JSON" > /tmp/vars.json
+          echo "$EVENT_JSON" > /tmp/event.json
+          echo "Dispatching agents for event: $EVENT_NAME"
+          MATCHED=$(python3 .github/claude/scripts/match-agents.py "$EVENT_NAME" \
+            --vars /tmp/vars.json --event-context /tmp/event.json)
+          echo "Matched: $MATCHED"
+          echo "agents=$(echo "$MATCHED" | python3 -c 'import sys,json; print(json.dumps(json.load(sys.stdin).get("agents", [])))')" >> "$GITHUB_OUTPUT"
+
+  # One matrix over ALL matched agents — no rounds. Every agent starts at once;
+  # those with `needs:` wait for their specific upstream jobs inside run-agent
+  # (the "Wait for and download upstream artifacts" step), so a dependent runs
+  # as soon as ITS upstream finishes rather than waiting on a whole round.
+  # fail-fast: false keeps independent agents running if one fails.
+  run-agents:
+    # Constant middle segment (NOT the agent name). GitHub's "All jobs" sidebar
+    # shows the LEAF reusable job's name — run-agent's `agent` job, which we name
+    # after the agent — so the agent name belongs there, not here. Putting it
+    # here too would double the graph path to `dispatch / <agent> / <agent>`.
+    # With a constant the path reads cleanly as `dispatch / agent / <agent>` in
+    # the graph while the sidebar stays `<agent>`. The upstream-wait step matches
+    # the agent name as the trailing path segment, so this is safe.
+    name: agent
+    needs: discover
+    if: needs.discover.outputs.agents != '[]'
+    strategy:
+      fail-fast: false
+      matrix:
+        agent: ${{ fromJSON(needs.discover.outputs.agents) }}
+    uses: ./.github/workflows/run-agent.yml
+    with:
+      agent_name: ${{ matrix.agent.name }}
+      upstream_artifacts: ${{ join(matrix.agent.needs, ',') }}
+      timeout_minutes: ${{ matrix.agent.timeout_minutes }}
+      concurrency_group: ${{ matrix.agent.concurrency_group }}
+    secrets: inherit

--- a/.github/workflows/dispatch-pr.yml
+++ b/.github/workflows/dispatch-pr.yml
@@ -1,0 +1,19 @@
+name: SDLC Dispatch / PR
+
+on:
+  pull_request:
+    branches: [development-1.0]
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+permissions:
+  contents: read
+  pull-requests: write
+  checks: write
+  security-events: write
+  id-token: write   # required by anthropics/claude-code-action for OIDC auth
+  actions: read     # caller cap: run-agent.yml's `gh run download` needs this
+
+jobs:
+  dispatch:
+    uses: ./.github/workflows/dispatch-core.yml
+    secrets: inherit

--- a/.github/workflows/dispatch-schedule.yml
+++ b/.github/workflows/dispatch-schedule.yml
@@ -1,0 +1,26 @@
+name: SDLC Dispatch / Schedule
+
+# Batch dispatcher for agents that triage a standing backlog rather than gate a
+# PR (e.g. snyk-jira-ingest -> snyk-triage over the daily Jira report).
+#
+# IMPORTANT: both `schedule` and `workflow_dispatch` only fire when this file is
+# on the repository's DEFAULT branch — GitHub does not register either trigger
+# from a non-default branch.
+
+on:
+  schedule:
+    - cron: '0 6 * * *'   # daily 06:00 UTC (default branch only)
+  workflow_dispatch: {}    # manual run (default branch only)
+
+permissions:
+  contents: read
+  pull-requests: write
+  checks: write
+  security-events: write
+  id-token: write   # required by anthropics/claude-code-action for OIDC auth
+  actions: read     # caller cap: run-agent.yml's `gh run download` needs this
+
+jobs:
+  dispatch:
+    uses: ./.github/workflows/dispatch-core.yml
+    secrets: inherit

--- a/.github/workflows/run-agent.yml
+++ b/.github/workflows/run-agent.yml
@@ -1,0 +1,367 @@
+name: SDLC / Run Agent
+
+on:
+  workflow_call:
+    inputs:
+      agent_name:
+        required: true
+        type: string
+      upstream_artifacts:
+        description: 'Comma-separated agent names whose stage-output artifacts to download into upstream/{name}/ before running.'
+        required: false
+        type: string
+        default: ''
+      timeout_minutes:
+        description: 'Per-agent timeout in minutes (from manifest).'
+        required: false
+        type: number
+        default: 15
+      concurrency_group:
+        description: 'Concurrency group (from manifest or derived by the matcher).'
+        required: false
+        type: string
+        default: ''
+
+permissions:
+  contents: read
+  pull-requests: write
+  checks: write
+  security-events: write
+  id-token: write   # required by anthropics/claude-code-action for OIDC auth
+  actions: read     # `gh run download` (upstream-artifact step) hits the Actions API
+
+jobs:
+  agent:
+    # Name the inner (leaf) reusable job after the agent. GitHub's "All jobs"
+    # sidebar — the primary nav — shows the LEAF reusable job's name, so this is
+    # what makes each matrix row distinguishable (a generic `agent` rendered
+    # every row identically). The dispatcher's matrix job uses a constant middle
+    # segment, so the graph path reads `dispatch / agent / <agent>` (no doubling)
+    # while the sidebar reads `<agent>`. The upstream-wait step matches the agent
+    # name as the trailing path segment.
+    name: ${{ inputs.agent_name }}
+    runs-on: ubuntu-latest
+    # TEMPORARY (validation): use the security-review environment's DIAL key,
+    # which has the Anthropic route + the anthropic.claude-sonnet-4-6 deployment
+    # (same as the claude-security-review reference). Remove once the repo-level
+    # DIAL key has its own Anthropic-route model access. No protection rules, so
+    # it doesn't gate runs.
+    environment: security-review
+    timeout-minutes: ${{ inputs.timeout_minutes }}
+    concurrency:
+      group: ${{ inputs.concurrency_group != '' && inputs.concurrency_group || format('{0}-{1}-{2}', github.workflow, inputs.agent_name, github.ref) }}
+      cancel-in-progress: true
+    env:
+      # ANTHROPIC_API_KEY MUST be a job-level env: the composite action reads it
+      # via `${{ env.ANTHROPIC_API_KEY }}`, and a composite action's expression
+      # context does NOT see vars set with GITHUB_ENV in caller steps (only its
+      # process env does). DIAL key when DIAL_CORE_URL is set, else the direct
+      # Anthropic key.
+      ANTHROPIC_API_KEY: ${{ vars.DIAL_CORE_URL != '' && secrets.DIAL_API_KEY || secrets.ANTHROPIC_API_KEY }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Configure inference route
+        # ANTHROPIC_API_KEY is the job-level env above. Here we add the DIAL-only
+        # vars that claude-code-action reads from the PROCESS env (GITHUB_ENV DOES
+        # propagate to later steps' / the composite action's process env, even
+        # though it's invisible to their `${{ env.X }}` expressions). In direct-
+        # Anthropic mode these stay unset — exactly the prior behavior.
+        env:
+          DIAL_CORE_URL: ${{ vars.DIAL_CORE_URL }}
+          DIAL_API_KEY: ${{ secrets.DIAL_API_KEY }}
+          # DIAL deployment id to route to (e.g. anthropic.claude-sonnet-4-5-
+          # 20250929-v1:0). DIAL names rarely match Anthropic model strings, so
+          # set this to a deployment your key actually has. If unset, the
+          # platform falls back to `anthropic.<manifest model>`.
+          DIAL_MODEL: ${{ vars.DIAL_MODEL }}
+        run: |
+          set -euo pipefail
+          if [ -n "${DIAL_CORE_URL:-}" ]; then
+            if [ -z "${DIAL_API_KEY:-}" ]; then
+              echo "::error::DIAL_CORE_URL is set but the DIAL_API_KEY secret is missing."
+              exit 1
+            fi
+            base="${DIAL_CORE_URL%/}/anthropic"
+            { echo "ANTHROPIC_BASE_URL=${base}"
+              echo "ANTHROPIC_AUTH_TOKEN=${DIAL_API_KEY}"
+              echo "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1"
+              echo "SDLC_DIAL_MODE=1"
+              if [ -n "${DIAL_MODEL:-}" ]; then echo "SDLC_DIAL_MODEL=${DIAL_MODEL}"; fi
+            } >> "$GITHUB_ENV"
+            echo "Inference route: DIAL (${base}) deployment=${DIAL_MODEL:-anthropic.<manifest model>}"
+          else
+            echo "Inference route: direct Anthropic"
+          fi
+
+      - name: Install YAML parser
+        run: pip install --quiet pyyaml
+
+      - name: Wait for and download upstream artifacts
+        # No rounds: every matched agent starts at once, so a `needs:` upstream
+        # may still be running. For each one, poll until its artifact is ready
+        # (download succeeds), or until its job finishes WITHOUT one (failed /
+        # cancelled) — then proceed and let the agent-wrapper handle the absent
+        # artifact. This gives per-edge scheduling: a dependent waits only for
+        # ITS upstream, not a whole round.
+        if: inputs.upstream_artifacts != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          UPSTREAM: ${{ inputs.upstream_artifacts }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          set -uo pipefail   # NOT -e: the download retries are expected to fail until ready
+          mkdir -p upstream
+          IFS=',' read -ra NAMES <<< "$UPSTREAM"
+          for name in "${NAMES[@]}"; do
+            [ -z "$name" ] && continue
+            echo "Waiting for upstream agent: ${name}"
+            got=0
+            for i in $(seq 1 160); do   # ~40 min cap (160 × 15s)
+              if gh run download "$RUN_ID" -R "$REPO" -n "stage-output-${name}" -D "upstream/${name}/" 2>/dev/null; then
+                echo "  ✓ downloaded stage-output-${name}"; got=1; break
+              fi
+              # Break early if the upstream JOB has finished without an artifact.
+              # The dispatcher's matrix job is named after the agent, so the
+              # agent name is always a path segment of the job's full name
+              # (e.g. "dispatch / <agent> / …") — match it as a segment.
+              concl=$(gh api "repos/${REPO}/actions/runs/${RUN_ID}/jobs" --paginate \
+                --jq "[.jobs[] | select(.name | test(\"(^| / )${name}( / |\$)\")) | .conclusion] | map(select(. != null)) | last // \"\"" 2>/dev/null || echo "")
+              if [ -n "$concl" ] && [ "$concl" != "success" ]; then
+                echo "::warning::upstream ${name} finished as '${concl}' with no artifact; proceeding without it"
+                break
+              fi
+              sleep 15
+            done
+            [ "$got" = 1 ] || echo "::notice::upstream ${name} not available; the agent will note the absent artifact"
+          done
+          echo "Upstream payloads available at:"
+          find upstream/ -type f -name 'stage-output.json' 2>/dev/null || true
+
+      - name: Load manifest
+        id: manifest
+        env:
+          AGENT_NAME: ${{ inputs.agent_name }}
+        run: |
+          set -euo pipefail
+          MANIFEST="agents/${AGENT_NAME}/agent.yml"
+          if [ ! -f "$MANIFEST" ]; then
+            echo "::error::Manifest not found: $MANIFEST"
+            exit 1
+          fi
+          # Skill-only: no per-agent prompt.md. The composite action composes
+          # the full prompt from the manifest's `skill:` value. Fail loudly if
+          # a stray prompt.md is committed — it has no effect and signals drift.
+          if [ -f "agents/${AGENT_NAME}/prompt.md" ]; then
+            echo "::error::agents/${AGENT_NAME}/prompt.md exists but is no longer honored. Remove the file and put any reusable agent logic into a Claude skill at .claude/skills/<skill>/SKILL.md or .claude/commands/<skill>.md."
+            exit 1
+          fi
+          python3 - <<'EOF' >> "$GITHUB_OUTPUT"
+          import json, os, yaml
+          with open(f"agents/{os.environ['AGENT_NAME']}/agent.yml") as f:
+              m = yaml.safe_load(f) or {}
+          skill = m.get("skill")
+          if not skill:
+              raise SystemExit("::error::manifest missing required field: skill (agents must wrap a local skill)")
+          tools = m.get("allowed_tools")
+          if not tools:
+              raise SystemExit("::error::manifest missing required field: allowed_tools")
+          # tools.extra: optional list of CLI tools to install on the runner
+          # before invocation. Items can be either:
+          #   - a string (npm package name; installed via npm install -g)
+          #   - an object {name, install} where `install` is a shell command
+          # Emit as a single JSON line; the install step dispatches on shape.
+          extra = (m.get("tools") or {}).get("extra") or []
+          # secrets: declared env-var names the agent needs. The inject step
+          # below promotes ONLY these from the inherited secret bag into the
+          # job env. Emit as a JSON list (empty list when none declared).
+          secrets = m.get("secrets") or []
+          print(f"skill={skill}")
+          print(f"allowed_tools={tools}")
+          print(f"agent_version={m.get('agent_version', 'unknown')}")
+          print(f"model={m.get('model', '')}")
+          print(f"max_turns={m.get('max_turns', 18)}")
+          print(f"tools_extra_json={json.dumps(extra)}")
+          print(f"secrets_json={json.dumps(secrets)}")
+          # vars: declared NON-secret config names to inject from the Actions
+          # Variables context (operator-tunable knobs, e.g. JIRA_MAX_FINDINGS).
+          print(f"vars_json={json.dumps(m.get('vars') or [])}")
+          # private_output: encrypt this agent's artifact and decrypt encrypted
+          # upstream artifacts (public-repo leak protection). See the encrypt
+          # step in run-claude-stage and the decrypt step below.
+          print(f"private_output={str(m.get('private_output', False)).lower()}")
+          # analysis_ref: overlay this ref's source for the agent to inspect.
+          # emit_sarif: convert findings[] -> SARIF and upload to code scanning.
+          print(f"analysis_ref={m.get('analysis_ref', '')}")
+          print(f"emit_sarif={str(m.get('emit_sarif', False)).lower()}")
+          EOF
+
+      - name: Install agent-declared CLI tools
+        # Iterates `tools.extra` from the manifest. Three shapes:
+        #   - "pkg"                                          → npm install -g pkg
+        #   - {name: "pkg", version: "1.2.3"}                → npm install -g pkg@1.2.3
+        #   - {name: "x", version?: ..., install: "...{{version}}..."} → shell, with
+        #     {{version}} substituted from the sibling version field
+        # Failure exits early before Claude is invoked — loud failure, not silent.
+        # Agents without extra deps pay zero install cost (step skipped when array is empty).
+        if: steps.manifest.outputs.tools_extra_json != '[]' && steps.manifest.outputs.tools_extra_json != ''
+        env:
+          EXTRA_JSON: ${{ steps.manifest.outputs.tools_extra_json }}
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json, os, subprocess, sys
+          extra = json.loads(os.environ['EXTRA_JSON'])
+          for entry in extra:
+              if isinstance(entry, str):
+                  print(f"::group::npm install -g {entry}")
+                  subprocess.run(["npm", "install", "-g", entry], check=True)
+                  print("::endgroup::")
+                  continue
+              if not isinstance(entry, dict) or "name" not in entry:
+                  sys.stderr.write(f"::error::Invalid tools.extra entry shape: {entry!r}\n")
+                  sys.exit(1)
+              name = entry["name"]
+              version = entry.get("version")
+              install = entry.get("install")
+              if install:
+                  # Shell form. Substitute {{version}} placeholder (empty when no version).
+                  cmd = install.replace("{{version}}", version or "")
+                  label = f"{name}" + (f" v{version}" if version else "")
+                  print(f"::group::install {label}")
+                  print(f"+ {cmd}")
+                  subprocess.run(cmd, shell=True, check=True)
+                  print("::endgroup::")
+              else:
+                  # npm form, optionally pinned via @-syntax.
+                  pkg = f"{name}@{version}" if version else name
+                  print(f"::group::npm install -g {pkg}")
+                  subprocess.run(["npm", "install", "-g", pkg], check=True)
+                  print("::endgroup::")
+          PY
+
+      - name: Inject declared secrets
+        # Generic secret plumbing: promote ONLY the secrets a manifest declares
+        # (`secrets:` in agents/<name>/agent.yml) from the inherited secret bag
+        # into the job env, so the wrapped skill's committed helper scripts can
+        # read them. Adding a new secret-using agent needs NO platform edit —
+        # declare the name here and add the matching Actions secret.
+        #
+        # Why this shape: GitHub has no dynamic `secrets[name]` access, so we
+        # take the whole bag via toJSON(secrets) and select the declared names.
+        # Claude never types secret values (the agent-wrapper forbids shell
+        # expansion in Bash tool calls); secrets are referenced only inside
+        # committed scripts that read them from env. We print names only, never
+        # values — and GHA masks registered secret values in logs regardless.
+        if: steps.manifest.outputs.secrets_json != '[]' && steps.manifest.outputs.secrets_json != ''
+        env:
+          SECRETS_JSON: ${{ toJSON(secrets) }}
+          DECLARED: ${{ steps.manifest.outputs.secrets_json }}
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json, os
+          allsec = json.loads(os.environ["SECRETS_JSON"])
+          declared = json.loads(os.environ["DECLARED"])
+          missing = [n for n in declared if not allsec.get(n)]
+          if missing:
+              raise SystemExit(
+                  f"::error::Declared secrets unavailable to run-agent: {missing}. "
+                  "Add them under repo/org Settings -> Secrets -> Actions, or fix "
+                  "the manifest `secrets:` list.")
+          with open(os.environ["GITHUB_ENV"], "a") as fh:
+              for name in declared:
+                  fh.write(f"{name}<<__SDLC_SECRET_EOF__\n{allsec[name]}\n__SDLC_SECRET_EOF__\n")
+          print(f"Injected {len(declared)} declared secret(s) into job env: {', '.join(declared)}")
+          PY
+
+      - name: Inject declared vars
+        # Non-secret counterpart of secret injection: promote ONLY the Actions
+        # Variables a manifest declares (`vars:`) into the job env, so an
+        # operator can tune knobs (e.g. JIRA_MAX_FINDINGS) in Settings ->
+        # Variables WITHOUT editing the skill. Missing vars are skipped — the
+        # skill's own default applies — so this never fails the run.
+        if: steps.manifest.outputs.vars_json != '[]' && steps.manifest.outputs.vars_json != ''
+        env:
+          VARS_JSON: ${{ toJSON(vars) }}
+          DECLARED: ${{ steps.manifest.outputs.vars_json }}
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json, os
+          allvars = json.loads(os.environ["VARS_JSON"])
+          declared = json.loads(os.environ["DECLARED"])
+          injected = []
+          with open(os.environ["GITHUB_ENV"], "a") as fh:
+              for name in declared:
+                  val = allvars.get(name)
+                  if val not in (None, ""):
+                      fh.write(f"{name}<<__SDLC_VAR_EOF__\n{val}\n__SDLC_VAR_EOF__\n")
+                      injected.append(name)
+          print(f"Injected vars: {injected or '(none set; skill defaults apply)'}")
+          PY
+
+      - name: Decrypt upstream artifacts
+        # Upstream producers flagged `private_output` upload their stage-output
+        # AES-encrypted (.enc). Decrypt any here — after secret injection, so
+        # SDLC_ARTIFACT_KEY is in the env — into the plaintext path the agent
+        # expects (upstream/<name>/stage-output.json). No-op when no .enc exists.
+        if: inputs.upstream_artifacts != ''
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          enc_found=0
+          for enc in upstream/*/stage-output.json.enc; do
+            enc_found=1
+            if [ -z "${SDLC_ARTIFACT_KEY:-}" ]; then
+              echo "::error::Encrypted upstream artifact ${enc} but SDLC_ARTIFACT_KEY is not in env. Add it to this agent's manifest \`secrets:\` list."
+              exit 1
+            fi
+            out="$(dirname "$enc")/stage-output.json"
+            openssl enc -d -aes-256-cbc -pbkdf2 -in "$enc" -out "$out" -pass env:SDLC_ARTIFACT_KEY
+            echo "Decrypted ${enc} -> ${out}"
+          done
+          if [ "$enc_found" = 0 ]; then echo "No encrypted upstream artifacts to decrypt."; fi
+
+      - name: Overlay analysis-ref source
+        # When a manifest declares `analysis_ref`, the agent must inspect THAT
+        # ref's code (e.g. snyk-triage validates findings against `development`,
+        # the branch the scanner ran on — not the sandbox base). We cannot
+        # `actions/checkout` that ref: the framework (composite action, prompts,
+        # schemas, skills) lives ONLY on the sandbox base, so a full checkout
+        # would strip it. Instead overlay the ref's source while preserving the
+        # framework paths (.github, .claude, agents). Also capture its sha/ref so
+        # an emit_sarif upload can be scoped to the scanned commit.
+        #
+        # `agents` is excluded alongside .github/.claude because the overlaid ref
+        # is untrusted under pull_request_target (a fork PR head). The base
+        # manifest — already read into step outputs before this step — must keep
+        # governing the run; letting the overlaid ref replace agents/<name>/agent.yml
+        # would expose tools.extra/secrets/allowed_tools to attacker control.
+        if: steps.manifest.outputs.analysis_ref != ''
+        env:
+          ANALYSIS_REF: ${{ steps.manifest.outputs.analysis_ref }}
+        run: |
+          set -euo pipefail
+          git fetch --depth=1 origin "$ANALYSIS_REF"
+          SHA="$(git rev-parse FETCH_HEAD)"
+          git checkout FETCH_HEAD -- . ':(exclude).github' ':(exclude).claude' ':(exclude)agents'
+          echo "ANALYSIS_SHA=${SHA}" >> "$GITHUB_ENV"
+          echo "ANALYSIS_REF_FULL=refs/heads/${ANALYSIS_REF}" >> "$GITHUB_ENV"
+          echo "Overlaid source from ${ANALYSIS_REF}@${SHA:0:7}; .github/.claude/agents preserved."
+
+      - id: stage
+        uses: ./.github/actions/run-claude-stage
+        with:
+          stage_name: ${{ inputs.agent_name }}
+          skill: ${{ steps.manifest.outputs.skill }}
+          allowed_tools: ${{ steps.manifest.outputs.allowed_tools }}
+          agent_version: ${{ steps.manifest.outputs.agent_version }}
+          model: ${{ steps.manifest.outputs.model }}
+          max_turns: ${{ steps.manifest.outputs.max_turns }}
+          upstream_artifacts: ${{ inputs.upstream_artifacts }}
+          private_output: ${{ steps.manifest.outputs.private_output }}
+          emit_sarif: ${{ steps.manifest.outputs.emit_sarif }}

--- a/agents/_proactive-security-monitor/agent.yml
+++ b/agents/_proactive-security-monitor/agent.yml
@@ -1,0 +1,43 @@
+contract_version: "0.1"
+name: proactive-security-monitor
+skill: proactive-security-monitor
+agent_version: "0.1.0"
+description: "Proactive supply-chain watch (producer): resolves the npm SBOM from package-lock.json (no install), batch-queries OSV.dev for freshly-modified advisories, and runs an industry-news pass (CISA KEV, OpenSSF, GitHub Security Lab, Socket, The Hacker News) filtered to this repo's stack. Emits OSV findings + tagged news for the security-monitor-triager stage. Ports the dial-core .security-poc producer to the Node ecosystem."
+# This is a batch job over the standing dependency surface + security press, so
+# its real triggers are `schedule` (daily) + `workflow_dispatch` (manual) via
+# dispatch-schedule.yml. `pull_request` is a TEMPORARY sandbox-only harness:
+# schedule/workflow_dispatch don't fire from the non-default sdlc-test-base
+# branch, so PR is the only way to exercise the chain there. Drop `pull_request`
+# once the framework lands on the default branch.
+triggers: [pull_request, schedule, workflow_dispatch]
+
+# The only Bash capability is invoking the committed fetch script (SBOM + OSV).
+# The industry-news pass is the model's own WebFetch step. No git/shell beyond
+# the script — the agent reads code only through Read (it does NOT assess
+# reachability; that is the triager's job against analysis_ref source).
+allowed_tools: "Bash(bash .claude/skills/proactive-security-monitor/fetch.sh:*),Read,WebFetch,Skill"
+
+# This repo is PUBLIC and artifacts are world-downloadable. The OSV/news content
+# is public, but encrypt the output anyway so the chain is uniform and the
+# triager (private_output) can decrypt this upstream artifact. SDLC_ARTIFACT_KEY
+# is the shared key (add under repo/org Actions secrets).
+secrets: [SDLC_ARTIFACT_KEY]
+private_output: true
+
+# Operator-tunable, non-secret knobs from Actions Variables (Settings → Variables):
+#   PSM_WINDOW_DAYS  advisory recency window (default 7; widen for a catch-up run)
+#   PSM_MAX_FINDINGS cap on inlined OSV findings (default 50; 0 = no cap)
+vars: [PSM_WINDOW_DAYS, PSM_MAX_FINDINGS]
+
+# Inspect chat-2.0's real dependency surface + lockfile, not the sandbox base.
+# The platform overlays development-1.0 source (preserving .github/.claude/agents)
+# so fetch.sh reads that branch's package-lock.json.
+analysis_ref: development-1.0
+
+# Sonnet: the OSV pass is deterministic (script), but the news pass needs real
+# RELEVANT/TANGENTIAL/IGNORE judgement against the stack.
+model: claude-sonnet-4-6
+phase: sandbox
+cost_class: light
+timeout_minutes: 15
+max_turns: 25

--- a/agents/_scan-deps/agent.yml
+++ b/agents/_scan-deps/agent.yml
@@ -1,0 +1,21 @@
+contract_version: "0.1"
+name: scan-deps
+skill: dep-scan
+agent_version: "0.1.0"
+description: "Filesystem dependency scan (Trivy). Detects known CVEs in repo lockfiles and emits structured findings for downstream triage."
+triggers: [pull_request]
+allowed_tools: "Read,Glob,Bash(trivy:*),Skill"
+tools:
+  extra:
+    - name: trivy
+      # Version intentionally unpinned: pinning to v0.69.0 caused install.sh
+      # to fail silently after "install trivy v0.69.0" — likely the release
+      # asset for that tag isn't where install.sh expects (the tag may be
+      # missing the standard tarball naming, or simply isn't a real release).
+      # install.sh's default = latest stable, which works reliably. Add a
+      # `version:` field back once we confirm a specific tarball-shipped
+      # release tag.
+      install: 'mkdir -p "$HOME/.local/bin" && curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b "$HOME/.local/bin" && echo "$HOME/.local/bin" >> "$GITHUB_PATH"'
+model: claude-sonnet-4-6
+phase: pilot
+cost_class: medium

--- a/agents/_security-monitor-triager/agent.yml
+++ b/agents/_security-monitor-triager/agent.yml
@@ -1,0 +1,38 @@
+contract_version: "0.1"
+name: security-monitor-triager
+skill: security-monitor-triager
+agent_version: "0.1.0"
+description: "Read-only AppSec triage (reviewer): re-verifies version-match + reachability of proactive-security-monitor's OSV advisories against this repo's actual code, and re-judges the news pass's RELEVANT/TANGENTIAL/IGNORE calls. Emits per-item verdicts (CONFIRMED / OVERSTATED / FALSE_POSITIVE / NEEDS_REVIEW). Ports the dial-core .security-poc reviewer to the Node ecosystem."
+# Batch reviewer of the producer's output: real triggers are `schedule` (daily)
+# + `workflow_dispatch` (manual) via dispatch-schedule.yml. `pull_request` is a
+# TEMPORARY sandbox-only harness (schedule/workflow_dispatch can't fire from the
+# non-default sdlc-test-base branch); drop it once on the default branch.
+triggers: [pull_request, schedule, workflow_dispatch]
+allowed_tools: "Read,Grep,Glob,Bash(git diff:*),Bash(python3:*),Skill"
+
+# Public repo: encrypt this agent's verdicts, and decrypt the encrypted producer
+# artifact it consumes. SDLC_ARTIFACT_KEY is the shared key; run-agent injects it
+# for both decrypt and encrypt.
+secrets: [SDLC_ARTIFACT_KEY]
+private_output: true
+model: claude-sonnet-4-6
+phase: sandbox
+cost_class: medium
+timeout_minutes: 30
+max_turns: 60
+
+# Consume the producer's findings + news at
+# upstream/proactive-security-monitor/stage-output.json (payload.findings[] +
+# payload.news[]). The platform downloads + decrypts it before this agent runs.
+needs: [proactive-security-monitor]
+
+# The SBOM + advisories were resolved against chat-2.0 (development-1.0). The
+# platform overlays that branch's source so reachability is validated against the
+# right code, and scopes the SARIF upload to that branch/commit.
+analysis_ref: development-1.0
+
+# SARIF -> Security tab: convert CONFIRMED/NEEDS_REVIEW payload.findings[] into
+# alerts (non-actionable verdicts upload as dismissed), scoped to analysis_ref.
+# PAUSED for the first sandbox runs while we validate the chain + encryption;
+# flip to true once verdicts look trustworthy.
+emit_sarif: false

--- a/agents/_snyk-jira-ingest/agent.yml
+++ b/agents/_snyk-jira-ingest/agent.yml
@@ -1,0 +1,43 @@
+contract_version: "0.1"
+name: snyk-jira-ingest
+skill: snyk-jira-ingest
+agent_version: "0.1.0"
+description: "Pulls real Snyk SAST findings from EPAM Jira (Data Center) via the search-export API using a PAT, and emits them under payload as a Jira XML export artifact for downstream triage. Real-data counterpart to the synthetic snyk-scan-stub producer."
+# This is a batch job over the standing Jira backlog, so its real triggers are
+# `schedule` (daily) + `workflow_dispatch` (manual) — both via dispatch-schedule.yml.
+# `pull_request` is a TEMPORARY sandbox-only harness: schedule/workflow_dispatch
+# don't fire from the non-default sdlc-test-base branch, so PR is the only way to
+# exercise the chain there. Drop `pull_request` once the framework lands on the
+# default branch.
+triggers: [pull_request, schedule, workflow_dispatch]
+
+# The agent's only Bash capability is invoking the committed fetch script.
+# The PAT is read inside that script from env (injected below) — the model
+# never types or sees the token (the agent-wrapper forbids shell expansion).
+allowed_tools: "Bash(bash .claude/skills/snyk-jira-ingest/fetch.sh:*),Read,Skill"
+
+# Declared secrets. run-agent.yml promotes ONLY these from the inherited
+# secret bag into the job env before the agent runs, and fails loudly if any
+# is absent. Add JIRA_PAT and SDLC_ARTIFACT_KEY under repo/org Settings →
+# Secrets → Actions. SDLC_ARTIFACT_KEY is the shared key for `private_output`.
+secrets: [JIRA_PAT, SDLC_ARTIFACT_KEY]
+
+# Operator-tunable, non-secret knobs injected from Actions Variables (Settings →
+# Variables). JIRA_MAX_FINDINGS caps how many findings reach triage — change it
+# in the UI/`gh variable set`, no skill edit. Unset → fetch.sh default (10).
+vars: [JIRA_MAX_FINDINGS]
+
+# This repo is PUBLIC and artifacts are world-downloadable, so encrypt the Jira
+# findings before they're uploaded for the triage handoff; triage decrypts.
+private_output: true
+
+# Sonnet: matches the triage agent so a single DIAL deployment
+# (claude-sonnet-4-6) serves the whole chain. The work is light — run one
+# script and confirm the envelope — so cost stays low regardless of model.
+model: claude-sonnet-4-6
+phase: sandbox
+cost_class: light
+
+# Trivial run: one Bash call + one Read. Low turn cap cuts context resends.
+max_turns: 4
+timeout_minutes: 10

--- a/agents/_snyk-scan-stub/agent.yml
+++ b/agents/_snyk-scan-stub/agent.yml
@@ -1,0 +1,17 @@
+contract_version: "0.1"
+name: snyk-scan-stub
+skill: snyk-scan-stub
+agent_version: "0.2.0"
+description: "Synthetic scanner-report producer for chain validation. Emits a fixed, real-shape Snyk Code SARIF 2.1.0 report under payload.sarif so snyk-triage exercises actual SARIF parsing. Test fixture — remove when the real Snyk pipeline (stage-snyk.yml) lands."
+triggers: [pull_request]
+allowed_tools: "Skill"
+# Haiku: adequate to copy a fixed SARIF block verbatim, and keeps this
+# producer's token footprint (and likely rate-limit pool) off the Sonnet
+# triage agent. If it ever mangles the SARIF, bump back to sonnet.
+model: claude-haiku-4-5-20251001
+phase: sandbox
+cost_class: light
+# Trivial run: invoke the skill, Write one file. Low turn cap reduces
+# context resends (input-tokens-per-minute → rate-limit pressure).
+max_turns: 4
+timeout_minutes: 10

--- a/agents/_snyk-triage/agent.yml
+++ b/agents/_snyk-triage/agent.yml
@@ -1,0 +1,51 @@
+contract_version: "0.1"
+name: snyk-triage
+skill: snyk-triage
+agent_version: "0.1.0"
+description: "Read-only AppSec triage wrapping the local /snyk-triage skill: validates scanner (Snyk SAST / Code, Jira-exported) findings against repo evidence and emits per-finding verdicts."
+# Batch triage of the standing backlog: real triggers are `schedule` (daily) +
+# `workflow_dispatch` (manual) via dispatch-schedule.yml. `pull_request` is a
+# TEMPORARY sandbox-only harness (schedule/workflow_dispatch can't fire from the
+# non-default sdlc-test-base branch); drop it once on the default branch.
+triggers: [pull_request, schedule, workflow_dispatch]
+allowed_tools: "Read,Grep,Glob,Bash(git diff:*),Bash(python3:*),Skill"
+
+# Public repo: encrypt this agent's artifact, and decrypt the encrypted ingest
+# artifact it consumes. SDLC_ARTIFACT_KEY is the shared key (add it under repo/
+# org Actions secrets); run-agent injects it for both encrypt and decrypt.
+secrets: [SDLC_ARTIFACT_KEY]
+private_output: true
+model: claude-sonnet-4-6
+phase: sandbox
+cost_class: medium
+timeout_minutes: 30
+# The lean skill (envelope-only, full version kept at SKILL.full.md) plus a
+# strict "be decisive, write before the limit" directive fixed the recurring
+# error_max_turns: triage now writes its output instead of over-analyzing
+# forever. Cap=3 passed comfortably at 25 turns. With the ingest cap removed
+# (analyze all ~34 repo findings), this is set to the schema max of 60 — even
+# so, a backlog that large may not fully fit; the termination directive makes
+# the agent write a partial/NEEDS_REVIEW envelope rather than error. Re-cap via
+# JIRA_MAX_FINDINGS if a thorough per-finding pass is needed.
+max_turns: 60
+
+# Consume the REAL Jira-sourced findings from snyk-jira-ingest at
+# upstream/snyk-jira-ingest/stage-output.json. The findings are inlined under
+# .payload.issues[] (each a Jira issue: key/title/labels/status plus raw
+# `description`/`environment` carrying the SAST file/line/Issue Hash). The
+# synthetic snyk-scan-stub producer is disabled for now (its agent dir is
+# underscore-prefixed); to fall back to it, re-enable the stub and point this
+# `needs:` at snyk-scan-stub (findings under .payload.sarif).
+needs: [snyk-jira-ingest]
+
+# The Snyk findings were scanned against `development` (verified: the findings'
+# file paths exist on origin/development, not on development-1.0 or the sandbox
+# base). The platform overlays development's source so triage validates against
+# the right code, and scopes the SARIF upload to that branch/commit.
+analysis_ref: development
+
+# SARIF -> Security tab is wired (platform converts payload.findings[] -> SARIF
+# and uploads it), but PAUSED for now while we validate artifact encryption and
+# the aggregate (counts-only) public surface. Flip to true to publish to the
+# Security tab (scoped to analysis_ref's branch/commit).
+emit_sarif: false

--- a/agents/_template/agent.yml
+++ b/agents/_template/agent.yml
@@ -1,0 +1,68 @@
+# Agent manifest. An agent is a manifest + a skill reference.
+# All reusable agent logic lives in `.claude/skills/<skill>/SKILL.md` (or
+# `.claude/commands/<skill>.md`); the runtime wires CI and composes a
+# uniform prompt that invokes the skill. There is NO per-agent prompt.md.
+#
+# To add an agent: copy this directory, rename it, edit the required fields
+# below, point `skill:` at a local skill, commit. The dispatcher picks the
+# agent up on the next PR.
+
+contract_version: "0.1"               # required: pin schema version
+name: my-agent                         # required: kebab-case; surfaces in PR comments + kill-switch var
+
+# The local skill this agent wraps. Must be addressable as `/<skill>` in a
+# prompt (e.g. `code-review-and-quality`, `opsx:verify`, `feature-research`).
+# If your task needs custom orchestration, put it INSIDE the skill file —
+# the agent layer is just CI plumbing.
+skill: my-skill                        # required
+
+# When the agent runs.
+# Short form: triggers: [pull_request]
+# Long form with filters (branches + labels honored; paths reserved for v0.3):
+#   triggers:
+#     - on: pull_request
+#       filters:
+#         branches: [main, development-1.0]   # PR target branches
+#         labels: [review-me]                  # all must be present on PR
+triggers: [pull_request]               # required
+
+# Comma-separated Claude tool allowlist. Include the tools the wrapped
+# skill needs, plus `Skill` itself.
+# Tiers: read-only         = "Read,Grep,Glob,Skill"
+#        + git diff         = "Read,Grep,Glob,Bash(git diff:*),Skill"
+#        + MCP context      = append ",mcp__dial-context__*"
+allowed_tools: "Read,Grep,Glob,Skill"  # required
+
+# Optional metadata
+agent_version: "0.1.0"                 # appears in the output envelope
+description: "One-line description of what this agent does."
+model: claude-sonnet-4-6               # claude-opus-4-7 / claude-sonnet-4-6 / claude-haiku-4-5-20251001 / etc.
+phase: pilot                           # sandbox | pilot | production
+cost_class: light                      # light (<$0.50/run) | medium | heavy
+
+# Kill switch (optional override). Default derived from name: code-review → STAGE_CODE_REVIEW_ENABLED.
+# Set the corresponding repo or org variable to "false" to disable without a revert.
+# kill_switch_var: STAGE_MY_AGENT_ENABLED
+
+# Chaining (optional). List of upstream agents whose output this agent reads.
+# The platform downloads their stage-output.json files into upstream/{name}/
+# before running. Your skill reads upstream/<upstream-name>/stage-output.json.
+# Leave empty (or omit) if your agent runs independently — the common case.
+# needs: [scan-deps]
+
+# Per-agent timeout (optional, default 15 min, max 360).
+# timeout_minutes: 30
+
+# GHA permissions (optional). Validated against the platform-supported set:
+#   contents: read           — the default; you don't need to declare it
+#   pull-requests: write     — the default; you don't need to declare it
+#   checks: write            — opt-in: required only if you create check runs
+#   security-events: write   — opt-in: required only if you upload SARIF
+# Any value outside the supported set rejects the manifest at discovery.
+# permissions:
+#   checks: write
+
+# Concurrency override (optional). Default: dispatch-pr-<name>-<ref>.
+# concurrency:
+#   group: "${{ github.workflow }}-special-${{ github.ref }}"
+#   cancel_in_progress: true

--- a/agents/_triage-deps/agent.yml
+++ b/agents/_triage-deps/agent.yml
@@ -1,0 +1,11 @@
+contract_version: "0.1"
+name: triage-deps
+skill: dep-triage
+agent_version: "0.1.0"
+description: "Triages upstream dependency-scan findings against repo code. Marks each as confirmed (real risk) or false_positive (not exploitable in this codebase context)."
+triggers: [pull_request]
+needs: [scan-deps]
+allowed_tools: "Read,Grep,Glob,Bash(git diff:*),Skill"
+model: claude-sonnet-4-6
+phase: pilot
+cost_class: medium

--- a/agents/code-review/agent.yml
+++ b/agents/code-review/agent.yml
@@ -1,0 +1,10 @@
+contract_version: "0.1"
+name: code-review
+skill: code-review-and-quality
+agent_version: "0.1.0"
+description: "AI code review wrapping the local /code-review-and-quality skill."
+triggers: [pull_request]
+allowed_tools: "Read,Grep,Glob,Bash(git diff:*),Skill"
+model: claude-sonnet-4-6
+phase: pilot
+cost_class: light

--- a/agents/security-review/agent.yml
+++ b/agents/security-review/agent.yml
@@ -1,0 +1,18 @@
+contract_version: "0.1"
+name: security-review
+# Wraps the pre-existing BUILT-IN Claude Code `security-review` skill (no
+# .claude/skills/ file is authored for it). The composite action resolves
+# `/security-review` at runtime. This mirrors the deployed
+# ai-dial-chat@development-1.0/.github/workflows/claude-security-review.yml,
+# which moved off the specialized claude-code-security-review Action onto this
+# built-in skill. See security/ satellite for sourcing rationale.
+skill: security-review
+agent_version: "0.1.0"
+description: "AI security code review of the PR diff via the built-in /security-review skill."
+triggers: [pull_request]
+allowed_tools: "Read,Grep,Glob,LS,Task,Bash(git diff:*),Bash(git log:*),Bash(git show:*),Skill"
+model: claude-sonnet-4-6
+phase: sandbox
+cost_class: medium
+timeout_minutes: 15
+max_turns: 50


### PR DESCRIPTION
## Description of changes

Adds the AI-SDLC agent dispatch framework to `development-1.0`, enabling two
automated agents to run on every PR.

**Dispatch system** (new GitHub Actions workflows):
- `dispatch-pr.yml` — triggered on every PR to `development-1.0`
- `dispatch-schedule.yml` — daily batch run (fires on default branch only)
- `dispatch-core.yml` / `run-agent.yml` — reusable orchestrator that discovers
  agent manifests, applies kill-switch variables, resolves producer→consumer
  dependencies, and runs each agent as an isolated matrix job

**Agents now active on every PR:**
| Agent | What it does |
|---|---|
| `code-review` | Automated code-quality review; posts inline PR comments |
| `security-review` | Security-focused review via the built-in `/security-review` skill |

**Agents included but dormant** (underscore-prefixed, skipped by dispatcher):
`_proactive-security-monitor`, `_security-monitor-triager`, `_snyk-jira-ingest`,
`_snyk-triage`, `_scan-deps`, `_triage-deps`, `_snyk-scan-stub`

To disable any active agent without a code change: set
`STAGE_<AGENT_NAME>_ENABLED=false` in Settings → Variables → Actions.

No application code was modified. This PR contains CI workflows, agent
manifests, and paired Claude Code skill files only.

## Applicable issues

- No Issue exists

## UI changes

N/A — CI infrastructure changes only, no user-facing modifications.

## Checklist

- [ ] the pull request name ends with `(Issue #<ISSUE_ID>)` (comma-separated list of issues)
- [x] I confirm that I don't share any confidential information like API keys or any other secrets and private URLs
