### PR TITLE
fix(chat): fix prompt field cursor position after tab change (#7908)

### DIFF
--- a/apps/chat/src/components/Chat/Chat.tsx
+++ b/apps/chat/src/components/Chat/Chat.tsx
@@ -633,9 +633,16 @@ const ChatView = memo(({ isPreview, customViewer }: ChatViewProps) => {
     );
 
   useEffect(() => {
+    const activeElement = document.activeElement;
+    const isSomethingElseFocused =
+      activeElement &&
+      activeElement !== document.body &&
+      activeElement !== textareaRef.current;
+
     if (
       !enabledFeatures.has(Feature.SkipFocusChatInputOnLoad) &&
-      !asrFlowRef.current
+      !asrFlowRef.current &&
+      !isSomethingElseFocused
     ) {
       textareaRef.current?.focus();
     }


### PR DESCRIPTION
## Description of changes

New values in Prompt fields disappear; the cursor is moved into input chat field when user switches between browsers tabs

## Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #7908

## Checklist

- [x] the pull request name ends with `(Issue #<ISSUE_ID>)` (comma-separated list of issues)
- [x] I confirm that I don't share any confidential information like API keys or any other secrets and private URLs

<details>
  <summary>PR title cheatsheet</summary>

`<type>[optional scope]: <description>`

1. type (required)
    - `feat` - A new feature
    - `fix` - A bug fix
    - `docs` - Documentation only changes
    - `test` - Adding missing tests or correcting existing tests
    - `ci` - Changes to our CI configuration files and scripts
    - `chore` - Other changes that are minor and/or not user-facing
2. scope (optional, current repo suggestions below)
    - `chat`
    - `overlay`
    - `shared`
    - `sandbox-overlay`
    - `visualizer-connector`

</details>
