### PR TITLE
feat(ci): make DIAL route path configurable via environment variable

### DIFF
--- a/.github/workflows/claude-security-review.yml
+++ b/.github/workflows/claude-security-review.yml
@@ -61,6 +61,6 @@ jobs:
             --max-turns 50
             --allowedTools "Glob,Grep,LS,Read,Task,Skill,Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(gh pr checks:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr review:--comment*),Bash(gh pr comment:*),mcp__github_comment__update_claude_comment,mcp__github_inline_comment__create_inline_comment"
         env:
-          ANTHROPIC_BASE_URL: "${{ vars.DIAL_CORE_URL }}/anthropic"
+          ANTHROPIC_BASE_URL: "${{ vars.DIAL_CORE_URL }}/${{ vars.DIAL_ROUTE_PATH || 'anthropic' }}"
           ANTHROPIC_AUTH_TOKEN: ${{ secrets.DIAL_API_KEY }}
           CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: 1

--- a/.github/workflows/run-agent.yml
+++ b/.github/workflows/run-agent.yml
@@ -71,6 +71,10 @@ jobs:
           # set this to a deployment your key actually has. If unset, the
           # platform falls back to `anthropic.<manifest model>`.
           DIAL_MODEL: ${{ vars.DIAL_MODEL }}
+          # Route segment appended to DIAL_CORE_URL for the Anthropic-compatible
+          # endpoint. Defaults to `anthropic`; override via the DIAL_ROUTE_PATH
+          # Actions variable (e.g. `claude_code_router`) without editing code.
+          DIAL_ROUTE_PATH: ${{ vars.DIAL_ROUTE_PATH }}
         run: |
           set -euo pipefail
           if [ -n "${DIAL_CORE_URL:-}" ]; then
@@ -78,7 +82,7 @@ jobs:
               echo "::error::DIAL_CORE_URL is set but the DIAL_API_KEY secret is missing."
               exit 1
             fi
-            base="${DIAL_CORE_URL%/}/anthropic"
+            base="${DIAL_CORE_URL%/}/${DIAL_ROUTE_PATH:-anthropic}"
             { echo "ANTHROPIC_BASE_URL=${base}"
               echo "ANTHROPIC_AUTH_TOKEN=${DIAL_API_KEY}"
               echo "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1"


### PR DESCRIPTION
**Description:**

Enable configurability of the DIAL route path in CI/CD workflows via the `DIAL_ROUTE_PATH` environment variable, defaulting to `anthropic`. This allows deployments to use custom route paths (e.g., `claude_code_router`) without modifying workflow code.

**UI changes**

No UI changes

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `feat(ci):`
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs