### PR TITLE
fix(chat): fix incorrect propmt json import error toast (Issue #1310)

### DIFF
--- a/apps/chat/src/store/import-export/importExport.epics.ts
+++ b/apps/chat/src/store/import-export/importExport.epics.ts
@@ -426,7 +426,16 @@ const importPromptsEpic: AppEpic = (action$) =>
       });
 
       if (!preparedPrompts.length) {
-        return of(ImportExportActions.importPromptsFail());
+        return concat(
+          of(ImportExportActions.importPromptsFail()),
+          of(
+            UIActions.showErrorToast({
+              message: translate(CommonI18nKeys.ImportPromptsFailed, {
+                ns: Translation.Common,
+              }),
+            }),
+          ),
+        );
       }
 
       return PromptService.getPrompts(undefined, true).pipe(

--- a/apps/chat/src/utils/app/data/prompt-service.ts
+++ b/apps/chat/src/utils/app/data/prompt-service.ts
@@ -113,23 +113,27 @@ export const getImportPreparedPrompts = ({
   prompts: Prompt[];
   folders: FolderInterface[];
 }): Prompt[] =>
-  prompts.map((prompt) => {
-    const { path } = getPathToFolderById(folders, prompt.folderId, {
-      forRenaming: false,
-      trimEndDotsRequired: true,
-      prepareNames: true,
-    });
-    const newName = prepareEntityName(prompt.name);
+  prompts
+    .map((prompt) => {
+      const { path } = getPathToFolderById(folders, prompt.folderId, {
+        forRenaming: false,
+        trimEndDotsRequired: true,
+        prepareNames: true,
+      });
+      const newName = prepareEntityName(prompt.name ?? '');
 
-    const folderId = isRootPromptId(path)
-      ? path
-      : constructPath(getPromptRootId(), path);
-    const promptId = constructPath(folderId, newName);
+      if (!newName) return null;
 
-    return {
-      ...prompt,
-      id: promptId,
-      name: newName,
-      folderId: folderId,
-    };
-  }); // to send prompts with proper parentPath
+      const folderId = isRootPromptId(path)
+        ? path
+        : constructPath(getPromptRootId(), path);
+      const promptId = constructPath(folderId, newName);
+
+      return {
+        ...prompt,
+        id: promptId,
+        name: newName,
+        folderId: folderId,
+      };
+    })
+    .filter((prompt): prompt is Prompt => prompt !== null); // to send prompts with proper parentPath


### PR DESCRIPTION
## Description of changes

Error message should appear : 'Import of prompts failed'

## Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #1310

## Checklist

- [x] the pull request name ends with `(Issue #<ISSUE_ID>)` (comma-separated list of issues)
- [x] I confirm that I don't share any confidential information like API keys or any other secrets and private URLs

<details>
  <summary>PR title cheatsheet</summary>

`<type>[optional scope]: <description>`

1. type (required)
    - `feat` - A new feature
    - `fix` - A bug fix
    - `docs` - Documentation only changes
    - `test` - Adding missing tests or correcting existing tests
    - `ci` - Changes to our CI configuration files and scripts
    - `chore` - Other changes that are minor and/or not user-facing
2. scope (optional, current repo suggestions below)
    - `chat`
    - `overlay`
    - `shared`
    - `sandbox-overlay`
    - `visualizer-connector`

</details>
