### PR TITLE
feat: implement draft toolset creation and unsaved changes persistence before login

### DIFF
--- a/apps/chat-api/src/toolsets/dto/toolset-body.dto.ts
+++ b/apps/chat-api/src/toolsets/dto/toolset-body.dto.ts
@@ -8,6 +8,7 @@ import {
   IsString,
   Matches,
   MaxLength,
+  ValidateIf,
   ValidateNested,
 } from 'class-validator';
 
@@ -139,9 +140,16 @@ export class ToolsetBodyDto {
   @MaxLength(90)
   intro?: string;
 
+  /*
+   * Empty string is allowed: the toolset editor creates a draft toolset
+   * right after its first (General) step, before the endpoint is collected
+   * on the second (Settings) step. `ValidateIf` makes every validator below
+   * conditional, so a missing `endpoint` (not the same as an empty string)
+   * still fails `@IsString()` and is rejected.
+   */
   @ApiProperty({ example: 'https://my-toolset.example.com/mcp' })
   @IsString()
-  @IsNotEmpty()
+  @ValidateIf((o: ToolsetBodyDto) => o.endpoint !== '')
   @Matches(ENDPOINT_URL_PATTERN, { message: ENDPOINT_URL_MESSAGE })
   endpoint!: string;
 

--- a/apps/chat-api/src/toolsets/tests/toolset-body.dto.spec.ts
+++ b/apps/chat-api/src/toolsets/tests/toolset-body.dto.spec.ts
@@ -46,3 +46,21 @@ describe('ToolsetBodyDto — intro', () => {
     expect(errors.some((e) => e.property === 'intro')).toBe(true);
   });
 });
+
+describe('ToolsetBodyDto — endpoint', () => {
+  it('passes when endpoint is an empty string (draft toolset)', async () => {
+    const errors = await validateDto({ ...BASE_BODY, endpoint: '' });
+    expect(errors).toHaveLength(0);
+  });
+
+  it('rejects when endpoint is missing', async () => {
+    const { endpoint: _omitted, ...noEndpoint } = BASE_BODY;
+    const errors = await validateDto(noEndpoint);
+    expect(errors.some((e) => e.property === 'endpoint')).toBe(true);
+  });
+
+  it('rejects a non-empty endpoint with an invalid protocol', async () => {
+    const errors = await validateDto({ ...BASE_BODY, endpoint: 'ftp://nope' });
+    expect(errors.some((e) => e.property === 'endpoint')).toBe(true);
+  });
+});

--- a/apps/chat/src/constants/translation-keys.ts
+++ b/apps/chat/src/constants/translation-keys.ts
@@ -579,6 +579,7 @@ export enum ToolsetEditorI18nKeys {
   ErrorLogoutFailed = 'toolsetEditor.error.logoutFailed',
   ErrorPopupBlocked = 'toolsetEditor.error.popupBlocked',
   LoginSuccess = 'toolsetEditor.success.login',
+  LogoutSuccess = 'toolsetEditor.success.logout',
 }
 
 export enum ErrorBoundaryI18nKeys {

--- a/apps/chat/src/i18n/locales/en.json
+++ b/apps/chat/src/i18n/locales/en.json
@@ -670,7 +670,8 @@
       "popupBlocked": "The login popup was blocked by your browser. Please allow popups for this site and try again."
     },
     "success": {
-      "login": "Successfully logged in."
+      "login": "Successfully logged in.",
+      "logout": "Successfully logged out."
     }
   }
 }

