### PR TITLE
fix(chat): fix prompt highlighting (#3744)

### DIFF
--- a/apps/chat/src/components/Chatbar/Conversation.tsx
+++ b/apps/chat/src/components/Chatbar/Conversation.tsx
@@ -248,7 +248,15 @@ export const ConversationComponent = memo(
       if (hasParentWithFloatingOverlay(e.target as Element)) {
         return;
       }
+      window.getSelection()?.removeAllRanges();
       setIsContextMenu(true);
+    }, []);
+
+    const handleContextMenuOpenChange = useCallback((open: boolean) => {
+      if (open) {
+        window.getSelection()?.removeAllRanges();
+      }
+      setIsContextMenu(open);
     }, []);
 
     useScrollToEntity({
@@ -319,6 +327,7 @@ export const ConversationComponent = memo(
           }
           onClick={() => {
             if (!isSelectMode || !isExternal) {
+              window.getSelection()?.removeAllRanges();
               dispatch(
                 !isSelectMode
                   ? ConversationsActions.selectConversations({
@@ -369,7 +378,7 @@ export const ConversationComponent = memo(
             <ConversationContextMenu
               conversation={conversation}
               isOpen={isContextMenu}
-              setIsOpen={setIsContextMenu}
+              setIsOpen={handleContextMenuOpenChange}
               publicationUrl={additionalItemData?.publicationUrl}
               className="p-2"
             />

--- a/apps/chat/src/components/Files/FileItem.tsx
+++ b/apps/chat/src/components/Files/FileItem.tsx
@@ -79,7 +79,15 @@ export const FileItem = ({
   const canAttachFiles = !!additionalItemData?.canAttachFiles;
 
   const handleContextMenuOpen = useCallback(() => {
+    window.getSelection()?.removeAllRanges();
     setIsContextMenu(true);
+  }, []);
+
+  const handleContextMenuOpenChange = useCallback((open: boolean) => {
+    if (open) {
+      window.getSelection()?.removeAllRanges();
+    }
+    setIsContextMenu(open);
   }, []);
 
   useContextMenuTrigger(handleContextMenuOpen, fileRef);
@@ -276,7 +284,7 @@ export const FileItem = ({
             onDelete={handleDelete}
             onUnshare={handleUnshare}
             isOpen={isContextMenu}
-            onOpenChange={setIsContextMenu}
+            onOpenChange={handleContextMenuOpenChange}
             onRemoveAccess={handleRemoveAccess}
             onUnpublish={handleOpenUnpublishing}
             onSelect={canAttachFiles ? handleToggleFile : undefined}

--- a/apps/chat/src/components/Folder/Folder.tsx
+++ b/apps/chat/src/components/Folder/Folder.tsx
@@ -257,10 +257,18 @@ export const Folder = <T extends ConversationInfo | PromptInfo | DialFile>({
       ) {
         return;
       }
+      window.getSelection()?.removeAllRanges();
       setIsContextMenu(true);
     },
     [featureType],
   );
+
+  const handleContextMenuOpenChange = useCallback((open: boolean) => {
+    if (open) {
+      window.getSelection()?.removeAllRanges();
+    }
+    setIsContextMenu(open);
+  }, []);
 
   useContextMenuTrigger(handleContextMenuOpen, dragDropElement);
 
@@ -424,7 +432,7 @@ export const Folder = <T extends ConversationInfo | PromptInfo | DialFile>({
 
   const { refs, context } = useFloating({
     open: isContextMenu,
-    onOpenChange: setIsContextMenu,
+    onOpenChange: handleContextMenuOpenChange,
   });
 
   const dismiss = useDismiss(context);
@@ -1260,7 +1268,7 @@ export const Folder = <T extends ConversationInfo | PromptInfo | DialFile>({
                     }
                     onUnpublish={handleOpenUnpublishing}
                     onPublishUpdate={handleOpenPublishing}
-                    onOpenChange={setIsContextMenu}
+                    onOpenChange={handleContextMenuOpenChange}
                     onUpload={onFileUpload && onUpload}
                     isOpen={isContextMenu}
                     isEmpty={!hasChildItemOnAnyLevel}

--- a/apps/chat/src/components/Promptbar/components/Prompt.tsx
+++ b/apps/chat/src/components/Promptbar/components/Prompt.tsx
@@ -5,6 +5,7 @@ import React, {
   MouseEventHandler,
   memo,
   useCallback,
+  useEffect,
   useMemo,
   useRef,
   useState,
@@ -118,7 +119,15 @@ export const PromptComponent = memo(
       if (hasParentWithFloatingOverlay(e.target as Element)) {
         return;
       }
+      window.getSelection()?.removeAllRanges();
       setIsContextMenu(true);
+    }, []);
+
+    const handleContextMenuOpenChange = useCallback((open: boolean) => {
+      if (open) {
+        window.getSelection()?.removeAllRanges();
+      }
+      setIsContextMenu(open);
     }, []);
 
     useScrollToEntity({
@@ -127,6 +136,19 @@ export const PromptComponent = memo(
     });
 
     useContextMenuTrigger(handleContextMenuOpen, promptRef);
+
+    useEffect(() => {
+      const element = promptRef.current;
+      if (!element) {
+        return;
+      }
+
+      const handleSelectStart = (e: Event) => e.preventDefault();
+      element.addEventListener('selectstart', handleSelectStart);
+
+      return () =>
+        element.removeEventListener('selectstart', handleSelectStart);
+    }, []);
 
     const screenState = useScreenState();
     const isMobileOrTablet =
@@ -155,7 +177,7 @@ export const PromptComponent = memo(
 
     const { refs, context } = useFloating({
       open: isContextMenu,
-      onOpenChange: setIsContextMenu,
+      onOpenChange: handleContextMenuOpenChange,
     });
 
     const dismiss = useDismiss(context);
@@ -178,6 +200,7 @@ export const PromptComponent = memo(
       ) => {
         e.stopPropagation();
         e.preventDefault();
+        window.getSelection()?.removeAllRanges();
 
         dispatch(
           PromptsActions.selectPrompt({
@@ -374,7 +397,7 @@ export const PromptComponent = memo(
                     ? undefined
                     : handleUnpublish
                 }
-                onOpenChange={setIsContextMenu}
+                onOpenChange={handleContextMenuOpenChange}
                 onDuplicate={handleDuplicate}
                 onView={handleOpenViewModal}
                 isOpen={isContextMenu}


### PR DESCRIPTION
## Description of changes

Context menu and View prompt fields are highlighted if any prompt was opened by double-click

## Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #3744

## Checklist

- [x] the pull request name ends with `(Issue #<ISSUE_ID>)` (comma-separated list of issues)
- [x] I confirm that I don't share any confidential information like API keys or any other secrets and private URLs

<details>
  <summary>PR title cheatsheet</summary>

`<type>[optional scope]: <description>`

1. type (required)
    - `feat` - A new feature
    - `fix` - A bug fix
    - `docs` - Documentation only changes
    - `test` - Adding missing tests or correcting existing tests
    - `ci` - Changes to our CI configuration files and scripts
    - `chore` - Other changes that are minor and/or not user-facing
2. scope (optional, current repo suggestions below)
    - `chat`
    - `overlay`
    - `shared`
    - `sandbox-overlay`
    - `visualizer-connector`

</details>
