### PR TITLE
fix: enforce max attachments limit (#7833)

### DIFF
--- a/apps/chat/src/components/ConversationView/ConversationMessageItem.tsx
+++ b/apps/chat/src/components/ConversationView/ConversationMessageItem.tsx
@@ -112,6 +112,8 @@ interface Props {
   validateAttachment?: (
     attachment: Attachment,
   ) => AttachmentErrorReason | undefined;
+  maximumAttachmentsAmount?: number;
+  onAttachmentsLimitExceeded?: (count: number, limit: number) => void;
   hideAttachFile?: boolean;
   /** `accept` attribute value forwarded to the edit-message native file picker. */
   fileAccept?: string;
@@ -156,6 +158,8 @@ const ConversationMessageItem: FC<Props> = ({
   executedLabel,
   stepsLabel,
   validateAttachment,
+  maximumAttachmentsAmount,
+  onAttachmentsLimitExceeded,
   hideAttachFile,
   fileAccept,
   onAttachmentClick: onAttachmentClickProp,
@@ -253,6 +257,8 @@ const ConversationMessageItem: FC<Props> = ({
             pendingDropFiles={pendingDropFiles}
             onDropFilesConsumed={onDropFilesConsumed}
             validateAttachment={validateAttachment}
+            maximumAttachmentsAmount={maximumAttachmentsAmount}
+            onAttachmentsLimitExceeded={onAttachmentsLimitExceeded}
             hideAttachFile={hideAttachFile}
             fileAccept={fileAccept}
           />

--- a/apps/chat/src/components/ConversationView/ConversationView.tsx
+++ b/apps/chat/src/components/ConversationView/ConversationView.tsx
@@ -47,6 +47,7 @@ import {
 } from '../../constants/translation-keys';
 import { useUser } from '../../context/auth/UserContext';
 import { useDeployments } from '../../context/DeploymentsContext';
+import { useNotification } from '../../context/NotificationContext';
 import { useAttachmentValidation } from '../../hooks/attachment/useAttachmentValidation';
 import { useOpenAttachmentCanvas } from '../../hooks/attachment/useOpenAttachmentCanvas';
 import { useIsMobile } from '../../hooks/breakpoint/useBreakpoint';
@@ -159,6 +160,7 @@ const ConversationView: FC<Props> = ({
 }) => {
   const isModelFixed = !!fixedModel;
   const { t } = useTranslation();
+  const { showNotification } = useNotification();
   const isMobile = useIsMobile();
   const { preference: sendOnEnter } = useKeyboardShortcutPreference();
   const { user } = useUser();
@@ -168,6 +170,7 @@ const ConversationView: FC<Props> = ({
   const [pendingDialAttachments, setPendingDialAttachments] = useState<
     Attachment[]
   >([]);
+  const [attachmentsAmount, setAttachmentsAmount] = useState(0);
   const { openAttachmentCanvas } = useOpenAttachmentCanvas();
   const isEditActive = !!editingMessageIndexes?.size;
   const {
@@ -428,6 +431,28 @@ const ConversationView: FC<Props> = ({
     [bucket],
   );
 
+  const handleAttachmentsChange = useCallback(
+    (attachments: Attachment[]) => {
+      setAttachmentsAmount(attachments.length);
+      onAttachmentsChange?.(attachments);
+    },
+    [onAttachmentsChange],
+  );
+
+  const handleAttachmentsLimitExceeded = useCallback(
+    (count: number, limit: number) => {
+      showNotification({
+        variant: NotificationVariant.Error,
+        title: t(DialFileManagerI18nKeys.TooManyFilesSelected),
+        message: t(DialFileManagerI18nKeys.TooManyFilesDescription, {
+          count,
+          limit,
+        }),
+      });
+    },
+    [showNotification, t],
+  );
+
   const handleInputAttachmentClick = useCallback(
     (attachment: Attachment) => {
       void openAttachmentCanvas(attachment);
@@ -539,6 +564,10 @@ const ConversationView: FC<Props> = ({
                         ? validateAttachment
                         : undefined
                     }
+                    maximumAttachmentsAmount={
+                      selectedDeployment?.maxInputAttachments
+                    }
+                    onAttachmentsLimitExceeded={handleAttachmentsLimitExceeded}
                     hideAttachFile={!isAttachmentsAllowed}
                     fileAccept={fileAccept}
                     onAttachmentClick={handleMessageAttachmentClick}
@@ -592,7 +621,7 @@ const ConversationView: FC<Props> = ({
                 onUploadAttachment={onUploadAttachment}
                 onStop={canStopAssistant ? onStop : undefined}
                 isStreaming={isAssistantTyping}
-                onAttachmentsChange={onAttachmentsChange}
+                onAttachmentsChange={handleAttachmentsChange}
                 placeholder={placeholder}
                 deployments={
                   fixedModel ? fixedDeploymentItems : deploymentItems
@@ -638,6 +667,10 @@ const ConversationView: FC<Props> = ({
                 validateAttachment={
                   selectedDeployment != null ? validateAttachment : undefined
                 }
+                maximumAttachmentsAmount={
+                  selectedDeployment?.maxInputAttachments
+                }
+                onAttachmentsLimitExceeded={handleAttachmentsLimitExceeded}
                 hideAttachFile={!isAttachmentsAllowed}
                 fileAccept={fileAccept}
                 onAttachmentClick={handleInputAttachmentClick}
@@ -687,6 +720,7 @@ const ConversationView: FC<Props> = ({
                   maximumAttachmentsAmount={
                     selectedDeployment?.maxInputAttachments
                   }
+                  existingAttachmentsAmount={attachmentsAmount}
                   canAttachFolders={
                     selectedDeployment?.features?.folderAttachments
                   }

--- a/apps/chat/src/components/DialFileManagerModal/DialFileManagerModal.tsx
+++ b/apps/chat/src/components/DialFileManagerModal/DialFileManagerModal.tsx
@@ -75,6 +75,7 @@ interface Props {
   allowedTypes?: string[];
   maxSelectableFileSize?: number;
   maximumAttachmentsAmount?: number;
+  existingAttachmentsAmount?: number;
   canAttachFolders?: boolean;
   allowedTypesLabel?: string;
   autoSelectUploadedItems?: boolean;
@@ -110,6 +111,7 @@ const DialFileManagerModal: FC<Props> = ({
   allowedTypes,
   maxSelectableFileSize,
   maximumAttachmentsAmount,
+  existingAttachmentsAmount = 0,
   canAttachFolders = false,
   allowedTypesLabel,
   autoSelectUploadedItems = false,
@@ -280,7 +282,10 @@ const DialFileManagerModal: FC<Props> = ({
       ];
     });
 
-    const totalCount = dedupedFiles.length + dialCoreFolderPaths.length;
+    const totalCount =
+      existingAttachmentsAmount +
+      dedupedFiles.length +
+      dialCoreFolderPaths.length;
     if (
       maximumAttachmentsAmount != null &&
       maximumAttachmentsAmount > 0 &&
@@ -303,6 +308,7 @@ const DialFileManagerModal: FC<Props> = ({
     selectedFiles,
     allowedTypes,
     maximumAttachmentsAmount,
+    existingAttachmentsAmount,
     showNotification,
     t,
     filesByPath,

--- a/apps/chat/src/components/DialFileManagerModal/tests/DialFileManagerModal.spec.tsx
+++ b/apps/chat/src/components/DialFileManagerModal/tests/DialFileManagerModal.spec.tsx
@@ -3,6 +3,7 @@ import {
   DialFileManagerTabs,
   DialFileNodeType,
   FileManagerColumnKey,
+  NotificationVariant,
 } from '@epam/ai-dial-ui-kit';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -28,12 +29,16 @@ const { mockShowNotification } = vi.hoisted(() => ({
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
-    t: (key: string, params?: Record<string, string>) => {
+    t: (key: string, params?: Record<string, string | number>) => {
       if (
         key === 'dialFileManager.unsupportedFileTypeTooltip' &&
         params?.allowedExtensions != null
       ) {
         return `Unsupported file type. Supported types: ${params.allowedExtensions}.`;
+      }
+
+      if (key === 'dialFileManager.tooManyFilesDescription') {
+        return `You selected ${params?.count} files, including previously attached ones. You can attach up to ${params?.limit} files.`;
       }
 
       return key;
@@ -551,6 +556,30 @@ describe('DialFileManagerModal', () => {
     expect(onAttach).toHaveBeenCalledWith({
       files: [expect.objectContaining({ name: 'report.pdf' })],
       folderPaths: [],
+    });
+  });
+
+  it('does not attach when selected files plus existing attachments exceed the maximum amount', () => {
+    const onAttach = vi.fn();
+    mockUseDialFileManager.mockReturnValue(defaultHookResult);
+    render(
+      <DialFileManagerModal
+        {...defaultProps}
+        onAttach={onAttach}
+        maximumAttachmentsAmount={2}
+        existingAttachmentsAmount={2}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Select report' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Attach' }));
+
+    expect(onAttach).not.toHaveBeenCalled();
+    expect(mockShowNotification).toHaveBeenCalledWith({
+      variant: NotificationVariant.Error,
+      title: 'dialFileManager.tooManyFilesSelected',
+      message:
+        'You selected 3 files, including previously attached ones. You can attach up to 2 files.',
     });
   });
 

--- a/apps/chat/src/components/NewConversationComposer/NewConversationComposer.tsx
+++ b/apps/chat/src/components/NewConversationComposer/NewConversationComposer.tsx
@@ -108,6 +108,7 @@ const NewConversationComposer: FC<Props> = ({
   const bucket = user?.bucket ?? '';
 
   const [isSending, setIsSending] = useState(false);
+  const [attachmentsAmount, setAttachmentsAmount] = useState(0);
   const [chatSettingsValues, setChatSettingsValues] =
     useState<NewConversationChatSettings>({
       responseFormat: ResponseFormat.Markdown,
@@ -188,6 +189,24 @@ const NewConversationComposer: FC<Props> = ({
     [openAttachmentCanvas],
   );
 
+  const handleAttachmentsChange = useCallback((attachments: Attachment[]) => {
+    setAttachmentsAmount(attachments.length);
+  }, []);
+
+  const handleAttachmentsLimitExceeded = useCallback(
+    (count: number, limit: number) => {
+      showNotification({
+        variant: NotificationVariant.Error,
+        title: t(DialFileManagerI18nKeys.TooManyFilesSelected),
+        message: t(DialFileManagerI18nKeys.TooManyFilesDescription, {
+          count,
+          limit,
+        }),
+      });
+    },
+    [showNotification, t],
+  );
+
   const handleSend = useCallback(
     async (text: string, attachments: Attachment[]) => {
       if (isSending || !selectedDeploymentId) return;
@@ -238,6 +257,7 @@ const NewConversationComposer: FC<Props> = ({
         <ConversationInput
           onSend={handleSend}
           onUploadAttachment={handleUploadAttachment}
+          onAttachmentsChange={handleAttachmentsChange}
           message={message}
           welcomeText={getTimeOfDayGreeting(
             new Date().getHours(),
@@ -290,6 +310,8 @@ const NewConversationComposer: FC<Props> = ({
           validateAttachment={
             selectedDeployment != null ? validateAttachment : undefined
           }
+          maximumAttachmentsAmount={selectedDeployment?.maxInputAttachments}
+          onAttachmentsLimitExceeded={handleAttachmentsLimitExceeded}
           hideAttachFile={!isAttachmentsAllowed}
           fileAccept={fileAccept}
           onAttachmentClick={handleAttachmentClick}
@@ -306,6 +328,7 @@ const NewConversationComposer: FC<Props> = ({
           allowedTypes={inputAttachmentTypes}
           maxSelectableFileSize={MAX_SELECTABLE_FILE_SIZE_BYTES}
           maximumAttachmentsAmount={selectedDeployment?.maxInputAttachments}
+          existingAttachmentsAmount={attachmentsAmount}
           canAttachFolders={selectedDeployment?.features?.folderAttachments}
           title={t(BasicI18nKeys.AttachFiles)}
           attachLabel={t(DialFileManagerI18nKeys.Attach)}

--- a/apps/chat/src/i18n/locales/en.json
+++ b/apps/chat/src/i18n/locales/en.json
@@ -466,7 +466,7 @@
     "unsupportedFilesSkipped": "Some files were skipped",
     "unsupportedFilesDescription": "Files with unsupported type were not attached",
     "tooManyFilesSelected": "Too many files selected",
-    "tooManyFilesDescription": "You selected {{count}} files, limit is {{limit}}",
+    "tooManyFilesDescription": "You selected {{count}} files, including previously attached ones. You can attach up to {{limit}} files.",
     "deletingLabel": "Deleting…",
     "deleteConfirmTitleSingle": "Confirm deleting",
     "deleteConfirmTitleMultiple": "Confirm deleting items",

--- a/apps/chat/src/pages/AppsEditor/GeneralForm.tsx
+++ b/apps/chat/src/pages/AppsEditor/GeneralForm.tsx
@@ -58,6 +58,17 @@ const EMPTY_VALUES: DeploymentCreationFormValues = {
   intro: '',
 };
 
+const normalizeFormValues = (
+  values: Partial<DeploymentCreationFormValues>,
+): DeploymentCreationFormValues => ({
+  name: values.name ?? '',
+  description: values.description ?? '',
+  iconUrl: values.iconUrl ?? '',
+  version: values.version ?? '',
+  topics: values.topics ?? [],
+  intro: values.intro ?? '',
+});
+
 const GeneralForm = forwardRef<GeneralFormHandle, Props>(function GeneralForm(
   { schemaId, appId, initialValues, onCreated },
   ref,
@@ -74,7 +85,7 @@ const GeneralForm = forwardRef<GeneralFormHandle, Props>(function GeneralForm(
   useEffect(() => {
     if (hasSeededInitialValuesRef.current || !initialValues) return;
     hasSeededInitialValuesRef.current = true;
-    setValues({ ...EMPTY_VALUES, ...initialValues });
+    setValues(normalizeFormValues(initialValues));
   }, [initialValues]);
 
   const labels: DeploymentCreationFormLabels = useMemo(

--- a/apps/chat/src/pages/AppsEditor/tests/GeneralForm.spec.tsx
+++ b/apps/chat/src/pages/AppsEditor/tests/GeneralForm.spec.tsx
@@ -1,5 +1,6 @@
 import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import type { ComponentProps, Ref } from 'react';
 import { createRef } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
@@ -74,14 +75,16 @@ vi.mock('@epam/ai-dial-ui-kit', async (importOriginal) => {
   };
 });
 
-const DEFAULT_PROPS = {
+type GeneralFormProps = Omit<ComponentProps<typeof GeneralForm>, 'ref'>;
+
+const DEFAULT_PROPS: Pick<GeneralFormProps, 'schemaId' | 'onCreated'> = {
   schemaId: 'quickapps2-schema',
   onCreated: vi.fn(),
 };
 
 const renderForm = (
-  props?: Partial<typeof DEFAULT_PROPS>,
-  ref?: React.Ref<GeneralFormHandle>,
+  props?: Partial<GeneralFormProps>,
+  ref?: Ref<GeneralFormHandle>,
 ) => render(<GeneralForm {...DEFAULT_PROPS} {...props} ref={ref} />);
 
 const getNameInput = () =>
@@ -237,6 +240,37 @@ describe('GeneralForm', () => {
         },
       }),
     );
+  });
+
+  it('normalizes undefined initial values before preview and submit', async () => {
+    const onCreated = vi.fn();
+    const ref = createRef<GeneralFormHandle>();
+
+    renderForm(
+      {
+        appId: 'users/u/apps/existing',
+        onCreated,
+        initialValues: {
+          name: ' My App ',
+          description: undefined,
+          iconUrl: undefined,
+          version: undefined,
+          topics: undefined,
+        },
+      },
+      ref,
+    );
+
+    await act(async () => {
+      await ref.current?.submit();
+    });
+
+    expect(onCreated).toHaveBeenCalledWith(
+      'users/u/apps/existing',
+      'My App',
+      undefined,
+    );
+    expect(createApplication).not.toHaveBeenCalled();
   });
 
   it('shows error message when API call fails', async () => {

--- a/libs/conversation-input/src/components/EditMessageInput/EditMessageInput.tsx
+++ b/libs/conversation-input/src/components/EditMessageInput/EditMessageInput.tsx
@@ -34,6 +34,8 @@ export const EditMessageInput: FC<EditMessageInputProps> = ({
   validateAttachment,
   hideAttachFile = false,
   fileAccept,
+  maximumAttachmentsAmount,
+  onAttachmentsLimitExceeded,
 }) => {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [pendingDropFiles, setPendingDropFiles] = useState<File[]>([]);
@@ -111,6 +113,8 @@ export const EditMessageInput: FC<EditMessageInputProps> = ({
         prefixAttachments={keptAttachments}
         onRemovePrefixAttachment={handleRemovePreExisting}
         validateAttachment={validateAttachment}
+        maximumAttachmentsAmount={maximumAttachmentsAmount}
+        onAttachmentsLimitExceeded={onAttachmentsLimitExceeded}
       />
 
       {/* Action row — outside the bordered box */}

--- a/libs/conversation-input/src/components/Input/Input.tsx
+++ b/libs/conversation-input/src/components/Input/Input.tsx
@@ -92,6 +92,8 @@ export const Input: FC<InputProps> = ({
   validateAttachment,
   onAttachmentClick,
   modelPickerOverlay,
+  maximumAttachmentsAmount,
+  onAttachmentsLimitExceeded,
 }) => {
   const isMobile = useIsMobile();
   const [isPickerOpen, setIsPickerOpen] = useState(false);
@@ -160,6 +162,9 @@ export const Input: FC<InputProps> = ({
     pendingAttachments,
     onPendingAttachmentsConsumed,
     onExpandPastedText: handleExpandPastedText,
+    maximumAttachmentsAmount,
+    baseAttachmentsAmount: prefixAttachments.length,
+    onAttachmentsLimitExceeded,
   });
 
   const handleTranscript = useCallback(

--- a/libs/conversation-input/src/components/Input/tests/Input.spec.tsx
+++ b/libs/conversation-input/src/components/Input/tests/Input.spec.tsx
@@ -353,6 +353,69 @@ describe('Input', () => {
     );
   });
 
+  it('does not add a selected batch when it would exceed the attachment limit', () => {
+    const onAttachmentsLimitExceeded = vi.fn();
+    const onAttachmentsChange = vi.fn();
+    render(
+      <Input
+        maximumAttachmentsAmount={2}
+        onAttachmentsLimitExceeded={onAttachmentsLimitExceeded}
+        onAttachmentsChange={onAttachmentsChange}
+      />,
+    );
+    const fileInput = document.querySelector(
+      'input[type="file"]',
+    ) as HTMLInputElement;
+
+    fireEvent.change(fileInput, {
+      target: {
+        files: [
+          new File(['content'], 'first.pdf', { type: 'application/pdf' }),
+          new File(['content'], 'second.pdf', { type: 'application/pdf' }),
+          new File(['content'], 'third.pdf', { type: 'application/pdf' }),
+        ],
+      },
+    });
+
+    expect(screen.queryByText('first')).toBeNull();
+    expect(onAttachmentsChange).not.toHaveBeenCalled();
+    expect(onAttachmentsLimitExceeded).toHaveBeenCalledWith(3, 2);
+  });
+
+  it('counts existing attachments when checking a selected batch against the limit', () => {
+    const onAttachmentsLimitExceeded = vi.fn();
+    render(
+      <Input
+        maximumAttachmentsAmount={2}
+        onAttachmentsLimitExceeded={onAttachmentsLimitExceeded}
+      />,
+    );
+    const fileInput = document.querySelector(
+      'input[type="file"]',
+    ) as HTMLInputElement;
+
+    fireEvent.change(fileInput, {
+      target: {
+        files: [
+          new File(['content'], 'first.pdf', { type: 'application/pdf' }),
+        ],
+      },
+    });
+    fireEvent.change(fileInput, {
+      target: {
+        files: [
+          new File(['content'], 'second.pdf', { type: 'application/pdf' }),
+          new File(['content'], 'third.pdf', { type: 'application/pdf' }),
+        ],
+      },
+    });
+
+    expect(screen.getByText('first')).toBeTruthy();
+    expect(screen.queryByText('second')).toBeNull();
+    expect(screen.queryByText('third')).toBeNull();
+    expect(onAttachmentsLimitExceeded).toHaveBeenCalledWith(3, 2);
+  });
+
   it('should show mic button when isTranscriptionSupported and message is empty', () => {
     render(<Input isTranscriptionSupported micLabel="Record voice message" />);
     expect(screen.getByLabelText('Record voice message')).toBeTruthy();

--- a/libs/conversation-input/src/hooks/useAttachments.ts
+++ b/libs/conversation-input/src/hooks/useAttachments.ts
@@ -39,6 +39,12 @@ interface UseAttachmentsParams {
    * Receives the plain-text content of the attachment.
    */
   onExpandPastedText?: (text: string) => void;
+  /** Maximum number of attachments allowed in the tray. Undefined means unlimited. */
+  maximumAttachmentsAmount?: number;
+  /** Attachments rendered outside this hook but counted against the same limit. */
+  baseAttachmentsAmount?: number;
+  /** Called when adding a batch would exceed `maximumAttachmentsAmount`. */
+  onAttachmentsLimitExceeded?: (count: number, limit: number) => void;
 }
 
 /** Return value of the {@link useAttachments} hook. */
@@ -76,6 +82,9 @@ export const useAttachments = ({
   pendingAttachments,
   onPendingAttachmentsConsumed,
   onExpandPastedText,
+  maximumAttachmentsAmount,
+  baseAttachmentsAmount = 0,
+  onAttachmentsLimitExceeded,
 }: UseAttachmentsParams): UseAttachmentsResult => {
   const [attachments, setAttachments] =
     useState<Attachment[]>(initialAttachments);
@@ -113,7 +122,7 @@ export const useAttachments = ({
     (updater: (current: Attachment[]) => Attachment[]) => {
       setAttachments((prev) => {
         const updated = updater(prev);
-        onAttachmentsChange?.(updated);
+        if (updated !== prev) onAttachmentsChange?.(updated);
         return updated;
       });
     },
@@ -178,11 +187,42 @@ export const useAttachments = ({
   const addAttachments = useCallback(
     (newAttachments: Attachment[], upload = true) => {
       let toAdd: Attachment[] = [];
+      let exceededLimit:
+        | {
+            count: number;
+            limit: number;
+          }
+        | undefined;
       updateAttachments((prev) => {
         const existingIds = new Set(prev.map((a) => a.id));
         toAdd = newAttachments.filter((a) => !existingIds.has(a.id));
+
+        if (
+          maximumAttachmentsAmount != null &&
+          maximumAttachmentsAmount > 0 &&
+          Number.isFinite(maximumAttachmentsAmount)
+        ) {
+          const count = baseAttachmentsAmount + prev.length + toAdd.length;
+          if (count > maximumAttachmentsAmount) {
+            exceededLimit = {
+              count,
+              limit: maximumAttachmentsAmount,
+            };
+            return prev;
+          }
+        }
+
         return [...prev, ...toAdd];
       });
+
+      if (exceededLimit != null) {
+        toAdd.forEach((attachment) => {
+          if (attachment.previewUrl) URL.revokeObjectURL(attachment.previewUrl);
+        });
+        onAttachmentsLimitExceeded?.(exceededLimit.count, exceededLimit.limit);
+        return;
+      }
+
       if (upload) {
         const validToUpload: Attachment[] = [];
         toAdd.forEach((attachment) => {
@@ -202,7 +242,14 @@ export const useAttachments = ({
         void runAtRate(validToUpload, MAX_UPLOADS_PER_MINUTE, uploadAttachment);
       }
     },
-    [updateAttachments, uploadAttachment, validateAttachment],
+    [
+      baseAttachmentsAmount,
+      maximumAttachmentsAmount,
+      onAttachmentsLimitExceeded,
+      updateAttachments,
+      uploadAttachment,
+      validateAttachment,
+    ],
   );
 
   useEffect(() => {

--- a/libs/conversation-input/src/models/ConversationInput.ts
+++ b/libs/conversation-input/src/models/ConversationInput.ts
@@ -93,6 +93,16 @@ export interface EditMessageInputProps {
     attachment: Attachment,
   ) => AttachmentErrorReason | undefined;
   /**
+   * Maximum number of kept plus newly added attachments. Undefined, `0`, or
+   * non-finite values mean there is no count limit.
+   */
+  maximumAttachmentsAmount?: number;
+  /**
+   * Called when adding a file/drop batch would exceed
+   * `maximumAttachmentsAmount`.
+   */
+  onAttachmentsLimitExceeded?: (count: number, limit: number) => void;
+  /**
    * When `true`, the "Attach file" button is hidden.
    */
   hideAttachFile?: boolean;
@@ -229,6 +239,16 @@ export interface ConversationInputProps {
   validateAttachment?: (
     attachment: Attachment,
   ) => AttachmentErrorReason | undefined;
+  /**
+   * Maximum number of attachments allowed in the input tray. Undefined, `0`,
+   * or non-finite values mean there is no count limit.
+   */
+  maximumAttachmentsAmount?: number;
+  /**
+   * Called when adding a file/drop/pending attachment batch would exceed
+   * `maximumAttachmentsAmount`.
+   */
+  onAttachmentsLimitExceeded?: (count: number, limit: number) => void;
   /**
    * When `true`, the "Attach file" item is removed from the attach menu.
    * Other menu items (e.g. DIAL file system) remain visible. When no items

--- a/libs/conversation-input/src/models/Input.ts
+++ b/libs/conversation-input/src/models/Input.ts
@@ -247,6 +247,16 @@ export interface InputProps {
     attachment: Attachment,
   ) => AttachmentErrorReason | undefined;
   /**
+   * Maximum number of attachments allowed in the tray. Undefined, `0`, or
+   * non-finite values mean there is no count limit.
+   */
+  maximumAttachmentsAmount?: number;
+  /**
+   * Called when adding a file/drop/pending attachment batch would exceed
+   * `maximumAttachmentsAmount`.
+   */
+  onAttachmentsLimitExceeded?: (count: number, limit: number) => void;
+  /**
    * Called when the user clicks or keyboard-activates an attachment card.
    * Receives the full `Attachment` object (including the local `File`).
    * When absent the card is not rendered as interactive.

--- a/openspec/specs/conversation-input-attachments/spec.md
+++ b/openspec/specs/conversation-input-attachments/spec.md
@@ -235,6 +235,60 @@ When `validateAttachment` is not provided, existing behaviour is unchanged.
 
 ---
 
+### Requirement: Input enforces an optional maximum attachment count
+
+`ConversationInputProps`, `InputProps`, and `EditMessageInputProps` SHALL accept optional host-injected count-limit props:
+
+```ts
+maximumAttachmentsAmount?: number
+onAttachmentsLimitExceeded?: (count: number, limit: number) => void
+```
+
+When `maximumAttachmentsAmount` is a finite number greater than `0`, the input SHALL reject an entire newly added batch when the combined attachment count would exceed the limit. The combined count includes:
+- attachments already in the input tray;
+- pending attachments added from a native file picker, drag-and-drop, clipboard paste, or host-supplied `pendingAttachments`;
+- for `EditMessageInput`, pre-existing kept attachments rendered through `prefixAttachments`.
+
+When rejecting a batch, the input SHALL NOT add any attachment from that batch to the tray, SHALL NOT call `onUploadAttachment` for that batch, SHALL call `onAttachmentsLimitExceeded(count, limit)` when provided, and SHALL revoke any `previewUrl` object URLs created for rejected image attachments.
+
+When `maximumAttachmentsAmount` is `undefined`, `0`, negative, or non-finite, the input SHALL treat the count as unlimited.
+
+The lib SHALL remain host-agnostic: it must not know DIAL Core, quick apps, deployments, REST paths, notification UI, or i18n keys. The host app owns deriving the limit from the selected deployment and rendering any user-facing notification.
+
+#### Scenario: Selected file batch exceeds limit
+
+- **WHEN** `maximumAttachmentsAmount` is `2`
+- **AND** the user selects 3 files in one native file-picker batch
+- **THEN** no selected file is added to the tray
+- **AND** `onUploadAttachment` is NOT called for any selected file
+- **AND** `onAttachmentsLimitExceeded` is called with `count=3` and `limit=2`
+
+#### Scenario: Existing tray attachments count toward limit
+
+- **WHEN** the tray already contains 1 attachment
+- **AND** `maximumAttachmentsAmount` is `2`
+- **AND** the user selects 2 more files
+- **THEN** the new batch is rejected
+- **AND** the tray still contains only the original attachment
+- **AND** `onAttachmentsLimitExceeded` is called with `count=3` and `limit=2`
+
+#### Scenario: Edit-mode kept attachments count toward limit
+
+- **WHEN** `EditMessageInput` is rendered with 2 kept attachments
+- **AND** `maximumAttachmentsAmount` is `2`
+- **AND** the user selects 1 additional file
+- **THEN** the selected file is rejected
+- **AND** `onAttachmentsLimitExceeded` is called with `count=3` and `limit=2`
+
+#### Scenario: Empty maximum means unlimited
+
+- **WHEN** `maximumAttachmentsAmount` is `undefined`
+- **AND** the user selects any number of valid files
+- **THEN** all selected files are accepted subject to MIME/type/upload validation
+- **AND** no count-limit callback is called
+
+---
+
 ### Requirement: Attachments already in the tray are re-validated when validateAttachment changes
 
 `useAttachments` (`libs/conversation-input/src/hooks/useAttachments.ts`) SHALL re-run `validateAttachment` against every attachment already in the tray whenever the `validateAttachment` callback identity changes (e.g., because the host recomputed it after the user switched the selected model/deployment).
@@ -363,4 +417,3 @@ Because the browser `accept` attribute is only a selection hint (the user can st
 
 - **WHEN** `fileAccept` is provided and the user overrides the OS dialog to pick an unsupported file
 - **THEN** `validateAttachment` is still invoked for that file and rejects it as before
-

--- a/openspec/specs/dial-file-manager-attach-validation/spec.md
+++ b/openspec/specs/dial-file-manager-attach-validation/spec.md
@@ -130,9 +130,13 @@ Memoisation: `handleAttach` in `useCallback`
 
 ### Requirement: Attach handler blocks when count exceeds maximumAttachmentsAmount
 
-When `maximumAttachmentsAmount` is provided and greater than `0`, `DialFileManagerModal` SHALL check the count of the valid (post-filter) selection **after** applying hidden and MIME filters. If the count exceeds `maximumAttachmentsAmount`, the modal SHALL:
+When `maximumAttachmentsAmount` is provided as a finite number greater than `0`, `DialFileManagerModal` SHALL check the count of the valid (post-filter) selection **after** applying hidden and MIME filters. The count SHALL include both the valid current modal selection and `existingAttachmentsAmount` (default `0`) supplied by the host for attachments already present in the conversation input tray.
+
+If the combined count exceeds `maximumAttachmentsAmount`, the modal SHALL:
 1. Show an error notification (title: `DialFileManager.TooManyFilesSelected`, message: `DialFileManager.TooManyFilesDescription` with `{{count}}` and `{{limit}}`).
 2. **Not** call `onAttach` — the modal stays open.
+
+When `maximumAttachmentsAmount` is `undefined`, `0`, negative, or non-finite, no count restriction is applied.
 
 i18n keys: `DialFileManager.TooManyFilesSelected`, `DialFileManager.TooManyFilesDescription` (params: `count`, `limit`)
 RTL: none (toast only)
@@ -144,7 +148,15 @@ Memoisation: `handleAttach` in `useCallback`
 - **WHEN** `maximumAttachmentsAmount` is `3`, user selects 5 valid files, and clicks Attach
 - **THEN** an error toast is shown with count=5, limit=3, and `onAttach` is NOT called
 
-#### Scenario: Count at limit — attach succeeds
+#### Scenario: Previously attached files count toward limit
+
+- **WHEN** `maximumAttachmentsAmount` is `2`
+- **AND** `existingAttachmentsAmount` is `2`
+- **AND** user selects 1 valid file and clicks Attach
+- **THEN** an error toast is shown with count=3, limit=2
+- **AND** `onAttach` is NOT called
+
+#### Scenario: Count at limit
 
 - **WHEN** `maximumAttachmentsAmount` is `3` and user selects exactly 3 valid files
 - **THEN** `onAttach` is called with 3 files and the modal closes


### PR DESCRIPTION
## Description of changes

Fix quick app attachment limit enforcement in the chat.
The composer now blocks file batches that would exceed `maxInputAttachments`, including files already attached in the input tray. The DIAL file manager attach flow also counts existing attachments before allowing more files. When the limit is exceeded, users see a “Too many files selected” notification and no extra files are attached.

## Applicable issues

- https://github.com/epam/ai-dial-chat/issues/7833

## UI changes

<img width="1330" height="922" alt="2026-07-16_152506" src="https://github.com/user-attachments/assets/39623024-2f12-4d91-a574-5098e7abc268" />

## Checklist

- [X] the pull request name ends with `(Issue #<ISSUE_ID>)` (comma-separated list of issues)
- [X] I confirm that I don't share any confidential information like API keys or any other secrets and private URLs
