### PR TITLE
fix(chat): scroll to bottom on open a conversation (#7723)

### DIFF
--- a/apps/chat-api/src/share/tests/share.service.spec.ts
+++ b/apps/chat-api/src/share/tests/share.service.spec.ts
@@ -5,8 +5,8 @@ import {
 } from '@nestjs/common';
 import type { ConfigService } from '@nestjs/config';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import type { DialClientService } from '../../dial/dial-client.service';
 import type { EnvironmentVariables } from '../../config/environment.config';
+import type { DialClientService } from '../../dial/dial-client.service';
 import { ShareAccess } from '../dto/create-share-link.dto';
 import { ShareService } from '../share.service';
 

--- a/apps/chat/src/components/ConversationView/ConversationView.tsx
+++ b/apps/chat/src/components/ConversationView/ConversationView.tsx
@@ -347,7 +347,11 @@ const ConversationView: FC<Props> = ({
     isScrollButtonVisible,
     scrollToBottom,
     armAnchor,
-  } = useConversationScroll({ messages, isAssistantTyping });
+  } = useConversationScroll({
+    messages,
+    isAssistantTyping,
+    conversationId: conversation.id,
+  });
 
   const handleSendWithAnchor = useCallback(
     async (message: string, attachments: Attachment[]) => {

--- a/apps/chat/src/hooks/conversation/tests/useConversationScroll.spec.tsx
+++ b/apps/chat/src/hooks/conversation/tests/useConversationScroll.spec.tsx
@@ -138,4 +138,35 @@ describe('useConversationScroll', () => {
       behavior: 'smooth',
     });
   });
+
+  it('scrolls a selected conversation to the bottom after streaming stops when the switch happened during streaming', () => {
+    const messages = makeMessages(6);
+    const { rerender } = render(
+      <ScrollHarness conversationId="conversation-a" messages={messages} />,
+    );
+    scrollToMock.mockClear();
+
+    rerender(
+      <ScrollHarness
+        conversationId="conversation-b"
+        isAssistantTyping
+        messages={messages}
+      />,
+    );
+
+    expect(scrollToMock).not.toHaveBeenCalled();
+
+    rerender(
+      <ScrollHarness
+        conversationId="conversation-b"
+        isAssistantTyping={false}
+        messages={messages}
+      />,
+    );
+
+    expect(scrollToMock).toHaveBeenCalledWith({
+      top: 800,
+      behavior: 'smooth',
+    });
+  });
 });

