### PR TITLE
fix: uploaded file is automatically checked in File Manager (#7675)

### DIFF
--- a/apps/chat/src/components/DialFileManagerModal/DialFileManagerModal.tsx
+++ b/apps/chat/src/components/DialFileManagerModal/DialFileManagerModal.tsx
@@ -107,7 +107,7 @@ const DialFileManagerModal: FC<Props> = ({
   maximumAttachmentsAmount,
   canAttachFolders = false,
   allowedTypesLabel,
-  autoSelectUploadedItems = true,
+  autoSelectUploadedItems = false,
 }) => {
   const { t } = useTranslation();
   const { showNotification } = useNotification();

--- a/apps/chat/src/components/DialFileManagerModal/tests/DialFileManagerModal.spec.tsx
+++ b/apps/chat/src/components/DialFileManagerModal/tests/DialFileManagerModal.spec.tsx
@@ -916,24 +916,19 @@ describe('DialFileManagerModal — per-tab visibleColumns', () => {
 });
 
 describe('DialFileManagerModal — autoSelectUploadedItems', () => {
-  it('passes autoSelectUploadedItems=true by default', () => {
+  it('passes autoSelectUploadedItems=false by default', () => {
     render(<DialFileManagerModal {...defaultProps} />);
     const manager = screen.getByRole('region', { name: 'file manager' });
     expect(manager.getAttribute('data-auto-select-uploaded-items')).toBe(
-      'true',
+      'false',
     );
   });
 
-  it('passes autoSelectUploadedItems=false when prop is false', () => {
-    render(
-      <DialFileManagerModal
-        {...defaultProps}
-        autoSelectUploadedItems={false}
-      />,
-    );
+  it('passes autoSelectUploadedItems=true when prop is true', () => {
+    render(<DialFileManagerModal {...defaultProps} autoSelectUploadedItems />);
     const manager = screen.getByRole('region', { name: 'file manager' });
     expect(manager.getAttribute('data-auto-select-uploaded-items')).toBe(
-      'false',
+      'true',
     );
   });
 });

--- a/apps/chat/src/components/DialFileManagerShell/DialFileManagerShell.tsx
+++ b/apps/chat/src/components/DialFileManagerShell/DialFileManagerShell.tsx
@@ -52,7 +52,7 @@ const DialFileManagerShell: FC<Props> = ({
   onTabChange,
   selectedPaths,
   onSelectedPathsChange,
-  autoSelectUploadedItems = true,
+  autoSelectUploadedItems = false,
   allowedFileTypes,
   maxSelectableFileSize,
   isRowSelectable,

--- a/apps/chat/src/components/DialFileManagerShell/tests/DialFileManagerShell.spec.tsx
+++ b/apps/chat/src/components/DialFileManagerShell/tests/DialFileManagerShell.spec.tsx
@@ -14,6 +14,7 @@ import type { DialFileManagerShellLabels } from '../types/labels';
 const capturedDialFileManagerProps: {
   current: {
     onCreateFolder?: unknown;
+    autoSelectUploadedItems?: boolean;
     gridOptions?: {
       actionLabels?: Partial<Record<DialFileManagerActions, string>>;
     };
@@ -28,6 +29,7 @@ vi.mock('@epam/ai-dial-ui-kit', async (importOriginal) => {
       emptyStateTitle?: string;
       destinationFolderPopupOptions?: { sourceFolder?: string };
       onCreateFolder?: unknown;
+      autoSelectUploadedItems?: boolean;
       gridOptions?: {
         actionLabels?: Partial<Record<DialFileManagerActions, string>>;
       };
@@ -182,6 +184,13 @@ describe('DialFileManagerShell', () => {
   it('renders DialFileManager (ui-kit) with hook result data', () => {
     renderShell();
     expect(screen.getByRole('region', { name: 'file manager' })).toBeTruthy();
+  });
+
+  it('keeps uploaded items unselected by default', () => {
+    renderShell();
+    expect(capturedDialFileManagerProps.current?.autoSelectUploadedItems).toBe(
+      false,
+    );
   });
 
   it('shows the empty-state title from the current tab when items are empty', () => {

--- a/apps/chat/src/pages/DialFileManagerPage/DialFileManagerPage.tsx
+++ b/apps/chat/src/pages/DialFileManagerPage/DialFileManagerPage.tsx
@@ -249,7 +249,7 @@ const DialFileManagerPage: FC = () => {
         onTabChange={handleTabChangeWithReset}
         selectedPaths={selectedPaths}
         onSelectedPathsChange={setSelectedPaths}
-        autoSelectUploadedItems={true}
+        autoSelectUploadedItems={false}
       />
     </div>
   );

--- a/apps/chat/src/pages/DialFileManagerPage/tests/DialFileManagerPage.spec.tsx
+++ b/apps/chat/src/pages/DialFileManagerPage/tests/DialFileManagerPage.spec.tsx
@@ -52,6 +52,7 @@ vi.mock('@epam/ai-dial-ui-kit', async (importOriginal) => {
       items,
       gridOptions,
       bulkActionsToolbarOptions,
+      autoSelectUploadedItems,
     }: {
       items?: { path: string }[];
       gridOptions?: {
@@ -60,6 +61,7 @@ vi.mock('@epam/ai-dial-ui-kit', async (importOriginal) => {
       bulkActionsToolbarOptions?: {
         actionLabels?: Partial<Record<DialFileManagerActions, string>>;
       };
+      autoSelectUploadedItems?: boolean;
     }) => (
       <div
         role="region"
@@ -96,6 +98,9 @@ vi.mock('@epam/ai-dial-ui-kit', async (importOriginal) => {
         )}
         data-has-unshare={String(
           Actions.Unshare in (gridOptions?.actionLabels ?? {}),
+        )}
+        data-auto-select-uploaded-items={String(
+          autoSelectUploadedItems ?? true,
         )}
       >
         {items?.length ?? 0} items
@@ -186,6 +191,14 @@ describe('DialFileManagerPage', () => {
   it('does not render an Attach button or attach footer', () => {
     render(<DialFileManagerPage />);
     expect(screen.queryByRole('button', { name: /attach/i })).toBeNull();
+  });
+
+  it('keeps uploaded items unselected', () => {
+    render(<DialFileManagerPage />);
+    const manager = screen.getByRole('region', { name: 'file manager' });
+    expect(manager.getAttribute('data-auto-select-uploaded-items')).toBe(
+      'false',
+    );
   });
 
   it('renders the tab navigation for My files, Shared, and Organization', () => {


### PR DESCRIPTION
## Description of changes

Fixes File Manager upload selection behavior.
Changes:
- Disabled automatic selection of newly uploaded files by default.
- Applied the behavior to both inline attachment File Manager and standalone File Manager.
- Added regression coverage for modal, shell, and standalone page flows.

## Applicable issues

- https://github.com/epam/ai-dial-chat/issues/7675

## Checklist

- [X] the pull request name ends with `(Issue #<ISSUE_ID>)` (comma-separated list of issues)
- [X] I confirm that I don't share any confidential information like API keys or any other secrets and private URLs
