### PR TITLE
fix: Quick App preview using stale attachment settings (#7834)

### DIFF
--- a/apps/chat/src/components/ConversationView/ConversationView.tsx
+++ b/apps/chat/src/components/ConversationView/ConversationView.tsx
@@ -182,6 +182,7 @@ const ConversationView: FC<Props> = ({
     error,
   } = useDeployments();
   const { favoriteIds, toggleFavorite } = useFavoriteApplications();
+  const activeDeploymentId = fixedModel?.id ?? selectedItemId;
 
   const favoriteCatalogItems = useMemo(
     () =>
@@ -192,8 +193,8 @@ const ConversationView: FC<Props> = ({
   );
 
   const selectedDeployment = useMemo(
-    () => items.find((item) => item.id === selectedItemId),
-    [items, selectedItemId],
+    () => items.find((item) => item.id === activeDeploymentId),
+    [items, activeDeploymentId],
   );
 
   const selectedCatalogItem = useMemo(

--- a/apps/chat/src/pages/AppsEditor/AppsEditor.tsx
+++ b/apps/chat/src/pages/AppsEditor/AppsEditor.tsx
@@ -30,7 +30,7 @@ const AppsEditor: FC = () => {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
-  const { schemas, items: deployments } = useDeployments();
+  const { schemas, items: deployments, refetchDeployments } = useDeployments();
 
   const [createdAppId, setCreatedAppId] = useState<string | null>(null);
   const [submittedAppInfo, setSubmittedAppInfo] = useState<{
@@ -146,16 +146,32 @@ const AppsEditor: FC = () => {
     settingsStepRef.current?.triggerSave();
   }, [isPreviewing]);
 
+  const handleSettingsUpdated = useCallback(() => {
+    void refetchDeployments();
+  }, [refetchDeployments]);
+
   const handleSaveSuccess = useCallback(() => {
     if (isPreviewing) return;
-    setIsSaving(false);
-    if (pendingSaveAction === 'preview') {
-      setIsPreviewing(true);
-    } else {
-      navigate(returnUrl);
-    }
-    setPendingSaveAction(null);
-  }, [isPreviewing, pendingSaveAction, navigate, returnUrl]);
+
+    const completeSave = async () => {
+      await refetchDeployments().catch(() => undefined);
+      setIsSaving(false);
+      if (pendingSaveAction === 'preview') {
+        setIsPreviewing(true);
+      } else {
+        navigate(returnUrl);
+      }
+      setPendingSaveAction(null);
+    };
+
+    void completeSave();
+  }, [
+    isPreviewing,
+    pendingSaveAction,
+    refetchDeployments,
+    navigate,
+    returnUrl,
+  ]);
 
   const handleSaveError = useCallback(
     (error: string) => {
@@ -250,6 +266,7 @@ const AppsEditor: FC = () => {
             appDisplayName={appDisplayName}
             appIconUrl={appIconUrl}
             isPreviewing={isPreviewing}
+            onUpdated={handleSettingsUpdated}
             onSaveSuccess={handleSaveSuccess}
             onSaveError={handleSaveError}
           />

--- a/apps/chat/src/pages/AppsEditor/SettingsStep.tsx
+++ b/apps/chat/src/pages/AppsEditor/SettingsStep.tsx
@@ -17,6 +17,7 @@ interface Props {
   appDisplayName?: string;
   appIconUrl?: string;
   isPreviewing?: boolean;
+  onUpdated?: () => void;
   onSaveSuccess?: () => void;
   onSaveError?: (error: string) => void;
 }
@@ -29,6 +30,7 @@ const SettingsStep = forwardRef<SettingsStepHandle, Props>(
       appDisplayName,
       appIconUrl,
       isPreviewing = false,
+      onUpdated,
       onSaveSuccess,
       onSaveError,
     },
@@ -53,6 +55,7 @@ const SettingsStep = forwardRef<SettingsStepHandle, Props>(
               ref={iframeRef}
               schema={schema}
               appId={appId}
+              onUpdated={onUpdated}
               onSaveSuccess={onSaveSuccess}
               onSaveError={onSaveError}
             />

--- a/apps/chat/src/pages/AppsEditor/tests/AppsEditor.spec.tsx
+++ b/apps/chat/src/pages/AppsEditor/tests/AppsEditor.spec.tsx
@@ -1,4 +1,4 @@
-import { act, render, screen } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { forwardRef, useImperativeHandle } from 'react';
 import { MemoryRouter } from 'react-router-dom';
@@ -13,6 +13,7 @@ import * as DeploymentsContextModule from '../../../context/DeploymentsContext';
 import AppsEditor from '../AppsEditor';
 
 let latestSettingsStepProps: {
+  onUpdated?: () => void;
   onSaveSuccess?: () => void;
   onSaveError?: (error: string) => void;
   isPreviewing?: boolean;
@@ -21,6 +22,7 @@ let latestSettingsStepProps: {
 vi.mock('../SettingsStep', () => ({
   default: forwardRef(function MockSettingsStep(
     props: {
+      onUpdated?: () => void;
       onSaveSuccess?: () => void;
       onSaveError?: (error: string) => void;
       isPreviewing?: boolean;
@@ -40,6 +42,7 @@ vi.mock('../SettingsStep', () => ({
 vi.mock('../../../context/DeploymentsContext');
 
 const mockUseDeployments = vi.mocked(DeploymentsContextModule.useDeployments);
+const refetchDeployments = vi.fn();
 
 const SCHEMA = {
   id: 'quickapps2-schema',
@@ -57,10 +60,13 @@ const renderEditor = (search: string) =>
 describe('AppsEditor', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    refetchDeployments.mockReset();
+    refetchDeployments.mockResolvedValue(undefined);
     latestSettingsStepProps = {};
     mockUseDeployments.mockReturnValue({
       schemas: [SCHEMA],
       items: [],
+      refetchDeployments,
     } as unknown as ReturnType<typeof DeploymentsContextModule.useDeployments>);
   });
 
@@ -90,12 +96,54 @@ describe('AppsEditor', () => {
       latestSettingsStepProps.onSaveSuccess?.();
     });
 
+    expect(refetchDeployments).toHaveBeenCalledOnce();
     expect(
-      screen.getByRole('button', {
+      await screen.findByRole('button', {
         name: AppsEditorI18nKeys.ExitPreviewButton,
       }),
     ).toBeTruthy();
     expect(screen.getByText('settings-step').dataset.previewing).toBe('true');
+  });
+
+  it('waits for deployments refetch before entering preview mode', async () => {
+    let resolveRefetch: () => void = () => undefined;
+    const refetchPromise = new Promise<void>((resolve) => {
+      resolveRefetch = resolve;
+    });
+    refetchDeployments.mockReturnValueOnce(refetchPromise);
+    renderEditor('step=settings&schema=quickapps2-schema&appId=abc');
+
+    await userEvent.click(
+      screen.getByRole('button', { name: BasicI18nKeys.Preview }),
+    );
+    act(() => {
+      latestSettingsStepProps.onSaveSuccess?.();
+    });
+
+    expect(refetchDeployments).toHaveBeenCalledOnce();
+    expect(screen.getByText('settings-step').dataset.previewing).toBe('false');
+
+    await act(async () => {
+      resolveRefetch();
+      await refetchPromise;
+    });
+
+    expect(
+      await screen.findByRole('button', {
+        name: AppsEditorI18nKeys.ExitPreviewButton,
+      }),
+    ).toBeTruthy();
+    expect(screen.getByText('settings-step').dataset.previewing).toBe('true');
+  });
+
+  it('refetches deployments when settings report an update', () => {
+    renderEditor('step=settings&schema=quickapps2-schema&appId=abc');
+
+    act(() => {
+      latestSettingsStepProps.onUpdated?.();
+    });
+
+    expect(refetchDeployments).toHaveBeenCalledOnce();
   });
 
   it('stays on the iframe and shows an error notification when the preview save fails', async () => {
@@ -129,6 +177,7 @@ describe('AppsEditor', () => {
       latestSettingsStepProps.onSaveSuccess?.();
     });
 
+    await waitFor(() => expect(refetchDeployments).toHaveBeenCalledOnce());
     expect(
       screen.queryByRole('button', {
         name: AppsEditorI18nKeys.ExitPreviewButton,
@@ -146,9 +195,13 @@ describe('AppsEditor', () => {
       latestSettingsStepProps.onSaveSuccess?.();
     });
 
+    expect(refetchDeployments).toHaveBeenCalledOnce();
     const cancelButton = screen.getByRole('button', {
       name: ButtonsI18nKeys.Cancel,
     }) as HTMLButtonElement;
+    await screen.findByRole('button', {
+      name: AppsEditorI18nKeys.ExitPreviewButton,
+    });
     expect(cancelButton.disabled).toBe(true);
     expect(
       screen.getByRole('button', {

--- a/openspec/changes/add-app-editor-flow/specs/app-editor-flow/spec.md
+++ b/openspec/changes/add-app-editor-flow/specs/app-editor-flow/spec.md
@@ -70,6 +70,8 @@ The `AppsEditorPage` SHALL read all params exclusively via `useSearchParams` fro
 `apps/chat/src/pages/AppsEditor/AppsEditor.tsx` SHALL manage a two-step creation flow.
 
 State owned locally via `useState`:
+- `pendingSaveAction: 'save' | 'preview' | null` — distinguishes Save & Exit from Preview-triggered saves
+- `isPreviewing: boolean` — true while the Settings step shows the in-page chat preview instead of the editor iframe
 - `createdAppId: string | null` — populated after step-1 create succeeds
 - `isSaving: boolean` — true while a create (step 1) or save (step 2) action is in-flight; disables the header's Cancel/Save buttons
 - `saveError: string` — inline error message shown above the Settings step when a save fails
@@ -89,6 +91,7 @@ The page header SHALL be the shared `EditorHeader` component (see "Shared editor
 - `steps` / `currentStep`: the two-step stepper
 - `saveButtonLabel`: `appsEditor.generalForm.nextButton` ("Next") while on the General step, `appsEditor.saveButton` ("Save & Exit") while on the Settings step
 - `onSave`: on the General step, calls `generalFormRef.current.submit()`; on the Settings step, clears `saveError` and calls `settingsStepRef.current.triggerSave()`
+- `onPreview`: on the Settings step, exits preview when `isPreviewing` is true; otherwise clears `saveError`, sets `pendingSaveAction = 'preview'`, and calls `settingsStepRef.current.triggerSave()`
 - `onCancel`: navigates to `returnUrl`
 
 **i18n keys** (all under `appsEditor.*`):
@@ -118,7 +121,7 @@ The page header SHALL be the shared `EditorHeader` component (see "Shared editor
 | `appsEditor.error.createFailed` | `Failed to create application. Please try again.` |
 | `appsEditor.error.saveFailed` | `Failed to save application settings. Please try again.` |
 
-**Memoisation**: The resolved schema object and the `returnUrl` value SHALL be wrapped in `useMemo`. The `handleCreated`, `handleSave`, `handleSaveSuccess`, and `handleSaveError` callbacks SHALL be wrapped in `useCallback`.
+**Memoisation**: The resolved schema object and the `returnUrl` value SHALL be wrapped in `useMemo`. The `handleCreated`, `handleSave`, `handlePreview`, `handleSettingsUpdated`, `handleSaveSuccess`, and `handleSaveError` callbacks SHALL be wrapped in `useCallback`.
 
 **Accessibility**: The step indicator region SHALL have `role="navigation"` and `aria-label="Editor steps"`.
 
@@ -156,7 +159,20 @@ The page header SHALL be the shared `EditorHeader` component (see "Shared editor
 
 - **WHEN** the user is on the Settings step and clicks the header's "Save & Exit" button
 - **THEN** `isSaving` becomes true and `settingsStepRef.current.triggerSave()` is called
-- **AND** when the iframe posts back a `SAVE_SUCCESS` message, the page navigates to `returnUrl`
+- **AND** when the iframe posts back a `SAVE_SUCCESS` message, `refetchDeployments()` is awaited
+- **AND** the page navigates to `returnUrl`
+
+#### Scenario: Preview on Settings step uses freshly saved deployment settings
+
+- **WHEN** the user is on the Settings step and clicks the header's "Preview" button
+- **THEN** `isSaving` becomes true, `pendingSaveAction` is set to `preview`, and `settingsStepRef.current.triggerSave()` is called
+- **AND** when the iframe posts back a `SAVE_SUCCESS` message, `refetchDeployments()` is awaited before `isPreviewing` becomes true
+- **AND** the preview chat input derives attachment availability and limits from the refreshed deployment's `inputAttachmentTypes` and `maxInputAttachments`
+
+#### Scenario: Settings updates refresh deployment metadata before preview
+
+- **WHEN** the iframe posts back a `<displayName>/updatedApplicationSuccess` message while the Settings step is mounted
+- **THEN** `AppsEditor` calls `refetchDeployments()` through the `onUpdated` callback passed to `SettingsStep`
 
 #### Scenario: Save failure on Settings step shows inline error and stays on the page
 
@@ -296,6 +312,8 @@ interface Props {
 - If `schema.editorUrl` is truthy → render `<AppEditorIframe schema={schema} appId={appId} onSaveSuccess={onSaveSuccess} onSaveError={onSaveError} />`.
 - Otherwise → render a placeholder message (`appsEditor.settingsStep.noEditorPlaceholder`).
 
+When rendering `AppEditorIframe`, `SettingsStep` SHALL pass `onUpdated`, `onSaveSuccess`, and `onSaveError` through unchanged.
+
 `SettingsStep` SHALL be wrapped in `forwardRef<SettingsStepHandle, Props>` and expose, via `useImperativeHandle`, a `triggerSave()` that forwards to the inner `AppEditorIframe`'s own `triggerSave()` (a no-op when no iframe is rendered):
 
 ```ts
@@ -309,6 +327,7 @@ Props:
 interface Props {
   schema: ApplicationSchemaSummaryDto | undefined;
   appId: string;
+  onUpdated?: () => void;
   onSaveSuccess?: () => void;
   onSaveError?: (error: string) => void;
 }


### PR DESCRIPTION
## Description of changes

- Refresh deployments after Quick App settings are updated or saved from the apps editor iframe.
- Wait for the refreshed deployment metadata before entering Preview mode, so attachment type and max attachment settings are reflected immediately.
- Use the fixed preview deployment when deriving attachment support in `ConversationView`.


## Applicable issues

- https://github.com/epam/ai-dial-chat/issues/7834

## Checklist

- [X] the pull request name ends with `(Issue #<ISSUE_ID>)` (comma-separated list of issues)
- [X] I confirm that I don't share any confidential information like API keys or any other secrets and private URLs