--- a/apps/chat/src/hooks/conversation/tests/useConversationScroll.spec.tsx
+++ b/apps/chat/src/hooks/conversation/tests/useConversationScroll.spec.tsx
@@ -1,0 +1,141 @@
+import type { Message as MessageType } from '@epam/ai-dial-chat-shared';
+import { MessageRole } from '@epam/ai-dial-chat-shared';
+import { render } from '@testing-library/react';
+import type { RefObject } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useConversationScroll } from '../useConversationScroll';
+
+const scrollToMock = vi.fn();
+
+const makeMessages = (count: number): MessageType[] =>
+  Array.from({ length: count }, (_, index) => ({
+    role: index % 2 === 0 ? MessageRole.User : MessageRole.Assistant,
+    content: `message ${index}`,
+  })) as MessageType[];
+
+const assignRef = (
+  ref: RefObject<HTMLDivElement | null>,
+  el: HTMLDivElement | null,
+) => {
+  (ref as { current: HTMLDivElement | null }).current = el;
+};
+
+const setRect = (el: HTMLDivElement, rect: Pick<DOMRect, 'top' | 'bottom'>) => {
+  el.getBoundingClientRect = vi.fn(
+    () =>
+      ({
+        top: rect.top,
+        bottom: rect.bottom,
+        left: 0,
+        right: 100,
+        width: 100,
+        height: rect.bottom - rect.top,
+        x: 0,
+        y: rect.top,
+        toJSON: () => ({}),
+      }) as DOMRect,
+  );
+};
+
+const configureContainer = (el: HTMLDivElement) => {
+  Object.defineProperty(el, 'clientHeight', {
+    configurable: true,
+    value: 400,
+  });
+  Object.defineProperty(el, 'scrollTop', {
+    configurable: true,
+    writable: true,
+    value: 0,
+  });
+  Object.defineProperty(el, 'scrollTo', {
+    configurable: true,
+    value: scrollToMock,
+  });
+  setRect(el, { top: 0, bottom: 400 });
+};
+
+const configureContent = (el: HTMLDivElement) => {
+  setRect(el, { top: 0, bottom: 1_200 });
+};
+
+const ScrollHarness = ({
+  messages,
+  conversationId,
+  isAssistantTyping = false,
+}: {
+  messages: MessageType[];
+  conversationId: string;
+  isAssistantTyping?: boolean;
+}) => {
+  const { containerRef, contentRef, spacerRef, setMessageRef } =
+    useConversationScroll({
+      messages,
+      isAssistantTyping,
+      conversationId,
+    });
+
+  return (
+    <div
+      ref={(el) => {
+        if (el) configureContainer(el);
+        assignRef(containerRef, el);
+      }}
+    >
+      <div
+        ref={(el) => {
+          if (el) configureContent(el);
+          assignRef(contentRef, el);
+        }}
+      >
+        {messages.map((_, index) => (
+          <div
+            key={index}
+            ref={(el) => {
+              if (el)
+                setRect(el, { top: index * 100, bottom: index * 100 + 50 });
+              setMessageRef(index, el);
+            }}
+          />
+        ))}
+      </div>
+      <div ref={(el) => assignRef(spacerRef, el)} />
+    </div>
+  );
+};
+
+describe('useConversationScroll', () => {
+  beforeEach(() => {
+    scrollToMock.mockClear();
+  });
+
+  it('scrolls a loaded conversation history to the bottom on mount', () => {
+    render(
+      <ScrollHarness
+        conversationId="conversation-a"
+        messages={makeMessages(6)}
+      />,
+    );
+
+    expect(scrollToMock).toHaveBeenCalledWith({
+      top: 800,
+      behavior: 'smooth',
+    });
+  });
+
+  it('scrolls a newly selected conversation to the bottom when the message count stays the same', () => {
+    const messages = makeMessages(6);
+    const { rerender } = render(
+      <ScrollHarness conversationId="conversation-a" messages={messages} />,
+    );
+    scrollToMock.mockClear();
+
+    rerender(
+      <ScrollHarness conversationId="conversation-b" messages={messages} />,
+    );
+
+    expect(scrollToMock).toHaveBeenCalledWith({
+      top: 800,
+      behavior: 'smooth',
+    });
+  });
+});

