### PR TITLE
feat(chat): add process large files and file tools toggles into quick app 2 editor (Issues #7525, #7524)

### DIFF
--- a/apps/chat/public/locales/en/chat.json
+++ b/apps/chat/public/locales/en/chat.json
@@ -413,5 +413,6 @@
   "Importing": "Importing",
   "Exporting": "Exporting",
   "Maximize": "Maximize",
-  "This application has no chat endpoint and cannot be selected for conversations": "This application has no chat endpoint and cannot be selected for conversations"
+  "This application has no chat endpoint and cannot be selected for conversations": "This application has no chat endpoint and cannot be selected for conversations",
+  "File tools": "File tools"
 }

--- a/apps/chat/public/locales/en/chat.json
+++ b/apps/chat/public/locales/en/chat.json
@@ -414,5 +414,6 @@
   "Exporting": "Exporting",
   "Maximize": "Maximize",
   "This application has no chat endpoint and cannot be selected for conversations": "This application has no chat endpoint and cannot be selected for conversations",
-  "File tools": "File tools"
+  "File tools": "File tools",
+  "Process large files": "Process large files"
 }

--- a/apps/chat/public/locales/en/marketplace.json
+++ b/apps/chat/public/locales/en/marketplace.json
@@ -218,5 +218,8 @@
   "This application has no chat endpoint and cannot be selected for conversations": "This application has no chat endpoint and cannot be selected for conversations",
   "File tools": "File tools",
   "Allow the agent to access app files": "Allow the agent to access app files",
-  "Enables the orchestrator’s built-in file tools for this app. When enabled, the agent can browse, search, read, and write or edit files in the app’s file context. When disabled, no file tools are exposed to the orchestrator.": "Enables the orchestrator’s built-in file tools for this app. When enabled, the agent can browse, search, read, and write or edit files in the app’s file context. When disabled, no file tools are exposed to the orchestrator."
+  "Enables the orchestrator’s built-in file tools for this app. When enabled, the agent can browse, search, read, and write or edit files in the app’s file context. When disabled, no file tools are exposed to the orchestrator.": "Enables the orchestrator’s built-in file tools for this app. When enabled, the agent can browse, search, read, and write or edit files in the app’s file context. When disabled, no file tools are exposed to the orchestrator.",
+  "Allow orchestrator to process large files": "Allow orchestrator to process large files",
+  "Process large files": "Process large files",
+  "Lets the orchestrator handle large or many attachments by reading file content on demand instead of including all attachment content in the initial prompt. This helps reduce context window usage while preserving access to the files when needed.": "Lets the orchestrator handle large or many attachments by reading file content on demand instead of including all attachment content in the initial prompt. This helps reduce context window usage while preserving access to the files when needed."
 }

--- a/apps/chat/public/locales/en/marketplace.json
+++ b/apps/chat/public/locales/en/marketplace.json
@@ -215,5 +215,8 @@
   "You don't have any toolsets.": "You don't have any toolsets.",
   "No agents": "No agents",
   "You don't have any agents.": "You don't have any agents.",
-  "This application has no chat endpoint and cannot be selected for conversations": "This application has no chat endpoint and cannot be selected for conversations"
+  "This application has no chat endpoint and cannot be selected for conversations": "This application has no chat endpoint and cannot be selected for conversations",
+  "File tools": "File tools",
+  "Allow the agent to access app files": "Allow the agent to access app files",
+  "Enables the orchestrator’s built-in file tools for this app. When enabled, the agent can browse, search, read, and write or edit files in the app’s file context. When disabled, no file tools are exposed to the orchestrator.": "Enables the orchestrator’s built-in file tools for this app. When enabled, the agent can browse, search, read, and write or edit files in the app’s file context. When disabled, no file tools are exposed to the orchestrator."
 }

--- a/apps/chat/src/components/AppsEditor/EditorForm/QuickApp2Form/QuickApp2Form.tsx
+++ b/apps/chat/src/components/AppsEditor/EditorForm/QuickApp2Form/QuickApp2Form.tsx
@@ -124,11 +124,21 @@ export const QuickApp2Form: FC<AppsEditorProps> = ({ onAutoSave }) => {
     control,
     name: 'documentRelativeUrl',
   });
