### PR TITLE
fix: refresh catalog toolset list after create/update a toolset (#7643)

### DIFF
--- a/apps/chat/src/components/CatalogView/tests/CatalogView.spec.tsx
+++ b/apps/chat/src/components/CatalogView/tests/CatalogView.spec.tsx
@@ -99,6 +99,7 @@ describe('CatalogView', () => {
       error: null,
       schemas: [],
       toolsets: [],
+      refetchToolsets: vi.fn(),
     });
     vi.mocked(useNotification).mockReturnValue({
       notifications: [],
@@ -149,6 +150,7 @@ describe('CatalogView', () => {
           displayName: 'Search',
         },
       ],
+      refetchToolsets: vi.fn(),
     });
 
     render(<CatalogView />);
@@ -176,6 +178,7 @@ describe('CatalogView', () => {
           displayName: 'Search',
         },
       ],
+      refetchToolsets: vi.fn(),
     });
     vi.mocked(useFavoriteApplications).mockReturnValue({
       favoriteIds: new Set(),
@@ -216,6 +219,7 @@ describe('CatalogView', () => {
       error: null,
       schemas: [],
       toolsets: [],
+      refetchToolsets: vi.fn(),
     });
 
     render(<CatalogView />);
@@ -246,6 +250,7 @@ describe('CatalogView', () => {
       error: null,
       schemas: [],
       toolsets: [],
+      refetchToolsets: vi.fn(),
     });
 
     render(<CatalogView />);
@@ -273,6 +278,7 @@ describe('CatalogView', () => {
       error: null,
       schemas: [],
       toolsets: [],
+      refetchToolsets: vi.fn(),
     });
 
     render(<CatalogView />);

--- a/apps/chat/src/constants/translation-keys.ts
+++ b/apps/chat/src/constants/translation-keys.ts
@@ -163,6 +163,7 @@ export enum DeploymentsI18nKeys {
   SelectorError = 'deployments.selector.error',
   SelectorEmpty = 'deployments.selector.empty',
   SelectorCloseLabel = 'deployments.selector.closeLabel',
+  RefetchToolsetsFailed = 'deployments.refetchToolsetsFailed',
 }
 
 export enum ConversationI18nKeys {

--- a/apps/chat/src/context/DeploymentsContext.tsx
+++ b/apps/chat/src/context/DeploymentsContext.tsx
@@ -44,6 +44,8 @@ export interface DeploymentsContextType {
   schemas: ApplicationSchemaSummaryDto[];
   /** Toolsets fetched from the dedicated toolsets API for catalog surfaces. */
   toolsets: DialToolsetDto[];
+  /** Re-fetches toolsets from the API and updates the catalog list. Call after creating/updating a toolset. */
+  refetchToolsets: () => Promise<void>;
 }
 
 export const DeploymentsContext = createContext<
@@ -178,6 +180,15 @@ export const DeploymentsProvider = ({ children }: { children: ReactNode }) => {
     };
   }, [loadDeployments]);
 
+  const refetchToolsets = useCallback(async () => {
+    try {
+      const { data } = await listToolsets();
+      setToolsets(sortToolsets(data ?? []));
+    } catch (err) {
+      console.warn('[DeploymentsContext] Failed to refetch toolsets', err);
+    }
+  }, []);
+
   const items = useMemo<DeploymentItemDto[]>(() => {
     if (schemas.length === 0) return rawDeployments;
     const schemaById = new Map(schemas.map((s) => [s.id, s]));
@@ -252,6 +263,7 @@ export const DeploymentsProvider = ({ children }: { children: ReactNode }) => {
       error,
       schemas,
       toolsets,
+      refetchToolsets,
     }),
     [
       items,
@@ -263,6 +275,7 @@ export const DeploymentsProvider = ({ children }: { children: ReactNode }) => {
       error,
       schemas,
       toolsets,
+      refetchToolsets,
     ],
   );
 

--- a/apps/chat/src/context/DeploymentsContext.tsx
+++ b/apps/chat/src/context/DeploymentsContext.tsx
@@ -1,4 +1,5 @@
 import type { DeploymentConfigurationSchema } from '@epam/ai-dial-chat-shared';
+import { NotificationVariant } from '@epam/ai-dial-ui-kit';
 import {
   ListDeploymentsInterfaceTypeEnum,
   type ApplicationSchemaSummaryDto,
@@ -14,11 +15,14 @@ import {
   useMemo,
   useState,
 } from 'react';
+import { useTranslation } from 'react-i18next';
+import { DeploymentsI18nKeys } from '../constants/translation-keys';
 import { getApplicationSchemas } from '../server-api/application-schemas';
 import { getDeploymentConfiguration } from '../server-api/deployments';
 import { getDeployments } from '../server-api/deployments.api';
 import { listToolsets } from '../server-api/toolsets';
 import { useAppConfig } from './AppConfigContext';
+import { useNotification } from './NotificationContext';
 import { useUserConfig } from './UserConfigContext';
 
 export interface DeploymentsContextType {
@@ -104,6 +108,8 @@ const resolveInitialSelection = (
 };
 
 export const DeploymentsProvider = ({ children }: { children: ReactNode }) => {
+  const { t } = useTranslation();
+  const { showNotification } = useNotification();
   const { selectedDeploymentId: userConfigSelectedId, setSelectedDeployment } =
     useUserConfig();
   const { config: appConfig } = useAppConfig();
@@ -184,10 +190,13 @@ export const DeploymentsProvider = ({ children }: { children: ReactNode }) => {
     try {
       const { data } = await listToolsets();
       setToolsets(sortToolsets(data ?? []));
-    } catch (err) {
-      console.warn('[DeploymentsContext] Failed to refetch toolsets', err);
+    } catch {
+      showNotification({
+        variant: NotificationVariant.Error,
+        message: t(DeploymentsI18nKeys.RefetchToolsetsFailed),
+      });
     }
-  }, []);
+  }, [showNotification, t]);
 
   const items = useMemo<DeploymentItemDto[]>(() => {
     if (schemas.length === 0) return rawDeployments;

--- a/apps/chat/src/context/tests/DeploymentsContext.spec.tsx
+++ b/apps/chat/src/context/tests/DeploymentsContext.spec.tsx
@@ -476,5 +476,58 @@ describe('DeploymentsContext', () => {
         expect(result.current.toolsets).toEqual([]);
       });
     });
+
+    it('refetchToolsets re-fetches and exposes the newly created toolset', async () => {
+      const { result } = renderHook(() => useDeployments(), {
+        wrapper: DeploymentsProvider,
+      });
+
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+      expect(result.current.toolsets).toEqual([]);
+
+      const created = {
+        id: 'toolsets/b/new-tool__0.0.1',
+        toolset: 'toolsets/b/new-tool__0.0.1',
+        displayName: 'New Tool',
+      };
+      mockListToolsets.mockResolvedValueOnce({ data: [created] });
+
+      await act(async () => {
+        await result.current.refetchToolsets();
+      });
+
+      expect(result.current.toolsets.map((item) => item.id)).toEqual([
+        created.id,
+      ]);
+    });
+
+    it('refetchToolsets leaves toolsets unchanged when the re-fetch fails', async () => {
+      const existing = {
+        id: 'toolsets/b/alpha__0.0.1',
+        toolset: 'toolsets/b/alpha__0.0.1',
+        displayName: 'Alpha Toolset',
+      };
+      mockListToolsets.mockResolvedValueOnce({ data: [existing] });
+
+      const { result } = renderHook(() => useDeployments(), {
+        wrapper: DeploymentsProvider,
+      });
+
+      await waitFor(() =>
+        expect(result.current.toolsets.map((item) => item.id)).toEqual([
+          existing.id,
+        ]),
+      );
+
+      mockListToolsets.mockRejectedValueOnce(new Error('Toolsets failed'));
+
+      await act(async () => {
+        await result.current.refetchToolsets();
+      });
+
+      expect(result.current.toolsets.map((item) => item.id)).toEqual([
+        existing.id,
+      ]);
+    });
   });
 });

