### PR TITLE
fix: file manager labels (#7725)

### DIFF
--- a/apps/chat/src/components/DialFileManagerModal/DialFileManagerModal.tsx
+++ b/apps/chat/src/components/DialFileManagerModal/DialFileManagerModal.tsx
@@ -527,11 +527,11 @@ const DialFileManagerModal: FC<Props> = ({
       deletingLabel,
       renameLabel: t(ButtonsI18nKeys.Rename),
       renamingLabel: t(DialFileManagerI18nKeys.RenamingLabel),
-      copyLabel: t(ButtonsI18nKeys.Copy),
+      copyLabel: t(DialFileManagerI18nKeys.CopyAction),
       moveLabel: t(DialFileManagerI18nKeys.MoveAction),
       duplicateLabel: t(ButtonsI18nKeys.Duplicate),
       addFolderLabel: t(DialFileManagerI18nKeys.FolderPickerAddFolderLabel),
-      hiddenFilesSwitcherLabel: t(DialFileManagerI18nKeys.ShowHiddenFiles),
+      hiddenFilesSwitcherLabel: t(DialFileManagerI18nKeys.HiddenFiles),
       getCopyHeader: (count, name) =>
         count === 1
           ? t(DialFileManagerI18nKeys.CopyHeaderSingle, { name })

--- a/apps/chat/src/components/DialFileManagerModal/tests/DialFileManagerModal.spec.tsx
+++ b/apps/chat/src/components/DialFileManagerModal/tests/DialFileManagerModal.spec.tsx
@@ -54,8 +54,8 @@ vi.mock('@epam/ai-dial-ui-kit', async (importOriginal) => {
       activeTab: mockActiveTab.value ?? Tabs.MyFiles,
       handleTabChange: mockHandleTabChange,
       tabs: [
-        { id: Tabs.MyFiles, name: 'My files' },
-        { id: Tabs.Shared, name: 'Shared with me' },
+        { id: Tabs.MyFiles, name: 'My Files' },
+        { id: Tabs.Shared, name: 'Shared with Me' },
         { id: Tabs.Organization, name: 'Organization' },
       ],
     })),
@@ -673,8 +673,8 @@ describe('DialFileManagerModal — tab navigation', () => {
     render(<DialFileManagerModal {...defaultProps} />);
     const manager = screen.getByRole('region', { name: 'file manager' });
     expect(manager.getAttribute('data-tab-count')).toBe('3');
-    expect(screen.getByRole('button', { name: 'My files' })).toBeTruthy();
-    expect(screen.getByRole('button', { name: 'Shared with me' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'My Files' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Shared with Me' })).toBeTruthy();
     expect(screen.getByRole('button', { name: 'Organization' })).toBeTruthy();
   });
 
@@ -687,7 +687,7 @@ describe('DialFileManagerModal — tab navigation', () => {
     );
   });
 
-  it('passes My files as rootLabel for the My files tab', () => {
+  it('passes My Files as rootLabel for the My Files tab', () => {
     mockActiveTab.value = DialFileManagerTabs.MyFiles;
     mockUseDialFileManager.mockReturnValue(defaultHookResult);
 
@@ -701,7 +701,7 @@ describe('DialFileManagerModal — tab navigation', () => {
     );
   });
 
-  it('passes Shared with me as rootLabel for the Shared tab', () => {
+  it('passes Shared with Me as rootLabel for the Shared tab', () => {
     mockActiveTab.value = DialFileManagerTabs.Shared;
     mockUseDialFileManager.mockReturnValue(defaultHookResult);
 
@@ -738,7 +738,7 @@ describe('DialFileManagerModal — tab navigation', () => {
     expect(screen.getByText('1 item selected')).toBeTruthy();
 
     // Switch tab — this should clear selectedPaths and call handleTabChange
-    fireEvent.click(screen.getByRole('button', { name: 'Shared with me' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Shared with Me' }));
 
     expect(mockHandleTabChange).toHaveBeenCalledWith(
       DialFileManagerTabs.Shared,
@@ -869,7 +869,7 @@ describe('DialFileManagerModal — sharedWithMeIds', () => {
     );
   });
 
-  it('passes undefined sharedWithMeIds on My files tab', () => {
+  it('passes undefined sharedWithMeIds on My Files tab', () => {
     mockUseDialFileManager.mockReturnValue({
       ...defaultHookResult,
       sharedWithMeIds: undefined,

--- a/apps/chat/src/components/DialFileManagerShell/tests/DialFileManagerShell.spec.tsx
+++ b/apps/chat/src/components/DialFileManagerShell/tests/DialFileManagerShell.spec.tsx
@@ -18,6 +18,15 @@ const capturedDialFileManagerProps: {
     gridOptions?: {
       actionLabels?: Partial<Record<DialFileManagerActions, string>>;
     };
+    bulkActionsToolbarOptions?: {
+      actionLabels?: Partial<Record<DialFileManagerActions, string>>;
+    };
+    destinationFolderPopupOptions?: {
+      copyLabel?: string;
+      moveLabel?: string;
+      hiddenFilesSwitcherLabel?: string;
+      sourceFolder?: string;
+    };
   } | null;
 } = { current: null };
 
@@ -27,10 +36,18 @@ vi.mock('@epam/ai-dial-ui-kit', async (importOriginal) => {
     ...actual,
     DialFileManager: (props: {
       emptyStateTitle?: string;
-      destinationFolderPopupOptions?: { sourceFolder?: string };
+      destinationFolderPopupOptions?: {
+        copyLabel?: string;
+        moveLabel?: string;
+        hiddenFilesSwitcherLabel?: string;
+        sourceFolder?: string;
+      };
       onCreateFolder?: unknown;
       autoSelectUploadedItems?: boolean;
       gridOptions?: {
+        actionLabels?: Partial<Record<DialFileManagerActions, string>>;
+      };
+      bulkActionsToolbarOptions?: {
         actionLabels?: Partial<Record<DialFileManagerActions, string>>;
       };
     }) => {
@@ -107,11 +124,11 @@ const baseLabels: DialFileManagerShellLabels = {
   deletingLabel: 'Deleting…',
   renameLabel: 'Rename',
   renamingLabel: 'Renaming…',
-  copyLabel: 'Copy',
-  moveLabel: 'Move',
+  copyLabel: 'Copy to',
+  moveLabel: 'Move to',
   duplicateLabel: 'Duplicate',
   addFolderLabel: 'Add folder',
-  hiddenFilesSwitcherLabel: 'Show hidden files',
+  hiddenFilesSwitcherLabel: 'Hidden files',
   getCopyHeader: (count, name) =>
     count === 1 ? `Copy "${name}"` : `Copy ${count} items`,
   getMoveHeader: (count, name) =>
@@ -140,8 +157,8 @@ const baseLabels: DialFileManagerShellLabels = {
     [DialFileManagerTabs.Review]: emptyStateCopy,
   },
   treeHeaderByTab: {
-    [DialFileManagerTabs.MyFiles]: 'My files',
-    [DialFileManagerTabs.Shared]: 'Shared with me',
+    [DialFileManagerTabs.MyFiles]: 'My Files',
+    [DialFileManagerTabs.Shared]: 'Shared with Me',
     [DialFileManagerTabs.Organization]: 'Organization',
     [DialFileManagerTabs.Review]: '',
   },
@@ -173,7 +190,7 @@ const renderShell = (
       hookResult={{ ...baseHookResult, ...hookResultOverrides }}
       labels={baseLabels}
       activeTab={DialFileManagerTabs.MyFiles}
-      tabs={[{ id: DialFileManagerTabs.MyFiles, label: 'My files' }]}
+      tabs={[{ id: DialFileManagerTabs.MyFiles, label: 'My Files' }]}
       onTabChange={vi.fn()}
       selectedPaths={selectedPaths}
       onSelectedPathsChange={vi.fn()}
@@ -262,6 +279,43 @@ describe('DialFileManagerShell', () => {
         DialFileManagerActions.Duplicate
       ],
     ).toBe(baseLabels.duplicateLabel);
+  });
+
+  it('passes File manager copy, move, and hidden-files labels to action surfaces', () => {
+    renderShell({
+      actionLabels: {
+        [DialFileManagerActions.Download]: 'Download',
+        [DialFileManagerActions.Copy]: 'Copy',
+        [DialFileManagerActions.Move]: 'Move',
+      },
+    });
+
+    const props = capturedDialFileManagerProps.current;
+    expect(
+      props?.gridOptions?.actionLabels?.[DialFileManagerActions.Copy],
+    ).toBe(baseLabels.copyLabel);
+    expect(
+      props?.gridOptions?.actionLabels?.[DialFileManagerActions.Move],
+    ).toBe(baseLabels.moveLabel);
+    expect(
+      props?.bulkActionsToolbarOptions?.actionLabels?.[
+        DialFileManagerActions.Copy
+      ],
+    ).toBe(baseLabels.copyLabel);
+    expect(
+      props?.bulkActionsToolbarOptions?.actionLabels?.[
+        DialFileManagerActions.Move
+      ],
+    ).toBe(baseLabels.moveLabel);
+    expect(props?.destinationFolderPopupOptions?.copyLabel).toBe(
+      baseLabels.copyLabel,
+    );
+    expect(props?.destinationFolderPopupOptions?.moveLabel).toBe(
+      baseLabels.moveLabel,
+    );
+    expect(
+      props?.destinationFolderPopupOptions?.hiddenFilesSwitcherLabel,
+    ).toBe(baseLabels.hiddenFilesSwitcherLabel);
   });
 
   it('omits Duplicate from DialFileManager action labels when the hook result excludes it', () => {

--- a/apps/chat/src/constants/translation-keys.ts
+++ b/apps/chat/src/constants/translation-keys.ts
@@ -256,6 +256,7 @@ export enum DialFileManagerI18nKeys {
   RenameReservedName = 'dialFileManager.renameReservedName',
   RenameInvalidChars = 'dialFileManager.renameInvalidChars',
   RenameNameTooLong = 'dialFileManager.renameNameTooLong',
+  CopyAction = 'dialFileManager.copyAction',
   MoveAction = 'dialFileManager.moveAction',
   CopyingLabel = 'dialFileManager.copyingLabel',
   MovingLabel = 'dialFileManager.movingLabel',

--- a/apps/chat/src/i18n/locales/en.json
+++ b/apps/chat/src/i18n/locales/en.json
@@ -409,7 +409,8 @@
     "renameReservedName": "This name is reserved",
     "renameInvalidChars": "Name contains invalid characters",
     "renameNameTooLong": "Name must be 255 characters or fewer",
-    "moveAction": "Move",
+    "copyAction": "Copy to",
+    "moveAction": "Move to",
     "copyingLabel": "Copying...",
     "movingLabel": "Moving...",
     "copyError": "Failed to copy the selected items",
@@ -427,8 +428,8 @@
     "folderPickerEmptyStateTitle": "No folders here",
     "folderPickerEmptyStateDescription": "Create a folder or choose another location",
     "tab": {
-      "myFiles": "My files",
-      "shared": "Shared with me"
+      "myFiles": "My Files",
+      "shared": "Shared with Me"
     },
     "myFiles": {
       "treeHeader": "Folder tree",

--- a/apps/chat/src/pages/DialFileManagerPage/DialFileManagerPage.tsx
+++ b/apps/chat/src/pages/DialFileManagerPage/DialFileManagerPage.tsx
@@ -151,11 +151,11 @@ const DialFileManagerPage: FC = () => {
       deletingLabel: t(DialFileManagerI18nKeys.DeletingLabel),
       renameLabel: t(ButtonsI18nKeys.Rename),
       renamingLabel: t(DialFileManagerI18nKeys.RenamingLabel),
-      copyLabel: t(ButtonsI18nKeys.Copy),
+      copyLabel: t(DialFileManagerI18nKeys.CopyAction),
       moveLabel: t(DialFileManagerI18nKeys.MoveAction),
       duplicateLabel: t(ButtonsI18nKeys.Duplicate),
       addFolderLabel: t(DialFileManagerI18nKeys.FolderPickerAddFolderLabel),
-      hiddenFilesSwitcherLabel: t(DialFileManagerI18nKeys.ShowHiddenFiles),
+      hiddenFilesSwitcherLabel: t(DialFileManagerI18nKeys.HiddenFiles),
       getCopyHeader: (count, name) =>
         count === 1
           ? t(DialFileManagerI18nKeys.CopyHeaderSingle, { name })

--- a/apps/chat/src/pages/DialFileManagerPage/tests/DialFileManagerPage.spec.tsx
+++ b/apps/chat/src/pages/DialFileManagerPage/tests/DialFileManagerPage.spec.tsx
@@ -43,8 +43,8 @@ vi.mock('@epam/ai-dial-ui-kit', async (importOriginal) => {
       activeTab: mockActiveTab.value ?? Tabs.MyFiles,
       handleTabChange: mockHandleTabChange,
       tabs: [
-        { id: Tabs.MyFiles, label: 'My files' },
-        { id: Tabs.Shared, label: 'Shared with me' },
+        { id: Tabs.MyFiles, label: 'My Files' },
+        { id: Tabs.Shared, label: 'Shared with Me' },
         { id: Tabs.Organization, label: 'Organization' },
       ],
     })),
@@ -201,7 +201,7 @@ describe('DialFileManagerPage', () => {
     );
   });
 
-  it('renders the tab navigation for My files, Shared, and Organization', () => {
+  it('renders the tab navigation for My Files, Shared, and Organization', () => {
     mockActiveTab.value = DialFileManagerTabs.MyFiles;
     render(<DialFileManagerPage />);
     expect(screen.getByRole('region', { name: 'file manager' })).toBeTruthy();


### PR DESCRIPTION
## Description of changes

Make File Manager labels consistent with an old Dial Chat.

## Applicable issues

- https://github.com/epam/ai-dial-chat/issues/7725

## Checklist

- [X] the pull request name ends with `(Issue #<ISSUE_ID>)` (comma-separated list of issues)
- [X] I confirm that I don't share any confidential information like API keys or any other secrets and private URLs