--- a/apps/chat/src/pages/ToolsetEditor/EditorForm/AuthSection.tsx
+++ b/apps/chat/src/pages/ToolsetEditor/EditorForm/AuthSection.tsx
@@ -55,6 +55,7 @@ interface Props {
   toolsetId: string;
   endpoint: string;
   onAuthChange: (patch: Partial<ToolsetAuthFormData>) => void;
+  onEnsureSaved: () => Promise<boolean>;
 }
 
 const ORDERED_AUTH_TYPES = [
@@ -88,6 +89,7 @@ const AuthSection: FC<Props> = ({
   toolsetId,
   endpoint,
   onAuthChange,
+  onEnsureSaved,
 }) => {
   const { t } = useTranslation();
   const { showNotification } = useNotification();
@@ -116,6 +118,9 @@ const AuthSection: FC<Props> = ({
 
   const handleLogIn = async () => {
     if (!canLogIn) return;
+
+    const saved = await onEnsureSaved();
+    if (!saved) return;
 
     if (auth.authenticationType === ToolsetAuthTypes.OAuth) {
       const initiation = initiateOAuthLogin(auth, toolsetId);
@@ -209,6 +214,10 @@ const AuthSection: FC<Props> = ({
       await logoutToolset(toolsetId, body);
       onAuthChange({ isLoggedIn: false });
       setShowLogoutConfirm(false);
+      showNotification({
+        variant: NotificationVariant.Success,
+        message: t(ToolsetEditorI18nKeys.LogoutSuccess),
+      });
     } catch {
       showNotification({
         variant: NotificationVariant.Error,

--- a/apps/chat/src/pages/ToolsetEditor/EditorForm/SettingsForm.tsx
+++ b/apps/chat/src/pages/ToolsetEditor/EditorForm/SettingsForm.tsx
@@ -36,6 +36,7 @@ interface Props {
   toolsetId: string;
   onChange: (patch: Partial<ToolsetFormData>) => void;
   onAuthChange: (patch: Partial<ToolsetAuthFormData>) => void;
+  onEnsureSaved: () => Promise<boolean>;
 }
 
 const SettingsForm: FC<Props> = ({
@@ -45,6 +46,7 @@ const SettingsForm: FC<Props> = ({
   toolsetId,
   onChange,
   onAuthChange,
+  onEnsureSaved,
 }) => {
   const { t } = useTranslation();
   const { config } = useAppConfig();
@@ -144,6 +146,7 @@ const SettingsForm: FC<Props> = ({
         toolsetId={toolsetId}
         endpoint={form.endpoint}
         onAuthChange={onAuthChange}
+        onEnsureSaved={onEnsureSaved}
       />
 
       {isConnectVisible && (

--- a/apps/chat/src/pages/ToolsetEditor/EditorForm/tests/AuthSection.spec.tsx
+++ b/apps/chat/src/pages/ToolsetEditor/EditorForm/tests/AuthSection.spec.tsx
@@ -1,5 +1,5 @@
 import { NotificationVariant } from '@epam/ai-dial-ui-kit';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type { ReactNode } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -219,6 +219,7 @@ const renderSection = (
   onAuthChange = vi.fn(),
   endpoint = VALID_ENDPOINT,
   errors: ToolsetFormErrors = {},
+  onEnsureSaved = vi.fn().mockResolvedValue(true),
 ) =>
   render(
     <AuthSection
@@ -228,6 +229,7 @@ const renderSection = (
       toolsetId={toolsetId}
       endpoint={endpoint}
       onAuthChange={onAuthChange}
+      onEnsureSaved={onEnsureSaved}
     />,
   );
 
@@ -430,6 +432,24 @@ describe('AuthSection', () => {
       );
     });
 
+    it('does not open a popup when saving unsaved changes fails', async () => {
+      const onEnsureSaved = vi.fn().mockResolvedValue(false);
+      renderSection(
+        oauthWithConfigAuth(),
+        'toolsets/b/my__1.0.0',
+        vi.fn(),
+        VALID_ENDPOINT,
+        {},
+        onEnsureSaved,
+      );
+      await user.click(
+        screen.getByRole('button', { name: ButtonsI18nKeys.LogIn }),
+      );
+      await waitFor(() => expect(onEnsureSaved).toHaveBeenCalledOnce());
+      expect(window.open).not.toHaveBeenCalled();
+      expect(capturedPopup).toBeUndefined();
+    });
+
     it('does not open a popup when authorizationEndpoint is missing', async () => {
       renderSection({
         ...oauthWithConfigAuth(),
@@ -623,6 +643,41 @@ describe('AuthSection', () => {
       );
     });
 
+    it('saves unsaved changes before logging in', async () => {
+      vi.mocked(toolsetsApi.loginToolset).mockResolvedValue({ success: true });
+      const onEnsureSaved = vi.fn().mockResolvedValue(true);
+      renderSection(
+        apiKeyAuth(),
+        'toolsets/b/my__1.0.0',
+        vi.fn(),
+        VALID_ENDPOINT,
+        {},
+        onEnsureSaved,
+      );
+      await user.click(
+        screen.getByRole('button', { name: ButtonsI18nKeys.LogIn }),
+      );
+      await waitFor(() => expect(onEnsureSaved).toHaveBeenCalledOnce());
+      expect(toolsetsApi.loginToolset).toHaveBeenCalled();
+    });
+
+    it('does not attempt to log in when saving unsaved changes fails', async () => {
+      const onEnsureSaved = vi.fn().mockResolvedValue(false);
+      renderSection(
+        apiKeyAuth(),
+        'toolsets/b/my__1.0.0',
+        vi.fn(),
+        VALID_ENDPOINT,
+        {},
+        onEnsureSaved,
+      );
+      await user.click(
+        screen.getByRole('button', { name: ButtonsI18nKeys.LogIn }),
+      );
+      await waitFor(() => expect(onEnsureSaved).toHaveBeenCalledOnce());
+      expect(toolsetsApi.loginToolset).not.toHaveBeenCalled();
+    });
+
     it('disables the Log In button when endpoint is empty', () => {
       renderSection(apiKeyAuth(), 'toolsets/b/my__1.0.0', vi.fn(), '');
       const btn = screen.getByRole('button', {
@@ -671,6 +726,76 @@ describe('AuthSection', () => {
         name: ButtonsI18nKeys.LogIn,
       }) as HTMLButtonElement;
       expect(btn.disabled).toBe(true);
+    });
+  });
+
+  describe('Logout', () => {
+    it('calls logoutToolset, shows a success notification, and closes the confirm dialog', async () => {
+      vi.mocked(toolsetsApi.logoutToolset).mockResolvedValue({
+        success: true,
+      });
+      const onAuthChange = vi.fn();
+      renderSection(
+        { ...apiKeyAuth(), isLoggedIn: true },
+        'toolsets/b/my__1.0.0',
+        onAuthChange,
+      );
+
+      await user.click(
+        screen.getByRole('button', { name: ButtonsI18nKeys.LogOut }),
+      );
+      const dialog = screen.getByRole('dialog');
+      await user.click(
+        within(dialog).getByRole('button', { name: ButtonsI18nKeys.LogOut }),
+      );
+
+      await waitFor(() =>
+        expect(toolsetsApi.logoutToolset).toHaveBeenCalledWith(
+          'toolsets/b/my__1.0.0',
+          expect.objectContaining({ url: 'toolsets/b/my__1.0.0' }),
+        ),
+      );
+      expect(onAuthChange).toHaveBeenCalledWith({ isLoggedIn: false });
+      expect(mockShowNotification).toHaveBeenCalledWith({
+        variant: NotificationVariant.Success,
+        message: ToolsetEditorI18nKeys.LogoutSuccess,
+      });
+      expect(screen.queryByRole('dialog')).toBeNull();
+    });
+
+    it('shows an error notification when logout fails', async () => {
+      vi.mocked(toolsetsApi.logoutToolset).mockRejectedValue(new Error('fail'));
+      renderSection({ ...apiKeyAuth(), isLoggedIn: true });
+
+      await user.click(
+        screen.getByRole('button', { name: ButtonsI18nKeys.LogOut }),
+      );
+      const dialog = screen.getByRole('dialog');
+      await user.click(
+        within(dialog).getByRole('button', { name: ButtonsI18nKeys.LogOut }),
+      );
+
+      await waitFor(() =>
+        expect(mockShowNotification).toHaveBeenCalledWith({
+          variant: NotificationVariant.Error,
+          message: ToolsetEditorI18nKeys.ErrorLogoutFailed,
+        }),
+      );
+    });
+
+    it('does not call logoutToolset when the confirm dialog is cancelled', async () => {
+      renderSection({ ...apiKeyAuth(), isLoggedIn: true });
+
+      await user.click(
+        screen.getByRole('button', { name: ButtonsI18nKeys.LogOut }),
+      );
+      const dialog = screen.getByRole('dialog');
+      await user.click(
+        within(dialog).getByRole('button', { name: ButtonsI18nKeys.Cancel }),
+      );
+
+      expect(toolsetsApi.logoutToolset).not.toHaveBeenCalled();
+      expect(screen.queryByRole('dialog')).toBeNull();
     });
   });
 });

--- a/apps/chat/src/pages/ToolsetEditor/EditorForm/tests/SettingsForm.spec.tsx
+++ b/apps/chat/src/pages/ToolsetEditor/EditorForm/tests/SettingsForm.spec.tsx
@@ -169,6 +169,7 @@ const renderSettings = (endpoint = 'https://example.com/mcp') =>
       toolsetId="toolsets/b/my__1.0.0"
       onChange={vi.fn()}
       onAuthChange={vi.fn()}
+      onEnsureSaved={vi.fn().mockResolvedValue(true)}
     />,
   );
 
@@ -223,6 +224,7 @@ describe('SettingsForm — copy endpoint', () => {
         toolsetId=""
         onChange={vi.fn()}
         onAuthChange={vi.fn()}
+        onEnsureSaved={vi.fn().mockResolvedValue(true)}
       />,
     );
     expect(screen.getByRole('alert').textContent).toContain(
@@ -262,6 +264,7 @@ describe('SettingsForm — Connect toolset section', () => {
         toolsetId=""
         onChange={vi.fn()}
         onAuthChange={vi.fn()}
+        onEnsureSaved={vi.fn().mockResolvedValue(true)}
       />,
     );
     expect(screen.queryByText(CatalogI18nKeys.ConnectToolsetTitle)).toBeNull();
@@ -284,6 +287,7 @@ describe('SettingsForm — Connect toolset section', () => {
         toolsetId="toolsets/b/my__1.0.0"
         onChange={vi.fn()}
         onAuthChange={vi.fn()}
+        onEnsureSaved={vi.fn().mockResolvedValue(true)}
       />,
     );
     expect(screen.queryByText(CatalogI18nKeys.ConnectToolsetTitle)).toBeNull();

--- a/apps/chat/src/pages/ToolsetEditor/ToolsetEditor.tsx
+++ b/apps/chat/src/pages/ToolsetEditor/ToolsetEditor.tsx
@@ -5,7 +5,7 @@ import {
 import { NotificationVariant } from '@epam/ai-dial-ui-kit';
 import type { ToolsetLoginBodyDto } from '@epam/chat-api-client';
 import type { FC } from 'react';
-import { memo, useCallback, useEffect, useMemo, useState } from 'react';
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import RouteFallback from '../../components/RouteFallback/RouteFallback';
@@ -85,8 +85,10 @@ const ToolsetEditor: FC = () => {
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
 
-  const toolsetId = searchParams.get(ToolsetEditorQuery.Id) ?? '';
-  const isEditMode = Boolean(toolsetId);
+  const routeToolsetId = searchParams.get(ToolsetEditorQuery.Id) ?? '';
+  const isEditMode = Boolean(routeToolsetId);
+  const [draftToolsetId, setDraftToolsetId] = useState('');
+  const persistedToolsetId = routeToolsetId || draftToolsetId;
   const step =
     (searchParams.get(ToolsetEditorQuery.Step) as ToolsetEditorSteps) ??
     ToolsetEditorSteps.General;
@@ -100,6 +102,7 @@ const ToolsetEditor: FC = () => {
   const [isSaving, setIsSaving] = useState(false);
   const [errors, setErrors] = useState<ToolsetFormErrors>({});
   const [dirtyFields, setDirtyFields] = useState<ToolsetDirtyFields>({});
+  const lastPersistedFormRef = useRef<ToolsetFormData | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -108,8 +111,12 @@ const ToolsetEditor: FC = () => {
       if (isEditMode) {
         setIsLoading(true);
         try {
-          const dto = await getToolset(toolsetId);
-          if (!cancelled) setForm(toolsetDtoToForm(dto));
+          const dto = await getToolset(routeToolsetId);
+          const loadedForm = toolsetDtoToForm(dto);
+          if (!cancelled) {
+            setForm(loadedForm);
+            lastPersistedFormRef.current = loadedForm;
+          }
         } catch {
           // Edit target missing/unreachable — leave the editor.
           if (!cancelled) navigate(returnUrl, { replace: true });
@@ -137,7 +144,7 @@ const ToolsetEditor: FC = () => {
     return () => {
       cancelled = true;
     };
-  }, [isEditMode, toolsetId, navigate, returnUrl]);
+  }, [isEditMode, routeToolsetId, navigate, returnUrl]);
 
   const handleChange = useCallback((patch: Partial<ToolsetFormData>) => {
     setForm((prev) => (prev ? { ...prev, ...patch } : prev));
@@ -194,25 +201,87 @@ const ToolsetEditor: FC = () => {
     [setSearchParams],
   );
 
-  const handleNext = useCallback(() => {
+  /**
+   * Creates the toolset (if it has no id yet) or updates it (if the form has
+   * changed since it was last persisted), so the backend reflects whatever
+   * the user has typed so far. Returns the toolset id on success — including
+   * when nothing needed to be sent — or `null` if a create/update call
+   * failed. Shared by "Next" (advancing past General) and by Log In (which
+   * must not authenticate against stale endpoint/auth settings).
+   */
+  const persistFormIfChanged = useCallback(async (): Promise<string | null> => {
+    if (!form) return null;
+
+    const isUnchangedSincePersist =
+      persistedToolsetId &&
+      lastPersistedFormRef.current != null &&
+      JSON.stringify(lastPersistedFormRef.current) === JSON.stringify(form);
+    if (isUnchangedSincePersist) return persistedToolsetId;
+
+    setIsSaving(true);
+    try {
+      const body = formToToolsetBody(form, getToolsetRedirectUri());
+      let id: string;
+      if (persistedToolsetId) {
+        const result = await updateToolset(persistedToolsetId, body);
+        id = result.id;
+      } else {
+        const result = await createToolset(body);
+        setDraftToolsetId(result.id);
+        id = result.id;
+      }
+      lastPersistedFormRef.current = form;
+      await refetchToolsets();
+      return id;
+    } catch (err) {
+      const upstreamMessage = await extractToolsetApiErrorMessage(err);
+      showNotification({
+        variant: NotificationVariant.Error,
+        message:
+          upstreamMessage ??
+          t(
+            persistedToolsetId
+              ? ToolsetEditorI18nKeys.ErrorUpdateFailed
+              : ToolsetEditorI18nKeys.ErrorCreateFailed,
+          ),
+      });
+      return null;
+    } finally {
+      setIsSaving(false);
+    }
+  }, [form, persistedToolsetId, t, showNotification, refetchToolsets]);
+
+  const handleNext = useCallback(async () => {
     if (!form) return;
     if (!form.name.trim()) {
       setErrors({ name: t(EditorI18nKeys.NameRequired) });
       return;
     }
     setErrors({});
-    setEditorStep(ToolsetEditorSteps.Settings);
-  }, [form, t, setEditorStep]);
+
+    const id = await persistFormIfChanged();
+    if (id != null) {
+      setEditorStep(ToolsetEditorSteps.Settings);
+    }
+  }, [form, t, persistFormIfChanged, setEditorStep]);
+
+  const handleEnsureSaved = useCallback(
+    async () => (await persistFormIfChanged()) != null,
+    [persistFormIfChanged],
+  );
 
   const handleChangeStep = useCallback(
     (stepId: string) => {
-      if (!isEditMode && stepId === ToolsetEditorSteps.Settings) {
-        handleNext();
+      if (
+        stepId === ToolsetEditorSteps.Settings &&
+        step === ToolsetEditorSteps.General
+      ) {
+        void handleNext();
         return;
       }
       setEditorStep(stepId);
     },
-    [isEditMode, handleNext, setEditorStep],
+    [step, handleNext, setEditorStep],
   );
 
   const handleCancel = useCallback(() => {
@@ -327,8 +396,8 @@ const ToolsetEditor: FC = () => {
     setIsSaving(true);
     try {
       const body = formToToolsetBody(form, getToolsetRedirectUri());
-      const result = isEditMode
-        ? await updateToolset(toolsetId, body)
+      const result = persistedToolsetId
+        ? await updateToolset(persistedToolsetId, body)
         : await createToolset(body);
       await refetchToolsets();
       try {
@@ -347,7 +416,7 @@ const ToolsetEditor: FC = () => {
         message:
           upstreamMessage ??
           t(
-            isEditMode
+            persistedToolsetId
               ? ToolsetEditorI18nKeys.ErrorUpdateFailed
               : ToolsetEditorI18nKeys.ErrorCreateFailed,
           ),
@@ -358,8 +427,7 @@ const ToolsetEditor: FC = () => {
   }, [
     form,
     validate,
-    isEditMode,
-    toolsetId,
+    persistedToolsetId,
     navigate,
     returnUrl,
     t,
@@ -412,9 +480,10 @@ const ToolsetEditor: FC = () => {
         form={form}
         errors={visibleErrors}
         isSaving={isSaving}
-        toolsetId={toolsetId}
+        toolsetId={persistedToolsetId}
         onNext={handleNext}
         onCancel={handleCancel}
+        onEnsureSaved={handleEnsureSaved}
         onChange={handleChange}
         onAuthChange={handleAuthChange}
       />

--- a/apps/chat/src/pages/ToolsetEditor/ToolsetEditorView.tsx
+++ b/apps/chat/src/pages/ToolsetEditor/ToolsetEditorView.tsx
@@ -23,6 +23,7 @@ interface Props {
   toolsetId: string;
   onNext: () => void;
   onCancel: () => void;
+  onEnsureSaved: () => Promise<boolean>;
   onChange: (patch: Partial<ToolsetFormData>) => void;
   onAuthChange: (patch: Partial<ToolsetAuthFormData>) => void;
 }
@@ -35,6 +36,7 @@ const ToolsetEditorView: FC<Props> = ({
   toolsetId,
   onNext,
   onCancel,
+  onEnsureSaved,
   onChange,
   onAuthChange,
 }) => {
@@ -55,6 +57,7 @@ const ToolsetEditorView: FC<Props> = ({
               toolsetId={toolsetId}
               onChange={onChange}
               onAuthChange={onAuthChange}
+              onEnsureSaved={onEnsureSaved}
             />
           )}
         </div>
@@ -65,11 +68,13 @@ const ToolsetEditorView: FC<Props> = ({
               type="button"
               label={t(ButtonsI18nKeys.Cancel)}
               onClick={onCancel}
+              disabled={isSaving}
             />
             <PrimaryButton
               type="button"
               label={t(EditorI18nKeys.NextButton)}
               onClick={onNext}
+              disabled={isSaving}
             />
           </div>
         )}

--- a/apps/chat/src/pages/ToolsetEditor/tests/ToolsetEditor.spec.tsx
+++ b/apps/chat/src/pages/ToolsetEditor/tests/ToolsetEditor.spec.tsx
@@ -48,11 +48,14 @@ vi.mock('../ToolsetEditorHeader', () => ({
 vi.mock('../ToolsetEditorView', () => ({
   default: ({
     step,
+    toolsetId,
     errors,
     onChange,
     onAuthChange,
+    onNext,
   }: {
     step: string;
+    toolsetId: string;
     errors: {
       endpoint?: string;
       authorizationEndpoint?: string;
@@ -60,9 +63,14 @@ vi.mock('../ToolsetEditorView', () => ({
     };
     onChange: (patch: Record<string, unknown>) => void;
     onAuthChange: (patch: Record<string, unknown>) => void;
+    onNext: () => void;
   }) => (
     <div>
       <span>{`current-step-${step}`}</span>
+      <span>{`toolset-id-${toolsetId}`}</span>
+      <button type="button" onClick={onNext}>
+        go-next
+      </button>
       {errors.endpoint && <p role="alert">{errors.endpoint}</p>}
       {errors.authorizationEndpoint && (
         <p role="alert">{errors.authorizationEndpoint}</p>
@@ -75,6 +83,14 @@ vi.mock('../ToolsetEditorView', () => ({
         }}
       >
         touch-empty-endpoint
+      </button>
+      <button
+        type="button"
+        onClick={() => {
+          onChange({ name: 'Updated name' });
+        }}
+      >
+        change-name
       </button>
       <button
         type="button"
@@ -432,6 +448,113 @@ describe('ToolsetEditor', () => {
         message: ToolsetEditorI18nKeys.ErrorCreateFailed,
       }),
     );
+  });
+
+  it('creates a draft toolset with the General-step fields when Next is clicked, then moves to Settings', async () => {
+    renderEditor();
+
+    await user.click(await screen.findByRole('button', { name: 'go-next' }));
+
+    await waitFor(() =>
+      expect(toolsetsApi.createToolset).toHaveBeenCalledWith(
+        expect.objectContaining({ name: expect.any(String) }),
+      ),
+    );
+    expect(await screen.findByText('current-step-settings')).toBeTruthy();
+    expect(
+      await screen.findByText('toolset-id-toolsets/b/my__0.0.1'),
+    ).toBeTruthy();
+    expect(mockRefetchToolsets).toHaveBeenCalledOnce();
+  });
+
+  it('does not send another request when Next is clicked again with no changes', async () => {
+    renderEditor();
+
+    const nextButton = await screen.findByRole('button', { name: 'go-next' });
+    await user.click(nextButton);
+    await waitFor(() =>
+      expect(toolsetsApi.createToolset).toHaveBeenCalledOnce(),
+    );
+
+    await user.click(nextButton);
+
+    expect(await screen.findByText('current-step-settings')).toBeTruthy();
+    expect(toolsetsApi.createToolset).toHaveBeenCalledOnce();
+    expect(toolsetsApi.updateToolset).not.toHaveBeenCalled();
+  });
+
+  it('does not send an update when Next is clicked in edit mode with no changes', async () => {
+    vi.mocked(toolsetsApi.getToolset).mockResolvedValue({
+      id: 'toolsets/b/my__1.0.0',
+      toolset: 'toolsets/b/my__1.0.0',
+      displayName: 'Existing toolset',
+      endpoint: 'https://example.com/mcp',
+      transport: 'HTTP',
+      authSettings: { authenticationType: 'NONE' },
+    } as never);
+
+    renderEditor(`${ROUTES.ToolsetEditor}?id=toolsets%2Fb%2Fmy__1.0.0`);
+
+    await user.click(await screen.findByRole('button', { name: 'go-next' }));
+
+    expect(await screen.findByText('current-step-settings')).toBeTruthy();
+    expect(toolsetsApi.updateToolset).not.toHaveBeenCalled();
+    expect(toolsetsApi.createToolset).not.toHaveBeenCalled();
+  });
+
+  it('updates the draft toolset with General-step edits when Next is clicked again', async () => {
+    renderEditor();
+
+    await user.click(await screen.findByRole('button', { name: 'go-next' }));
+    await waitFor(() =>
+      expect(toolsetsApi.createToolset).toHaveBeenCalledOnce(),
+    );
+
+    await user.click(screen.getByRole('button', { name: 'change-name' }));
+    await user.click(screen.getByRole('button', { name: 'go-next' }));
+
+    await waitFor(() =>
+      expect(toolsetsApi.updateToolset).toHaveBeenCalledWith(
+        'toolsets/b/my__0.0.1',
+        expect.objectContaining({ name: 'Updated name' }),
+      ),
+    );
+    expect(toolsetsApi.createToolset).toHaveBeenCalledOnce();
+  });
+
+  it('shows an error notification when updating the draft on Next fails', async () => {
+    renderEditor();
+
+    await user.click(await screen.findByRole('button', { name: 'go-next' }));
+    await waitFor(() =>
+      expect(toolsetsApi.createToolset).toHaveBeenCalledOnce(),
+    );
+
+    vi.mocked(toolsetsApi.updateToolset).mockRejectedValue(new Error('fail'));
+    await user.click(screen.getByRole('button', { name: 'change-name' }));
+    await user.click(screen.getByRole('button', { name: 'go-next' }));
+
+    await waitFor(() =>
+      expect(mockShowNotification).toHaveBeenCalledWith({
+        variant: NotificationVariant.Error,
+        message: ToolsetEditorI18nKeys.ErrorUpdateFailed,
+      }),
+    );
+  });
+
+  it('shows an error notification when the draft creation on Next fails', async () => {
+    vi.mocked(toolsetsApi.createToolset).mockRejectedValue(new Error('fail'));
+    renderEditor();
+
+    await user.click(await screen.findByRole('button', { name: 'go-next' }));
+
+    await waitFor(() =>
+      expect(mockShowNotification).toHaveBeenCalledWith({
+        variant: NotificationVariant.Error,
+        message: ToolsetEditorI18nKeys.ErrorCreateFailed,
+      }),
+    );
+    expect(screen.getByText('current-step-general')).toBeTruthy();
   });
 
   it('shows the DIAL Core error reason instead of a generic message when create fails', async () => {

--- a/openspec/specs/toolset-authentication/spec.md
+++ b/openspec/specs/toolset-authentication/spec.md
@@ -44,6 +44,31 @@ and whether a login is triggered on save.
 - **THEN** the configuration can be saved without submitting credentials and without
   triggering a login
 
+### Requirement: Persist unsaved changes before login
+Clicking "Log in" (API Key or OAuth) SHALL first persist any unsaved editor changes — creating
+the toolset if it has no id yet, or updating it if the form has changed since it was last
+persisted — using the same persist logic as advancing past the General step. If the form has
+not changed since it was last persisted, no create/update request SHALL be sent. If persisting
+fails, the system SHALL show an error notification and SHALL NOT proceed to submit credentials
+or open the OAuth authorization popup, so login never runs against a stale endpoint or
+authentication configuration.
+
+#### Scenario: Log in persists unsaved endpoint/auth changes first
+- **WHEN** a user edits the endpoint or authentication fields on the Settings step without
+  saving, then clicks "Log in"
+- **THEN** the system updates the toolset with the current form values before submitting
+  credentials or opening the OAuth authorization popup
+
+#### Scenario: Log in sends no request when nothing changed
+- **WHEN** a user clicks "Log in" without having changed anything since the toolset was last
+  persisted
+- **THEN** the system sends no create/update request and proceeds directly to login
+
+#### Scenario: Login is blocked when persisting fails
+- **WHEN** persisting unsaved changes before login fails
+- **THEN** the system shows an error notification and does not submit credentials or open the
+  OAuth authorization popup
+
 ### Requirement: OAuth redirect and callback handshake
 For OAuth login with config, the system SHALL save the OAuth configuration (Editor) or use the
 already-configured toolset (Catalog), persist the redirect state (`toolsetId`,
@@ -94,7 +119,8 @@ refresh; the user reopens it to see updated status.
 ### Requirement: Logged-in state and logout
 When a toolset is logged in at a credentials level, the system SHALL disable the
 authentication type selector and credential fields and SHALL offer a Log out action guarded
-by a confirmation dialog that revokes the credentials on confirm.
+by a confirmation dialog that revokes the credentials on confirm and shows a success
+notification.
 
 #### Scenario: Disabled fields when logged in
 - **WHEN** the loaded toolset is already logged in
@@ -102,11 +128,16 @@ by a confirmation dialog that revokes the credentials on confirm.
 
 #### Scenario: Confirm logout
 - **WHEN** a user clicks Log out and confirms the dialog
-- **THEN** the system calls the logout endpoint to revoke the credentials
+- **THEN** the system calls the logout endpoint to revoke the credentials, closes the confirm
+  dialog, and shows a success notification
 
 #### Scenario: Cancel logout
 - **WHEN** a user clicks Log out and cancels the dialog
 - **THEN** no logout request is sent and the logged-in state is unchanged
+
+#### Scenario: Logout failure
+- **WHEN** the logout endpoint call fails
+- **THEN** the system shows an error notification and the logged-in state is unchanged
 
 ### Requirement: Auth section disabled while saving
 The authentication section SHALL be disabled while a save is in progress to prevent a race

--- a/openspec/specs/toolset-authoring/spec.md
+++ b/openspec/specs/toolset-authoring/spec.md
@@ -34,6 +34,47 @@ in the URL via a `step` search param so navigation and reloads preserve the curr
 - **WHEN** a user is on the Settings step and reloads the page
 - **THEN** the editor reopens on the Settings step
 
+### Requirement: Draft toolset creation on advancing to Settings
+When a user advances from the General step to the Settings step for a toolset that has not
+yet been persisted, the editor SHALL create the toolset via the backend write API using the
+General-step field values (name, version, icon URL, description, topics, intro) and an empty
+endpoint, before switching to the Settings step. The returned toolset id SHALL be used for
+the remainder of the session — Settings-step actions, login, the Connect toolset section, and
+the final Save, which SHALL update rather than re-create the toolset.
+
+If the toolset already has a persisted id (a draft created by an earlier Next, or an existing
+toolset opened in edit mode) and the form has changed since it was last persisted, advancing
+to the Settings step again SHALL update (not re-create) the toolset with the current form
+values before switching steps. If the form has not changed since it was last persisted, the
+editor SHALL NOT send a create or update request and SHALL just switch to the Settings step.
+
+#### Scenario: Next creates a draft toolset
+- **WHEN** a user on the General step with a valid name clicks Next
+- **THEN** the editor calls the create endpoint with the General-step field values and an
+  empty endpoint, receives a toolset id, and switches to the Settings step
+
+#### Scenario: Next updates a persisted toolset with unsaved changes
+- **WHEN** a user returns to the General step of an already-persisted toolset (draft or
+  existing), edits a field, and clicks Next again
+- **THEN** the editor calls the update endpoint (not create) with the current form values
+  before switching to the Settings step
+
+#### Scenario: Next sends no request when nothing changed
+- **WHEN** a user returns to the General step of an already-persisted toolset without editing
+  anything and clicks Next again
+- **THEN** the editor sends neither a create nor an update request and switches straight to
+  the Settings step
+
+#### Scenario: Final save updates the draft
+- **WHEN** a user completes the Settings step and clicks Save & Exit for a toolset created via
+  Next
+- **THEN** the editor calls the update endpoint, not create, using the previously created
+  toolset id
+
+#### Scenario: Draft creation failure
+- **WHEN** the create call triggered by Next fails
+- **THEN** the editor stays on the General step and shows an error notification
+
 ### Requirement: General step fields
 The General step SHALL allow editing the toolset name, version, icon URL, description,
 topics, and intro. The icon SHALL be entered as a plain URL text field (no file-manager).
@@ -86,11 +127,12 @@ URL to the clipboard.
 
 ### Requirement: Settings step — Connect toolset section
 
-When the user is editing an existing toolset (edit mode, `toolsetId` is non-empty) and
-`config.dialCoreExternalUrl` is configured, the Settings step SHALL render a "Connect
-toolset" section at the bottom of the form, below the authentication section. The section
-SHALL be visually separated from the authentication content by a subtle horizontal rule.
-It SHALL contain:
+When the toolset being edited has a persisted id — either because the editor was opened in
+edit mode for an existing toolset, or because a draft toolset was already created by
+advancing past the General step — and `config.dialCoreExternalUrl` is configured, the
+Settings step SHALL render a "Connect toolset" section at the bottom of the form, below the
+authentication section. The section SHALL be visually separated from the authentication
+content by a subtle horizontal rule. It SHALL contain:
 - A title: "Connect toolset"
 - A description: "Copy endpoint URL to easily integrate toolset into your workflows"
 - A `NeutralButton` labelled "Copy URL" from the shared Connect MCP URL content that,
@@ -100,7 +142,8 @@ It SHALL contain:
   transient "Copied!" feedback; the feedback is also announced via an `aria-live="polite"`
   SR-only region.
 
-The section SHALL NOT render in create mode (when `toolsetId` is empty) or when
+The section SHALL NOT render before the toolset has a persisted id (i.e. still on the
+General step of a brand-new toolset, before Next has created the draft) or when
 `config.dialCoreExternalUrl` is absent.
 
 The title and description strings SHALL reuse the existing
@@ -119,9 +162,16 @@ its English value `"Copy URL"` are added to `translation-keys.ts` and `en.json`.
 - **THEN** the "Connect toolset" section is visible at the bottom of the form, below the
   authentication section
 
-#### Scenario: Connect section is hidden in create mode
+#### Scenario: Connect section renders for a draft toolset created via Next
 
-- **WHEN** the user opens the Settings step in create mode (no `toolsetId` yet)
+- **WHEN** a user creates a new toolset, clicks Next to advance past the General step, and
+  `config.dialCoreExternalUrl` is set
+- **THEN** the "Connect toolset" section is visible on the Settings step, using the draft
+  toolset's id
+
+#### Scenario: Connect section is hidden before the toolset is created
+
+- **WHEN** the user is still on the General step of a brand-new toolset (no persisted id yet)
 - **THEN** no "Connect toolset" section renders, regardless of `dialCoreExternalUrl`
 
 #### Scenario: Connect section is hidden when the external URL is absent

--- a/openspec/specs/toolset-write-api/spec.md
+++ b/openspec/specs/toolset-write-api/spec.md
@@ -9,7 +9,20 @@ Core using the caller's session access token. The request body SHALL be validate
 including an optional `intro` string field limited to 90 characters, the per-user toolset
 list cache SHALL be invalidated on success, and DIAL Core error statuses SHALL be mapped to
 typed HTTP responses. When `intro` is provided, it SHALL be forwarded to DIAL Core as part of
-the create request body.
+the create request body. The `endpoint` field SHALL be required to be present but MAY be an
+empty string — an empty string is accepted so the toolset editor can create a draft toolset
+right after its General step, before the endpoint is collected on the Settings step; when
+non-empty, `endpoint` SHALL still be validated as a well-formed `http(s)://` or `sse://` URL.
+
+#### Scenario: Successful create with a draft (empty) endpoint
+- **WHEN** an authenticated user POSTs a toolset body with `endpoint` set to an empty string
+- **THEN** the service proxies the create to DIAL Core and returns the created toolset
+  identifier
+
+#### Scenario: Missing endpoint field
+- **WHEN** an authenticated user POSTs a toolset body with the `endpoint` field omitted
+  entirely
+- **THEN** the endpoint responds with a 400 and does not call DIAL Core
 
 #### Scenario: Successful create
 - **WHEN** an authenticated user POSTs a valid toolset body


### PR DESCRIPTION


## Description of changes

<!-- Please explain the changes you made right below this line. -->

## Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #<ISSUE_ID>

## UI changes

<Please, provide Screenshots or Figma links>

## Checklist

- [ ] the pull request name ends with `(Issue #<ISSUE_ID>)` (comma-separated list of issues)
- [ ] I confirm that I don't share any confidential information like API keys or any other secrets and private URLs

<details>
  <summary>PR title cheatsheet</summary>

`<type>[optional scope]: <description>`

1. type (required)
    - `feat` - A new feature
    - `fix` - A bug fix
    - `docs` - Documentation only changes
    - `test` - Adding missing tests or correcting existing tests
    - `ci` - Changes to our CI configuration files and scripts
    - `chore` - Other changes that are minor and/or not user-facing
2. scope (optional, current repo suggestions below)
    - `chat`
    - `overlay`
    - `shared`
    - `sandbox-overlay`
    - `visualizer-connector`

</details>
