### PR TITLE
fix: double pre-release suffix in npm versioning

### DIFF
--- a/tools/publish-lib.mjs
+++ b/tools/publish-lib.mjs
@@ -117,6 +117,13 @@ for (const nodeName of Object.keys(graph.nodes)) {
 const isWorkspaceLib = (dep) => workspacePackageNames.has(dep);
 
 function getDevelopmentVersion(packageName, baseVersion) {
+  // If the base version is already a pre-release (e.g. computed per-build by
+  // CI as #.#.#-dev.N), it's already unique — reuse it as-is. Appending our
+  // own "-dev.N" on top would produce an invalid double pre-release version.
+  if (baseVersion.includes('-')) {
+    return baseVersion;
+  }
+
   let publishedVersions;
 
   try {


### PR DESCRIPTION
## Description of changes

`getDevelopmentVersion()` in `tools/publish-lib.mjs` unconditionally appended `-dev.N` to the base version, assuming it was always a plain `#.#.#`. When the root `package.json` version is already a pre-release computed upstream by CI (e.g. `1.1.0-dev.249`, a per-build counter), this produced an invalid double pre-release string (`1.1.0-dev.249-dev.0`), which npm rejected during publish.

## Checklist

- [ ] the pull request name ends with `(Issue #<ISSUE_ID>)` (comma-separated list of issues)
- [X] I confirm that I don't share any confidential information like API keys or any other secrets and private URLs
