### PR TITLE
fix: do not allow to attach hidden files (#7640)

### DIFF
--- a/apps/chat/src/components/DialFileManagerModal/DialFileManagerModal.tsx
+++ b/apps/chat/src/components/DialFileManagerModal/DialFileManagerModal.tsx
@@ -164,6 +164,12 @@ const DialFileManagerModal: FC<Props> = ({
     () => new Set(),
   );
 
+  const handleSelectedPathsChange = useCallback((paths: Set<string>) => {
+    setSelectedPaths(
+      new Set(Array.from(paths).filter((path) => !isHiddenPath(path))),
+    );
+  }, []);
+
   const handleTabChangeWithReset = useCallback(
     (tab: DialFileManagerTabs) => {
       setSelectedPaths(new Set());
@@ -207,6 +213,8 @@ const DialFileManagerModal: FC<Props> = ({
     const selectedFileNodes: DialFile[] = [];
 
     for (const file of selectedFiles) {
+      if (isHiddenPath(file.path)) continue;
+
       if (file.nodeType === DialFileNodeType.FOLDER) {
         selectedFolderPaths.push(file.path);
       } else {
@@ -669,7 +677,7 @@ const DialFileManagerModal: FC<Props> = ({
         tabs={tabs}
         onTabChange={handleTabChangeWithReset}
         selectedPaths={selectedPaths}
-        onSelectedPathsChange={setSelectedPaths}
+        onSelectedPathsChange={handleSelectedPathsChange}
         variant={DialFileManagerVariant.Attach}
         actionProfile={DialFileManagerActionProfile.Attach}
         autoSelectUploadedItems={autoSelectUploadedItems}

--- a/apps/chat/src/components/DialFileManagerModal/tests/DialFileManagerModal.spec.tsx
+++ b/apps/chat/src/components/DialFileManagerModal/tests/DialFileManagerModal.spec.tsx
@@ -70,6 +70,7 @@ vi.mock('@epam/ai-dial-ui-kit', async (importOriginal) => {
       allowedFileTypes,
       maxSelectableFileSize,
       unsupportedFileTypeTooltip,
+      getDisabledTooltip,
       selectedPaths,
       onSelectedPathsChange,
       sharedWithMeIds,
@@ -112,6 +113,10 @@ vi.mock('@epam/ai-dial-ui-kit', async (importOriginal) => {
       allowedFileTypes?: string[];
       maxSelectableFileSize?: number;
       unsupportedFileTypeTooltip?: string;
+      getDisabledTooltip?: (row: {
+        nodeType?: string;
+        path: string;
+      }) => string | undefined;
       selectedPaths?: Set<string>;
       onSelectedPathsChange?: (paths: Set<string>) => void;
       sharedWithMeIds?: string[];
@@ -145,6 +150,10 @@ vi.mock('@epam/ai-dial-ui-kit', async (importOriginal) => {
         data-allowed-file-types={allowedFileTypes?.join(',')}
         data-max-selectable-file-size={maxSelectableFileSize}
         data-unsupported-file-type-tooltip={unsupportedFileTypeTooltip}
+        data-hidden-file-tooltip={getDisabledTooltip?.({
+          nodeType: DialFileNodeType.ITEM,
+          path: '/My files/.hidden/report.pdf',
+        })}
         data-upload-enabled={uploadEnabled}
         data-new-button-disabled={toolbarOptions?.isNewButtonDisabled}
         data-new-button-tooltip={toolbarOptions?.disabledNewButtonTooltip}
@@ -205,6 +214,14 @@ vi.mock('@epam/ai-dial-ui-kit', async (importOriginal) => {
         data-auto-select-uploaded-items={String(
           autoSelectUploadedItems ?? true,
         )}
+        data-hidden-file-selectable={String(
+          gridOptions?.additionalGridOptions?.rowSelection?.isRowSelectable?.({
+            data: {
+              nodeType: DialFileNodeType.ITEM,
+              path: '/My files/.hidden/report.pdf',
+            },
+          }) ?? false,
+        )}
       >
         {toolbarOptions?.tabs?.map((tab) => (
           <button
@@ -237,6 +254,14 @@ vi.mock('@epam/ai-dial-ui-kit', async (importOriginal) => {
           }
         >
           Select report
+        </button>
+        <button
+          type="button"
+          onClick={() =>
+            onSelectedPathsChange?.(new Set(['/My files/.hidden/report.pdf']))
+          }
+        >
+          Select hidden file
         </button>
         <button
           type="button"
@@ -278,6 +303,15 @@ const defaultHookResult: UseDialFileManagerResult = {
           name: 'report.pdf',
           path: '/My files/report.pdf',
           parentPath: '/My files',
+          nodeType: DialFileNodeType.ITEM,
+          folderId: 'test-bucket',
+          contentType: 'application/pdf',
+        },
+        {
+          id: '.hidden/report.pdf',
+          name: 'report.pdf',
+          path: '/My files/.hidden/report.pdf',
+          parentPath: '/My files/.hidden/',
           nodeType: DialFileNodeType.ITEM,
           folderId: 'test-bucket',
           contentType: 'application/pdf',
@@ -605,6 +639,24 @@ describe('DialFileManagerModal', () => {
     ).toBe(false);
 
     fireEvent.click(screen.getByRole('button', { name: 'Clear selection' }));
+
+    expect(screen.queryByText('1 item selected')).toBeNull();
+    expect(
+      screen.getByRole('button', { name: 'Attach' }).hasAttribute('disabled'),
+    ).toBe(true);
+  });
+
+  it('blocks dot-prefixed hidden files from attach selection', () => {
+    mockUseDialFileManager.mockReturnValue(defaultHookResult);
+    render(<DialFileManagerModal {...defaultProps} />);
+
+    const manager = screen.getByRole('region', { name: 'file manager' });
+    expect(manager.getAttribute('data-hidden-file-selectable')).toBe('false');
+    expect(manager.getAttribute('data-hidden-file-tooltip')).toBe(
+      'dialFileManager.attachingHiddenFilesNotAllowed',
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Select hidden file' }));
 
     expect(screen.queryByText('1 item selected')).toBeNull();
     expect(

--- a/apps/chat/src/utils/file-path.ts
+++ b/apps/chat/src/utils/file-path.ts
@@ -1,4 +1,2 @@
-import { HIDDEN_FILE } from '@epam/ai-dial-chat-shared';
-
 export const isHiddenPath = (path: string): boolean =>
-  path.includes(HIDDEN_FILE);
+  path.split('/').some((segment) => segment.startsWith('.'));

--- a/apps/chat/src/utils/tests/file-path.spec.ts
+++ b/apps/chat/src/utils/tests/file-path.spec.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+import { isHiddenPath } from '../file-path';
+
+describe('isHiddenPath', () => {
+  it('returns true when any path segment starts with a dot', () => {
+    expect(isHiddenPath('/My files/.env')).toBe(true);
+    expect(isHiddenPath('/My files/.hidden/report.pdf')).toBe(true);
+    expect(isHiddenPath('/My files/docs/.dial_folder')).toBe(true);
+  });
+
+  it('returns false for visible files with dots in their names', () => {
+    expect(isHiddenPath('/My files/report.pdf')).toBe(false);
+    expect(isHiddenPath('/My files/folder.with.dots/report.pdf')).toBe(false);
+  });
+});

--- a/openspec/specs/dial-file-manager-attach-folders/spec.md
+++ b/openspec/specs/dial-file-manager-attach-folders/spec.md
@@ -1,8 +1,12 @@
-## ADDED Requirements
+## Purpose
+
+Define folder-selection behavior for the DIAL file manager attach modal when a selected deployment supports folder attachments.
+
+## Requirements
 
 ### Requirement: Folder rows are selectable when canAttachFolders is enabled
 
-When `canAttachFolders` is `true`, `DialFileManagerModal` SHALL allow selection of `DialFileNodeType.FOLDER` rows in the grid. The `isRowSelectable` predicate SHALL return `true` for folder rows, except for hidden-path folders (which remain non-selectable regardless of `canAttachFolders`).
+When `canAttachFolders` is `true`, `DialFileManagerModal` SHALL allow selection of `DialFileNodeType.FOLDER` rows in the grid. The `isRowSelectable` predicate SHALL return `true` for folder rows, except for hidden-path folders (any path segment starts with `.`), which remain non-selectable regardless of `canAttachFolders`.
 
 When `canAttachFolders` is `false` (the default), folder rows SHALL remain non-selectable — this preserves current behavior.
 
@@ -24,7 +28,7 @@ Memoisation: `isRowSelectable` inside `useMemo` grid options; `filesByPath` in `
 
 #### Scenario: Hidden folder is never selectable even with canAttachFolders
 
-- **WHEN** `canAttachFolders` is `true` and a folder row has a hidden path (contains `.dial_folder`)
+- **WHEN** `canAttachFolders` is `true` and a folder row has a hidden path such as `/My files/.hidden/`
 - **THEN** `isRowSelectable` returns `false`
 
 ---

--- a/openspec/specs/dial-file-manager-attach-ui/spec.md
+++ b/openspec/specs/dial-file-manager-attach-ui/spec.md
@@ -1,4 +1,8 @@
-## ADDED Requirements
+## Purpose
+
+Define the DIAL file manager attach modal UI contract, including tab chrome, attachment constraints copy, and disabled-row feedback.
+
+## Requirements
 
 ### Requirement: Tab navigation UI in DialFileManagerModal
 
@@ -87,8 +91,6 @@ RTL: tab bar direction is handled by the ui-kit; no physical direction classes o
 
 ---
 
-## MODIFIED Requirements
-
 ### Requirement: Modal header shows attachment constraints description
 
 When the modal is in attach mode (i.e., the `onAttach` callback is present), `DialFileManagerModal` SHALL render a description paragraph below the modal title that summarises the active constraints:
@@ -132,6 +134,8 @@ Memoisation: description string computed in `useMemo` from props.
 - Return the string `t(DialFileManagerI18nKeys.AttachingHiddenFilesNotAllowed)` when `isHiddenPath(row.path)` is `true`.
 - Return `undefined` for all other rows.
 
+`isHiddenPath` SHALL treat any path segment starting with `.` as hidden, including `.env`, `.hidden`, and the file-manager placeholder `.dial_folder`.
+
 The callback behavior is unchanged by `activeTab`.
 
 i18n key: `DialFileManager.AttachingHiddenFilesNotAllowed`
@@ -141,10 +145,10 @@ Memoisation: `getDisabledTooltip` in `useCallback`.
 
 #### Scenario: Hidden path row shows tooltip
 
-- **WHEN** a grid row has `path` containing `.dial_folder` and the user hovers or focuses the row
-- **THEN** the tooltip "Attaching hidden files is not allowed" (or its translation) is displayed
+- **WHEN** a grid row has `path` containing a dot-prefixed segment such as `/My files/.hidden/report.pdf` and the user hovers or focuses the row
+- **THEN** the tooltip "Attaching hidden files is not allowed." (or its translation) is displayed
 
 #### Scenario: Normal path row shows no tooltip
 
-- **WHEN** a grid row has a normal (non-hidden) path
+- **WHEN** a grid row has a path with no dot-prefixed segment
 - **THEN** no tooltip is shown from `getDisabledTooltip`

--- a/openspec/specs/dial-file-manager-attach-validation/spec.md
+++ b/openspec/specs/dial-file-manager-attach-validation/spec.md
@@ -1,29 +1,33 @@
-## ADDED Requirements
+## Purpose
+
+Define how the DIAL file manager attach modal validates selectable rows and the final attach payload before files are added to a chat message.
+
+## Requirements
 
 ### Requirement: Hidden-path rows are not selectable
 
-`DialFileManagerModal` SHALL prevent selection of any grid row whose `path` contains `.dial_folder` (including files inside hidden folders). The `isRowSelectable` predicate SHALL return `false` for such rows.
+`DialFileManagerModal` SHALL prevent selection of any grid row whose `path` contains a hidden path segment. A segment is hidden when it starts with `.` (for example `.env`, `.hidden`, or the file-manager placeholder `.dial_folder`). This includes files inside hidden folders. The `isRowSelectable` predicate SHALL return `false` for such rows.
 
-A utility function `isHiddenPath(path: string): boolean` SHALL be created in `apps/chat/src/utils/file-path.ts` (or an existing app-level file-path utility) using the `HIDDEN_FILE` constant from `@epam/ai-dial-chat-shared`. This helper MUST NOT be placed inside any `libs/*` package.
+A utility function `isHiddenPath(path: string): boolean` SHALL live in `apps/chat/src/utils/file-path.ts` (or an existing app-level file-path utility) and evaluate path segments rather than relying on a single marker string. This helper MUST NOT be placed inside any `libs/*` package.
 
 i18n: tooltip key `DialFileManager.AttachingHiddenFilesNotAllowed`
 RTL: none (tooltip text only)
 Feature flag: none
 Memoisation: `isRowSelectable` is already inside `useMemo`-wrapped `gridOptions`; no additional memoisation needed.
 
-#### Scenario: Hidden marker file is not selectable
+#### Scenario: Dot-prefixed hidden file is not selectable
 
-- **WHEN** a row with `path` containing `.dial_folder` is rendered in the grid
+- **WHEN** a row with `path` containing a dot-prefixed segment such as `/My files/.env` is rendered in the grid
 - **THEN** `isRowSelectable` returns `false` for that row and the checkbox is not rendered / is disabled
 
 #### Scenario: File inside a hidden folder is not selectable
 
-- **WHEN** a file row has a `path` like `files/bucket/.dial_folder/child.txt`
+- **WHEN** a file row has a `path` like `/My files/.hidden/child.txt`
 - **THEN** `isRowSelectable` returns `false` for that row
 
 #### Scenario: Normal file is still selectable
 
-- **WHEN** a file row has a `path` that does not contain `.dial_folder`
+- **WHEN** a file row has a `path` with no dot-prefixed segments
 - **THEN** `isRowSelectable` returns `true` for that row (subject to MIME and size rules)
 
 ---
@@ -96,7 +100,7 @@ Memoisation: same `isRowSelectable` in `useMemo` grid options
 ### Requirement: Attach handler skips hidden and MIME-invalid files with info toast
 
 When the user clicks Attach, `DialFileManagerModal` SHALL:
-1. Remove from the resolved set any selected file that is hidden (`isHiddenPath`) or has a disallowed MIME type (when `allowedTypes` is provided).
+1. Remove from the resolved set any selected file that is hidden (`isHiddenPath`: any path segment starts with `.`) or has a disallowed MIME type (when `allowedTypes` is provided).
 2. If any files were removed due to unsupported type, show an info notification (title: `DialFileManager.UnsupportedFilesSkipped`, message: `DialFileManager.UnsupportedFilesDescription`).
 3. Call `onAttach` with the filtered set (modal closes).
 


### PR DESCRIPTION
## Description of changes

Fix File Manager attach mode to block hidden files/folders. Hidden paths now include any dot-prefixed path segment, show the expected tooltip, and are filtered out defensively from selection and attach payloads.

## Applicable issues

- https://github.com/epam/ai-dial-chat/issues/7640

## UI changes

<img width="1349" height="939" alt="2026-07-16_085420" src="https://github.com/user-attachments/assets/c7e29f94-e4b8-4e8e-9cbf-0dba59b41415" />


## Checklist

- [X] the pull request name ends with `(Issue #<ISSUE_ID>)` (comma-separated list of issues)
- [X] I confirm that I don't share any confidential information like API keys or any other secrets and private URLs
