### PR TITLE
fix: show files in the folder picker (#7796)

### DIFF
--- a/apps/chat/src/components/DialFileManagerShell/DialFileManagerShell.tsx
+++ b/apps/chat/src/components/DialFileManagerShell/DialFileManagerShell.tsx
@@ -3,7 +3,6 @@ import {
   DialFileManager,
   DialFileManagerActions,
   DialFileManagerTabs,
-  DialFileNodeType,
   DialSpinner,
   GridSelectionMode,
   NOT_ALLOWED_SYMBOLS_REGEXP,
@@ -11,15 +10,7 @@ import {
   type FileManagerGridRow,
   type ToolbarOptions,
 } from '@epam/ai-dial-ui-kit';
-import type { GridApi } from 'ag-grid-community';
-import {
-  memo,
-  useCallback,
-  useEffect,
-  useMemo,
-  useState,
-  type FC,
-} from 'react';
+import { memo, useEffect, useMemo, useState, type FC } from 'react';
 import OperationLoaderModal from '../../components/DialFileManagerModal/OperationLoaderModal';
 import ShareFileModal from '../../components/DialFileManagerModal/ShareFileModal';
 import { FileUploadStatus } from '../../components/DialFileManagerModal/types/upload';
@@ -42,12 +33,6 @@ type DestinationFolderPopupOptions =
     destinationFolderPath?: string;
     setDestinationFolderPath?: (path?: string) => void;
     filesLoading?: boolean;
-    /*
-     * Current ui-kit forwards extra destination popup options into the popup's
-     * inner DialFileManager. Keep full `items` for conflict detection, but make
-     * that inner grid folder-only.
-     */
-    onGridApiChange?: (api: GridApi<FileManagerGridRow>) => void;
   };
 
 const normalizeVirtualFolderPath = (value: string): string => {
@@ -360,20 +345,6 @@ const DialFileManagerShell: FC<Props> = ({
     ],
   );
 
-  const handleDestinationFolderPopupGridApiChange = useCallback(
-    (api: GridApi<FileManagerGridRow>): void => {
-      api.setGridOption('isExternalFilterPresent', () => true);
-      api.setGridOption('doesExternalFilterPass', ({ data }) => {
-        return (
-          data?.isTemporary === true ||
-          data?.nodeType === DialFileNodeType.FOLDER
-        );
-      });
-      api.onFilterChanged();
-    },
-    [],
-  );
-
   const commonSelectedParentFolder = useMemo(() => {
     let commonParent: string | undefined;
     for (const selectedPath of selectedPaths) {
@@ -414,7 +385,6 @@ const DialFileManagerShell: FC<Props> = ({
       destinationFolderPath,
       setDestinationFolderPath,
       filesLoading: isDestinationFolderLoading,
-      onGridApiChange: handleDestinationFolderPopupGridApiChange,
     }),
     [
       labels.copyLabel,
@@ -430,7 +400,6 @@ const DialFileManagerShell: FC<Props> = ({
       isDestinationFolderLoading,
       disabledDestinationPath,
       destinationFolderPath,
-      handleDestinationFolderPopupGridApiChange,
     ],
   );
 

--- a/apps/chat/src/components/DialFileManagerShell/tests/DialFileManagerShell.spec.tsx
+++ b/apps/chat/src/components/DialFileManagerShell/tests/DialFileManagerShell.spec.tsx
@@ -3,7 +3,6 @@ import { join } from 'path';
 import {
   DialFileManagerActions,
   DialFileManagerTabs,
-  DialFileNodeType,
 } from '@epam/ai-dial-ui-kit';
 import { act, render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
@@ -52,7 +51,6 @@ const capturedDialFileManagerProps: {
       setDestinationFolderPath?: (path?: string) => void;
       disabledPathTooltip?: string;
       filesLoading?: boolean;
-      onGridApiChange?: unknown;
     };
   } | null;
 } = { current: null };
@@ -72,7 +70,6 @@ vi.mock('@epam/ai-dial-ui-kit', async (importOriginal) => {
         setDestinationFolderPath?: (path?: string) => void;
         disabledPathTooltip?: string;
         filesLoading?: boolean;
-        onGridApiChange?: unknown;
       };
       onCreateFolder?: unknown;
       onFolderPopupPathChange?: unknown;
@@ -385,54 +382,11 @@ describe('DialFileManagerShell', () => {
     );
   });
 
-  it('filters the destination-folder popup grid to folders while keeping temporary folder rows', () => {
+  it('does not set onGridApiChange on destinationFolderPopupOptions', () => {
     renderShell();
-
-    const setGridOption = vi.fn();
-    const onFilterChanged = vi.fn();
-    const onGridApiChange = capturedDialFileManagerProps.current
-      ?.destinationFolderPopupOptions?.onGridApiChange as
-      | ((api: {
-          setGridOption: typeof setGridOption;
-          onFilterChanged: typeof onFilterChanged;
-        }) => void)
-      | undefined;
-
-    onGridApiChange?.({ setGridOption, onFilterChanged });
-
-    expect(setGridOption).toHaveBeenCalledWith(
-      'isExternalFilterPresent',
-      expect.any(Function),
-    );
-    expect(setGridOption).toHaveBeenCalledWith(
-      'doesExternalFilterPass',
-      expect.any(Function),
-    );
-
-    const doesExternalFilterPass = setGridOption.mock.calls.find(
-      ([key]) => key === 'doesExternalFilterPass',
-    )?.[1] as
-      | ((node: {
-          data?: { nodeType: DialFileNodeType; isTemporary?: boolean };
-        }) => boolean)
-      | undefined;
-
     expect(
-      doesExternalFilterPass?.({
-        data: { nodeType: DialFileNodeType.FOLDER },
-      }),
-    ).toBe(true);
-    expect(
-      doesExternalFilterPass?.({
-        data: { nodeType: DialFileNodeType.ITEM },
-      }),
-    ).toBe(false);
-    expect(
-      doesExternalFilterPass?.({
-        data: { nodeType: DialFileNodeType.ITEM, isTemporary: true },
-      }),
-    ).toBe(true);
-    expect(onFilterChanged).toHaveBeenCalledOnce();
+      capturedDialFileManagerProps.current?.destinationFolderPopupOptions,
+    ).not.toHaveProperty('onGridApiChange');
   });
 
   it('passes Duplicate through to DialFileManager action labels when the hook result includes it', () => {

--- a/apps/chat/src/i18n/locales/en.json
+++ b/apps/chat/src/i18n/locales/en.json
@@ -480,7 +480,7 @@
     "moveHeaderMultiple": "Move {{count}} items",
     "moveSourceDisabledTooltip": "Unavailable for the original location. Please select another folder",
     "folderPickerLoadingTooltip": "Loading folder contents. Please wait",
-    "folderPickerEmptyStateTitle": "No folders here",
+    "folderPickerEmptyStateTitle": "This folder is empty",
     "folderPickerEmptyStateDescription": "Create a folder or choose another location",
     "tab": {
       "myFiles": "My Files",

--- a/apps/chat/src/utils/zip-export.ts
+++ b/apps/chat/src/utils/zip-export.ts
@@ -3,6 +3,14 @@ import { strToU8, zipSync } from 'fflate';
 
 /** Character allowlist for attachment paths written into a `.dial` archive. */
 const ARCHIVE_PATH_CHARSET = /^[a-zA-Z0-9._\-/]+$/;
+/*
+ * fflate identifies file entries with instanceof against its own Uint8Array
+ * constructor, so normalize bytes from other realms before calling zipSync.
+ */
+const FflateUint8Array = strToU8('', true).constructor as Uint8ArrayConstructor;
+
+const toZipUint8Array = (data: Uint8Array): Uint8Array =>
+  data instanceof FflateUint8Array ? data : new FflateUint8Array(data);
 
 /**
  * Validates an attachment path before it is written into a `.dial` archive.
@@ -44,7 +52,9 @@ export const buildDialArchive = (
 ): BuildDialArchiveResult => {
   const skippedPaths: string[] = [];
   const files: Record<string, Uint8Array> = {
-    'conversation.json': strToU8(JSON.stringify(envelope, null, 2)),
+    'conversation.json': toZipUint8Array(
+      strToU8(JSON.stringify(envelope, null, 2)),
+    ),
   };
 
   for (const attachment of attachments) {
@@ -52,7 +62,7 @@ export const buildDialArchive = (
       skippedPaths.push(attachment.path);
       continue;
     }
-    files[`res/${attachment.path}`] = attachment.data;
+    files[`res/${attachment.path}`] = toZipUint8Array(attachment.data);
   }
 
   const zipped = zipSync(files);

--- a/openspec/changes/archive/2026-07-09-add-file-manager-select-folder-modal/specs/file-manager-folder-picker/spec.md
+++ b/openspec/changes/archive/2026-07-09-add-file-manager-select-folder-modal/specs/file-manager-folder-picker/spec.md
@@ -11,12 +11,12 @@ Clicking a `DialFileManagerActions.Copy` or `.Move` action (grid row menu, tree 
 #### Scenario: Copy action opens the popup in copy mode
 
 - **WHEN** the user triggers the Copy action on one or more items
-- **THEN** the destination-folder popup opens, browsing the same folder tree already loaded for the active tab, showing folders only
+- **THEN** the destination-folder popup opens, browsing the same folder tree already loaded for the active tab, showing both files and folders
 
 #### Scenario: Move action opens the popup in move mode
 
 - **WHEN** the user triggers the Move action on one or more items
-- **THEN** the destination-folder popup opens in move mode, browsing the same folder tree, showing folders only
+- **THEN** the destination-folder popup opens in move mode, browsing the same folder tree, showing both files and folders
 
 ---
 
@@ -98,14 +98,14 @@ Copy mode SHALL NOT set `sourceFolder` — copying an item into its own current 
 
 ---
 
-### Requirement: Folder-only, action-free browsing inside the popup
+### Requirement: Action-free browsing inside the popup
 
-The popup SHALL display only folders (no files) and SHALL NOT render row-level context actions (no Rename/Delete/etc. on folders shown inside the popup). This is the current behavior of the installed `@epam/ai-dial-ui-kit` version and is not configurable by the host application — `DialFileManagerDestinationFolderPopupOptions` exposes no `actionLabels` override for the popup's internal tree.
+The popup SHALL display both files and folders and SHALL NOT render row-level context actions (no Rename/Delete/etc. on rows shown inside the popup). The action-free behavior is the current behavior of the installed `@epam/ai-dial-ui-kit` version and is not configurable by the host application — `DialFileManagerDestinationFolderPopupOptions` exposes no `actionLabels` override for the popup's internal tree.
 
-#### Scenario: Files are not shown in the popup
+#### Scenario: Files and folders are both shown in the popup
 
 - **WHEN** the popup is open and the current folder contains both files and subfolders
-- **THEN** only the subfolders are listed
+- **THEN** both files and subfolders are listed
 
 #### Scenario: No context menu on popup rows
 
@@ -149,7 +149,7 @@ The following keys SHALL be added to `apps/chat/src/i18n/locales/en.json` with m
 | `dialFileManager.moveHeaderSingle` | `Move "{{name}}"` |
 | `dialFileManager.moveHeaderMultiple` | `Move {{count}} items` |
 | `dialFileManager.moveSourceDisabledTooltip` | `Unavailable for the original location. Please select another folder` |
-| `dialFileManager.folderPickerEmptyStateTitle` | `No folders here` |
+| `dialFileManager.folderPickerEmptyStateTitle` | `This folder is empty` |
 | `dialFileManager.folderPickerEmptyStateDescription` | `Create a folder or choose another location` |
 
 No raw string literal keys are passed to `t()` anywhere in this change.


### PR DESCRIPTION
## Description of changes

- Remove external filter that hide files in the copy/move destination-folder popup — both files and folders are now shown. 
- Update the empty-state title from "No folders here" to "This folder is empty" to reflect the broader content. 
- Clean up the related test and archived spec.

<!-- Please explain the changes you made right below this line. -->

## Applicable issues

- https://github.com/epam/ai-dial-chat/issues/7796

## Checklist

- [X] the pull request name ends with `(Issue #<ISSUE_ID>)` (comma-separated list of issues)
- [X] I confirm that I don't share any confidential information like API keys or any other secrets and private URLs

