### PR TITLE
fix: show conversation starters and intro text (#7783)

### DIFF
--- a/apps/chat-api/src/deployments/deployments.controller.ts
+++ b/apps/chat-api/src/deployments/deployments.controller.ts
@@ -1,7 +1,15 @@
-import { Controller, Get, Header, Param, Query, Req } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Header,
+  Param,
+  Query,
+  Req,
+  Res,
+} from '@nestjs/common';
 import { ApiOperation, ApiQuery, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { Throttle } from '@nestjs/throttler';
-import type { Request } from 'express';
+import type { Request, Response } from 'express';
 import type { SessionUser } from '../auth/session/session.types';
 import { DeploymentLimitsResponseDto } from '../openapi/openapi-response.dto';
 import { DeploymentsService } from './deployments.service';
@@ -17,7 +25,6 @@ export class DeploymentsController {
 
   @Get()
   @Throttle({ default: { limit: 60, ttl: 60000 } })
-  @Header('Cache-Control', 'private, max-age=30')
   @ApiOperation({
     operationId: 'listDeployments',
     summary: 'List deployments by interface type',
@@ -29,6 +36,13 @@ export class DeploymentsController {
     enum: ['chat', 'embedding', 'mcp', 'custom_ui', 'all'],
     description: 'Filter by interface type (repeatable)',
     example: ['chat', 'mcp'],
+  })
+  @ApiQuery({
+    name: 'refresh',
+    required: false,
+    type: Boolean,
+    description:
+      'Bypass the short server-side deployments list cache and refresh from DIAL Core',
   })
   @ApiResponse({ status: 200, type: DeploymentsResponseDto })
   @ApiResponse({ status: 400, description: 'Invalid query parameter' })
@@ -46,13 +60,22 @@ export class DeploymentsController {
     status: 503,
     description: 'DIAL Core is unavailable or timed out',
   })
-  listDeployments(@Query() query: DeploymentsQueryDto, @Req() req: Request) {
+  listDeployments(
+    @Query() query: DeploymentsQueryDto,
+    @Req() req: Request,
+    @Res({ passthrough: true }) res: Response,
+  ) {
     const { sub, at, bucket } = req.user as SessionUser;
+    res.setHeader(
+      'Cache-Control',
+      query.refresh ? 'private, no-store' : 'private, max-age=30',
+    );
     return this.deploymentsService.listDeployments(
       sub,
       at,
       bucket,
       query.interface_type,
+      query.refresh,
     );
   }
 

--- a/apps/chat-api/src/deployments/deployments.service.ts
+++ b/apps/chat-api/src/deployments/deployments.service.ts
@@ -21,6 +21,7 @@ import type {
   ToolsetAuthSettingsDto,
 } from './dto/deployment-details.dto';
 import type {
+  ConversationStartersDto,
   DeploymentItemDto,
   DeploymentsResponseDto,
 } from './dto/deployment-item.dto';
@@ -76,6 +77,39 @@ const getStringArray = (
   return Array.isArray(value)
     ? value.filter((item): item is string => typeof item === 'string')
     : undefined;
+};
+
+const mapConversationStarters = (
+  raw: unknown,
+): ConversationStartersDto | undefined => {
+  if (!isRecord(raw) || !Array.isArray(raw.starters)) return undefined;
+
+  const starters = raw.starters
+    .filter(isRecord)
+    .map((starter) => {
+      const title = getString(starter, 'title')?.trim();
+      const text = getString(starter, 'text')?.trim();
+      return title && text ? { title, text } : undefined;
+    })
+    .filter((starter): starter is { title: string; text: string } =>
+      Boolean(starter),
+    );
+
+  if (starters.length === 0) return undefined;
+
+  const introText = getString(raw, 'intro_text');
+  const autoSubmit = getBoolean(raw, 'auto_submit');
+  const chatMessageInputDisabled = getBoolean(
+    raw,
+    'chat_message_input_disabled',
+  );
+
+  return {
+    ...(introText != null && { introText }),
+    ...(autoSubmit != null && { autoSubmit }),
+    ...(chatMessageInputDisabled != null && { chatMessageInputDisabled }),
+    starters,
+  };
 };
 
 /**
@@ -214,6 +248,13 @@ const mapToDeploymentItem = (
     raw.features?.mcp === true ||
     raw.mcp != null ||
     !!interfaces?.includes('mcp');
+  const applicationProperties = isRecord(raw.application_properties)
+    ? raw.application_properties
+    : undefined;
+  const conversationStarters =
+    type === 'application'
+      ? mapConversationStarters(applicationProperties?.conversation_starters)
+      : undefined;
 
   return {
     id: raw.id,
@@ -256,6 +297,7 @@ const mapToDeploymentItem = (
       type === 'application' && raw.id.includes('/')
         ? raw.id.substring(0, raw.id.lastIndexOf('/'))
         : undefined,
+    conversationStarters,
   };
 };
 
@@ -359,6 +401,7 @@ export class DeploymentsService {
     accessToken: string,
     bucket: string,
     interfaceType?: DeploymentInterfaceType[],
+    refresh = false,
   ): Promise<DeploymentsResponseDto> {
     const baseCacheKey = `deployments:list:${userSub}`;
     const normalizedTypes = interfaceType?.filter(
@@ -372,11 +415,12 @@ export class DeploymentsService {
     const cacheKey = interfaceFilter
       ? `${baseCacheKey}:interface:${interfaceFilter.join(',')}`
       : baseCacheKey;
-    const cached =
-      (await this.cacheManager.get<DeploymentItemDto[]>(cacheKey)) ??
-      (interfaceFilter
-        ? await this.cacheManager.get<DeploymentItemDto[]>(baseCacheKey)
-        : undefined);
+    const cached = refresh
+      ? undefined
+      : ((await this.cacheManager.get<DeploymentItemDto[]>(cacheKey)) ??
+        (interfaceFilter
+          ? await this.cacheManager.get<DeploymentItemDto[]>(baseCacheKey)
+          : undefined));
 
     let allItems: DeploymentItemDto[];
     if (cached) {

--- a/apps/chat-api/src/deployments/dto/deployment-item.dto.ts
+++ b/apps/chat-api/src/deployments/dto/deployment-item.dto.ts
@@ -1,5 +1,38 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
+export class ConversationStarterDto {
+  @ApiProperty({ description: 'Starter button label' })
+  title!: string;
+
+  @ApiProperty({ description: 'Text inserted into the chat input' })
+  text!: string;
+}
+
+export class ConversationStartersDto {
+  @ApiPropertyOptional({
+    description: 'Optional text shown above the conversation starter buttons',
+  })
+  introText?: string;
+
+  @ApiPropertyOptional({
+    description:
+      'When true, starter buttons submit immediately after selection',
+  })
+  autoSubmit?: boolean;
+
+  @ApiPropertyOptional({
+    description:
+      'When true, the chat input is disabled and users can only use starters',
+  })
+  chatMessageInputDisabled?: boolean;
+
+  @ApiProperty({
+    type: [ConversationStarterDto],
+    description: 'Conversation starter buttons configured by the application',
+  })
+  starters!: ConversationStarterDto[];
+}
+
 export class DeploymentFeaturesDto {
   @ApiProperty({
     description: 'Whether the deployment supports a custom system prompt',
@@ -143,6 +176,13 @@ export class DeploymentItemDto {
       'Parent folder path for application-type deployments (absent for root-level or non-application items)',
   })
   applicationFolder?: string;
+
+  @ApiPropertyOptional({
+    type: ConversationStartersDto,
+    description:
+      'Quick Apps conversation starter settings from application properties',
+  })
+  conversationStarters?: ConversationStartersDto;
 }
 
 export class DeploymentsResponseDto {

--- a/apps/chat-api/src/deployments/dto/deployments-query.dto.ts
+++ b/apps/chat-api/src/deployments/dto/deployments-query.dto.ts
@@ -1,5 +1,5 @@
 import { Transform } from 'class-transformer';
-import { IsArray, IsIn, IsOptional } from 'class-validator';
+import { IsArray, IsBoolean, IsIn, IsOptional } from 'class-validator';
 
 export enum DeploymentInterfaceType {
   Chat = 'chat',
@@ -20,4 +20,13 @@ export class DeploymentsQueryDto {
     return value;
   })
   interface_type?: DeploymentInterfaceType[];
+
+  @IsOptional()
+  @IsBoolean()
+  @Transform(({ value }: { value: unknown }) => {
+    if (value === 'true') return true;
+    if (value === 'false') return false;
+    return value;
+  })
+  refresh?: boolean;
 }

--- a/apps/chat-api/src/deployments/dto/raw-deployment.dto.ts
+++ b/apps/chat-api/src/deployments/dto/raw-deployment.dto.ts
@@ -23,6 +23,7 @@ export interface RawDeploymentDto {
   max_input_attachments?: number;
   description_keywords?: string[];
   owner?: string;
+  application_properties?: Record<string, unknown>;
   features?: RawDeploymentFeaturesDto;
   /**
    * Root-level MCP descriptor DIAL Core attaches to MCP-capable applications

--- a/apps/chat-api/src/deployments/tests/deployments.controller.integration.spec.ts
+++ b/apps/chat-api/src/deployments/tests/deployments.controller.integration.spec.ts
@@ -95,10 +95,12 @@ describe('DeploymentsController (integration)', () => {
         .expect(200);
 
       expect(res.body).toEqual(mockResponse);
+      expect(res.headers['cache-control']).toBe('private, max-age=30');
       expect(service.listDeployments).toHaveBeenCalledWith(
         TEST_USER.sub,
         TEST_USER.at,
         TEST_USER.bucket,
+        undefined,
         undefined,
       );
     });
@@ -189,7 +191,29 @@ describe('DeploymentsController (integration)', () => {
         TEST_USER.at,
         TEST_USER.bucket,
         ['chat'],
+        undefined,
       );
+    });
+
+    it('passes refresh=true to service', async () => {
+      const res = await request(app.getHttpServer())
+        .get('/api/v1/deployments?refresh=true')
+        .expect(200);
+
+      expect(res.headers['cache-control']).toBe('private, no-store');
+      expect(service.listDeployments).toHaveBeenCalledWith(
+        TEST_USER.sub,
+        TEST_USER.at,
+        TEST_USER.bucket,
+        undefined,
+        true,
+      );
+    });
+
+    it('returns 400 for invalid refresh value', async () => {
+      await request(app.getHttpServer())
+        .get('/api/v1/deployments?refresh=maybe')
+        .expect(400);
     });
 
     it('returns 400 with invalid interface_type', async () => {
@@ -221,6 +245,7 @@ describe('DeploymentsController (integration)', () => {
         TEST_USER.at,
         TEST_USER.bucket,
         ['embedding'],
+        undefined,
       );
     });
 

--- a/apps/chat-api/src/deployments/tests/deployments.controller.spec.ts
+++ b/apps/chat-api/src/deployments/tests/deployments.controller.spec.ts
@@ -1,5 +1,5 @@
 import { NotFoundException } from '@nestjs/common';
-import type { Request } from 'express';
+import type { Request, Response } from 'express';
 import { describe, expect, it, vi } from 'vitest';
 import { DeploymentsController } from '../deployments.controller';
 import type { DeploymentsService } from '../deployments.service';
@@ -14,6 +14,10 @@ const TEST_USER = {
   bucket: 'test-bucket',
 };
 const mockReq = { user: TEST_USER } as unknown as Request;
+const makeMockRes = () =>
+  ({ setHeader: vi.fn() }) as unknown as Response & {
+    setHeader: ReturnType<typeof vi.fn>;
+  };
 
 function makeController() {
   const service = {
@@ -30,30 +34,60 @@ function makeController() {
 describe('DeploymentsController', () => {
   it('delegates to service with parsed query and extracts sub and at from request', async () => {
     const { controller, service } = makeController();
+    const mockRes = makeMockRes();
     const query: DeploymentsQueryDto = {
       interface_type: [DeploymentInterfaceType.Chat],
     };
 
-    await controller.listDeployments(query, mockReq);
+    await controller.listDeployments(query, mockReq, mockRes);
 
+    expect(mockRes.setHeader).toHaveBeenCalledWith(
+      'Cache-Control',
+      'private, max-age=30',
+    );
     expect(service.listDeployments).toHaveBeenCalledWith(
       TEST_USER.sub,
       TEST_USER.at,
       TEST_USER.bucket,
       [DeploymentInterfaceType.Chat],
+      undefined,
+    );
+  });
+
+  it('passes refresh flag to service', async () => {
+    const { controller, service } = makeController();
+    const mockRes = makeMockRes();
+    const query: DeploymentsQueryDto = {
+      refresh: true,
+    };
+
+    await controller.listDeployments(query, mockReq, mockRes);
+
+    expect(mockRes.setHeader).toHaveBeenCalledWith(
+      'Cache-Control',
+      'private, no-store',
+    );
+    expect(service.listDeployments).toHaveBeenCalledWith(
+      TEST_USER.sub,
+      TEST_USER.at,
+      TEST_USER.bucket,
+      undefined,
+      true,
     );
   });
 
   it('passes undefined interface_type when query has no filter', async () => {
     const { controller, service } = makeController();
+    const mockRes = makeMockRes();
     const query: DeploymentsQueryDto = {};
 
-    await controller.listDeployments(query, mockReq);
+    await controller.listDeployments(query, mockReq, mockRes);
 
     expect(service.listDeployments).toHaveBeenCalledWith(
       TEST_USER.sub,
       TEST_USER.at,
       TEST_USER.bucket,
+      undefined,
       undefined,
     );
   });

--- a/apps/chat-api/src/deployments/tests/deployments.service.spec.ts
+++ b/apps/chat-api/src/deployments/tests/deployments.service.spec.ts
@@ -181,6 +181,29 @@ describe('DeploymentsService', () => {
       expect(sdkClient.listDeployments).not.toHaveBeenCalled();
     });
 
+    it('bypasses cached deployments when refresh is true', async () => {
+      const cached: DeploymentItemDto[] = [
+        { id: 'cached', displayName: 'Cached', type: 'model' },
+      ];
+      const { service, sdkClient } = makeService({ cached });
+      sdkClient.listDeployments.mockResolvedValue({
+        error: false,
+        response: { status: 200 },
+        data: [mockModel],
+      });
+
+      const result = await service.listDeployments(
+        'user1',
+        'token',
+        'bucket-1',
+        undefined,
+        true,
+      );
+
+      expect(result.deployments[0].id).toBe(mockModel.id);
+      expect(sdkClient.listDeployments).toHaveBeenCalledOnce();
+    });
+
     it('applies interface_type filter in-process after cache hit', async () => {
       const cached: DeploymentItemDto[] = [
         {
@@ -250,6 +273,47 @@ describe('DeploymentsService', () => {
       expect(result.deployments[0].applicationTypeSchemaId).toBe(
         'https://example.com/schemas/quick-app',
       );
+    });
+
+    it('maps Quick Apps conversation starters from application properties', async () => {
+      const { service, sdkClient } = makeService();
+      sdkClient.listDeployments.mockResolvedValue({
+        error: false,
+        response: { status: 200 },
+        data: [
+          {
+            ...mockApplication,
+            application_properties: {
+              conversation_starters: {
+                intro_text: 'Choose a starting point',
+                auto_submit: false,
+                chat_message_input_disabled: true,
+                starters: [
+                  { title: 'Summarize', text: 'Summarize this document' },
+                  { title: ' ', text: 'Ignored' },
+                  { title: 'Explain', text: 'Explain the key points' },
+                ],
+              },
+            },
+          },
+        ],
+      });
+
+      const result = await service.listDeployments(
+        'user1',
+        'token',
+        'bucket-1',
+      );
+
+      expect(result.deployments[0].conversationStarters).toEqual({
+        introText: 'Choose a starting point',
+        autoSubmit: false,
+        chatMessageInputDisabled: true,
+        starters: [
+          { title: 'Summarize', text: 'Summarize this document' },
+          { title: 'Explain', text: 'Explain the key points' },
+        ],
+      });
     });
 
     it('does not set applicationTypeSchemaId for model deployments', async () => {

--- a/apps/chat/src/components/NewConversationComposer/NewConversationComposer.tsx
+++ b/apps/chat/src/components/NewConversationComposer/NewConversationComposer.tsx
@@ -70,6 +70,8 @@ interface Props {
   modelSelectorError?: unknown;
   isInputDisabled?: boolean;
   placeholder: string;
+  /** Optional text shown above the starter buttons and the composer input. */
+  introText?: string;
   /** Initial textarea content (e.g. populated by a starter selection). */
   message?: string;
   inputStyles?: ConversationInputStyles;
@@ -79,7 +81,7 @@ interface Props {
     attachments: Attachment[],
     chatSettings: NewConversationChatSettings,
   ) => Promise<void>;
-  /** Rendered below the composer (e.g. starter buttons). */
+  /** Rendered above the composer input (e.g. starter buttons). */
   children?: ReactNode;
 }
 
@@ -94,6 +96,7 @@ const NewConversationComposer: FC<Props> = ({
   modelSelectorError = null,
   isInputDisabled = false,
   placeholder,
+  introText,
   message,
   inputStyles,
   onCreateConversation,
@@ -256,6 +259,12 @@ const NewConversationComposer: FC<Props> = ({
         role="region"
         aria-label={t(ChatI18nKeys.WelcomeScreen)}
       >
+        {introText && (
+          <p className="mb-4 max-w-3xl text-center text-sm text-secondary">
+            {introText}
+          </p>
+        )}
+        {children}
         <ConversationInput
           onSend={handleSend}
           onUploadAttachment={handleUploadAttachment}
@@ -319,7 +328,6 @@ const NewConversationComposer: FC<Props> = ({
           onAttachmentClick={handleAttachmentClick}
           modelPickerOverlay={modelPickerOverlay}
         />
-        {children}
       </div>
       {isDialFileManagerOpen && (
         <DialFileManagerModal

--- a/apps/chat/src/components/NewConversationComposer/NewConversationComposer.tsx
+++ b/apps/chat/src/components/NewConversationComposer/NewConversationComposer.tsx
@@ -260,7 +260,7 @@ const NewConversationComposer: FC<Props> = ({
         aria-label={t(ChatI18nKeys.WelcomeScreen)}
       >
         {introText && (
-          <p className="mb-4 max-w-3xl text-center text-sm text-secondary">
+          <p className="dial-small-text mb-4 max-w-3xl text-center text-secondary">
             {introText}
           </p>
         )}

--- a/apps/chat/src/context/DeploymentsContext.tsx
+++ b/apps/chat/src/context/DeploymentsContext.tsx
@@ -269,9 +269,10 @@ export const DeploymentsProvider = ({ children }: { children: ReactNode }) => {
   const refetchDeployments = useCallback(async () => {
     const requestId = ++deploymentsRequestIdRef.current;
     try {
-      const { deployments } = await getDeployments([
-        ListDeploymentsInterfaceTypeEnum.Chat,
-      ]);
+      const { deployments } = await getDeployments(
+        [ListDeploymentsInterfaceTypeEnum.Chat],
+        true,
+      );
       if (deploymentsRequestIdRef.current !== requestId) return;
       setRawDeployments(sortDeployments(deployments ?? []));
     } catch {

--- a/apps/chat/src/pages/AppsEditor/AppPreviewChat.tsx
+++ b/apps/chat/src/pages/AppsEditor/AppPreviewChat.tsx
@@ -1,9 +1,11 @@
 import {
   MessageRating,
   MessageRole,
+  ResponseFormat,
   type Attachment,
   type Conversation,
   type Message,
+  type StarterOption,
 } from '@epam/ai-dial-chat-shared';
 import {
   ConfirmationPopupVariant,
@@ -27,6 +29,7 @@ import ConversationView from '../../components/ConversationView/ConversationView
 import NewConversationComposer, {
   type NewConversationChatSettings,
 } from '../../components/NewConversationComposer/NewConversationComposer';
+import StarterButtons from '../../components/StarterButtons/StarterButtons';
 import { CONVERSATION_ROUTE_INPUT_STYLES } from '../../constants/input-styles';
 import {
   AppsEditorI18nKeys,
@@ -40,6 +43,7 @@ import { useNotification } from '../../context/NotificationContext';
 import { useAudioTranscription } from '../../hooks/conversation/useAudioTranscription';
 import { useConversationHandlers } from '../../hooks/conversation/useConversationHandlers';
 import { useConversationStream } from '../../hooks/conversation/useConversationStream';
+import { getApiErrorMessage } from '../../server-api/api-error';
 import { CompletionMode } from '../../server-api/chat-stream.api';
 import {
   createConversation as apiCreateConversation,
@@ -52,6 +56,8 @@ import { attachmentsToDtos } from '../../utils/attachment-to-dto';
 import { getConversationPath } from '../../utils/conversation-path';
 import { encodeDeploymentId } from '../../utils/deployment-id';
 import { resolveCatalogIconUrl } from '../../utils/icon-path';
+import { getQuickAppConversationStarters } from '../../utils/quick-app-conversation-starters';
+import { getStarterPopulateText } from '../../utils/starter-option';
 
 interface Props {
   appId: string;
@@ -89,9 +95,14 @@ const AppPreviewChat: FC<Props> = ({ appId, appDisplayName, appIconUrl }) => {
     () => items.find((item) => item.id === deploymentId),
     [items, deploymentId],
   );
+  const quickAppStarters = useMemo(
+    () => getQuickAppConversationStarters(appDeployment?.conversationStarters),
+    [appDeployment?.conversationStarters],
+  );
 
   const [conversationId, setConversationId] = useState<string | null>(null);
   const [conversation, setConversation] = useState<Conversation | null>(null);
+  const [inputMessage, setInputMessage] = useState<string | undefined>();
   const conversationRef = useRef<Conversation | null>(null);
   const conversationIdRef = useRef<string | null>(null);
   useEffect(() => {
@@ -199,6 +210,35 @@ const AppPreviewChat: FC<Props> = ({ appId, appDisplayName, appIconUrl }) => {
     [deploymentId, startStream],
   );
 
+  const handleStarterSelect = useCallback(
+    (starter: StarterOption) => {
+      const text = getStarterPopulateText(starter);
+      if (!starter['dial:widgetOptions'].submit) {
+        setInputMessage(text);
+        return;
+      }
+
+      const createFromStarter = async () => {
+        try {
+          await handleCreateConversation(text, [], {
+            responseFormat: ResponseFormat.Markdown,
+            systemPrompt: '',
+            temperature: 0.5,
+          });
+        } catch (err) {
+          const errorMessage = await getApiErrorMessage(err);
+          showNotification({
+            variant: NotificationVariant.Error,
+            message: errorMessage ?? t(ChatI18nKeys.CreateConversationError),
+          });
+        }
+      };
+
+      void createFromStarter();
+    },
+    [handleCreateConversation, showNotification, t],
+  );
+
   /*
    * useConversationHandlers only ever calls `navigate(ROUTES.Root)`, triggered by
    * deleting the last message in the conversation. This stub handles only that
@@ -282,10 +322,18 @@ const AppPreviewChat: FC<Props> = ({ appId, appDisplayName, appIconUrl }) => {
             selectedDeploymentId={deploymentId}
             isModelSelectorDisabled
             selectedDeployment={appDeployment}
+            isInputDisabled={quickAppStarters.isChatMessageInputDisabled}
             placeholder={t(AppsEditorI18nKeys.PreviewChatPlaceholder)}
+            introText={quickAppStarters.introText}
+            message={inputMessage}
             inputStyles={CONVERSATION_ROUTE_INPUT_STYLES}
             onCreateConversation={handleCreateConversation}
-          />
+          >
+            <StarterButtons
+              starters={quickAppStarters.starters}
+              onSelect={handleStarterSelect}
+            />
+          </NewConversationComposer>
         </Suspense>
       </div>
     );

--- a/apps/chat/src/pages/AppsEditor/tests/AppPreviewChat.spec.tsx
+++ b/apps/chat/src/pages/AppsEditor/tests/AppPreviewChat.spec.tsx
@@ -1,0 +1,173 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import * as DeploymentsContextModule from '../../../context/DeploymentsContext';
+import AppPreviewChat from '../AppPreviewChat';
+
+vi.mock('../../../context/AppConfigContext', () => ({
+  useAppConfig: () => ({
+    config: { asrModelId: null, transcribeSizeLimitBytes: 5 * 1024 * 1024 },
+  }),
+}));
+
+vi.mock('../../../context/auth/UserContext', () => ({
+  useUser: () => ({
+    user: { bucket: 'bucket' },
+  }),
+}));
+
+vi.mock('../../../context/NotificationContext', () => ({
+  useNotification: () => ({
+    showNotification: vi.fn(),
+  }),
+}));
+
+vi.mock('../../../context/DeploymentsContext');
+
+vi.mock('../../../hooks/conversation/useAudioTranscription', () => ({
+  useAudioTranscription: () => ({
+    handleUploadAudio: vi.fn(),
+    handleTranscribeAudio: vi.fn(),
+    isTranscriptionSupported: false,
+  }),
+}));
+
+vi.mock('../../../hooks/conversation/useConversationStream', () => ({
+  useConversationStream: () => ({
+    startStream: vi.fn(),
+    handleStop: vi.fn(),
+    isStreaming: false,
+    canStopStreaming: false,
+    hasStreamError: false,
+  }),
+}));
+
+vi.mock('../../../hooks/conversation/useConversationHandlers', () => ({
+  useConversationHandlers: () => ({
+    handleSend: vi.fn(),
+    handleUploadAttachment: vi.fn(),
+    handleRegenerateMessage: vi.fn(),
+    handleDeleteMessage: vi.fn(),
+    handleConfirmDelete: vi.fn(),
+    handleRateMessage: vi.fn(),
+    handleStartEdit: vi.fn(),
+    handleCancelEdit: vi.fn(),
+    handleEditMessage: vi.fn(),
+    editingMessageIndexes: new Set<number>(),
+    pendingDeleteIndex: null,
+    setPendingDeleteIndex: vi.fn(),
+  }),
+}));
+
+vi.mock('../../../server-api/conversations.api', () => ({
+  createConversation: vi.fn(),
+  deleteConversation: vi.fn(),
+  saveConversation: vi.fn(),
+}));
+
+vi.mock('../../../components/ConversationView/ConversationView', () => ({
+  default: () => <div>conversation-view</div>,
+}));
+
+vi.mock(
+  '../../../components/NewConversationComposer/NewConversationComposer',
+  () => ({
+    default: ({
+      children,
+      introText,
+      isInputDisabled,
+      message,
+    }: {
+      children?: ReactNode;
+      introText?: string;
+      isInputDisabled?: boolean;
+      message?: string;
+    }) => (
+      <div>
+        <output aria-label="Intro text">{introText ?? ''}</output>
+        <output aria-label="Input disabled">
+          {String(isInputDisabled ?? false)}
+        </output>
+        <output aria-label="Input message">{message ?? ''}</output>
+        {children}
+      </div>
+    ),
+  }),
+);
+
+vi.mock('../../../components/StarterButtons/StarterButtons', () => ({
+  default: ({
+    starters,
+    onSelect,
+  }: {
+    starters: Array<{
+      const: number;
+      title: string;
+      'dial:widgetOptions': {
+        populateText: string | null;
+        submit: boolean;
+        confirmationMessage: string | null;
+      };
+    }>;
+    onSelect: (starter: {
+      const: number;
+      title: string;
+      'dial:widgetOptions': {
+        populateText: string | null;
+        submit: boolean;
+        confirmationMessage: string | null;
+      };
+    }) => void;
+  }) => (
+    <div>
+      {starters.map((starter) => (
+        <button
+          key={starter.const}
+          type="button"
+          onClick={() => onSelect(starter)}
+        >
+          {starter.title}
+        </button>
+      ))}
+    </div>
+  ),
+}));
+
+describe('AppPreviewChat', () => {
+  const mockUseDeployments = vi.mocked(DeploymentsContextModule.useDeployments);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseDeployments.mockReturnValue({
+      items: [
+        {
+          id: 'applications/bucket/My%20App',
+          displayName: 'My App',
+          type: 'application',
+          conversationStarters: {
+            introText: 'Choose how to start',
+            autoSubmit: false,
+            chatMessageInputDisabled: true,
+            starters: [{ title: 'Draft', text: 'Write a draft' }],
+          },
+        },
+      ],
+    } as unknown as ReturnType<typeof DeploymentsContextModule.useDeployments>);
+  });
+
+  it('renders Quick Apps starter settings in preview before a conversation exists', async () => {
+    render(<AppPreviewChat appId="applications/bucket/My App" />);
+
+    expect(screen.getByLabelText('Intro text').textContent).toBe(
+      'Choose how to start',
+    );
+    expect(screen.getByLabelText('Input disabled').textContent).toBe('true');
+
+    await userEvent.click(screen.getByRole('button', { name: 'Draft' }));
+
+    expect(screen.getByLabelText('Input message').textContent).toBe(
+      'Write a draft',
+    );
+  });
+});

--- a/apps/chat/src/pages/ConversationRoute/ConversationRoute.spec.tsx
+++ b/apps/chat/src/pages/ConversationRoute/ConversationRoute.spec.tsx
@@ -92,6 +92,7 @@ vi.mock('@epam/ai-dial-conversation-input', async (importOriginal) => {
       deployments,
       selectedDeploymentId,
       isInputDisabled,
+      message,
       sendOnEnter,
     }: {
       onSend?: (msg: string, att: never[]) => Promise<void> | void;
@@ -102,6 +103,7 @@ vi.mock('@epam/ai-dial-conversation-input', async (importOriginal) => {
       deployments?: unknown[];
       selectedDeploymentId?: string | null;
       isInputDisabled?: boolean;
+      message?: string;
       sendOnEnter?: string;
     }) => (
       <div>
@@ -114,6 +116,7 @@ vi.mock('@epam/ai-dial-conversation-input', async (importOriginal) => {
         <output aria-label="Input disabled">
           {String(isInputDisabled ?? false)}
         </output>
+        <output aria-label="Input message">{message ?? ''}</output>
         <output aria-label="Send on enter">{sendOnEnter ?? 'none'}</output>
         <button
           type="button"
@@ -363,6 +366,85 @@ describe('ConversationRoute', () => {
     renderRoute();
     await waitFor(() => {
       expect(screen.getByLabelText('Input disabled').textContent).toBe('false');
+    });
+  });
+
+  it('renders Quick Apps intro text and populates input from non-submit starter', async () => {
+    mockUseDeployments.mockReturnValue({
+      items: [
+        {
+          ...mockItems[0],
+          conversationStarters: {
+            introText: 'Choose how to start',
+            autoSubmit: false,
+            chatMessageInputDisabled: true,
+            starters: [{ title: 'Draft', text: 'Write a draft' }],
+          },
+        },
+      ],
+      selectedItemId: 'gpt-4o',
+      setSelectedItemId: vi.fn(),
+      restoreSelectedItemId: vi.fn(),
+      selectedDeploymentConfiguration: null,
+      isLoading: false,
+      error: null,
+      schemas: [],
+      toolsets: [],
+      refetchToolsets: vi.fn(),
+      refetchDeployments: vi.fn(),
+    });
+
+    renderRoute();
+
+    expect(await screen.findByText('Choose how to start')).toBeTruthy();
+    expect(screen.getByLabelText('Input disabled').textContent).toBe('true');
+
+    await act(async () => {
+      screen.getByText('Draft').click();
+    });
+
+    expect(screen.getByLabelText('Input message').textContent).toBe(
+      'Write a draft',
+    );
+    expect(mockCreateConversation).not.toHaveBeenCalled();
+  });
+
+  it('creates a conversation from auto-submit Quick Apps starter without configuration value', async () => {
+    mockUseDeployments.mockReturnValue({
+      items: [
+        {
+          ...mockItems[0],
+          conversationStarters: {
+            autoSubmit: true,
+            starters: [{ title: 'Summarize', text: 'Summarize this' }],
+          },
+        },
+      ],
+      selectedItemId: 'gpt-4o',
+      setSelectedItemId: vi.fn(),
+      restoreSelectedItemId: vi.fn(),
+      selectedDeploymentConfiguration: null,
+      isLoading: false,
+      error: null,
+      schemas: [],
+      toolsets: [],
+      refetchToolsets: vi.fn(),
+      refetchDeployments: vi.fn(),
+    });
+
+    renderRoute();
+
+    await act(async () => {
+      screen.getByText('Summarize').click();
+    });
+
+    await waitFor(() => {
+      expect(mockCreateConversation).toHaveBeenCalledWith(
+        'Summarize this',
+        'gpt-4o',
+        [],
+        undefined,
+      );
     });
   });
 

--- a/apps/chat/src/pages/ConversationRoute/ConversationRoute.tsx
+++ b/apps/chat/src/pages/ConversationRoute/ConversationRoute.tsx
@@ -41,6 +41,7 @@ import { attachmentsToDtos } from '../../utils/attachment-to-dto';
 import { getConversationPath } from '../../utils/conversation-path';
 import { resolveCatalogIconUrl } from '../../utils/icon-path';
 import { mapDeploymentToCatalogItem } from '../../utils/map-deployment-to-catalog-item';
+import { getQuickAppConversationStarters } from '../../utils/quick-app-conversation-starters';
 import {
   getStarterPopulateText,
   getStartersFromSchema,
@@ -113,10 +114,23 @@ const ConversationRoute: FC = () => {
     () => getStartersFromSchema(selectedDeploymentConfiguration),
     [selectedDeploymentConfiguration],
   );
+  const quickAppStarters = useMemo(
+    () =>
+      getQuickAppConversationStarters(selectedDeployment?.conversationStarters),
+    [selectedDeployment?.conversationStarters],
+  );
+  const activeStarters =
+    starters.length > 0 ? starters : quickAppStarters.starters;
+  const starterIntroText = description ?? quickAppStarters.introText;
 
   const isInputDisabled = useMemo(
-    () => !!selectedDeploymentConfiguration?.isChatMessageInputDisabled,
-    [selectedDeploymentConfiguration],
+    () =>
+      !!selectedDeploymentConfiguration?.isChatMessageInputDisabled ||
+      quickAppStarters.isChatMessageInputDisabled,
+    [
+      selectedDeploymentConfiguration,
+      quickAppStarters.isChatMessageInputDisabled,
+    ],
   );
 
   const handleCreateConversation = useCallback(
@@ -198,6 +212,7 @@ const ConversationRoute: FC = () => {
         selectedDeployment={selectedDeployment}
         isInputDisabled={isInputDisabled}
         placeholder={t(ChatI18nKeys.Placeholder)}
+        introText={starterIntroText}
         message={inputMessage}
         inputStyles={CONVERSATION_ROUTE_INPUT_STYLES}
         onCreateConversation={handleCreateConversation}
@@ -230,7 +245,10 @@ const ConversationRoute: FC = () => {
           </Suspense>
         )}
       >
-        <StarterButtons starters={starters} onSelect={handleStarterSelect} />
+        <StarterButtons
+          starters={activeStarters}
+          onSelect={handleStarterSelect}
+        />
       </NewConversationComposer>
       <Suspense fallback={null}>
         <CatalogModal

--- a/apps/chat/src/server-api/deployments.api.ts
+++ b/apps/chat/src/server-api/deployments.api.ts
@@ -6,9 +6,11 @@ import { deploymentsApi } from './api-client';
 
 export const getDeployments = (
   interfaceType?: string[],
+  refresh?: boolean,
 ): Promise<DeploymentsResponseDto> =>
   deploymentsApi.listDeployments({
     interfaceType: interfaceType as Array<
       (typeof ListDeploymentsInterfaceTypeEnum)[keyof typeof ListDeploymentsInterfaceTypeEnum]
     >,
+    refresh,
   });

--- a/apps/chat/src/utils/quick-app-conversation-starters.ts
+++ b/apps/chat/src/utils/quick-app-conversation-starters.ts
@@ -1,0 +1,61 @@
+import type { StarterOption } from '@epam/ai-dial-chat-shared';
+
+interface QuickAppConversationStartersSettings {
+  starters: StarterOption[];
+  introText: string | undefined;
+  isChatMessageInputDisabled: boolean;
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  value != null && typeof value === 'object' && !Array.isArray(value);
+
+const getTrimmedString = (value: unknown): string | undefined => {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  return trimmed || undefined;
+};
+
+export const getQuickAppConversationStarters = (
+  conversationStarters: unknown,
+): QuickAppConversationStartersSettings => {
+  if (
+    !isRecord(conversationStarters) ||
+    !Array.isArray(conversationStarters.starters)
+  ) {
+    return {
+      starters: [],
+      introText: undefined,
+      isChatMessageInputDisabled: false,
+    };
+  }
+
+  const shouldSubmit = conversationStarters.autoSubmit !== false;
+  const starters = conversationStarters.starters
+    .filter(isRecord)
+    .map((starter) => ({
+      title: getTrimmedString(starter.title),
+      text: getTrimmedString(starter.text),
+    }))
+    .filter(
+      (starter): starter is { title: string; text: string } =>
+        starter.title != null && starter.text != null,
+    )
+    .map(
+      (starter, index): StarterOption => ({
+        const: index,
+        title: starter.title,
+        'dial:widgetOptions': {
+          populateText: starter.text,
+          submit: shouldSubmit,
+          confirmationMessage: null,
+        },
+      }),
+    );
+
+  return {
+    starters,
+    introText: getTrimmedString(conversationStarters.introText),
+    isChatMessageInputDisabled:
+      conversationStarters.chatMessageInputDisabled === true,
+  };
+};

--- a/apps/chat/src/utils/tests/quick-app-conversation-starters.spec.ts
+++ b/apps/chat/src/utils/tests/quick-app-conversation-starters.spec.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { getQuickAppConversationStarters } from '../quick-app-conversation-starters';
+
+describe('quick-app-conversation-starters', () => {
+  it('maps valid Quick Apps starters to StarterOption entries', () => {
+    const result = getQuickAppConversationStarters({
+      introText: '  Pick a task  ',
+      autoSubmit: false,
+      chatMessageInputDisabled: true,
+      starters: [
+        { title: ' Summarize ', text: ' Summarize this ' },
+        { title: '', text: 'Ignored' },
+        { title: 'Explain', text: ' ' },
+      ],
+    });
+
+    expect(result).toEqual({
+      introText: 'Pick a task',
+      isChatMessageInputDisabled: true,
+      starters: [
+        {
+          const: 0,
+          title: 'Summarize',
+          'dial:widgetOptions': {
+            populateText: 'Summarize this',
+            submit: false,
+            confirmationMessage: null,
+          },
+        },
+      ],
+    });
+  });
+
+  it('defaults starter buttons to auto-submit when the setting is absent', () => {
+    const result = getQuickAppConversationStarters({
+      starters: [{ title: 'Start', text: 'Begin' }],
+    });
+
+    expect(result.starters[0]['dial:widgetOptions'].submit).toBe(true);
+  });
+
+  it('returns empty settings for invalid payloads', () => {
+    expect(getQuickAppConversationStarters(null)).toEqual({
+      starters: [],
+      introText: undefined,
+      isChatMessageInputDisabled: false,
+    });
+  });
+});

--- a/libs/chat-api-client/openapi.json
+++ b/libs/chat-api-client/openapi.json
@@ -422,6 +422,15 @@
         "operationId": "listDeployments",
         "parameters": [
           {
+            "name": "refresh",
+            "required": false,
+            "in": "query",
+            "description": "Bypass the short server-side deployments list cache and refresh from DIAL Core",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
             "name": "interface_type",
             "required": false,
             "in": "query",
@@ -3834,6 +3843,45 @@
         },
         "required": ["systemPrompt", "temperature"]
       },
+      "ConversationStarterDto": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string",
+            "description": "Starter button label"
+          },
+          "text": {
+            "type": "string",
+            "description": "Text inserted into the chat input"
+          }
+        },
+        "required": ["title", "text"]
+      },
+      "ConversationStartersDto": {
+        "type": "object",
+        "properties": {
+          "introText": {
+            "type": "string",
+            "description": "Optional text shown above the conversation starter buttons"
+          },
+          "autoSubmit": {
+            "type": "boolean",
+            "description": "When true, starter buttons submit immediately after selection"
+          },
+          "chatMessageInputDisabled": {
+            "type": "boolean",
+            "description": "When true, the chat input is disabled and users can only use starters"
+          },
+          "starters": {
+            "description": "Conversation starter buttons configured by the application",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ConversationStarterDto"
+            }
+          }
+        },
+        "required": ["starters"]
+      },
       "DeploymentItemDto": {
         "type": "object",
         "properties": {
@@ -3942,6 +3990,14 @@
           "applicationFolder": {
             "type": "string",
             "description": "Parent folder path for application-type deployments (absent for root-level or non-application items)"
+          },
+          "conversationStarters": {
+            "description": "Quick Apps conversation starter settings from application properties",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ConversationStartersDto"
+              }
+            ]
           }
         },
         "required": ["id", "displayName", "type"]

--- a/libs/chat-api-client/src/generated/src/apis/DeploymentsApi.ts
+++ b/libs/chat-api-client/src/generated/src/apis/DeploymentsApi.ts
@@ -33,6 +33,7 @@ export interface GetDeploymentLimitsRequest {
 }
 
 export interface ListDeploymentsRequest {
+  refresh?: boolean;
   interfaceType?: Array<ListDeploymentsInterfaceTypeEnum>;
 }
 
@@ -207,6 +208,10 @@ export class DeploymentsApi extends runtime.BaseAPI {
     initOverrides?: RequestInit | runtime.InitOverrideFunction,
   ): Promise<runtime.ApiResponse<DeploymentsResponseDto>> {
     const queryParameters: runtime.HTTPQuery = {};
+
+    if (requestParameters['refresh'] != null) {
+      queryParameters['refresh'] = requestParameters['refresh'];
+    }
 
     if (requestParameters['interfaceType'] != null) {
       queryParameters['interface_type'] = requestParameters['interfaceType'];

--- a/libs/chat-api-client/src/generated/src/models/index.ts
+++ b/libs/chat-api-client/src/generated/src/models/index.ts
@@ -919,6 +919,56 @@ export type ConversationResponseDtoResponseFormatEnum =
 /**
  *
  * @export
+ * @interface ConversationStarterDto
+ */
+export interface ConversationStarterDto {
+  /**
+   * Starter button label
+   * @type {string}
+   * @memberof ConversationStarterDto
+   */
+  title: string;
+  /**
+   * Text inserted into the chat input
+   * @type {string}
+   * @memberof ConversationStarterDto
+   */
+  text: string;
+}
+/**
+ *
+ * @export
+ * @interface ConversationStartersDto
+ */
+export interface ConversationStartersDto {
+  /**
+   * Optional text shown above the conversation starter buttons
+   * @type {string}
+   * @memberof ConversationStartersDto
+   */
+  introText?: string;
+  /**
+   * When true, starter buttons submit immediately after selection
+   * @type {boolean}
+   * @memberof ConversationStartersDto
+   */
+  autoSubmit?: boolean;
+  /**
+   * When true, the chat input is disabled and users can only use starters
+   * @type {boolean}
+   * @memberof ConversationStartersDto
+   */
+  chatMessageInputDisabled?: boolean;
+  /**
+   * Conversation starter buttons configured by the application
+   * @type {Array<ConversationStarterDto>}
+   * @memberof ConversationStartersDto
+   */
+  starters: Array<ConversationStarterDto>;
+}
+/**
+ *
+ * @export
  * @interface ConversationsConfigDto
  */
 export interface ConversationsConfigDto {
@@ -1774,6 +1824,12 @@ export interface DeploymentItemDto {
    * @memberof DeploymentItemDto
    */
   applicationFolder?: string;
+  /**
+   * Quick Apps conversation starter settings from application properties
+   * @type {ConversationStartersDto}
+   * @memberof DeploymentItemDto
+   */
+  conversationStarters?: ConversationStartersDto;
 }
 
 /**

--- a/libs/starter-buttons/src/components/StarterButtons/StarterButtons.tsx
+++ b/libs/starter-buttons/src/components/StarterButtons/StarterButtons.tsx
@@ -103,7 +103,7 @@ export const StarterButtons: FC<StarterButtonsProps> = ({
   );
 
   return (
-    <div ref={containerRef} className="mt-4 w-full">
+    <div ref={containerRef} className="mb-4 w-full">
       <div
         role="list"
         aria-label={labels.list}

--- a/openspec/changes/add-app-editor-flow/specs/deployments-context/spec.md
+++ b/openspec/changes/add-app-editor-flow/specs/deployments-context/spec.md
@@ -10,11 +10,13 @@
 - `setSelectedItemId: (id: string | null) => void` — persists selection to user config via `setSelectedDeployment` from `useUserConfig()` (user-initiated model change); does NOT write to `localStorage`
 - `restoreSelectedItemId: (id: string) => void` — sets `selectedItemId` in local state **without** calling `setSelectedDeployment`; used when restoring a conversation's last-used model so the user's own new-chat preference is preserved
 - `selectedDeploymentConfiguration: DeploymentConfigurationSchema | null` — JSON Schema config for the currently selected deployment; loaded via `getDeploymentConfiguration(selectedItemId)` whenever `selectedItemId` changes; `null` when no deployment is selected or the fetch fails
+- `refetchDeployments: () => Promise<void>` — explicitly re-fetches chat deployments with `refresh=true` after application-mutating flows so newly saved Quick App settings are visible without waiting for the deployments cache TTL
 - `isLoading: boolean`
 - `error: Error | null`
 
 The provider SHALL:
 - Fetch deployments on mount using `getDeployments([ListDeploymentsInterfaceTypeEnum.Chat])` from `server-api/deployments.api.ts` filtered to `Chat` interface type only.
+- Refetch deployments on explicit `refetchDeployments()` calls using `getDeployments([ListDeploymentsInterfaceTypeEnum.Chat], true)` so the backend receives `refresh=true`.
 - Fetch application schemas on mount using `getApplicationSchemas()` from `server-api/application-schemas.ts` in parallel with `getDeployments()` via `Promise.allSettled`. A schemas fetch failure SHALL be logged as a warning but SHALL NOT set `error` or block deployment loading.
 - **Schema icon fallback**: after both fetches resolve, `items` SHALL be derived via `useMemo` — for each deployment where `type === 'application'`, `iconUrl` is absent, and `applicationTypeSchemaId` matches a schema entry, the schema's `iconUrl` is merged in. Deployments without a matching schema or that already have an icon are returned unchanged.
 - Use a cancellation flag (`{ isCancelled: boolean }`) inside `useEffect` to guard against setState-on-unmount.
@@ -58,6 +60,11 @@ The state management pattern SHALL follow `ThemeContext.tsx` as the reference im
 
 - **WHEN** `getApplicationSchemas()` resolves with `[{ id: "https://...quickapps2", displayName: "Quick App 2.0", editorUrl: "https://editor.example.com" }]`
 - **THEN** `useDeployments().schemas` contains that entry
+
+#### Scenario: refetchDeployments bypasses deployments cache
+
+- **WHEN** `refetchDeployments()` is called after an application save/delete/share flow
+- **THEN** it calls `getDeployments([ListDeploymentsInterfaceTypeEnum.Chat], true)`
 
 #### Scenario: Initial selectedItemId follows user config preference
 

--- a/openspec/specs/app-preview-chat/spec.md
+++ b/openspec/specs/app-preview-chat/spec.md
@@ -88,6 +88,40 @@ The preview pane SHALL use the same conversation-creation, streaming, and intera
 - **WHEN** the user attaches a file, uses audio transcription, or opens chat settings in the preview pane
 - **THEN** the feature behaves exactly as it does in a normal chat, since the same underlying hooks and endpoints are used
 
+### Requirement: Preview chat renders Quick Apps conversation starters
+When a Settings-step save succeeds for a preview request, `AppsEditor` SHALL await `refetchDeployments()` before switching to preview mode. `refetchDeployments()` owns bypassing the deployments cache; if the refetch fails, preview entry SHALL NOT be blocked, but the preview pane may use the best-known deployment list already in context.
+
+`AppPreviewChat` SHALL resolve the application deployment from `useDeployments().items` and render Quick Apps `conversationStarters` through the same `getQuickAppConversationStarters` utility used by the main new-conversation screen.
+
+The preview composer SHALL:
+- Render `conversationStarters.introText` above the starter buttons and the input when present.
+- Render `StarterButtons` above the input when valid starters are present.
+- Disable free-form input when `conversationStarters.chatMessageInputDisabled === true`.
+- Treat `autoSubmit` as `true` unless the API value is explicitly `false`.
+
+Selecting a starter with submit enabled SHALL create or append to the preview conversation through the same preview conversation creation/streaming path used for manually typed messages, targeting the fixed app deployment. Selecting a starter with submit disabled SHALL populate the preview input with the starter text and SHALL NOT create a conversation.
+
+**i18n impact:** None; starter labels and intro text are user-configured application data, and the preview placeholder already has an i18n key.
+
+**RTL / UI impact:** Starter layout is delegated to `StarterButtons`; intro text is plain centered text and inherits page direction.
+
+**Memoisation:** Quick Apps starter settings SHALL be memoized from the resolved app deployment's `conversationStarters`; starter selection handlers SHALL be wrapped in `useCallback`.
+
+**Accessibility:** Starter controls SHALL remain real buttons via `StarterButtons`; intro text is static descriptive copy and does not need a live region.
+
+#### Scenario: Preview shows saved Quick Apps starters without page reload
+- **WHEN** the user changes conversation starters in the Settings iframe, clicks Preview, and the iframe posts `AppsEditorEvent.SaveSuccess`
+- **THEN** `AppsEditor` awaits `refetchDeployments()` before entering preview mode
+- **AND** the preview chat shows the saved starter buttons and intro text without a full browser reload
+
+#### Scenario: Preview non-submit starter populates input
+- **WHEN** the user selects a preview starter whose normalized `submit` flag is false
+- **THEN** the preview input is populated with the starter text and no preview conversation is created
+
+#### Scenario: Preview submit starter creates conversation
+- **WHEN** the user selects a preview starter whose normalized `submit` flag is true
+- **THEN** the preview conversation is created or appended using the starter text and the fixed application deployment id
+
 ### Requirement: Preview conversation is deleted when the editor is left
 The preview conversation, if one was created during the session, SHALL be deleted when the Apps editor Settings step (and therefore the component owning the preview conversation) unmounts — including when the user clicks Cancel, when a normal Save succeeds and navigates away, or when the user otherwise navigates away from `/apps-editor`. Deletion failures SHALL be logged and SHALL NOT block or surface an error during navigation.
 
@@ -137,4 +171,3 @@ The preview capability SHALL be available to any user who can already reach the 
 #### Scenario: Available to all Apps-editor users
 - **WHEN** any user who can already open `/apps-editor` for an app reaches the Settings step with a saved app id
 - **THEN** the preview button is shown, with no additional role or feature-flag check beyond existing Apps-editor access
-

--- a/openspec/specs/conversation-deployment-selection/spec.md
+++ b/openspec/specs/conversation-deployment-selection/spec.md
@@ -148,6 +148,55 @@ The send callback SHALL NOT fire when `selectedItemId` is `null` — enforced by
 
 ---
 
+### Requirement: ConversationRoute renders deployment conversation starters
+
+`apps/chat/src/pages/ConversationRoute/ConversationRoute.tsx` SHALL render starter buttons and intro text for the selected deployment on the new-conversation screen.
+
+The route SHALL derive schema-based starters from `selectedDeploymentConfiguration` first. If the selected deployment configuration does not provide schema starter buttons, the route SHALL fall back to Quick Apps starters from `selectedDeployment.conversationStarters`, normalized through `getQuickAppConversationStarters`.
+
+Quick Apps mapping on the frontend SHALL:
+- Trim `introText`, starter `title`, and starter `text`.
+- Omit invalid starters whose title or text is blank.
+- Treat `autoSubmit` as `true` unless the API value is explicitly `false`.
+- Map `chatMessageInputDisabled === true` to the composer's disabled input state.
+
+The displayed intro text SHALL use the schema description when present; otherwise it SHALL use Quick Apps `conversationStarters.introText`. The input SHALL be disabled when either `selectedDeploymentConfiguration.isChatMessageInputDisabled` or Quick Apps `conversationStarters.chatMessageInputDisabled` is true.
+
+Selecting a starter with submit enabled SHALL create a conversation through the existing first-message flow using the starter text and the selected deployment id, without adding any schema `configuration_value`. Selecting a starter with submit disabled SHALL populate the chat input with the starter text without creating a conversation.
+
+State ownership: `ConversationRoute` owns the derived starter list, intro text, input-disabled state, and transient populated input message. `DeploymentsContext` owns the selected deployment item and deployment configuration fetch.
+
+**i18n impact:** None; this uses user-configured starter/intro text and existing composer labels.
+
+**RTL / UI impact:** Starter layout is delegated to `StarterButtons`, which already owns RTL overflow behavior. New intro text is plain centered text and uses logical layout inherited from the page.
+
+**Memoisation:** Derived Quick Apps starter settings SHALL be memoized from `selectedDeployment.conversationStarters`; starter selection handlers SHALL be wrapped in `useCallback`.
+
+**Accessibility:** Starter controls SHALL remain real buttons via `StarterButtons`; intro text is static descriptive copy and does not need a live region.
+
+#### Scenario: Quick Apps intro and starters render on new conversation screen
+
+- **WHEN** the selected application deployment has `conversationStarters.introText` and valid `starters`, and its deployment configuration does not define schema starters
+- **THEN** the new-conversation screen shows the intro text and renders the starter buttons above the input
+
+#### Scenario: Schema starters take precedence over Quick Apps starters
+
+- **WHEN** `selectedDeploymentConfiguration` provides schema starters and the selected deployment also has `conversationStarters`
+- **THEN** the rendered starters come from the schema configuration, not the Quick Apps fallback
+
+#### Scenario: Non-submit Quick Apps starter populates the input
+
+- **WHEN** a user selects a Quick Apps starter whose normalized `submit` flag is false
+- **THEN** the chat input is populated with the starter text and no conversation is created
+
+#### Scenario: Submit Quick Apps starter creates a conversation without schema configuration
+
+- **WHEN** a user selects a Quick Apps starter whose normalized `submit` flag is true
+- **THEN** `apiCreateConversation` is called with the starter text, selected deployment id, and attachments only
+- **AND** no schema `configuration_value` is added to the first message
+
+---
+
 ### Requirement: Backend and frontend tests for catalogItemId
 
 `apps/chat-api/src/conversations/tests/conversation.controller.integration.spec.ts` SHALL cover:

--- a/openspec/specs/deployments-api/spec.md
+++ b/openspec/specs/deployments-api/spec.md
@@ -4,7 +4,8 @@ The system SHALL expose `GET /api/v1/deployments` that proxies DIAL Core `GET /v
 
 The endpoint:
 - MUST require authentication via `SessionGuard`; respond 401 when no valid session is present.
-- SHALL accept an optional `interface_type` query parameter as a repeatable string value validated against `('chat' | 'embeddings' | 'mcp' | 'custom_ui' | 'all')`; passing an unrecognised value MUST respond 400.
+- SHALL accept an optional `interface_type` query parameter as a repeatable string value validated against `('chat' | 'embedding' | 'mcp' | 'custom_ui' | 'all')`; passing an unrecognised value MUST respond 400.
+- SHALL accept an optional `refresh` query parameter validated as a boolean (`true` or `false` after DTO transformation); passing any other value MUST respond 400.
 - SHALL forward the `interface_type` values to DIAL Core `GET /v1/deployments` when provided.
 - SHALL call DIAL Core using the `@epam/ai-dial-typescript-sdk` client (`listDeployments`), passing the session access token.
 - SHALL map the DIAL Core response `deployments` array to `DeploymentItemDto[]` using the normalisation rules in the `DeploymentItemDto shape` requirement below.
@@ -12,8 +13,11 @@ The endpoint:
 - SHALL respond 502 when DIAL Core returns a non-2xx response.
 - SHALL respond 503 when DIAL Core is unreachable or times out.
 - SHALL apply `@Throttle({ default: { limit: 60, ttl: 60000 } })`.
-- SHALL cache the **unfiltered** full DIAL Core response under key `deployments:list:<userSub>` for 30 000 ms; `interface_type` filtering SHALL be applied in-process after cache retrieval.
-- SHALL set response header `Cache-Control: private, max-age=30`.
+- SHALL cache the unfiltered DIAL Core response under key `deployments:list:<userSub>` for 30 000 ms and filtered DIAL Core responses under key `deployments:list:<userSub>:interface:<type[,type]>` for 30 000 ms.
+- SHALL, when a filtered cache entry is absent but the unfiltered cache entry is present, apply `interface_type` filtering in-process after cache retrieval without calling DIAL Core.
+- SHALL bypass server-side deployments cache entirely when `refresh=true`, call DIAL Core, and replace the relevant cache entry with the fresh mapped response.
+- SHALL set response header `Cache-Control: private, max-age=30` for normal requests.
+- SHALL set response header `Cache-Control: private, no-store` when `refresh=true`.
 - MUST NOT log the session access token.
 
 #### Scenario: Authenticated user receives all deployments without filter
@@ -46,6 +50,11 @@ The endpoint:
 - **WHEN** `GET /api/v1/deployments?interface_type=unknown` is called
 - **THEN** the endpoint responds 400 with a validation error referencing `interface_type`
 
+#### Scenario: Invalid refresh value returns 400
+
+- **WHEN** `GET /api/v1/deployments?refresh=maybe` is called
+- **THEN** the endpoint responds 400 with a validation error referencing `refresh`
+
 #### Scenario: Unauthenticated request rejected
 
 - **WHEN** `GET /api/v1/deployments` is called without a valid session cookie
@@ -71,6 +80,12 @@ The endpoint:
 - **WHEN** `deployments:list:<userSub>` is present in cache and `interface_type=chat` is requested
 - **THEN** the service returns cached deployments filtered in-process without calling DIAL Core
 
+#### Scenario: Refresh bypasses deployments cache
+
+- **WHEN** `deployments:list:<userSub>:interface:chat` is present in cache and `GET /api/v1/deployments?interface_type=chat&refresh=true` is requested
+- **THEN** the service calls DIAL Core instead of returning the cached entry
+- **AND** the response header is `Cache-Control: private, no-store`
+
 ---
 
 ### Requirement: DeploymentItemDto shape
@@ -88,6 +103,16 @@ The endpoint:
 - `isMy?: boolean` — `true` when the session `bucket` appears as a path segment of the deployment `id` (e.g. `applications/{bucket}/{name}`); `false` otherwise; computed post-cache and never stored in the cache entry
 - `applicationFolder?: string` — parent directory path of the application derived from `id` (everything before the last `/`); set only for `type === 'application'` items whose `id` contains a `/`; absent for root-level applications and all non-application types
 - `features?: DeploymentFeaturesDto` — feature flags from DIAL Core, including the new `mcp?: boolean` field (see below)
+
+`DeploymentItemDto.conversationStarters?: ConversationStartersDto` SHALL expose Quick Apps conversation starter settings mapped from `application_properties.conversation_starters`. It SHALL be set only for `type === 'application'` items with at least one valid starter.
+
+`ConversationStartersDto` SHALL contain:
+- `introText?: string` mapped from `application_properties.conversation_starters.intro_text`
+- `autoSubmit?: boolean` mapped from `application_properties.conversation_starters.auto_submit`
+- `chatMessageInputDisabled?: boolean` mapped from `application_properties.conversation_starters.chat_message_input_disabled`
+- `starters: ConversationStarterDto[]`, where each starter contains `title: string` and `text: string` from the corresponding raw starter
+
+Invalid or blank starters SHALL be omitted. If no valid starters remain, `conversationStarters` SHALL be omitted. Non-application deployments SHALL NOT expose `conversationStarters`, even if a malformed source payload contains `application_properties`.
 
 `DeploymentFeaturesDto.mcp?: boolean` SHALL be `true` when any of the following is present on the raw DIAL Core list entry, and `undefined` (omitted) otherwise:
 - `features.mcp === true` (read defensively, the same way `DeploymentFeaturesDetailsDto.mcp` is already populated for the deployment-details endpoint);
@@ -157,17 +182,32 @@ The `DeploymentItem` interface in `libs/chat-shared/src/models/deployment.ts` SH
 - **WHEN** a DIAL Core `ApplicationOpenAi` entry has `interfaces` containing `'mcp'` and neither `features.mcp` nor a root-level `mcp` descriptor
 - **THEN** the mapped `DeploymentItemDto` has `features.mcp: true`
 
+#### Scenario: Application conversation starters mapped from application properties
+
+- **WHEN** a DIAL Core `ApplicationOpenAi` entry has `application_properties.conversation_starters` with `intro_text`, `auto_submit`, `chat_message_input_disabled`, and one starter `{ title, text }`
+- **THEN** the mapped `DeploymentItemDto` has `conversationStarters.introText`, `conversationStarters.autoSubmit`, `conversationStarters.chatMessageInputDisabled`, and `conversationStarters.starters[0]` mapped to `{ title, text }`
+
+#### Scenario: Non-application item omits conversationStarters
+
+- **WHEN** a model or toolset entry contains a malformed `application_properties.conversation_starters` payload
+- **THEN** the mapped `DeploymentItemDto` has `conversationStarters` as `undefined`
+
+#### Scenario: Empty or invalid starters omit conversationStarters
+
+- **WHEN** an application entry has `application_properties.conversation_starters.starters` with no valid `{ title, text }` pairs
+- **THEN** the mapped `DeploymentItemDto` has `conversationStarters` as `undefined`
+
 ---
 
 ### Requirement: Deployments domain structure
 
 The backend SHALL implement the deployments feature in `apps/chat-api/src/deployments/` following the established domain pattern:
 
-- `deployments.controller.ts` — thin controller with `@Get() listDeployments(@Query() query: DeploymentsQueryDto, @Req() req)`
+- `deployments.controller.ts` — thin controller with `@Get() listDeployments(@Query() query: DeploymentsQueryDto, @Req() req, @Res({ passthrough: true }) res)`
 - `deployments.service.ts` — `DeploymentsService` injects `DialClientService` (`apps/chat-api/src/dial/dial-client.service.ts`) for the shared DIAL SDK client; calls SDK `listDeployments`; maps and caches results
 - `deployments.module.ts` — `DeploymentsModule` providing `DeploymentsService`; no external domain imports needed
 - `dto/deployment-item.dto.ts` — `DeploymentItemDto` and `DeploymentsResponseDto` with `@ApiProperty` decorators
-- `dto/deployments-query.dto.ts` — `DeploymentsQueryDto` with `interface_type` field: `@IsOptional`, `@IsArray`, `@IsIn([...], { each: true })`, `@Transform` for comma-separated coercion
+- `dto/deployments-query.dto.ts` — `DeploymentsQueryDto` with `interface_type` field: `@IsOptional`, `@IsArray`, `@IsIn([...], { each: true })`, `@Transform` for comma-separated coercion, and `refresh?: boolean` with `@IsBoolean` plus `true`/`false` string coercion
 - `tests/deployments.controller.spec.ts`
 - `tests/deployments.service.spec.ts`
 - `tests/deployments.controller.integration.spec.ts`
@@ -182,7 +222,7 @@ The backend SHALL implement the deployments feature in `apps/chat-api/src/deploy
 #### Scenario: Controller delegates to service with parsed query
 
 - **WHEN** `listDeployments` is called with a validated `DeploymentsQueryDto`
-- **THEN** the controller extracts `sub` and `at` from `req.user` and calls `deploymentsService.listDeployments(sub, at, query.interface_type)`
+- **THEN** the controller extracts `sub`, `at`, and `bucket` from `req.user`, sets the appropriate `Cache-Control` header, and calls `deploymentsService.listDeployments(sub, at, bucket, query.interface_type, query.refresh)`
 
 ---
 
@@ -193,17 +233,18 @@ The `listDeployments` handler SHALL be annotated:
 - `@ApiTags('deployments')`
 - `@ApiOperation({ operationId: 'listDeployments', summary: 'List deployments by interface type' })`
 - `@ApiQuery` for `interface_type` with enum values and multi-value example
+- `@ApiQuery` for `refresh` as an optional boolean cache-bypass flag
 - `@ApiResponse({ status: 200, type: DeploymentsResponseDto })`
 - Standard 400, 401, 403, 429, 502, 503 `@ApiResponse` entries
 
 The `'deployments'` tag SHALL be added in `openapi.config.ts`; the `'catalog'` tag SHALL be removed.
 
-Running `npm run openapi` SHALL produce a `DeploymentsApi` class in `@epam/chat-api-client` with a `listDeployments(params?: ListDeploymentsRequest)` method typed to return `Promise<DeploymentsResponseDto>` where `ListDeploymentsRequest` contains `interfaceType?: string[]`.
+Running `npm run openapi` SHALL produce a `DeploymentsApi` class in `@epam/chat-api-client` with a `listDeployments(params?: ListDeploymentsRequest)` method typed to return `Promise<DeploymentsResponseDto>` where `ListDeploymentsRequest` contains `interfaceType?: string[]` and `refresh?: boolean`.
 
 #### Scenario: Generated client exposes typed listDeployments method
 
 - **WHEN** `npm run openapi` runs after adding the deployments controller
-- **THEN** `@epam/chat-api-client` exports a `DeploymentsApi` class with `listDeployments` method accepting optional `interfaceType` array
+- **THEN** `@epam/chat-api-client` exports a `DeploymentsApi` class with `listDeployments` method accepting optional `interfaceType` array and `refresh` boolean
 
 ---
 
@@ -212,8 +253,11 @@ Running `npm run openapi` SHALL produce a `DeploymentsApi` class in `@epam/chat-
 `apps/chat/src/server-api/deployments.api.ts` SHALL export:
 
 ```ts
-export const getDeployments = (interfaceType?: string[]): Promise<DeploymentsResponseDto> =>
-  deploymentsApi.listDeployments({ interfaceType });
+export const getDeployments = (
+  interfaceType?: string[],
+  refresh?: boolean,
+): Promise<DeploymentsResponseDto> =>
+  deploymentsApi.listDeployments({ interfaceType, refresh });
 ```
 
 `deploymentsApi` SHALL be instantiated in `api-client.ts`. Any existing `catalogApi` instance SHALL be removed.
@@ -228,6 +272,11 @@ export const getDeployments = (interfaceType?: string[]): Promise<DeploymentsRes
 - **WHEN** `getDeployments(['chat'])` is called
 - **THEN** it calls `deploymentsApi.listDeployments({ interfaceType: ['chat'] })`
 
+#### Scenario: getDeployments can request a fresh list
+
+- **WHEN** `getDeployments(['chat'], true)` is called
+- **THEN** it calls `deploymentsApi.listDeployments({ interfaceType: ['chat'], refresh: true })`
+
 ---
 
 ### Requirement: Backend service tests for deployments
@@ -237,8 +286,10 @@ export const getDeployments = (interfaceType?: string[]): Promise<DeploymentsRes
 - Successful mapping of `ModelOpenAi`, `ApplicationOpenAi`, `ToolsetOpenAi` entries to `DeploymentItemDto[]`
 - Items without `id` are skipped
 - `displayName` falls back to `id` when `display_name` is absent
+- Quick Apps `application_properties.conversation_starters` is mapped to `conversationStarters`
 - Cache hit — returns cached value without calling DIAL Core
 - `interface_type` filter applied after cache hit — correct item count returned
+- `refresh=true` bypasses the cached deployments list and calls DIAL Core
 - DIAL Core 502 → service throws `BadGatewayException`
 - DIAL Core unreachable → service throws `ServiceUnavailableException`
 
@@ -253,6 +304,11 @@ All DIAL Core calls SHALL be mocked; no live network calls.
 
 - **WHEN** `deployments:list:<userSub>` is populated in cache
 - **THEN** the SDK `listDeployments` is NOT called on the second request
+
+#### Scenario: Service test — refresh skips cached value
+
+- **WHEN** `listDeployments` is called with `refresh=true` while a deployments cache entry exists
+- **THEN** the SDK `listDeployments` is called and the returned deployments come from the fresh DIAL Core response
 
 ---
 

--- a/openspec/specs/deployments-context/spec.md
+++ b/openspec/specs/deployments-context/spec.md
@@ -286,6 +286,8 @@ The raw `'dial:chatMessageInputDisabled'` field SHALL be removed — the backend
 
 This prevents a race where the initial mount-time list fetch (unavoidably in flight before any resource could have been shared to the user) resolves *after* a later, deliberate `refetchDeployments()`/`refetchToolsets()` call (e.g. one triggered right after accepting a share invitation) and overwrites its fresher result with the stale pre-share snapshot.
 
+`refetchDeployments()` SHALL call `getDeployments([ListDeploymentsInterfaceTypeEnum.Chat], true)` so app create/delete/share/save flows that need a just-written Quick App deployment bypass the deployments endpoint's 30-second browser/server cache window.
+
 #### Scenario: A later refetch's result is not clobbered by a slower initial load
 
 - **WHEN** the initial mount-time deployments fetch is still in flight and `refetchDeployments()` is called and resolves first with a fresh list
@@ -303,8 +305,12 @@ This prevents a race where the initial mount-time list fetch (unavoidably in fli
 - **WHEN** `refetchDeployments()` (or `refetchToolsets()`) is called with no other in-flight request for that resource
 - **THEN** its result is applied to `items`/`toolsets` as before, unaffected by the request-id guard
 
+#### Scenario: Explicit deployments refetch requests a fresh backend list
+
+- **WHEN** `refetchDeployments()` is called after a Quick App save or other deployment-mutating flow
+- **THEN** it calls `getDeployments([ListDeploymentsInterfaceTypeEnum.Chat], true)` so the backend receives `refresh=true`
+
 #### Scenario: A superseded response does not trigger an error notification
 
 - **WHEN** a stale response for a since-superseded request arrives (successfully, from the network's perspective)
 - **THEN** no `showNotification` error call is made and no state changes — the response is discarded because it is stale, not because it failed
-


### PR DESCRIPTION
## Description of changes

### Summary

Fixed Quick Apps conversation starters and intro text not appearing in both the main new-chat screen and Apps Editor Preview.

### Root Cause

Quick Apps settings store conversation starter data under `application_properties.conversation_starters`, but the deployments list API was not exposing that data to the frontend. The frontend only handled schema-based starters, so Quick Apps `intro_text`, starter buttons, `auto_submit`, and `chat_message_input_disabled` were ignored.

Preview also reused the deployments list after saving settings, but that list could still be served from the short deployments cache, so newly saved settings were not reflected immediately.

## Applicable issues

- https://github.com/epam/ai-dial-chat/issues/7783

## UI changes

<img width="1161" height="693" alt="2026-07-17_151616" src="https://github.com/user-attachments/assets/3098c6cb-78de-4a9e-a35c-454f779608e8" />


## Checklist

- [X] the pull request name ends with `(Issue #<ISSUE_ID>)` (comma-separated list of issues)
- [X] I confirm that I don't share any confidential information like API keys or any other secrets and private URLs