--- a/apps/chat/src/context/tests/DeploymentsContext.spec.tsx
+++ b/apps/chat/src/context/tests/DeploymentsContext.spec.tsx
@@ -1,5 +1,7 @@
+import { NotificationVariant } from '@epam/ai-dial-ui-kit';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { DeploymentsI18nKeys } from '../../constants/translation-keys';
 import * as applicationSchemasApi from '../../server-api/application-schemas';
 import * as deploymentsApi from '../../server-api/deployments.api';
 import * as toolsetsApi from '../../server-api/toolsets';
@@ -9,6 +11,7 @@ const contextMocks = vi.hoisted(() => ({
   defaultDeploymentId: null as string | null,
   selectedDeploymentId: null as string | null,
   setSelectedDeployment: vi.fn(),
+  showNotification: vi.fn(),
 }));
 
 vi.mock('../../server-api/deployments.api');
@@ -25,6 +28,13 @@ vi.mock('../UserConfigContext', () => ({
   useUserConfig: () => ({
     selectedDeploymentId: contextMocks.selectedDeploymentId,
     setSelectedDeployment: contextMocks.setSelectedDeployment,
+  }),
+}));
+vi.mock('../NotificationContext', () => ({
+  useNotification: () => ({
+    notifications: [],
+    showNotification: contextMocks.showNotification,
+    dismissNotification: vi.fn(),
   }),
 }));
 