+  const inputAttachmentTypes = useWatch({
+    control,
+    name: 'inputAttachmentTypes',
+  });
+  const processLargeFiles = useWatch({
+    control,
+    name: 'processLargeFiles',
+  });
 
   const showTemperatureSlider = useMemo(() => {
     const selectedModel = modelsMap[modelId];
     return selectedModel ? doesModelAllowTemperature(selectedModel) : true;
   }, [modelId, modelsMap]);
+
+  const showProcessLargeFiles = !!inputAttachmentTypes?.length;
 
   const hasStarters = useMemo(
     () => starters.some((s) => s.title.trim() && s.text.trim()),
@@ -236,6 +246,15 @@ export const QuickApp2Form: FC<AppsEditorProps> = ({ onAutoSave }) => {
     }
   }, [dispatch, isPublicationReview, reviewBucket]);
 
+  useEffect(() => {
+    if (!inputAttachmentTypes.length && processLargeFiles) {
+      setValue('processLargeFiles', false, {
+        shouldDirty: true,
+        shouldTouch: true,
+      });
+    }
+  }, [inputAttachmentTypes.length, processLargeFiles, setValue]);
+
   return (
     <div
       className="flex size-full grow flex-col divide-y divide-tertiary overflow-hidden overflow-y-auto bg-layer-2"
@@ -285,6 +304,27 @@ export const QuickApp2Form: FC<AppsEditorProps> = ({ onAutoSave }) => {
             />
           )}
         />
+
+        {showProcessLargeFiles && (
+          <Controller
+            name="processLargeFiles"
+            control={control}
+            render={({ field }) => (
+              <ToggleSwitchField
+                isOn={field.value}
+                handleSwitch={() => field.onChange(!field.value)}
+                switchOnText="ON"
+                switchOFFText="OFF"
+                label={t(MarketplaceI18nKeys.ProcessLargeFiles)}
+                additionalText={t(
+                  MarketplaceI18nKeys.AllowOrchestratorToProcessLargeFiles,
+                )}
+                info={t(MarketplaceI18nKeys.ProcessLargeFilesDescription)}
+                className="flex items-center gap-2"
+              />
+            )}
+          />
+        )}
       </FormCollapsibleSection>
 
       <FormCollapsibleSection

