### PR TITLE
fix(chat): update MD table toolbar buttons and export filename format (Issue #7563)

### DIFF
--- a/apps/chat-e2e/src/ui/selectors/chatSelectors.ts
+++ b/apps/chat-e2e/src/ui/selectors/chatSelectors.ts
@@ -166,9 +166,9 @@ export const DragFileSelectors = {
 export const TableSelectors = {
   tableContainer: '[data-qa="table"]',
   tableControls: '[data-qa="table-controls"]',
-  copyAsCsvIcon: '[data-qa="csv-icon"]',
-  copyAsTxtIcon: '[data-qa="txt-icon"]',
-  copyAsMdIcon: '[data-qa="md-icon"]',
+  copyAsCsvIcon: '[data-qa="copy-csv-icon"]',
+  copyAsTxtIcon: '[data-qa="copy-txt-icon"]',
+  copyAsMdIcon: '[data-qa="copy-md-icon"]',
 };
 
 export const PublicationReviewControls = {

--- a/apps/chat/src/components/Markdown/Table.tsx
+++ b/apps/chat/src/components/Markdown/Table.tsx
@@ -1,5 +1,4 @@
 import {
-  Icon,
   IconCheck,
   IconCsv,
   IconDownload,
@@ -30,35 +29,9 @@ import { Translation } from '@/src/types/translation';
 import { MarkdownI18nKeys } from '@/src/constants/i18n';
 import { DEFAULT_ICON_SIZES } from '@/src/constants/icons';
 
-import { Tooltip } from '@/src/components/Common/Tooltip';
 import { DownloadTableCsvModal } from '@/src/components/Markdown/DownloadTableCsvModal';
 
-import { DialButton } from '@epam/ai-dial-ui-kit';
-
-interface CopyIconProps {
-  Icon: Icon;
-  onClick: () => void;
-  copied: boolean;
-  type: CopyTableType;
-}
-
-const CopyIcon = ({ Icon, onClick, copied, type }: CopyIconProps) => {
-  const IconComponent = copied ? IconCheck : Icon;
-
-  return (
-    <IconComponent
-      stroke={1.5}
-      className="cursor-pointer text-secondary hover:text-accent-primary"
-      size={DEFAULT_ICON_SIZES.STANDARD}
-      data-qa={type.concat('-icon')}
-      onClick={() => {
-        if (!copied) {
-          onClick();
-        }
-      }}
-    />
-  );
-};
+import { DialGhostIconButton, ElementSize } from '@epam/ai-dial-ui-kit';
 
 const buildCsvString = (
   headerRef: RefObject<HTMLTableElement | null>,
@@ -83,7 +56,7 @@ const buildCsvString = (
 
 const getDefaultFilename = (): string => {
   const date = new Date().toISOString().slice(0, 10);
-  return `table_${date}.csv`;
+  return `${date}_table.csv`;
 };
 
 interface Props {
@@ -294,47 +267,71 @@ export const Table = ({ children, isLastMessageStreaming }: Props) => {
           data-qa="table-controls"
         >
           <div data-no-context-menu className="flex gap-2">
-            <Tooltip
-              placement="top"
-              tooltip={t(MarkdownI18nKeys.CopyAsCSV, {
-                ns: Translation.Markdown,
-              })}
-            >
-              <CopyIcon
-                Icon={IconCsv}
-                onClick={copyTableToCSV}
-                copied={CopyTableType.CSV === copiedType}
-                type={CopyTableType.CSV}
-              />
-            </Tooltip>
-            <Tooltip
-              placement="top"
-              tooltip={t(MarkdownI18nKeys.CopyAsTXT, {
-                ns: Translation.Markdown,
-              })}
-            >
-              <CopyIcon
-                Icon={IconTxt}
-                onClick={copyTableToTXT}
-                copied={CopyTableType.TXT === copiedType}
-                type={CopyTableType.TXT}
-              />
-            </Tooltip>
-            <Tooltip
-              placement="top"
-              tooltip={t(MarkdownI18nKeys.CopyAsMD, {
-                ns: Translation.Markdown,
-              })}
-            >
-              <CopyIcon
-                Icon={IconMarkdown}
-                onClick={copyTableToMD}
-                copied={CopyTableType.MD === copiedType}
-                type={CopyTableType.MD}
-              />
-            </Tooltip>
-            <DialButton
-              className="flex max-h-[24px] items-center !px-0 text-secondary hover:text-accent-primary"
+            <DialGhostIconButton
+              size={ElementSize.Small}
+              data-qa="copy-csv-icon"
+              tooltipProps={{
+                placement: 'top',
+                isTriggerClickable: true,
+                tooltip: t(MarkdownI18nKeys.CopyAsCSV, {
+                  ns: Translation.Markdown,
+                }),
+              }}
+              onClick={() => {
+                if (CopyTableType.CSV !== copiedType) copyTableToCSV();
+              }}
+              icon={
+                CopyTableType.CSV === copiedType ? (
+                  <IconCheck size={DEFAULT_ICON_SIZES.SMALL} />
+                ) : (
+                  <IconCsv stroke={1.5} size={DEFAULT_ICON_SIZES.SMALL} />
+                )
+              }
+            />
+            <DialGhostIconButton
+              size={ElementSize.Small}
+              data-qa="copy-txt-icon"
+              tooltipProps={{
+                placement: 'top',
+                isTriggerClickable: true,
+                tooltip: t(MarkdownI18nKeys.CopyAsTXT, {
+                  ns: Translation.Markdown,
+                }),
+              }}
+              onClick={() => {
+                if (CopyTableType.TXT !== copiedType) copyTableToTXT();
+              }}
+              icon={
+                CopyTableType.TXT === copiedType ? (
+                  <IconCheck size={DEFAULT_ICON_SIZES.SMALL} />
+                ) : (
+                  <IconTxt stroke={1.5} size={DEFAULT_ICON_SIZES.SMALL} />
+                )
+              }
+            />
+            <DialGhostIconButton
+              size={ElementSize.Small}
+              data-qa="copy-md-icon"
+              tooltipProps={{
+                placement: 'top',
+                isTriggerClickable: true,
+                tooltip: t(MarkdownI18nKeys.CopyAsMD, {
+                  ns: Translation.Markdown,
+                }),
+              }}
+              onClick={() => {
+                if (CopyTableType.MD !== copiedType) copyTableToMD();
+              }}
+              icon={
+                CopyTableType.MD === copiedType ? (
+                  <IconCheck size={DEFAULT_ICON_SIZES.SMALL} />
+                ) : (
+                  <IconMarkdown stroke={1.5} size={DEFAULT_ICON_SIZES.SMALL} />
+                )
+              }
+            />
+            <DialGhostIconButton
+              size={ElementSize.Small}
               data-qa="download-csv"
               aria-label={t(MarkdownI18nKeys.DownloadAsCSV, {
                 ns: Translation.Markdown,
@@ -345,10 +342,9 @@ export const Table = ({ children, isLastMessageStreaming }: Props) => {
                 tooltip: t(MarkdownI18nKeys.DownloadAsCSV, {
                   ns: Translation.Markdown,
                 }),
-                contentClassName: 'text-base',
               }}
               onClick={() => setIsDownloadModalOpen(true)}
-              iconBefore={
+              icon={
                 <IconDownload size={DEFAULT_ICON_SIZES.SMALL} stroke={1.5} />
               }
             />

--- a/apps/chat/src/utils/app/import-export.ts
+++ b/apps/chat/src/utils/app/import-export.ts
@@ -156,8 +156,8 @@ export function cleanData(data: SupportedExportFormats): CleanDataResponse {
 
 export function getCurrentDate() {
   const date = new Date();
-  const month = date.getMonth() + 1;
-  const day = date.getDate();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
   const year = date.getFullYear();
   return `${year}-${month}-${day}`;
 }

--- a/openspec/changes/archive/2026-07-03-update-csv-download-buttons-and-filename-format/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-03-update-csv-download-buttons-and-filename-format/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-03

--- a/openspec/changes/archive/2026-07-03-update-csv-download-buttons-and-filename-format/design.md
+++ b/openspec/changes/archive/2026-07-03-update-csv-download-buttons-and-filename-format/design.md
@@ -1,0 +1,100 @@
+## Context
+
+Three fixes arising from designer review on GitHub issue #7563 (comment 2026-07-03).
+
+### Current state
+
+**Table toolbar buttons (`Table.tsx`)**  
+Copy buttons (CSV / TXT / MD) use a local `CopyIcon` component that renders raw Tabler icon elements with manual `className` styling. The Download button already uses `DialButton` from `@epam/ai-dial-ui-kit`. Result: mixed visual treatment.
+
+**Table CSV filename** (`Table.tsx` `getDefaultFilename`, line 84-87)  
+```
+table_2026-07-03.csv   ← label before date
+```
+
+**Chat/prompt export filenames** (`import-export.ts` `getCurrentDate`, lines 157-163)  
+```typescript
+const month = date.getMonth() + 1;  // no zero-padding
+const day = date.getDate();          // no zero-padding
+return `${year}-${month}-${day}`;    // → "2026-7-3"
+```
+All downstream filenames (`triggerDownloadConversation`, `triggerDownloadConversationsHistory`, `triggerDownloadPromptsHistory`, `triggerDownloadPrompt`) inherit the un-padded date.
+
+---
+
+## Goals / Non-Goals
+
+**Goals**
+- Unify all 4 table toolbar buttons to use `DialButton` from `@epam/ai-dial-ui-kit`.
+- Rename table CSV default filename to `YYYY-MM-DD_table.csv`.
+- Zero-pad month and day in `getCurrentDate()` so all exports use ISO-format dates.
+
+**Non-Goals**
+- Changing copy button behaviour (checkmark feedback stays).
+- Changing the downstream filename template structure beyond the date padding.
+- Adding any new UI or store logic.
+
+---
+
+## Decisions
+
+### 1. Migrate all toolbar buttons to `DialGhostIconButton`
+
+**Chosen**: Replace both the `CopyIcon` local component and the existing `DialButton` download button with `DialGhostIconButton` from `@epam/ai-dial-ui-kit` with `size={ElementSize.Small}`, using its built-in `tooltipProps` for the tooltip (no outer `<Tooltip>` wrapper needed).
+
+**Why**: `DialGhostIconButton` is the correct ghost-style icon button primitive used in toolbar contexts across the codebase, and it accepts `tooltipProps` directly — no wrapper required.
+
+**Before** (copy buttons):
+```tsx
+<Tooltip placement="top" tooltip={t(MarkdownI18nKeys.CopyAsCSV, { ns: Translation.Markdown })}>
+  <CopyIcon Icon={IconCsv} onClick={copyTableToCSV} copied={CopyTableType.CSV === copiedType} type={CopyTableType.CSV} />
+</Tooltip>
+```
+
+**Before** (download button):
+```tsx
+<DialButton className="flex max-h-[24px] items-center !px-0 text-secondary hover:text-accent-primary" ... />
+```
+
+**After** (all four buttons, same shape):
+```tsx
+<DialGhostIconButton
+  size={ElementSize.Small}
+  data-qa="copy-csv-icon"
+  tooltipProps={{ placement: 'top', isTriggerClickable: true, tooltip: t(MarkdownI18nKeys.CopyAsCSV, { ns: Translation.Markdown }) }}
+  onClick={() => { if (CopyTableType.CSV !== copiedType) copyTableToCSV(); }}
+  icon={CopyTableType.CSV === copiedType
+    ? <IconCheck size={DEFAULT_ICON_SIZES.SMALL} />
+    : <IconCsv stroke={1.5} size={DEFAULT_ICON_SIZES.SMALL} />}
+/>
+```
+
+Imports to add: `DialGhostIconButton`, `ElementSize` from `@epam/ai-dial-ui-kit`.  
+Imports to remove: `DialButton`, `Tooltip` (both replaced by `DialGhostIconButton` with `tooltipProps`).
+
+### 2. Rename table CSV filename
+
+**Chosen**: Change `getDefaultFilename()`:
+```typescript
+// before
+return `table_${date}.csv`;
+// after
+return `${date}_table.csv`;
+```
+
+**Why**: Aligns with all other export filenames which put the date first, making downloads sort correctly by name in file browsers.
+
+### 3. Zero-pad `getCurrentDate()`
+
+**Chosen**: Use `String(…).padStart(2, '0')` for month and day:
+```typescript
+export function getCurrentDate() {
+  const date = new Date();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  const year = date.getFullYear();
+  return `${year}-${month}-${day}`;
+}
+```
+
+**Why**: Minimal, isolated change. All callers (`triggerDownloadConversation`, `triggerDownloadConversationsHistory`, `triggerDownloadPromptsHistory`, `triggerDownloadPrompt`) automatically get correct filenames with no other edits.

--- a/openspec/changes/archive/2026-07-03-update-csv-download-buttons-and-filename-format/proposal.md
+++ b/openspec/changes/archive/2026-07-03-update-csv-download-buttons-and-filename-format/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+Following designer review (GitHub issue #7563, comment 2026-07-03), three polish items were identified for the CSV table download feature and existing export filename behaviour:
+
+1. The table toolbar buttons (Copy CSV / TXT / MD) use raw Tabler icon elements while the new Download button uses `DialButton` from the UI-kit — the toolbar is visually inconsistent.
+2. The table CSV download filename puts the label before the date (`table_2026-07-03.csv`) while all other chat exports put the date first (`2026-07-03_…`).
+3. All existing chat/prompt exports use an un-padded date string (`2026-7-3_…`) instead of the ISO-padded form (`2026-07-03_…`), making filenames sort incorrectly.
+
+## What Changes
+
+- All four icon buttons in the table toolbar (`Table.tsx`) are migrated to `DialButton` from `@epam/ai-dial-ui-kit` for visual consistency with the designer spec.
+- `getDefaultFilename()` in `Table.tsx` is updated: `table_${date}.csv` → `${date}_table.csv`.
+- `getCurrentDate()` in `apps/chat/src/utils/app/import-export.ts` is updated to zero-pad month and day so all export filenames use ISO-format dates.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `download-table-as-csv`: filename format changed to `YYYY-MM-DD_table.csv`.
+- `export-conversation`: export filename date portion is now zero-padded (`YYYY-MM-DD`).
+- `export-prompt`: export filename date portion is now zero-padded (`YYYY-MM-DD`).
+
+## Impact
+
+- **Component**: `apps/chat/src/components/Markdown/Table.tsx` — button migration + filename fix.
+- **Utility**: `apps/chat/src/utils/app/import-export.ts` — `getCurrentDate()` zero-padding.
+- **No store changes**, **no API changes**, **no new i18n keys**, **no feature flags**.

--- a/openspec/changes/archive/2026-07-03-update-csv-download-buttons-and-filename-format/tasks.md
+++ b/openspec/changes/archive/2026-07-03-update-csv-download-buttons-and-filename-format/tasks.md
@@ -1,0 +1,50 @@
+## 1. Fix `getCurrentDate()` zero-padding
+
+- [x] 1.1 In `apps/chat/src/utils/app/import-export.ts` lines 157-163, update `getCurrentDate()`:
+  ```typescript
+  export function getCurrentDate() {
+    const date = new Date();
+    const month = String(date.getMonth() + 1).padStart(2, '0');
+    const day = String(date.getDate()).padStart(2, '0');
+    const year = date.getFullYear();
+    return `${year}-${month}-${day}`;
+  }
+  ```
+
+## 2. Fix table CSV default filename
+
+- [x] 2.1 In `apps/chat/src/components/Markdown/Table.tsx` `getDefaultFilename()` (lines 84-87), change:
+  ```typescript
+  return `table_${date}.csv`;
+  ```
+  to:
+  ```typescript
+  return `${date}_table.csv`;
+  ```
+
+## 3. Migrate table toolbar buttons to `DialPrimaryIconButton`
+
+- [x] 3.1 In `Table.tsx`, remove the `CopyIcon` local component (lines 45-61), the `Tooltip` import (line 33), and the `DialButton` import (line 36).
+- [x] 3.2 Add imports: `DialGhostIconButton`, `ElementSize` from `@epam/ai-dial-ui-kit`.
+- [x] 3.3 Replace each of the three `<Tooltip> + <CopyIcon>` blocks with `<DialGhostIconButton>`:
+  - `size={ElementSize.Small}`
+  - `data-qa` matching the old icon's `data-qa` attribute (e.g. `"copy-csv-icon"`)
+  - `tooltipProps` with `placement: 'top'`, `isTriggerClickable: true`, `tooltip` (no `contentClassName`)
+  - `onClick` guarded against re-click while `copiedType` matches (same logic as old `CopyIcon`)
+  - `icon` switching between `IconCheck` and the type-specific icon based on `copiedType`
+- [x] 3.4 Replace the existing `<DialButton>` download button with `<DialGhostIconButton>`:
+  - `size={ElementSize.Small}`
+  - `data-qa="download-csv"`, `aria-label` preserved
+  - `tooltipProps` with `placement: 'top'`, `isTriggerClickable: true`, `tooltip` (no `contentClassName`)
+  - `icon={<IconDownload size={DEFAULT_ICON_SIZES.SMALL} stroke={1.5} />}`
+  - `onClick={() => setIsDownloadModalOpen(true)}`
+
+## 4. Verify and Test
+
+- [ ] 4.1 Export a conversation and confirm the filename is `2026-07-03_…` (zero-padded) for today's date.
+- [ ] 4.2 Export a prompt and confirm the same zero-padded date format.
+- [ ] 4.3 Click the Download CSV table button and confirm the prefilled filename is `2026-07-03_table.csv`.
+- [ ] 4.4 Confirm all four table toolbar buttons render consistently as UI-kit buttons.
+- [ ] 4.5 Confirm copy checkmark feedback still works for all three copy buttons.
+- [x] 4.6 Run `npm run lint:fix && npm run format:fix`.
+- [x] 4.7 Run `npm run affected:test` to ensure no unit test regressions.

--- a/openspec/specs/export/spec.md
+++ b/openspec/specs/export/spec.md
@@ -1,0 +1,38 @@
+## Purpose
+
+Defines the naming conventions for files produced by chat export actions (conversations, prompts, and table CSV downloads), ensuring consistent, sortable filenames across all export types.
+
+## Requirements
+
+### Requirement: Export filenames SHALL use a zero-padded ISO date prefix
+
+All files exported from the chat UI SHALL begin with a date segment in `YYYY-MM-DD` format, with month and day zero-padded to two digits.
+
+#### Scenario: Conversation export filename uses zero-padded date
+- **WHEN** the user exports a single conversation on a date such as 3 July 2026
+- **THEN** the exported filename SHALL begin with `2026-07-03_` (not `2026-7-3_`)
+
+#### Scenario: Conversations history export filename uses zero-padded date
+- **WHEN** the user exports all conversations
+- **THEN** the exported filename SHALL begin with `YYYY-MM-DD_` with zero-padded month and day
+
+#### Scenario: Prompt export filename uses zero-padded date
+- **WHEN** the user exports a single prompt
+- **THEN** the exported filename SHALL begin with `YYYY-MM-DD_` with zero-padded month and day
+
+#### Scenario: Prompts history export filename uses zero-padded date
+- **WHEN** the user exports all prompts
+- **THEN** the exported filename SHALL begin with `YYYY-MM-DD_` with zero-padded month and day
+
+### Requirement: Export filenames SHALL follow a date-first naming pattern
+
+The date prefix SHALL appear at the start of the filename so that exports sort chronologically by name in file browsers. Entity names and type suffixes follow the date.
+
+#### Scenario: Conversation export filename structure
+- **WHEN** the user exports a conversation named "My chat"
+- **THEN** the filename SHALL follow the pattern `YYYY-MM-DD_my_chat_chat_conversation.json`
+
+#### Scenario: Table CSV download filename structure
+- **WHEN** the user downloads a markdown table as CSV
+- **THEN** the default filename SHALL follow the pattern `YYYY-MM-DD_table.csv`
+- **THEN** the user MAY edit this filename before confirming the download

--- a/openspec/specs/markdown-table/spec.md
+++ b/openspec/specs/markdown-table/spec.md
@@ -1,0 +1,59 @@
+## Purpose
+
+Defines the toolbar actions available on rendered markdown tables in chat messages, covering copy and download capabilities and the visual/interaction requirements for toolbar buttons.
+
+## Requirements
+
+### Requirement: Table toolbar SHALL provide copy actions for every common format
+
+A toolbar SHALL be rendered above each markdown table in a chat message, offering one-click copy of the table data as CSV, plain text (TXT), and Markdown.
+
+#### Scenario: Copy as CSV places RFC 4180-formatted data on the clipboard
+- **WHEN** the user clicks the "Copy as CSV" toolbar button
+- **THEN** the table data SHALL be written to the clipboard as RFC 4180 CSV, with each cell double-quote-escaped and commas as delimiters
+
+#### Scenario: Copy as TXT places tab-separated data on the clipboard
+- **WHEN** the user clicks the "Copy as TXT" toolbar button
+- **THEN** the table data SHALL be written to the clipboard with cells separated by tab characters and rows separated by newlines
+
+#### Scenario: Copy as Markdown places a GFM table on the clipboard
+- **WHEN** the user clicks the "Copy as MD" toolbar button
+- **THEN** the table data SHALL be written to the clipboard as a GitHub-Flavored Markdown table, including a separator row with alignment markers
+
+#### Scenario: Checkmark feedback is shown after a successful copy
+- **WHEN** the user clicks any copy toolbar button
+- **THEN** the button icon SHALL switch to a checkmark for 2 seconds, then revert to the original icon
+- **THEN** clicking the button again while the checkmark is shown SHALL have no effect
+
+### Requirement: Table toolbar SHALL provide a download action for CSV
+
+A "Download as CSV" button SHALL be present in the table toolbar, allowing the user to save the table as a `.csv` file on their filesystem.
+
+#### Scenario: Clicking Download CSV opens a filename dialog
+- **WHEN** the user clicks the "Download as CSV" toolbar button
+- **THEN** a modal dialog SHALL open with a filename input pre-filled with `YYYY-MM-DD_table.csv` (current date, ISO zero-padded)
+
+#### Scenario: Confirming the dialog triggers the file download
+- **WHEN** the user confirms the filename dialog (non-empty filename)
+- **THEN** the browser SHALL initiate a file download with the specified filename
+- **THEN** the downloaded file SHALL be UTF-8 encoded with a BOM prefix so Excel opens it correctly
+
+#### Scenario: Cancelling the dialog performs no download
+- **WHEN** the user dismisses or cancels the filename dialog
+- **THEN** no file SHALL be downloaded and the modal SHALL close
+
+### Requirement: Table toolbar SHALL be hidden while the last message is streaming
+
+The toolbar SHALL not be rendered when the assistant message containing the table is still being streamed.
+
+#### Scenario: Toolbar absent during streaming
+- **WHEN** the last message in the conversation is actively streaming
+- **THEN** the table toolbar SHALL not be visible
+
+#### Scenario: Toolbar appears after streaming completes
+- **WHEN** streaming of the last message completes
+- **THEN** the table toolbar SHALL become visible
+
+### Requirement: Table toolbar buttons SHALL use consistent ghost icon button styling
+
+All buttons in the table toolbar SHALL use the `DialGhostIconButton` component from the UI kit with `size={ElementSize.Small}`, ensuring visual consistency across all toolbar actions.


### PR DESCRIPTION
## Description of changes

Follow-up polish from designer review on issue #7563.

**1. Table toolbar buttons — migrate to `DialGhostIconButton`**

All four table toolbar buttons (Copy CSV, Copy TXT, Copy MD, Download CSV) now use `DialGhostIconButton` from `@epam/ai-dial-ui-kit` with `tooltipProps`, replacing a mix of raw Tabler icon elements and `DialButton`. The local `CopyIcon` wrapper component, `Tooltip` import, and `DialButton` import are removed from `Table.tsx`.

**2. Table CSV download filename**

Default filename changed from `table_YYYY-MM-DD.csv` → `YYYY-MM-DD_table.csv` to match the date-first convention used by all other exports.

**3. Zero-padded dates on all exports**

`getCurrentDate()` in `import-export.ts` now zero-pads month and day (`padStart(2, '0')`), so conversation and prompt export filenames use `2026-07-03_…` instead of `2026-7-3_…`.

## Applicable issues

Closes #7563

## UI changes

<img width="717" height="186" alt="image" src="https://github.com/user-attachments/assets/ee3456b1-e410-4a6c-8720-14a035ba27cf" />

## Checklist

- [x] I have added needed tests
- [x] I have informed of all necessary changes in dependent services/repositories
- [x] I have updated the documentation (if applicable)