### PR TITLE
fix(sdlc): resolve DIAL key from repo-level secrets, drop env pin

### DIFF
--- a/.github/workflows/run-agent.yml
+++ b/.github/workflows/run-agent.yml
@@ -41,12 +41,6 @@ jobs:
     # name as the trailing path segment.
     name: ${{ inputs.agent_name }}
     runs-on: ubuntu-latest
-    # TEMPORARY (validation): use the security-review environment's DIAL key,
-    # which has the Anthropic route + the anthropic.claude-sonnet-4-6 deployment
-    # (same as the claude-security-review reference). Remove once the repo-level
-    # DIAL key has its own Anthropic-route model access. No protection rules, so
-    # it doesn't gate runs.
-    environment: security-review
     timeout-minutes: ${{ inputs.timeout_minutes }}
     concurrency:
       group: ${{ inputs.concurrency_group != '' && inputs.concurrency_group || format('{0}-{1}-{2}', github.workflow, inputs.agent_name, github.ref) }}


### PR DESCRIPTION
## What

Removes the `environment: security-review` pin from the `agent` job in `.github/workflows/run-agent.yml`, so the DIAL inference credentials resolve from the **common repo-level** secrets/vars instead of the environment-scoped ones.

## Why

The pin was a TEMPORARY validation measure — it existed only so `secrets.DIAL_API_KEY`, `vars.DIAL_CORE_URL`, and `vars.DIAL_MODEL` resolved from the `security-review` environment (the one with Anthropic-route model access). The repo now carries all of these at the common repo level:

- `DIAL_API_KEY` (secret)
- `DIAL_CORE_URL` = `https://core.aks.dev.dial.parts`
- `DIAL_MODEL` = `anthropic.claude-sonnet-4-6` — the Anthropic-route deployment the comment was waiting on

With the pin removed, the existing job-level `env:` expression and the "Configure inference route" step resolve against repo-level secrets/vars — no other edits needed.

## Risk

None to gating: the `security-review` environment had no protection rules, so runs were never blocked by it. Behavior is unchanged except the credential source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)