@@ -528,6 +538,10 @@ describe('DeploymentsContext', () => {
       expect(result.current.toolsets.map((item) => item.id)).toEqual([
         existing.id,
       ]);
+      expect(contextMocks.showNotification).toHaveBeenCalledWith({
+        variant: NotificationVariant.Error,
+        message: DeploymentsI18nKeys.RefetchToolsetsFailed,
+      });
     });
   });
 });

--- a/apps/chat/src/hooks/tests/useDeploymentChangeEffect.spec.ts
+++ b/apps/chat/src/hooks/tests/useDeploymentChangeEffect.spec.ts
@@ -20,6 +20,7 @@ const makeDeploymentsContext = (selectedItemId: string | null) => ({
   error: null,
   schemas: [],
   toolsets: [],
+  refetchToolsets: vi.fn(),
 });
 
 describe('useDeploymentChangeEffect', () => {

--- a/apps/chat/src/i18n/locales/en.json
+++ b/apps/chat/src/i18n/locales/en.json
@@ -141,7 +141,8 @@
       "error": "Failed to load models",
       "empty": "No models available",
       "closeLabel": "Close model selector"
-    }
+    },
+    "refetchToolsetsFailed": "Failed to refresh toolsets. The Catalog list may be out of date."
   },
   "buttons": {
     "showMore": "Show more",

--- a/apps/chat/src/pages/ConversationRoute/ConversationRoute.spec.tsx
+++ b/apps/chat/src/pages/ConversationRoute/ConversationRoute.spec.tsx
@@ -186,6 +186,7 @@ describe('ConversationRoute', () => {
       error: null,
       schemas: [],
       toolsets: [],
+      refetchToolsets: vi.fn(),
     });
     mockUseUser.mockReturnValue({
       user: { sub: 'u1', providerId: 'p1', claims: {}, bucket: 'user-bucket' },
@@ -295,6 +296,7 @@ describe('ConversationRoute', () => {
       error: null,
       schemas: [],
       toolsets: [],
+      refetchToolsets: vi.fn(),
     });
 
     renderRoute();
@@ -320,6 +322,7 @@ describe('ConversationRoute', () => {
       error: null,
       schemas: [],
       toolsets: [],
+      refetchToolsets: vi.fn(),
     });
     renderRoute();
     await waitFor(() => {
@@ -345,6 +348,7 @@ describe('ConversationRoute', () => {
       error: null,
       schemas: [],
       toolsets: [],
+      refetchToolsets: vi.fn(),
     });
     renderRoute();
     await waitFor(() => {
@@ -381,6 +385,7 @@ describe('ConversationRoute', () => {
       error: null,
       schemas: [],
       toolsets: [],
+      refetchToolsets: vi.fn(),
     });
 
     renderRoute();
@@ -429,6 +434,7 @@ describe('ConversationRoute', () => {
       error: null,
       schemas: [],
       toolsets: [],
+      refetchToolsets: vi.fn(),
     });
 
     renderRoute();
@@ -476,6 +482,7 @@ describe('ConversationRoute', () => {
       error: null,
       schemas: [],
       toolsets: [],
+      refetchToolsets: vi.fn(),
     });
     mockCreateConversation.mockRejectedValueOnce({
       response: {

--- a/apps/chat/src/pages/ToolsetEditor/ToolsetEditor.tsx
+++ b/apps/chat/src/pages/ToolsetEditor/ToolsetEditor.tsx
@@ -7,6 +7,7 @@ import { useNavigate, useSearchParams } from 'react-router-dom';
 import RouteFallback from '../../components/RouteFallback/RouteFallback';
 import { ToolsetEditorQuery } from '../../constants/toolsets';
 import { ToolsetEditorI18nKeys } from '../../constants/translation-keys';
+import { useDeployments } from '../../context/DeploymentsContext';
 import { useNotification } from '../../context/NotificationContext';
 import {
   createToolset,
@@ -40,6 +41,7 @@ import ToolsetEditorView from './ToolsetEditorView';
 const ToolsetEditor: FC = () => {
   const { t } = useTranslation();
   const { showNotification } = useNotification();
+  const { refetchToolsets } = useDeployments();
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
 
@@ -267,6 +269,7 @@ const ToolsetEditor: FC = () => {
       const result = isEditMode
         ? await updateToolset(toolsetId, body)
         : await createToolset(body);
+      await refetchToolsets();
       try {
         const isRedirecting = await runPostSaveAuth(result.id, form);
         if (!isRedirecting) navigate(returnUrl);
@@ -299,6 +302,7 @@ const ToolsetEditor: FC = () => {
     showNotification,
     handleChangeStep,
     runPostSaveAuth,
+    refetchToolsets,
   ]);
 
   if (isLoading || !form) {

--- a/apps/chat/src/pages/ToolsetEditor/tests/ToolsetEditor.spec.tsx
+++ b/apps/chat/src/pages/ToolsetEditor/tests/ToolsetEditor.spec.tsx
@@ -4,6 +4,7 @@ import userEvent from '@testing-library/user-event';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ToolsetEditorI18nKeys } from '../../../constants/translation-keys';
+import { useDeployments } from '../../../context/DeploymentsContext';
 import { useNotification } from '../../../context/NotificationContext';
 import * as toolsetsApi from '../../../server-api/toolsets';
 import { ROUTES } from '../../../types/routes';
@@ -19,8 +20,10 @@ vi.mock('../../../server-api/toolsets', () => ({
 }));
 
 vi.mock('../../../context/NotificationContext');
+vi.mock('../../../context/DeploymentsContext');
 
 const mockShowNotification = vi.fn();
+const mockRefetchToolsets = vi.fn();
 
 vi.mock('../../../components/RouteFallback/RouteFallback', () => ({
   default: () => <div>Loading</div>,
@@ -84,6 +87,10 @@ describe('ToolsetEditor', () => {
       showNotification: mockShowNotification,
       dismissNotification: vi.fn(),
     });
+    mockRefetchToolsets.mockResolvedValue(undefined);
+    vi.mocked(useDeployments).mockReturnValue({
+      refetchToolsets: mockRefetchToolsets,
+    } as unknown as ReturnType<typeof useDeployments>);
   });
 
   it('logs in a newly created API-key toolset using the returned id', async () => {
@@ -110,6 +117,23 @@ describe('ToolsetEditor', () => {
         }),
       ),
     );
+  });
+
+  it('refetches toolsets after a successful create so the catalog list stays in sync', async () => {
+    renderEditor();
+
+    await user.click(
+      await screen.findByRole('button', {
+        name: 'fill-api-key-toolset',
+      }),
+    );
+    await user.click(
+      screen.getByRole('button', {
+        name: 'save-toolset',
+      }),
+    );
+
+    await waitFor(() => expect(mockRefetchToolsets).toHaveBeenCalledOnce());
   });
 
   it('shows an error notification when create fails', async () => {


### PR DESCRIPTION
## Description of changes

- Newly created/updated toolsets didn't appear in the Catalog until a full page reload, because `DeploymentsContext` loaded toolsets once on mount with no way to re-fetch them.
- Added `refetchToolsets()` to `DeploymentsContext` and call it from `ToolsetEditor.handleSave` right after a successful create/update, before navigating back to the catalog.

## Applicable issues

- https://github.com/epam/ai-dial-chat/issues/7643

## Checklist

- [X] the pull request name ends with `(Issue #<ISSUE_ID>)` (comma-separated list of issues)
- [X] I confirm that I don't share any confidential information like API keys or any other secrets and private URLs