### PR TITLE
fix: failing docker builds on the CI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,9 @@ FROM deps AS builder
 COPY . .
 
 # Build the React SPA → apps/chat/dist/
-RUN npm exec nx build chat
+# Keep Docker builds deterministic: parallel Nx build/typecheck tasks can race
+# while reading and regenerating declaration outputs in a clean image layer.
+RUN npm exec -- nx run-many --target=build --projects=@epam/chat --parallel=1
 
 # Build NestJS, generate a pruned package.json/lockfile, and copy
 # workspace packages → apps/chat-api/dist/{main.js,package.json,...,workspace_modules/}


### PR DESCRIPTION
## Description of changes

Fix intermittent `docker_build` failures in CI by making the frontend Nx build deterministic inside the Docker image build.

## Root Cause

The Docker build was running:

`npm exec nx build chat`

In this workspace, `chat:build` can schedule build and typecheck tasks in parallel. Some of those tasks read and regenerate declaration files under `dist/libs/**`. On a clean Docker layer this occasionally races, causing transient **TS6305** errors such as missing `.d.ts` outputs. Reruns pass because task timing/cache state differs.

## Fix
Changed the Dockerfile to run the same build target through `nx run-many` with a single worker:
`npm exec -- nx run-many --target=build --projects=@epam/chat --parallel=1`
This only affects Docker image builds and keeps regular local/CI Nx build behavior unchanged.

## Checklist

- [X] the pull request name ends with `(Issue #<ISSUE_ID>)` (comma-separated list of issues)
- [X] I confirm that I don't share any confidential information like API keys or any other secrets and private URLs
