### PR TITLE
fix(chat): fix image reload does not respond when editing message (Issue #5650)

### DIFF
--- a/apps/chat/src/components/Chat/ChatInput/ChatInputMessage.tsx
+++ b/apps/chat/src/components/Chat/ChatInput/ChatInputMessage.tsx
@@ -19,6 +19,7 @@ import { useVoiceRecorder } from '@/src/hooks/useVoiceRecorder';
 
 import { addTrailingSlashIfAbsent } from '@/src/utils/app/common';
 import { getUserCustomContent } from '@/src/utils/app/file';
+import { dispatchRetryFileUpload } from '@/src/utils/app/file-upload-dispatch';
 import {
   getConversationSchema,
   isFormValueValid,
@@ -531,7 +532,7 @@ export const ChatInputMessage = Inversify.register(
 
     const handleRetry = useCallback(
       (fileId: string) => {
-        dispatch(FilesActions.reuploadFile({ fileId }));
+        dispatchRetryFileUpload(dispatch, fileId);
       },
       [dispatch],
     );

--- a/apps/chat/src/components/Chat/ChatMessage/ChatMessageContent/AssistantMessage.tsx
+++ b/apps/chat/src/components/Chat/ChatMessage/ChatMessageContent/AssistantMessage.tsx
@@ -26,6 +26,7 @@ import {
   getDialLinksFromAttachments,
   getUserCustomContent,
 } from '@/src/utils/app/file';
+import { dispatchRetryFileUpload } from '@/src/utils/app/file-upload-dispatch';
 import {
   getConfigurationSchema,
   getConfigurationValue,
@@ -374,7 +375,7 @@ const AssistantMessageEditor = memo(function AssistantMessageEditor({
 
   const handleRetry = useCallback(
     (fileId: string) => {
-      return () => dispatch(FilesActions.reuploadFile({ fileId }));
+      dispatchRetryFileUpload(dispatch, fileId);
     },
     [dispatch],
   );

--- a/apps/chat/src/components/Chat/ChatMessage/ChatMessageContent/UserMessage.tsx
+++ b/apps/chat/src/components/Chat/ChatMessage/ChatMessageContent/UserMessage.tsx
@@ -27,6 +27,7 @@ import {
   getDialLinksFromAttachments,
   getUserCustomContent,
 } from '@/src/utils/app/file';
+import { dispatchRetryFileUpload } from '@/src/utils/app/file-upload-dispatch';
 import {
   getConfigurationSchema,
   getConfigurationValue,
@@ -471,7 +472,7 @@ export const UserMessage = memo(function UserMessage({
 
   const handleRetry = useCallback(
     (fileId: string) => {
-      return () => dispatch(FilesActions.reuploadFile({ fileId }));
+      dispatchRetryFileUpload(dispatch, fileId);
     },
     [dispatch],
   );

--- a/apps/chat/src/utils/app/__tests__/file-upload-dispatch.test.ts
+++ b/apps/chat/src/utils/app/__tests__/file-upload-dispatch.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { dispatchRetryFileUpload } from '@/src/utils/app/file-upload-dispatch';
+
+import { FilesActions } from '@/src/store/actions';
+
+describe('dispatchRetryFileUpload', () => {
+  it('dispatches reuploadFile with the given fileId', () => {
+    const dispatch = vi.fn();
+
+    dispatchRetryFileUpload(dispatch, 'files/bucket/image.png');
+
+    expect(dispatch).toHaveBeenCalledOnce();
+    expect(dispatch).toHaveBeenCalledWith(
+      FilesActions.reuploadFile({ fileId: 'files/bucket/image.png' }),
+    );
+  });
+});

--- a/apps/chat/src/utils/app/file-upload-dispatch.ts
+++ b/apps/chat/src/utils/app/file-upload-dispatch.ts
@@ -1,0 +1,10 @@
+import { FilesActions } from '@/src/store/actions';
+
+import type { AppDispatch } from '@/src/store';
+
+export function dispatchRetryFileUpload(
+  dispatch: AppDispatch,
+  fileId: string,
+): void {
+  dispatch(FilesActions.reuploadFile({ fileId }));
+}


### PR DESCRIPTION
﻿## Description of changes

Fixed a bug where the file upload retry (reload) button had no effect when editing a user or assistant message after a failed upload.

- `handleRetry` in `UserMessage.tsx` and `AssistantMessage.tsx` was accidentally returning a closure (`return () => dispatch(...)`) instead of calling `dispatch` directly, so clicking the button discarded the return value and dispatched nothing.
- Added a unit test for the new utility.

## Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #5650

## UI changes

N/A

## Checklist

- [x] the pull request name ends with `(Issue #5650)` (comma-separated list of issues)
- [x] I confirm that I don't share any confidential information like API keys or any other secrets and private URLs

<details>
  <summary>PR title cheatsheet</summary>

`<type>[optional scope]: <description>`

1. type (required)
    - `feat` - A new feature
    - `fix` - A bug fix
    - `docs` - Documentation only changes
    - `test` - Adding missing tests or correcting existing tests
    - `ci` - Changes to our CI configuration files and scripts
    - `chore` - Other changes that are minor and/or not user-facing
2. scope (optional, current repo suggestions below)
    - `chat`
    - `overlay`
    - `shared`
    - `sandbox-overlay`
    - `visualizer-connector`

</details>
