### PR TITLE
feat(chat): add repair button for recalculating toolset auth settings (Issue #7685)

### DIFF
--- a/apps/chat/public/locales/en/common.json
+++ b/apps/chat/public/locales/en/common.json
@@ -277,5 +277,10 @@
   "RAG": "RAG",
   "Text Generation": "Text Generation",
   "Image Generation": "Image Generation",
-  "Image Recognition": "Image Recognition"
+  "Image Recognition": "Image Recognition",
+  "Continue": "Continue",
+  "Repair": "Repair",
+  "Repair will re-register this toolset with the Authorization Server and sign out all users. They will need to sign in again. Continue?": "Repair will re-register this toolset with the Authorization Server and sign out all users. They will need to sign in again. Continue?",
+  "Toolset repaired. Users must re-authenticate.": "Toolset repaired. Users must re-authenticate.",
+  "Authorization server is currently unavailable. Try again once the AS is back.": "Authorization server is currently unavailable. Try again once the AS is back."
 }

--- a/apps/chat/src/components/Common/ConfirmDialog.tsx
+++ b/apps/chat/src/components/Common/ConfirmDialog.tsx
@@ -16,6 +16,7 @@ interface Props {
   cancelLabel?: string | null;
   headingClassName?: string;
   showHeadingTooltip?: boolean;
+  overlayClassName?: string;
   onClose: (isConfirmed: boolean) => void;
 }
 
