### PR TITLE
fix(chat): change conversation scrolling container

### DIFF
--- a/apps/chat/src/components/ConversationView/ConversationView.tsx
+++ b/apps/chat/src/components/ConversationView/ConversationView.tsx
@@ -424,11 +424,11 @@ const ConversationView: FC<Props> = ({
           aria-label={t(ChatI18nKeys.ConversationMessages)}
           aria-live="polite"
           aria-relevant="additions"
-          className="mx-auto flex w-full max-w-[760px] flex-1 flex-col overflow-y-auto overflow-x-hidden"
+          className="flex w-full flex-1 flex-col overflow-y-auto overflow-x-hidden"
         >
           <div
             ref={contentRef}
-            className="flex min-w-0 shrink-0 flex-col gap-[26px] px-6 pt-7"
+            className="mx-auto flex w-full min-w-0 max-w-[760px] shrink-0 flex-col gap-[26px] px-6 pt-7"
           >
             {messages.map((msg, index) => {
               const isThisMessageEditing = editingMessageIndexes?.has(index);


### PR DESCRIPTION
## Description of changes

Move the chat message list's width constraint from the scroll container to its inner content wrapper, so the scrollbar sits at the chat panel's right edge instead of hugging the centered message column.

## UI changes

<img width="1398" height="1307" alt="2026-07-08_115739" src="https://github.com/user-attachments/assets/c4bb32fc-2710-4474-8abb-7e5d2470fa29" />


## Checklist

- [ ] the pull request name ends with `(Issue #<ISSUE_ID>)` (comma-separated list of issues)
- [X] I confirm that I don't share any confidential information like API keys or any other secrets and private URLs