--- a/apps/chat/src/components/AppsEditor/EditorForm/QuickApp2Form/QuickApp2Form.tsx
+++ b/apps/chat/src/components/AppsEditor/EditorForm/QuickApp2Form/QuickApp2Form.tsx
@@ -335,6 +335,25 @@ export const QuickApp2Form: FC<AppsEditorProps> = ({ onAutoSave }) => {
         <div data-qa="code-interpreter-field">
           <CodeInterpreterField />
         </div>
+
+        <Controller
+          name="fileTools"
+          control={control}
+          render={({ field }) => (
+            <ToggleSwitchField
+              isOn={field.value}
+              handleSwitch={() => field.onChange(!field.value)}
+              switchOnText="ON"
+              switchOFFText="OFF"
+              label={t(MarketplaceI18nKeys.FileTools)}
+              additionalText={t(
+                MarketplaceI18nKeys.AllowTheAgentToAccessAppFiles,
+              )}
+              info={t(MarketplaceI18nKeys.FileToolsDescription)}
+              className="flex items-center gap-2"
+            />
+          )}
+        />
       </FormCollapsibleSection>
 
       <FormCollapsibleSection

--- a/apps/chat/src/components/AppsEditor/form.ts
+++ b/apps/chat/src/components/AppsEditor/form.ts
@@ -278,6 +278,7 @@ export const QuickApp2Schema = zodValidation
     availableModelIds: zodValidation.array(zodValidation.string()).optional(),
     agentSkills: zodValidation.array(zodValidation.string()),
     timestamp: zodValidation.boolean(),
+    fileTools: zodValidation.boolean(),
   })
   .superRefine((data, ctx) => {
     if (data.isJsonView) {
@@ -531,6 +532,10 @@ const getQuickApp2FormData = (
     'timestamp' in (appProperties?.features ?? {})
       ? !!appProperties?.features?.timestamp
       : true;
+  const fileTools =
+    'dial_files' in (appProperties?.features ?? {})
+      ? !!appProperties?.features?.dial_files
+      : false;
 
   return {
     type: AppsEditorSchemaTypes.QuickApp2,
@@ -570,6 +575,7 @@ const getQuickApp2FormData = (
       .filter((s): s is DialPromptSkill => s.type === 'dial-prompt')
       .map((s) => ApiUtils.decodeApiUrl(s.url)),
     timestamp,
+    fileTools,
   };
 };
 
@@ -1029,6 +1035,7 @@ export const getApplicationPayload = ({
                   injection_strategy: 'tool_call',
                 }
               : null,
+            dial_files: data.fileTools ? {} : null,
           },
           ...(starters.length
             ? {

--- a/apps/chat/src/components/AppsEditor/form.ts
+++ b/apps/chat/src/components/AppsEditor/form.ts
@@ -279,6 +279,7 @@ export const QuickApp2Schema = zodValidation
     agentSkills: zodValidation.array(zodValidation.string()),
     timestamp: zodValidation.boolean(),
     fileTools: zodValidation.boolean(),
+    processLargeFiles: zodValidation.boolean(),
   })
   .superRefine((data, ctx) => {
     if (data.isJsonView) {
@@ -528,6 +529,7 @@ const getQuickApp2FormData = (
       ? defaultModelId // use default quick app model
       : (toolSupportingModelIds?.[0] ?? ''); // use first from list
   }
+
   const timestamp =
     'timestamp' in (appProperties?.features ?? {})
       ? !!appProperties?.features?.timestamp
@@ -535,6 +537,10 @@ const getQuickApp2FormData = (
   const fileTools =
     'dial_files' in (appProperties?.features ?? {})
       ? !!appProperties?.features?.dial_files
+      : false;
+  const processLargeFiles =
+    'attachment_strategy' in (appProperties?.orchestrator ?? {})
+      ? !!appProperties?.orchestrator?.attachment_strategy
       : false;
 
   return {
@@ -576,6 +582,7 @@ const getQuickApp2FormData = (
       .map((s) => ApiUtils.decodeApiUrl(s.url)),
     timestamp,
     fileTools,
+    processLargeFiles,
   };
 };
 
@@ -1011,6 +1018,11 @@ export const getApplicationPayload = ({
               variables: {},
               content: data.instructions,
             },
+            ...(!!data.inputAttachmentTypes.length && {
+              attachment_strategy: data.processLargeFiles
+                ? { type: 'lazy_on_demand' }
+                : null,
+            }),
           },
           contexts:
             data.documentRelativeUrl?.map((url) => ({

--- a/apps/chat/src/components/Chat/Publish/PublicationHandler/ReviewApplicationDialog/ReviewQuickApp2Section.tsx
+++ b/apps/chat/src/components/Chat/Publish/PublicationHandler/ReviewApplicationDialog/ReviewQuickApp2Section.tsx
@@ -148,6 +148,10 @@ const ReviewQuickApp2SectionView = ({
     'timestamp' in (config?.features ?? {})
       ? !!config?.features?.timestamp
       : true;
+  const fileTools =
+    'dial_files' in (config?.features ?? {})
+      ? !!config?.features?.dial_files
+      : false;
   const skills = useMemo(
     () =>
       (config?.skills ?? []).map(({ url }) => ({
@@ -169,6 +173,12 @@ const ReviewQuickApp2SectionView = ({
           valueClassName="max-w-[414px] break-all text-primary"
         />
       )}
+
+      <MarketplaceEntityInfoRow
+        label={t(ChatI18nKeys.FileTools)}
+        value={t(fileTools ? ChatI18nKeys.On : ChatI18nKeys.Off)}
+        valueClassName="max-w-[414px] break-all text-primary"
+      />
 
       <MarketplaceEntityInfoRow
         label={t(ChatI18nKeys.TimeAwareness)}

--- a/apps/chat/src/components/Chat/Publish/PublicationHandler/ReviewApplicationDialog/ReviewQuickApp2Section.tsx
+++ b/apps/chat/src/components/Chat/Publish/PublicationHandler/ReviewApplicationDialog/ReviewQuickApp2Section.tsx
@@ -152,6 +152,12 @@ const ReviewQuickApp2SectionView = ({
     'dial_files' in (config?.features ?? {})
       ? !!config?.features?.dial_files
       : false;
+  const showProcessLargeFiles =
+    'attachment_strategy' in (config?.orchestrator ?? {});
+  const processLargeFiles =
+    'attachment_strategy' in (config?.orchestrator ?? {})
+      ? !!config?.orchestrator?.attachment_strategy
+      : false;
   const skills = useMemo(
     () =>
       (config?.skills ?? []).map(({ url }) => ({
@@ -179,6 +185,14 @@ const ReviewQuickApp2SectionView = ({
         value={t(fileTools ? ChatI18nKeys.On : ChatI18nKeys.Off)}
         valueClassName="max-w-[414px] break-all text-primary"
       />
+
+      {showProcessLargeFiles && (
+        <MarketplaceEntityInfoRow
+          label={t(ChatI18nKeys.ProcessLargeFiles)}
+          value={t(processLargeFiles ? ChatI18nKeys.On : ChatI18nKeys.Off)}
+          valueClassName="max-w-[414px] break-all text-primary"
+        />
+      )}
 
       <MarketplaceEntityInfoRow
         label={t(ChatI18nKeys.TimeAwareness)}

--- a/apps/chat/src/constants/i18n.ts
+++ b/apps/chat/src/constants/i18n.ts
@@ -836,6 +836,7 @@ export enum ChatI18nKeys {
   On = 'On',
   Off = 'Off',
   TimeAwareness = 'Time awareness',
+  FileTools = 'File tools',
   AgentSkills = 'Agent Skills',
   Agents = 'Agents',
   Endpoint = 'Endpoint',
@@ -1241,4 +1242,7 @@ export enum MarketplaceI18nKeys {
   NoAgents = 'No agents',
   YouDontHaveAnyAgents = "You don't have any agents.",
   AbsentChatCompletionDisabledMessage = 'This application has no chat endpoint and cannot be selected for conversations',
+  FileTools = 'File tools',
+  AllowTheAgentToAccessAppFiles = 'Allow the agent to access app files',
+  FileToolsDescription = 'Enables the orchestrator’s built-in file tools for this app. When enabled, the agent can browse, search, read, and write or edit files in the app’s file context. When disabled, no file tools are exposed to the orchestrator.',
 }

--- a/apps/chat/src/constants/i18n.ts
+++ b/apps/chat/src/constants/i18n.ts
@@ -837,6 +837,7 @@ export enum ChatI18nKeys {
   Off = 'Off',
   TimeAwareness = 'Time awareness',
   FileTools = 'File tools',
+  ProcessLargeFiles = 'Process large files',
   AgentSkills = 'Agent Skills',
   Agents = 'Agents',
   Endpoint = 'Endpoint',
@@ -1245,4 +1246,7 @@ export enum MarketplaceI18nKeys {
   FileTools = 'File tools',
   AllowTheAgentToAccessAppFiles = 'Allow the agent to access app files',
   FileToolsDescription = 'Enables the orchestrator’s built-in file tools for this app. When enabled, the agent can browse, search, read, and write or edit files in the app’s file context. When disabled, no file tools are exposed to the orchestrator.',
+  AllowOrchestratorToProcessLargeFiles = 'Allow orchestrator to process large files',
+  ProcessLargeFiles = 'Process large files',
+  ProcessLargeFilesDescription = 'Lets the orchestrator handle large or many attachments by reading file content on demand instead of including all attachment content in the initial prompt. This helps reduce context window usage while preserving access to the files when needed.',
 }

--- a/apps/chat/src/types/quick-apps.ts
+++ b/apps/chat/src/types/quick-apps.ts
@@ -102,6 +102,7 @@ export interface QuickApp2Config {
       variables: object;
       content: string;
     };
+    attachment_strategy?: { type: 'lazy_on_demand' } | null;
   };
   contexts: FileContext[];
   tool_sets: AnyToolset[];

--- a/apps/chat/src/types/quick-apps.ts
+++ b/apps/chat/src/types/quick-apps.ts
@@ -113,6 +113,7 @@ export interface QuickApp2Config {
     timestamp?: {
       injection_strategy: 'tool_call';
     } | null;
+    dial_files?: object | null;
   };
 }
 


### PR DESCRIPTION
## Description of changes

- add **Process large files** toggle into Orchestrator section
- add **File tools** toggle into Context & Tools section

## Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- feat #7525 
- feat #7524 

## UI changes
Process large files toggle:
<img width="760" height="99" alt="image" src="https://github.com/user-attachments/assets/792ffcf6-3378-4be3-ad3a-65fec470603f" />
File tools toggle:
<img width="756" height="90" alt="image" src="https://github.com/user-attachments/assets/ed803af1-efed-4150-b1f5-2fd04b91a06b" />


## Checklist

- [x] the pull request name ends with `(Issue #<ISSUE_ID>)` (comma-separated list of issues)
- [x] I confirm that I don't share any confidential information like API keys or any other secrets and private URLs