@@ -28,6 +29,7 @@ export const ConfirmDialog = ({
   isOpen,
   onClose,
   showHeadingTooltip,
+  overlayClassName,
 }: Props) => {
   const confirmLabelRef = useRef<HTMLButtonElement>(null);
 
@@ -55,6 +57,7 @@ export const ConfirmDialog = ({
       state={isOpen ? ModalState.OPENED : ModalState.CLOSED}
       onClose={() => onClose(false)}
       dataQa="confirmation-dialog"
+      overlayClassName={overlayClassName}
       containerClassName="inline-block w-full min-w-[90%] px-3 py-4 md:p-6 text-center md:min-w-[300px] md:max-w-[500px]"
       dismissProps={DISALLOW_INTERACTIONS}
       hideClose

--- a/apps/chat/src/components/Marketplace/ToolsetRepairButton.tsx
+++ b/apps/chat/src/components/Marketplace/ToolsetRepairButton.tsx
@@ -1,0 +1,92 @@
+import { FC, useCallback, useState } from 'react';
+
+import { useTranslation } from '@/src/hooks/useTranslation';
+
+import { isMarketplaceEntityPublic } from '@/src/utils/app/application';
+import { isEntityIdExternal, isMyToolset } from '@/src/utils/app/id';
+import { isToolsetSignedIn } from '@/src/utils/app/toolsets';
+
+import { ToolsetModel } from '@/src/types/toolsets';
+import { Translation } from '@/src/types/translation';
+
+import { AuthSelectors } from '@/src/store/auth/auth.selectors';
+import { useAppDispatch, useAppSelector } from '@/src/store/hooks';
+import { ToolsetActions } from '@/src/store/toolset/toolset.reducer';
+import { ToolsetSelectors } from '@/src/store/toolset/toolset.selectors';
+
+import { CommonI18nKeys } from '@/src/constants/i18n';
+
+import { ConfirmDialog } from '@/src/components/Common/ConfirmDialog';
+
+import { SharePermission, ToolsetAuthTypes } from '@epam/ai-dial-shared';
+import { DialNeutralButton } from '@epam/ai-dial-ui-kit';
+
+interface ToolsetRepairButtonProps {
+  toolset?: ToolsetModel;
+  authType?: ToolsetAuthTypes;
+}
+
+export const ToolsetRepairButton: FC<ToolsetRepairButtonProps> = ({
+  toolset,
+  authType: authTypeProp,
+}) => {
+  const { t } = useTranslation(Translation.Common);
+  const dispatch = useAppDispatch();
+
+  const authType = authTypeProp ?? toolset?.authSettings?.authenticationType;
+
+  const isAdmin = useAppSelector(AuthSelectors.selectIsAdmin);
+  const isLoading = useAppSelector(
+    ToolsetSelectors.selectIsToolsetDetailsLoading,
+  );
+
+  const [isRepairing, setIsRepairing] = useState(false);
+
+  const isPublicAndAdmin =
+    !!toolset && isAdmin && isMarketplaceEntityPublic(toolset);
+  const isPrivateAndSignedOut =
+    !!toolset && isMyToolset(toolset) && !isToolsetSignedIn(toolset);
+
+  const canRepair =
+    toolset &&
+    (isPublicAndAdmin ||
+      isPrivateAndSignedOut ||
+      (isEntityIdExternal(toolset) &&
+        toolset.sharedWithMe &&
+        toolset.permissions?.includes(SharePermission.WRITE)));
+
+  const showRepair =
+    canRepair &&
+    toolset?.authSettings?.dynamicallyRegistered &&
+    authType === ToolsetAuthTypes.OAUTH;
+
+  const handleRepair = useCallback(() => {
+    dispatch(ToolsetActions.repairToolset({ id: toolset?.id as string }));
+    setIsRepairing(false);
+  }, [dispatch, toolset]);
+
+  if (!showRepair) return null;
+
+  return (
+    <>
+      <DialNeutralButton
+        disabled={isLoading}
+        label={t(CommonI18nKeys.Repair)}
+        onClick={() => setIsRepairing(true)}
+      />
+
+      <ConfirmDialog
+        isOpen={isRepairing}
+        overlayClassName="!z-[101]"
+        heading={t(CommonI18nKeys.Repair)}
+        description={t(CommonI18nKeys.RepairDescription)}
+        confirmLabel={t(CommonI18nKeys.Continue)}
+        cancelLabel={t(CommonI18nKeys.Cancel)}
+        onClose={(isConfirmed) => {
+          if (isConfirmed) handleRepair();
+          else setIsRepairing(false);
+        }}
+      />
+    </>
+  );
+};

--- a/apps/chat/src/components/Marketplace/ToolsetsDetails/ToolsetDetailsFooter.tsx
+++ b/apps/chat/src/components/Marketplace/ToolsetsDetails/ToolsetDetailsFooter.tsx
@@ -13,6 +13,7 @@ import { ModelVersionSelect } from '@/src/components/Chat/ModelVersionSelect';
 import { IconButton } from '@/src/components/Common/IconButton';
 import { MarketplaceEntityContextMenu } from '@/src/components/Marketplace/EntityContextMenu/MarketplaceEntityContextMenu';
 import { MarketplaceEntityBookmark } from '@/src/components/Marketplace/MarketplaceEntityBookmark';
+import { ToolsetRepairButton } from '@/src/components/Marketplace/ToolsetRepairButton';
 import { LoginButton } from '@/src/components/Marketplace/ToolsetsDetails/LoginButton';
 import { ToolsetDetailsFooterProps } from '@/src/components/Marketplace/ToolsetsDetails/ToolsetDetails';
 
@@ -90,6 +91,8 @@ export function ToolsetDetailsFooter({
           />
 
           <LoginButton entity={entity} />
+
+          <ToolsetRepairButton toolset={entity} />
         </div>
       </div>
     </section>

--- a/apps/chat/src/components/ToolsetEditor/EditorForm/AuthField.tsx
+++ b/apps/chat/src/components/ToolsetEditor/EditorForm/AuthField.tsx
@@ -131,6 +131,7 @@ const AuthTypeSection = ({
                 onLogout={onLogout}
                 disabled={isDisabled}
                 fieldsTooltip={tooltip}
+                withRepair
               />
             )}
           </>

--- a/apps/chat/src/components/ToolsetEditor/ToolsetLoginForm.tsx
+++ b/apps/chat/src/components/ToolsetEditor/ToolsetLoginForm.tsx
@@ -22,6 +22,7 @@ import { Field } from '@/src/components/Common/Forms/Field';
 import { withErrorMessage } from '@/src/components/Common/Forms/FieldErrorMessage';
 import { withLabel } from '@/src/components/Common/Forms/Label';
 import { MultipleComboBox } from '@/src/components/Common/MultipleComboBox';
+import { ToolsetRepairButton } from '@/src/components/Marketplace/ToolsetRepairButton';
 
 import { ToolsetLoginFormType, WithLogin } from './form';
 
@@ -50,6 +51,7 @@ interface ToolsetLoginFormProps {
   onLogin?: (data: ToolsetLoginFormType) => void;
   hideConfigFields?: boolean;
   fieldsInfo?: Partial<Record<keyof ToolsetLoginFormType, string>>;
+  withRepair?: boolean;
 }
 
 export const ToolsetLoginForm = ({
@@ -64,6 +66,7 @@ export const ToolsetLoginForm = ({
   onLogin,
   hideConfigFields = false,
   fieldsInfo,
+  withRepair = false,
 }: ToolsetLoginFormProps) => {
   const { t } = useTranslation(Translation.Common);
 
@@ -81,6 +84,8 @@ export const ToolsetLoginForm = ({
     name: 'withLogin',
     control,
   });
+
+  const showRepair = withRepair && withLogin === WithLogin.WithLogin;
 
   const handleSubmit = useCallback(() => {
     if (isSignedIn) {
@@ -200,19 +205,25 @@ export const ToolsetLoginForm = ({
           </>
         )}
 
-      {withLogin !== WithLogin.WithoutLogin && (
-        <LogInButton
-          className={classNames('flex w-fit items-center', buttonClassName)}
-          disabled={disabled || (!isValid && !isSignedIn)}
-          onClick={handleSubmit}
-          iconBefore={<LoginIcon size={18} />}
-          label={t(
-            isSignedIn
-              ? CommonI18nKeys.LogOutCommon
-              : CommonI18nKeys.LogInCommon,
-          )}
-        />
-      )}
+      <div className="flex items-center gap-2">
+        {withLogin !== WithLogin.WithoutLogin && (
+          <LogInButton
+            className={classNames('flex w-fit items-center', buttonClassName)}
+            disabled={disabled || (!isValid && !isSignedIn)}
+            onClick={handleSubmit}
+            iconBefore={<LoginIcon size={18} />}
+            label={t(
+              isSignedIn
+                ? CommonI18nKeys.LogOutCommon
+                : CommonI18nKeys.LogInCommon,
+            )}
+          />
+        )}
+
+        {showRepair && (
+          <ToolsetRepairButton toolset={toolset} authType={type} />
+        )}
+      </div>
     </div>
   );
 };

--- a/apps/chat/src/constants/i18n.ts
+++ b/apps/chat/src/constants/i18n.ts
@@ -349,6 +349,11 @@ export enum CommonI18nKeys {
   ShareApplicationWithPublicResourcesFailed = 'Sharing failed. You are only allowed to share applications with resources from "My files"',
   LogOutBeforeEditingToolset = 'Log out before editing toolset',
   TraceId = 'Trace ID',
+  Continue = 'Continue',
+  Repair = 'Repair',
+  RepairDescription = 'Repair will re-register this toolset with the Authorization Server and sign out all users. They will need to sign in again. Continue?',
+  ToolsetRepairSuccessMessage = 'Toolset repaired. Users must re-authenticate.',
+  ToolsetRepairFailedMessage = 'Authorization server is currently unavailable. Try again once the AS is back.',
 }
 
 // errors.json

--- a/apps/chat/src/constants/server.ts
+++ b/apps/chat/src/constants/server.ts
@@ -43,6 +43,9 @@ export const mappingServerUrls: Record<string, { response: boolean }> = {
   [ServerSlugs.TOOLSET_SIGN_OUT]: {
     response: false,
   },
+  [ServerSlugs.TOOLSET]: {
+    response: true,
+  },
 };
 
 export enum HeadersNames {

--- a/apps/chat/src/pages/api/ops/[...slug].ts
+++ b/apps/chat/src/pages/api/ops/[...slug].ts
@@ -3,4 +3,5 @@ import { createDialApiSlugsHandler } from '@/src/utils/server/api-slug-handler';
 export default createDialApiSlugsHandler({
   generalErrorMessage: 'Operation failed',
   pathParameter: 'ops',
+  dynamicSlugs: true,
 });

--- a/apps/chat/src/store/toolset/toolset.epics.ts
+++ b/apps/chat/src/store/toolset/toolset.epics.ts
@@ -1203,6 +1203,62 @@ const expireLoggedInToolsetsCredsEpic: AppEpic = (action$, state$) =>
     }),
   );
 
+const repairToolsetEpic: AppEpic = (action$) =>
+  action$.pipe(
+    ofType(ToolsetActions.repairToolset.type),
+    switchMap(({ payload }) =>
+      ToolsetService.repair(payload.id).pipe(
+        switchMap(() =>
+          ToolsetService.getToolsetById(payload.id).pipe(
+            switchMap((toolset) => {
+              return toolset
+                ? concat(
+                    of(ToolsetActions.getToolsetDetailsSuccess(toolset)),
+                    of(
+                      UIActions.showSuccessToast(
+                        translate(CommonI18nKeys.ToolsetRepairSuccessMessage, {
+                          ns: Translation.Common,
+                        }),
+                      ),
+                    ),
+                  )
+                : of(ToolsetActions.repairToolsetFailed(payload));
+            }),
+          ),
+        ),
+        catchError((err) => {
+          const { traceId } = parseApiError(err);
+
+          return of(
+            ToolsetActions.repairToolsetFailed({
+              ...payload,
+              traceId,
+              status: err.status as number | undefined,
+            }),
+          );
+        }),
+      ),
+    ),
+  );
+
+const repairToolsetFailEpic: AppEpic = (action$) =>
+  action$.pipe(
+    ofType(ToolsetActions.repairToolsetFailed.type),
+    map(({ payload }) => {
+      const message =
+        payload.status === 424
+          ? CommonI18nKeys.ToolsetRepairFailedMessage
+          : CommonI18nKeys.GeneralServerError;
+
+      return UIActions.showErrorToast({
+        message: translate(message, {
+          ns: Translation.Common,
+        }),
+        traceId: payload.traceId,
+      });
+    }),
+  );
+
 export const ToolsetEpics = combineEpics(
   initEpic,
   getToolsetsEpic,
@@ -1215,6 +1271,8 @@ export const ToolsetEpics = combineEpics(
   initQueryParamsEpic,
   exitEditorEpic,
   expireLoggedInToolsetsCredsEpic,
+  repairToolsetEpic,
+  repairToolsetFailEpic,
 
   //Delete
   deleteToolsetEpic,

--- a/apps/chat/src/store/toolset/toolset.reducer.ts
+++ b/apps/chat/src/store/toolset/toolset.reducer.ts
@@ -286,6 +286,15 @@ export const toolsetSlice = createSlice({
         shouldSelectToolset?: boolean;
       }>,
     ) => state,
+    repairToolset: (state, _action: PayloadAction<{ id: string }>) => {
+      state.toolsetDetailsStatus = UploadStatus.LOADING;
+    },
+    repairToolsetFailed: (
+      state,
+      _action: PayloadAction<{ id: string; status?: number; traceId?: string }>,
+    ) => {
+      state.toolsetDetailsStatus = UploadStatus.LOADED;
+    },
   },
 });
 

--- a/apps/chat/src/types/slugs-types.ts
+++ b/apps/chat/src/types/slugs-types.ts
@@ -14,6 +14,7 @@ export enum ServerSlugs {
   APPLICATION_UNDEPLOY = `application/${SimpleApplicationStatus.UNDEPLOY}`,
   APPLICATION_REDEPLOY = `application/${SimpleApplicationStatus.REDEPLOY}`,
   APPLICATION_LOGS = 'application/logs',
+  TOOLSET = 'toolset',
   TOOLSET_SIGN_IN = 'toolset/signin',
   TOOLSET_SIGN_OUT = 'toolset/signout',
 }

--- a/apps/chat/src/types/toolsets.ts
+++ b/apps/chat/src/types/toolsets.ts
@@ -35,6 +35,7 @@ export interface ToolsetModel extends ShareEntity {
 
   authSettings: {
     authenticationType: ToolsetAuthTypes;
+    dynamicallyRegistered?: boolean;
     // API Key flow
     apiKeyHeader?: string;
     // OAuth flow

--- a/apps/chat/src/utils/app/data/toolset-service.ts
+++ b/apps/chat/src/utils/app/data/toolset-service.ts
@@ -1,6 +1,9 @@
 import { Observable, catchError, map, of } from 'rxjs';
 
-import { isPredefinedEntity } from '@/src/utils/app/id';
+import {
+  getIdWithoutFeatureType,
+  isPredefinedEntity,
+} from '@/src/utils/app/id';
 import { convertToolsetFromApi } from '@/src/utils/app/toolsets';
 import { ApiUtils, getOpsApiUrl } from '@/src/utils/server/api';
 
@@ -72,5 +75,16 @@ export class ToolsetService {
       method: HTTPMethod.POST,
       body: JSON.stringify(data),
     });
+  }
+
+  public static repair(id: string): Observable<void> {
+    const path = getIdWithoutFeatureType(id);
+
+    return ApiUtils.request(
+      `/api/ops/toolset/${ApiUtils.encodeApiUrl(path)}/repair`,
+      {
+        method: HTTPMethod.POST,
+      },
+    );
   }
 }

--- a/apps/chat/src/utils/app/toolsets.ts
+++ b/apps/chat/src/utils/app/toolsets.ts
@@ -73,6 +73,8 @@ export const convertToolsetFromApi = (data: Toolset): ToolsetModel => {
     authSettings: {
       authenticationType:
         data.auth_settings?.authentication_type ?? ToolsetAuthTypes.NONE,
+      dynamicallyRegistered:
+        data.auth_settings?.dynamically_registered ?? false,
       authStatus: parseToolsetApiAuthStatus(data),
       clientId: data.auth_settings.client_id,
       clientSecret: data.auth_settings.client_secret,
@@ -120,6 +122,9 @@ const convertToolsetAuthSettingsToApi = (data: ToolsetModel) => {
         }),
         ...(data.authSettings.codeChallengeMethod && {
           code_challenge_method: data.authSettings.codeChallengeMethod,
+        }),
+        ...(data.authSettings.dynamicallyRegistered && {
+          dynamically_registered: data.authSettings.dynamicallyRegistered,
         }),
       };
     default:

--- a/libs/shared/src/types/toolsets.ts
+++ b/libs/shared/src/types/toolsets.ts
@@ -39,6 +39,7 @@ export interface Toolset {
 
   auth_settings: {
     authentication_type: ToolsetAuthTypes;
+    dynamically_registered?: boolean;
     // TODO: remove redirectUri after toolset login is stable with new flow (redirectUri will be sent in login request)
     redirect_uri?: string;
     api_key_header?: string;


### PR DESCRIPTION
## Description of changes

- add ***Repair*** button into toolset settings and marketplace card view for recalculating toolset auth settings that was dynamically set by Core. Only shown for toolsets with OAuth type.

## Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #7685

## Checklist

- [x] the pull request name ends with `(Issue #<ISSUE_ID>)` (comma-separated list of issues)
- [x] I confirm that I don't share any confidential information like API keys or any other secrets and private URLs