--- a/apps/chat/src/hooks/conversation/useConversationScroll.ts
+++ b/apps/chat/src/hooks/conversation/useConversationScroll.ts
@@ -13,6 +13,7 @@ const NEAR_BOTTOM_THRESHOLD = 80;
 interface Params {
   messages: MessageType[];
   isAssistantTyping: boolean;
+  conversationId?: string;
 }
 
 interface Result {
@@ -52,6 +53,7 @@ interface Result {
 export const useConversationScroll = ({
   messages,
   isAssistantTyping,
+  conversationId,
 }: Params): Result => {
   const [isScrollButtonVisible, setIsScrollButtonVisible] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -158,10 +160,14 @@ export const useConversationScroll = ({
    * loading a conversation or deleting a message, keep the old bottom-scroll
    * behavior.
    */
-  const prevLengthRef = useRef(messages.length);
+  const prevLengthRef = useRef(0);
+  const prevConversationIdRef = useRef<string | undefined>(undefined);
   useLayoutEffect(() => {
     const lengthChanged = messages.length !== prevLengthRef.current;
+    const conversationChanged =
+      conversationId !== prevConversationIdRef.current;
     prevLengthRef.current = messages.length;
+    prevConversationIdRef.current = conversationId;
 
     const container = containerRef.current;
     const spacer = spacerRef.current;
@@ -176,10 +182,16 @@ export const useConversationScroll = ({
       return;
     }
 
-    if (!isAssistantTyping && lengthChanged) {
+    if (!isAssistantTyping && (lengthChanged || conversationChanged)) {
       scrollToBottom(false);
     }
-  }, [messages, isAssistantTyping, scrollToBottom, scrollMessageToTop]);
+  }, [
+    messages,
+    isAssistantTyping,
+    conversationId,
+    scrollToBottom,
+    scrollMessageToTop,
+  ]);
 
   /*
    * MarkdownRenderer flushes buffered typewriter content synchronously when

--- a/apps/chat/src/hooks/conversation/useConversationScroll.ts
+++ b/apps/chat/src/hooks/conversation/useConversationScroll.ts
@@ -13,7 +13,7 @@ const NEAR_BOTTOM_THRESHOLD = 80;
 interface Params {
   messages: MessageType[];
   isAssistantTyping: boolean;
-  conversationId?: string;
+  conversationId: string;
 }
 
 interface Result {
@@ -160,14 +160,17 @@ export const useConversationScroll = ({
    * loading a conversation or deleting a message, keep the old bottom-scroll
    * behavior.
    */
-  const prevLengthRef = useRef(0);
-  const prevConversationIdRef = useRef<string | undefined>(undefined);
+  const prevLengthRef = useRef(messages.length);
+  const prevConversationIdRef = useRef<string | null>(null);
   useLayoutEffect(() => {
     const lengthChanged = messages.length !== prevLengthRef.current;
     const conversationChanged =
       conversationId !== prevConversationIdRef.current;
-    prevLengthRef.current = messages.length;
-    prevConversationIdRef.current = conversationId;
+
+    const commitObservedScrollState = () => {
+      prevLengthRef.current = messages.length;
+      prevConversationIdRef.current = conversationId;
+    };
 
     const container = containerRef.current;
     const spacer = spacerRef.current;
@@ -179,12 +182,17 @@ export const useConversationScroll = ({
         spacer.style.height = `${container.clientHeight}px`;
       }
       scrollMessageToTop(anchorIndex, false);
+      commitObservedScrollState();
       return;
     }
 
-    if (!isAssistantTyping && (lengthChanged || conversationChanged)) {
+    if (isAssistantTyping) return;
+
+    if (lengthChanged || conversationChanged) {
       scrollToBottom(false);
     }
+
+    commitObservedScrollState();
   }, [
     messages,
     isAssistantTyping,

--- a/package-lock.json
+++ b/package-lock.json
@@ -307,7 +307,8 @@
         "@epam/ai-dial-kit": "*",
         "@epam/ai-dial-ui-kit": "0.12.0-dev.25",
         "@tabler/icons-react": "^3.0.0",
-        "react": "^19.0.0"
+        "react": "^19.0.0",
+        "react-qr-code": "^2.2.0"
       }
     },
     "libs/sidebar": {


### PR DESCRIPTION
## Description of changes

Fixes conversation history scroll behavior so an opened existing conversation scrolls to the bottom and shows the latest messages, as required by the chat scroll behavior spec.

Changes:
- Pass `conversation.id` into `useConversationScroll`.
- Treat the initial loaded message list as a scroll event, so history loaded on mount scrolls to the bottom.
- Detect conversation changes by `conversationId`, so switching between conversations with the same message count still scrolls to the bottom.
- Preserve near-top anchoring only for explicit user actions such as send, regenerate, and edit-resubmit.
- Add regression tests for initial history load and switching conversations with the same message count.

## Applicable issues

- https://github.com/epam/ai-dial-chat/issues/7723

## Checklist

- [X] the pull request name ends with `(Issue #<ISSUE_ID>)` (comma-separated list of issues)
- [X] I confirm that I don't share any confidential information like API keys or any other secrets and private URLs