### PR TITLE
fix: change conversation starters placement

### DIFF
--- a/apps/chat/src/components/NewConversationComposer/NewConversationComposer.tsx
+++ b/apps/chat/src/components/NewConversationComposer/NewConversationComposer.tsx
@@ -70,7 +70,7 @@ interface Props {
   modelSelectorError?: unknown;
   isInputDisabled?: boolean;
   placeholder: string;
-  /** Optional text shown above the starter buttons and the composer input. */
+  /** Optional text shown below the composer input and above starter buttons. */
   introText?: string;
   /** Initial textarea content (e.g. populated by a starter selection). */
   message?: string;
@@ -81,7 +81,7 @@ interface Props {
     attachments: Attachment[],
     chatSettings: NewConversationChatSettings,
   ) => Promise<void>;
-  /** Rendered above the composer input (e.g. starter buttons). */
+  /** Rendered below the composer input (e.g. starter buttons). */
   children?: ReactNode;
 }
 
@@ -259,12 +259,6 @@ const NewConversationComposer: FC<Props> = ({
         role="region"
         aria-label={t(ChatI18nKeys.WelcomeScreen)}
       >
-        {introText && (
-          <p className="dial-small-text mb-4 max-w-3xl text-center text-secondary">
-            {introText}
-          </p>
-        )}
-        {children}
         <ConversationInput
           onSend={handleSend}
           onUploadAttachment={handleUploadAttachment}
@@ -328,6 +322,12 @@ const NewConversationComposer: FC<Props> = ({
           onAttachmentClick={handleAttachmentClick}
           modelPickerOverlay={modelPickerOverlay}
         />
+        {introText && (
+          <p className="dial-small-text mb-4 mt-4 max-w-3xl text-center text-secondary">
+            {introText}
+          </p>
+        )}
+        {children}
       </div>
       {isDialFileManagerOpen && (
         <DialFileManagerModal

--- a/apps/chat/src/components/NewConversationComposer/tests/NewConversationComposer.spec.tsx
+++ b/apps/chat/src/components/NewConversationComposer/tests/NewConversationComposer.spec.tsx
@@ -1,0 +1,140 @@
+import type { DeploymentItem } from '@epam/ai-dial-chat-shared';
+import { render, screen } from '@testing-library/react';
+import { Suspense } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import NewConversationComposer from '../NewConversationComposer';
+
+vi.mock('@epam/ai-dial-conversation-input', () => ({
+  ConversationInput: () => (
+    <div data-testid="conversation-input">Conversation input</div>
+  ),
+  FileDndOverlay: () => null,
+}));
+
+vi.mock('../../../context/AppConfigContext', () => ({
+  useAppConfig: () => ({
+    config: { asrModelId: null, transcribeSizeLimitBytes: 5 * 1024 * 1024 },
+  }),
+}));
+
+vi.mock('../../../context/auth/UserContext', () => ({
+  useUser: () => ({
+    user: { bucket: 'bucket' },
+  }),
+}));
+
+vi.mock('../../../context/NotificationContext', () => ({
+  useNotification: () => ({
+    showNotification: vi.fn(),
+  }),
+}));
+
+vi.mock('../../../hooks/attachment/useAttachmentValidation', () => ({
+  useAttachmentValidation: () => ({
+    inputAttachmentTypes: [],
+    isAttachmentsAllowed: true,
+    validateAttachment: vi.fn(),
+    fileAccept: undefined,
+  }),
+}));
+
+vi.mock('../../../hooks/attachment/useOpenAttachmentCanvas', () => ({
+  useOpenAttachmentCanvas: () => ({
+    openAttachmentCanvas: vi.fn(),
+  }),
+}));
+
+vi.mock('../../../hooks/breakpoint/useBreakpoint', () => ({
+  useIsMobile: () => false,
+}));
+
+vi.mock('../../../hooks/conversation/useAttachmentUpload', () => ({
+  useAttachmentUpload: () => ({
+    handleUploadAttachment: vi.fn(),
+  }),
+}));
+
+vi.mock('../../../hooks/conversation/useAudioTranscription', () => ({
+  useAudioTranscription: () => ({
+    handleUploadAudio: vi.fn(),
+    handleTranscribeAudio: vi.fn(),
+    isTranscriptionSupported: false,
+  }),
+}));
+
+vi.mock('../../../hooks/conversation/useChatSettingsFormConfig', () => ({
+  useChatSettingsFormConfig: () => ({}),
+}));
+
+vi.mock('../../../hooks/conversation/useModelSelectorLabels', () => ({
+  useModelSelectorLabels: () => ({}),
+}));
+
+vi.mock('../../../hooks/files/useDialFileManagerState', () => ({
+  useDialFileManagerState: () => ({
+    isOpen: false,
+    openModal: vi.fn(),
+    closeModal: vi.fn(),
+    pendingAttachments: [],
+    clearPendingAttachments: vi.fn(),
+    handleAttach: vi.fn(),
+  }),
+}));
+
+vi.mock(
+  '../../../hooks/keyboard-shortcut/useKeyboardShortcutPreference',
+  () => ({
+    useKeyboardShortcutPreference: () => ({
+      preference: 'enter',
+    }),
+  }),
+);
+
+vi.mock('../../../hooks/usePageFileDrag', () => ({
+  usePageFileDrag: () => ({
+    isDragging: false,
+    pendingFiles: [],
+    onFilesConsumed: vi.fn(),
+  }),
+}));
+
+vi.mock('../../../hooks/user-profile/useUserProfile', () => ({
+  useUserProfile: () => ({
+    displayName: 'Test User',
+  }),
+}));
+
+const deployments: DeploymentItem[] = [
+  { id: 'gpt-4o', displayName: 'GPT-4o', type: 'model' },
+];
+
+describe('NewConversationComposer', () => {
+  it('renders intro text and starter content below the conversation input', async () => {
+    render(
+      <Suspense fallback={null}>
+        <NewConversationComposer
+          deployments={deployments}
+          selectedDeploymentId="gpt-4o"
+          placeholder="Message"
+          introText="Choose how to start"
+          onCreateConversation={vi.fn()}
+        >
+          <button type="button">Draft</button>
+        </NewConversationComposer>
+      </Suspense>,
+    );
+
+    const input = await screen.findByTestId('conversation-input');
+    const introText = screen.getByText('Choose how to start');
+    const starterButton = screen.getByRole('button', { name: 'Draft' });
+
+    expect(
+      input.compareDocumentPosition(introText) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(
+      introText.compareDocumentPosition(starterButton) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+});

--- a/openspec/specs/app-preview-chat/spec.md
+++ b/openspec/specs/app-preview-chat/spec.md
@@ -126,8 +126,8 @@ When a Settings-step save succeeds for a preview request, `AppsEditor` SHALL awa
 - **AND** the subsequent `GET /api/v1/conversations?path=...` request for that conversation succeeds (no double-encoded segment, no 400 from DIAL Core)
 
 The preview composer SHALL:
-- Render `conversationStarters.introText` above the starter buttons and the input when present.
-- Render `StarterButtons` above the input when valid starters are present.
+- Render `conversationStarters.introText` below the input and above the starter buttons when present.
+- Render `StarterButtons` below the input when valid starters are present.
 - Disable free-form input when `conversationStarters.chatMessageInputDisabled === true`.
 - Treat `autoSubmit` as `true` unless the API value is explicitly `false`.
 
@@ -144,7 +144,7 @@ Selecting a starter with submit enabled SHALL create or append to the preview co
 #### Scenario: Preview shows saved Quick Apps starters without page reload
 - **WHEN** the user changes conversation starters in the Settings iframe, clicks Preview, and the iframe posts `AppsEditorEvent.SaveSuccess`
 - **THEN** `AppsEditor` awaits `refetchDeployments()` before entering preview mode
-- **AND** the preview chat shows the saved starter buttons and intro text without a full browser reload
+- **AND** the preview chat shows the saved starter buttons and intro text below the input without a full browser reload
 
 #### Scenario: Preview non-submit starter populates input
 - **WHEN** the user selects a preview starter whose normalized `submit` flag is false

--- a/openspec/specs/conversation-deployment-selection/spec.md
+++ b/openspec/specs/conversation-deployment-selection/spec.md
@@ -205,7 +205,7 @@ State ownership: `ConversationRoute` owns the derived starter list, intro text, 
 #### Scenario: Quick Apps intro and starters render on new conversation screen
 
 - **WHEN** the selected application deployment has `conversationStarters.introText` and valid `starters`, and its deployment configuration does not define schema starters
-- **THEN** the new-conversation screen shows the intro text and renders the starter buttons above the input
+- **THEN** the new-conversation screen shows the intro text and renders the starter buttons below the input
 
 #### Scenario: Quick Apps starters take precedence over a schema mirror
 


### PR DESCRIPTION
## Description of changes

Render Conversation starters and Intro text after the chat input.

## UI changes

<img width="967" height="886" alt="Screenshot 2026-07-22 092348" src="https://github.com/user-attachments/assets/291bae9d-d045-41bd-9540-21268f1c3094" />


## Checklist

- [ ] the pull request name ends with `(Issue #<ISSUE_ID>)` (comma-separated list of issues)
- [X] I confirm that I don't share any confidential information like API keys or any other secrets and private URLs
