### PR TITLE
fix: prevent replaying first message on refresh (#7562)

### DIFF
--- a/apps/chat/src/pages/Conversation/Conversation.tsx
+++ b/apps/chat/src/pages/Conversation/Conversation.tsx
@@ -61,7 +61,7 @@ interface Props {
 
 export const ConversationPage: FC<Props> = ({ onDuplicateReadonly }) => {
   const { '*': conversationId } = useParams<{ '*': string }>();
-  const { state } = useLocation();
+  const { state, pathname, search } = useLocation();
   const prefetchedConversation =
     (state as { conversation?: Conversation } | null)?.conversation ?? null;
   const [conversation, setConversation] = useState<Conversation | null>(
@@ -423,6 +423,17 @@ export const ConversationPage: FC<Props> = ({ onDuplicateReadonly }) => {
     // re-running when it changes would re-initialize an already-loaded conversation.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [conversationId, loadConversation]);
+
+  const clearedPrefetchIdRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!conversationId || !prefetchedConversation) return;
+    if (clearedPrefetchIdRef.current === conversationId) return;
+    clearedPrefetchIdRef.current = conversationId;
+    // history.state survives a hard refresh, so leaving the just-created
+    // user-only snapshot in it would make every reload re-run the auto-start
+    // stream instead of fetching the up-to-date conversation from the server.
+    navigate(`${pathname}${search}`, { replace: true, state: null });
+  }, [conversationId, prefetchedConversation, navigate, pathname, search]);
 
   const {
     handleSend,


### PR DESCRIPTION
## Description of changes

## Summary
- New chat → send first message → hard refresh: every refresh resent the first message and produced a new assistant answer, duplicating replies on each reload.
- Root cause: after creating a conversation, the app navigates with `state: { conversation }` (a user-only snapshot) so `ConversationPage` can skip a redundant GET. That router state lives in `history.state`, which survives a hard refresh — so each reload rehydrated from the same stale snapshot and re-triggered the `ContinueLastUser` auto-start, even after the backend already had (or was producing) the real reply.
- Fix: once `ConversationPage` consumes the prefetched conversation for a given `conversationId`, it clears the router state via `navigate(path, { replace: true, state: null })`. The optimization (skip GET right after creation) is preserved; a subsequent hard refresh now always does a fresh `GET` and only auto-starts if the server's own last message is still from the user.

## Applicable issues

- https://github.com/epam/ai-dial-chat/issues/7562

## Checklist

- [ X] the pull request name ends with `(Issue #<ISSUE_ID>)` (comma-separated list of issues)
- [ X] I confirm that I don't share any confidential information like API keys or any other secrets and private URLs
