### PR TITLE
fix(chat): fix resource name parsing in unshare dialog (Issue #6562)

### DIFF
--- a/apps/chat/src/components/Common/UnshareDialog.tsx
+++ b/apps/chat/src/components/Common/UnshareDialog.tsx
@@ -115,17 +115,22 @@ const view = withRenderWhen((state) => {
     const resourceId = unshareEntity?.id ?? unshareResourceId ?? '';
     const { bucket } = splitEntityId(resourceId);
     const isAuthor = isMyBucket(bucket);
-    const { name } = parseEntityApiKey(splitEntityId(resourceId).name, {
-      parseVersion: true,
-      parseModel: isConversationId(resourceId),
-    });
+
+    const { name: parsedName } = parseEntityApiKey(
+      splitEntityId(resourceId).name,
+      {
+        parseVersion: true,
+        parseModel: isConversationId(resourceId),
+      },
+    );
+    const name = unshareEntity?.name ?? shareResourceName ?? parsedName;
 
     return t(
       isAuthor
         ? CommonI18nKeys.ConfirmRemoveAllUsersAccess
         : CommonI18nKeys.ConfirmRemoveYourAccess,
       {
-        name: name ?? shareResourceName,
+        name,
       },
     );
   }, [


### PR DESCRIPTION
## Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #6562

## Checklist

- [x] the pull request name ends with `(Issue #<ISSUE_ID>)` (comma-separated list of issues)
- [x] I confirm that I don't share any confidential information like API keys or any other secrets and private URLs