### PR TITLE
fix: update onEnsureSaved to return toolset id instead of boolean, ensuring correct login for new toolsets

### DIFF
--- a/apps/chat/src/pages/ToolsetEditor/EditorForm/AuthSection.tsx
+++ b/apps/chat/src/pages/ToolsetEditor/EditorForm/AuthSection.tsx
@@ -55,7 +55,7 @@ interface Props {
   toolsetId: string;
   endpoint: string;
   onAuthChange: (patch: Partial<ToolsetAuthFormData>) => void;
-  onEnsureSaved: () => Promise<boolean>;
+  onEnsureSaved: () => Promise<string | false>;
 }
 
 const ORDERED_AUTH_TYPES = [
@@ -119,11 +119,11 @@ const AuthSection: FC<Props> = ({
   const handleLogIn = async () => {
     if (!canLogIn) return;
 
-    const saved = await onEnsureSaved();
-    if (!saved) return;
+    const savedToolsetId = await onEnsureSaved();
+    if (!savedToolsetId) return;
 
     if (auth.authenticationType === ToolsetAuthTypes.OAuth) {
-      const initiation = initiateOAuthLogin(auth, toolsetId);
+      const initiation = initiateOAuthLogin(auth, savedToolsetId);
       if (initiation.type !== ToolsetOAuthInitiationResultType.Started) {
         showNotification({
           variant: NotificationVariant.Error,
@@ -164,7 +164,7 @@ const AuthSection: FC<Props> = ({
          * stuck showing "logged out" for a login that already went through.
          */
         try {
-          const refreshed = await getToolset(toolsetId);
+          const refreshed = await getToolset(savedToolsetId);
           if (refreshed.authSettings?.userLevelAuthStatus === 'SIGNED_IN') {
             onAuthChange({ isLoggedIn: true });
             showNotification({
@@ -182,14 +182,14 @@ const AuthSection: FC<Props> = ({
     setIsAuthBusy(true);
     try {
       const body: ToolsetLoginBodyDto = {
-        url: toolsetId,
+        url: savedToolsetId,
         credentialsLevel:
           ToolsetCredentialsLevel.User as ToolsetLoginBodyDto['credentialsLevel'],
         authenticationType:
           auth.authenticationType as ToolsetLoginBodyDto['authenticationType'],
         apiKey: auth.apiKey?.trim(),
       };
-      await loginToolset(toolsetId, body);
+      await loginToolset(savedToolsetId, body);
       onAuthChange({ isLoggedIn: true });
     } catch {
       showNotification({

--- a/apps/chat/src/pages/ToolsetEditor/EditorForm/SettingsForm.tsx
+++ b/apps/chat/src/pages/ToolsetEditor/EditorForm/SettingsForm.tsx
@@ -36,7 +36,7 @@ interface Props {
   toolsetId: string;
   onChange: (patch: Partial<ToolsetFormData>) => void;
   onAuthChange: (patch: Partial<ToolsetAuthFormData>) => void;
-  onEnsureSaved: () => Promise<boolean>;
+  onEnsureSaved: () => Promise<string | false>;
 }
 
 const SettingsForm: FC<Props> = ({

--- a/apps/chat/src/pages/ToolsetEditor/EditorForm/tests/AuthSection.spec.tsx
+++ b/apps/chat/src/pages/ToolsetEditor/EditorForm/tests/AuthSection.spec.tsx
@@ -219,7 +219,7 @@ const renderSection = (
   onAuthChange = vi.fn(),
   endpoint = VALID_ENDPOINT,
   errors: ToolsetFormErrors = {},
-  onEnsureSaved = vi.fn().mockResolvedValue(true),
+  onEnsureSaved = vi.fn().mockResolvedValue(toolsetId),
 ) =>
   render(
     <AuthSection
@@ -604,6 +604,29 @@ describe('AuthSection', () => {
       }) as HTMLButtonElement;
       expect(btn.disabled).toBe(false);
     });
+
+    it('uses the id returned by onEnsureSaved, not a stale toolsetId prop, for the first login of a brand-new toolset', async () => {
+      const onEnsureSaved = vi
+        .fn()
+        .mockResolvedValue('toolsets/b/newly-created');
+      renderSection(
+        oauthWithConfigAuth(),
+        '',
+        vi.fn(),
+        VALID_ENDPOINT,
+        {},
+        onEnsureSaved,
+      );
+      await user.click(
+        screen.getByRole('button', { name: ButtonsI18nKeys.LogIn }),
+      );
+      await waitFor(() => expect(capturedPopup).toBeDefined());
+      const stored = capturedPopup?.sessionStorage.getItem(
+        TOOLSET_REDIRECT_STATE_KEY,
+      );
+      const state = JSON.parse(stored as string);
+      expect(state.toolsetId).toBe('toolsets/b/newly-created');
+    });
   });
 
   describe('API key login', () => {
@@ -645,7 +668,7 @@ describe('AuthSection', () => {
 
     it('saves unsaved changes before logging in', async () => {
       vi.mocked(toolsetsApi.loginToolset).mockResolvedValue({ success: true });
-      const onEnsureSaved = vi.fn().mockResolvedValue(true);
+      const onEnsureSaved = vi.fn().mockResolvedValue('toolsets/b/my__1.0.0');
       renderSection(
         apiKeyAuth(),
         'toolsets/b/my__1.0.0',
@@ -659,6 +682,30 @@ describe('AuthSection', () => {
       );
       await waitFor(() => expect(onEnsureSaved).toHaveBeenCalledOnce());
       expect(toolsetsApi.loginToolset).toHaveBeenCalled();
+    });
+
+    it('uses the id returned by onEnsureSaved, not a stale toolsetId prop, for the first login of a brand-new toolset', async () => {
+      vi.mocked(toolsetsApi.loginToolset).mockResolvedValue({ success: true });
+      const onEnsureSaved = vi
+        .fn()
+        .mockResolvedValue('toolsets/b/newly-created');
+      renderSection(
+        apiKeyAuth(),
+        '',
+        vi.fn(),
+        VALID_ENDPOINT,
+        {},
+        onEnsureSaved,
+      );
+      await user.click(
+        screen.getByRole('button', { name: ButtonsI18nKeys.LogIn }),
+      );
+      await waitFor(() =>
+        expect(toolsetsApi.loginToolset).toHaveBeenCalledWith(
+          'toolsets/b/newly-created',
+          expect.objectContaining({ url: 'toolsets/b/newly-created' }),
+        ),
+      );
     });
 
     it('does not attempt to log in when saving unsaved changes fails', async () => {

--- a/apps/chat/src/pages/ToolsetEditor/ToolsetEditor.tsx
+++ b/apps/chat/src/pages/ToolsetEditor/ToolsetEditor.tsx
@@ -266,7 +266,7 @@ const ToolsetEditor: FC = () => {
   }, [form, t, persistFormIfChanged, setEditorStep]);
 
   const handleEnsureSaved = useCallback(
-    async () => (await persistFormIfChanged()) != null,
+    async () => (await persistFormIfChanged()) ?? false,
     [persistFormIfChanged],
   );
 

--- a/apps/chat/src/pages/ToolsetEditor/ToolsetEditorView.tsx
+++ b/apps/chat/src/pages/ToolsetEditor/ToolsetEditorView.tsx
@@ -23,7 +23,7 @@ interface Props {
   toolsetId: string;
   onNext: () => void;
   onCancel: () => void;
-  onEnsureSaved: () => Promise<boolean>;
+  onEnsureSaved: () => Promise<string | false>;
   onChange: (patch: Partial<ToolsetFormData>) => void;
   onAuthChange: (patch: Partial<ToolsetAuthFormData>) => void;
 }

--- a/apps/chat/src/pages/ToolsetEditor/tests/ToolsetEditor.spec.tsx
+++ b/apps/chat/src/pages/ToolsetEditor/tests/ToolsetEditor.spec.tsx
@@ -2,6 +2,7 @@ import { NotificationVariant } from '@epam/ai-dial-ui-kit';
 import { ResponseError } from '@epam/chat-api-client';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { useState } from 'react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ToolsetEditorI18nKeys } from '../../../constants/translation-keys';
@@ -52,6 +53,7 @@ vi.mock('../ToolsetEditorView', () => ({
     onChange,
     onAuthChange,
     onNext,
+    onEnsureSaved,
   }: {
     step: string;
     toolsetId: string;
@@ -63,122 +65,140 @@ vi.mock('../ToolsetEditorView', () => ({
     onChange: (patch: Record<string, unknown>) => void;
     onAuthChange: (patch: Record<string, unknown>) => void;
     onNext: () => void;
-  }) => (
-    <div>
-      <span>{`current-step-${step}`}</span>
-      <span>{`toolset-id-${toolsetId}`}</span>
-      <button type="button" onClick={onNext}>
-        go-next
-      </button>
-      {errors.endpoint && <p role="alert">{errors.endpoint}</p>}
-      {errors.authorizationEndpoint && (
-        <p role="alert">{errors.authorizationEndpoint}</p>
-      )}
-      {errors.tokenEndpoint && <p role="alert">{errors.tokenEndpoint}</p>}
-      <button
-        type="button"
-        onClick={() => {
-          onChange({ endpoint: '' });
-        }}
-      >
-        touch-empty-endpoint
-      </button>
-      <button
-        type="button"
-        onClick={() => {
-          onChange({ name: 'Updated name' });
-        }}
-      >
-        change-name
-      </button>
-      <button
-        type="button"
-        onClick={() => {
-          onChange({ endpoint: 'https://example.com/mcp' });
-          onAuthChange({
-            authenticationType: ToolsetAuthTypes.ApiKey,
-            withLogin: WithLogin.WithLogin,
-            keyHeader: 'X-API-Key',
-            apiKey: 'secret',
-          });
-        }}
-      >
-        fill-api-key-toolset
-      </button>
-      <button
-        type="button"
-        onClick={() => {
-          onChange({ endpoint: 'https://example.com/mcp' });
-          onAuthChange({
-            authenticationType: ToolsetAuthTypes.ApiKey,
-            withLogin: WithLogin.WithoutLogin,
-            keyHeader: 'X-API-Key',
-            apiKey: '',
-          });
-        }}
-      >
-        fill-api-key-without-login-toolset
-      </button>
-      <button
-        type="button"
-        onClick={() => {
-          onChange({ endpoint: 'https://example.com/mcp' });
-          onAuthChange({
-            authenticationType: ToolsetAuthTypes.OAuth,
-            withLogin: WithLogin.WithConfig,
-            clientId: 'client-id',
-            clientSecret: 'client-secret',
-            authorizationEndpoint: 'https://auth.example.com/oauth/authorize',
-            tokenEndpoint: 'https://auth.example.com/oauth/token',
-          });
-        }}
-      >
-        fill-oauth-toolset
-      </button>
-      <button
-        type="button"
-        onClick={() => {
-          onChange({ endpoint: 'https://example.com/mcp' });
-          onAuthChange({
-            authenticationType: ToolsetAuthTypes.OAuth,
-            withLogin: WithLogin.WithLogin,
-          });
-        }}
-      >
-        fill-oauth-with-login-toolset
-      </button>
-      <button
-        type="button"
-        onClick={() => {
-          onChange({ endpoint: 'https://example.com/mcp' });
-          onAuthChange({
-            authenticationType: ToolsetAuthTypes.OAuth,
-            withLogin: WithLogin.WithConfig,
-            clientId: 'client-id',
-            clientSecret: 'client-secret',
-          });
-        }}
-      >
-        fill-oauth-toolset-without-endpoints
-      </button>
-      <button
-        type="button"
-        onClick={() => {
-          onChange({ endpoint: 'https://example.com/mcp' });
-          onAuthChange({
-            authenticationType: ToolsetAuthTypes.OAuth,
-            withLogin: WithLogin.WithConfig,
-            clientId: 'client-id',
-            clientSecret: 'client-secret',
-            authorizationEndpoint: 'not a url',
-            tokenEndpoint: 'https://auth.example.com/oauth/token',
-          });
-        }}
-      >
-        fill-invalid-oauth-toolset
-      </button>
-    </div>
-  ),
+    onEnsureSaved: () => Promise<string | false>;
+  }) => {
+    const [ensureSavedResult, setEnsureSavedResult] = useState<string | null>(
+      null,
+    );
+    return (
+      <div>
+        <span>{`current-step-${step}`}</span>
+        <span>{`toolset-id-${toolsetId}`}</span>
+        <button type="button" onClick={onNext}>
+          go-next
+        </button>
+        <button
+          type="button"
+          onClick={async () => {
+            const result = await onEnsureSaved();
+            setEnsureSavedResult(result === false ? 'false' : result);
+          }}
+        >
+          invoke-ensure-saved
+        </button>
+        {ensureSavedResult != null && (
+          <span>{`ensure-saved-result-${ensureSavedResult}`}</span>
+        )}
+        {errors.endpoint && <p role="alert">{errors.endpoint}</p>}
+        {errors.authorizationEndpoint && (
+          <p role="alert">{errors.authorizationEndpoint}</p>
+        )}
+        {errors.tokenEndpoint && <p role="alert">{errors.tokenEndpoint}</p>}
+        <button
+          type="button"
+          onClick={() => {
+            onChange({ endpoint: '' });
+          }}
+        >
+          touch-empty-endpoint
+        </button>
+        <button
+          type="button"
+          onClick={() => {
+            onChange({ name: 'Updated name' });
+          }}
+        >
+          change-name
+        </button>
+        <button
+          type="button"
+          onClick={() => {
+            onChange({ endpoint: 'https://example.com/mcp' });
+            onAuthChange({
+              authenticationType: ToolsetAuthTypes.ApiKey,
+              withLogin: WithLogin.WithLogin,
+              keyHeader: 'X-API-Key',
+              apiKey: 'secret',
+            });
+          }}
+        >
+          fill-api-key-toolset
+        </button>
+        <button
+          type="button"
+          onClick={() => {
+            onChange({ endpoint: 'https://example.com/mcp' });
+            onAuthChange({
+              authenticationType: ToolsetAuthTypes.ApiKey,
+              withLogin: WithLogin.WithoutLogin,
+              keyHeader: 'X-API-Key',
+              apiKey: '',
+            });
+          }}
+        >
+          fill-api-key-without-login-toolset
+        </button>
+        <button
+          type="button"
+          onClick={() => {
+            onChange({ endpoint: 'https://example.com/mcp' });
+            onAuthChange({
+              authenticationType: ToolsetAuthTypes.OAuth,
+              withLogin: WithLogin.WithConfig,
+              clientId: 'client-id',
+              clientSecret: 'client-secret',
+              authorizationEndpoint: 'https://auth.example.com/oauth/authorize',
+              tokenEndpoint: 'https://auth.example.com/oauth/token',
+            });
+          }}
+        >
+          fill-oauth-toolset
+        </button>
+        <button
+          type="button"
+          onClick={() => {
+            onChange({ endpoint: 'https://example.com/mcp' });
+            onAuthChange({
+              authenticationType: ToolsetAuthTypes.OAuth,
+              withLogin: WithLogin.WithLogin,
+            });
+          }}
+        >
+          fill-oauth-with-login-toolset
+        </button>
+        <button
+          type="button"
+          onClick={() => {
+            onChange({ endpoint: 'https://example.com/mcp' });
+            onAuthChange({
+              authenticationType: ToolsetAuthTypes.OAuth,
+              withLogin: WithLogin.WithConfig,
+              clientId: 'client-id',
+              clientSecret: 'client-secret',
+            });
+          }}
+        >
+          fill-oauth-toolset-without-endpoints
+        </button>
+        <button
+          type="button"
+          onClick={() => {
+            onChange({ endpoint: 'https://example.com/mcp' });
+            onAuthChange({
+              authenticationType: ToolsetAuthTypes.OAuth,
+              withLogin: WithLogin.WithConfig,
+              clientId: 'client-id',
+              clientSecret: 'client-secret',
+              authorizationEndpoint: 'not a url',
+              tokenEndpoint: 'https://auth.example.com/oauth/token',
+            });
+          }}
+        >
+          fill-invalid-oauth-toolset
+        </button>
+      </div>
+    );
+  },
 }));
 
 const renderEditor = (initialEntry: string = ROUTES.ToolsetEditor) =>
@@ -328,6 +348,51 @@ describe('ToolsetEditor', () => {
         }),
       ),
     );
+  });
+
+  it('resolves onEnsureSaved to the freshly created toolset id for a brand-new toolset', async () => {
+    renderEditor();
+
+    await user.click(
+      await screen.findByRole('button', {
+        name: 'fill-api-key-toolset',
+      }),
+    );
+    await user.click(
+      screen.getByRole('button', {
+        name: 'invoke-ensure-saved',
+      }),
+    );
+
+    expect(
+      await screen.findByText('ensure-saved-result-toolsets/b/my__0.0.1'),
+    ).toBeTruthy();
+    expect(toolsetsApi.createToolset).toHaveBeenCalledOnce();
+  });
+
+  it('resolves onEnsureSaved to the already-persisted id without another request when nothing changed', async () => {
+    renderEditor();
+
+    await user.click(
+      await screen.findByRole('button', {
+        name: 'fill-api-key-toolset',
+      }),
+    );
+    await user.click(
+      screen.getByRole('button', { name: 'invoke-ensure-saved' }),
+    );
+    await screen.findByText('ensure-saved-result-toolsets/b/my__0.0.1');
+
+    await user.click(
+      screen.getByRole('button', { name: 'invoke-ensure-saved' }),
+    );
+
+    await waitFor(() =>
+      expect(toolsetsApi.createToolset).toHaveBeenCalledOnce(),
+    );
+    expect(
+      screen.getByText('ensure-saved-result-toolsets/b/my__0.0.1'),
+    ).toBeTruthy();
   });
 
   it('saves a newly created API-key toolset without login using only the key header', async () => {

--- a/openspec/changes/archive/2026-07-22-fix-toolset-login-stale-id/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-22-fix-toolset-login-stale-id/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-22

--- a/openspec/changes/archive/2026-07-22-fix-toolset-login-stale-id/design.md
+++ b/openspec/changes/archive/2026-07-22-fix-toolset-login-stale-id/design.md
@@ -1,0 +1,64 @@
+## Context
+
+`persistFormIfChanged` (`ToolsetEditor.tsx:212-252`) already returns the toolset id as
+`Promise<string | null>` — it resolves to the current/created id on success (including the
+"nothing changed, no request sent" case) or `null` on failure. `handleEnsureSaved`
+(`ToolsetEditor.tsx:268-271`), the callback passed to `AuthSection` as `onEnsureSaved`, discards
+that id and hands `AuthSection` only a `boolean`:
+
+```ts
+const handleEnsureSaved = useCallback(
+  async () => (await persistFormIfChanged()) != null,
+  [persistFormIfChanged],
+);
+```
+
+`AuthSection.handleLogIn` (`AuthSection.tsx:119-202`) then falls back to the `toolsetId` prop it
+closed over at click time. For a brand-new toolset that prop is `''` at the moment "Log In" is
+clicked (`ToolsetEditor.tsx:90-91`: `draftToolsetId` starts as `''`, and `setDraftToolsetId` from
+inside `persistFormIfChanged` only takes effect on the next render). So the very first login
+call — the OAuth popup's `initiateOAuthLogin(auth, toolsetId)` at `AuthSection.tsx:126`, or the
+API-key `loginToolset(toolsetId, body)` at `AuthSection.tsx:192` — is sent with an empty id and
+fails. The next click, on the re-rendered form, has the real `toolsetId` prop and succeeds. The
+underlying id-returning plumbing is already in place; the only gap is that the id is thrown away
+at the `onEnsureSaved` boundary and never reaches the code that needs it.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- The first "Log In" click for a brand-new toolset succeeds without requiring a second click.
+- `AuthSection` always authenticates against the id that was actually just persisted, not a
+  value captured before persistence ran.
+
+**Non-Goals:**
+
+- No change to the OAuth redirect/callback handshake, popup mechanics, or logout flow.
+- No change to `persistFormIfChanged`'s existing return type or unchanged-form short-circuit —
+  it already returns the right value.
+- No change to backend endpoints or DTOs.
+
+## Decisions
+
+- **Change `onEnsureSaved`'s contract from `Promise<boolean>` to `Promise<string | false>`.**
+  `handleEnsureSaved` returns `(await persistFormIfChanged()) ?? false` instead of coercing to a
+  boolean, so the id `persistFormIfChanged` already computes reaches the caller instead of being
+  dropped. Chosen over adding a second callback (e.g. `getCurrentToolsetId`) or reading a ref,
+  because the id is already the resolved value of the promise the caller awaits — no new state
+  or plumbing is needed, just not discarding it.
+- **`AuthSection.handleLogIn` uses the id returned by `onEnsureSaved()` for every call that
+  follows it in the same invocation** — `initiateOAuthLogin(auth, savedId)`, the
+  Cancelled-recheck `getToolset(savedId)`, and `loginToolset(savedId, body)` — instead of the
+  `toolsetId` prop. The `toolsetId` prop remains used for anything evaluated *before* the
+  persist step (e.g. `isEditMode`, `canLogIn`), where it is not stale.
+- **`AuthSection`'s `Props.onEnsureSaved` type updates to `() => Promise<string | false>`** to
+  match, keeping the "id or failure" contract explicit at the type level rather than relying on
+  a truthy/falsy convention that previously hid the discarded id.
+
+## Risks / Trade-offs
+
+- [Call sites elsewhere assume `onEnsureSaved` returns a boolean] → Grep confirms `AuthSection`
+  is the only consumer of this prop; no other change needed.
+- [A `''` id could be mistaken for failure under the new `string | false` contract] →
+  `persistFormIfChanged` never resolves to `''` — it resolves to a real backend-issued id or
+  `null` (mapped to `false`), so an empty-string false-positive isn't reachable.

--- a/openspec/changes/archive/2026-07-22-fix-toolset-login-stale-id/proposal.md
+++ b/openspec/changes/archive/2026-07-22-fix-toolset-login-stale-id/proposal.md
@@ -1,0 +1,39 @@
+## Why
+
+In the Toolset Editor, clicking "Log In" for a brand-new (never-saved) toolset fails on the
+first click and only succeeds on the second. `AuthSection`'s `handleLogIn` calls
+`onEnsureSaved()` to persist the toolset (which creates it and asynchronously updates the
+parent's `draftToolsetId` state), but then immediately uses the `toolsetId` **prop** captured in
+the same render's closure — still `''` for a new toolset — to initiate the OAuth popup or send
+the API-key login request. The login call is sent with an empty toolset id and fails. Once the
+form re-renders with the real id (after the first failed attempt), every later click uses the
+correct id and succeeds, which is why the bug is easy to miss: it only reproduces on the very
+first login for a brand-new toolset.
+
+## What Changes
+
+- `onEnsureSaved` (in `ToolsetEditor.tsx`, passed to `AuthSection`) returns the persisted
+  toolset id on success (or `false` on failure) instead of a plain boolean.
+- `AuthSection.handleLogIn` uses the id returned by `onEnsureSaved()` — not the `toolsetId` prop
+  — for `initiateOAuthLogin`, `getToolset` (Cancelled-recheck path), and `loginToolset`, so the
+  very first login call for a new toolset always targets the id that was just created.
+- No change to persisted data shapes, API contracts, or the already-logged-in / logout flows.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `toolset-authentication`: the "Persist unsaved changes before login" requirement is
+  strengthened to require that the login call use the id returned by the persist step itself,
+  not a possibly-stale `toolsetId` value from before the persist completed.
+
+## Impact
+
+- `apps/chat/src/pages/ToolsetEditor/EditorForm/AuthSection.tsx` (`handleLogIn`, `Props`)
+- `apps/chat/src/pages/ToolsetEditor/ToolsetEditor.tsx` (`handleEnsureSaved`,
+  `persistFormIfChanged`)
+- No backend, API contract, or database changes.

--- a/openspec/changes/archive/2026-07-22-fix-toolset-login-stale-id/specs/toolset-authentication/spec.md
+++ b/openspec/changes/archive/2026-07-22-fix-toolset-login-stale-id/specs/toolset-authentication/spec.md
@@ -1,0 +1,39 @@
+## MODIFIED Requirements
+
+### Requirement: Persist unsaved changes before login
+Clicking "Log in" (API Key or OAuth) SHALL first persist any unsaved editor changes — creating
+the toolset if it has no id yet, or updating it if the form has changed since it was last
+persisted — using the same persist logic as advancing past the General step. If the form has
+not changed since it was last persisted, no create/update request SHALL be sent. If persisting
+fails, the system SHALL show an error notification and SHALL NOT proceed to submit credentials
+or open the OAuth authorization popup, so login never runs against a stale endpoint or
+authentication configuration. The persist step SHALL return the toolset id it just resolved
+(the newly created id, the updated id, or the already-persisted id when nothing changed), and
+every subsequent call in the same login attempt — initiating the OAuth popup, re-checking
+sign-in status after a Cancelled OAuth result, and the API-key login request — SHALL use that
+returned id rather than any toolset id value captured before the persist step ran, so the very
+first login for a brand-new toolset targets the id that was just created instead of an empty or
+stale id.
+
+#### Scenario: Log in persists unsaved endpoint/auth changes first
+- **WHEN** a user edits the endpoint or authentication fields on the Settings step without
+  saving, then clicks "Log in"
+- **THEN** the system updates the toolset with the current form values before submitting
+  credentials or opening the OAuth authorization popup
+
+#### Scenario: Log in sends no request when nothing changed
+- **WHEN** a user clicks "Log in" without having changed anything since the toolset was last
+  persisted
+- **THEN** the system sends no create/update request and proceeds directly to login
+
+#### Scenario: Login is blocked when persisting fails
+- **WHEN** persisting unsaved changes before login fails
+- **THEN** the system shows an error notification and does not submit credentials or open the
+  OAuth authorization popup
+
+#### Scenario: First login for a brand-new toolset uses the freshly created id
+- **WHEN** a user fills in a new toolset's settings and clicks "Log in" for the very first time,
+  before the toolset has ever been persisted
+- **THEN** the persist step creates the toolset and the login call (OAuth popup initiation or
+  API-key login request) uses the id the create call just returned, not an empty or otherwise
+  stale id, so the very first click succeeds

--- a/openspec/changes/archive/2026-07-22-fix-toolset-login-stale-id/tasks.md
+++ b/openspec/changes/archive/2026-07-22-fix-toolset-login-stale-id/tasks.md
@@ -1,0 +1,55 @@
+## 1. Propagate the persisted toolset id through `onEnsureSaved`
+
+- [x] 1.1 In `apps/chat/src/pages/ToolsetEditor/ToolsetEditor.tsx`, change `handleEnsureSaved` to
+      return `(await persistFormIfChanged()) ?? false` instead of coercing the result to
+      `boolean`, so it resolves to `string | false`.
+- [x] 1.2 Update the `onEnsureSaved` prop type on `AuthSection` (in
+      `apps/chat/src/pages/ToolsetEditor/EditorForm/AuthSection.tsx`'s `Props`) from
+      `() => Promise<boolean>` to `() => Promise<string | false>`. Also updated the two
+      intermediate pass-through components in the prop chain (`ToolsetEditorView.tsx`,
+      `EditorForm/SettingsForm.tsx`) to the same type — not anticipated by the design doc, but
+      required for the chain to typecheck end-to-end.
+
+## 2. Use the returned id in `AuthSection.handleLogIn`
+
+- [x] 2.1 In `handleLogIn` (`AuthSection.tsx`), capture the result of `onEnsureSaved()` into a
+      local (e.g. `savedToolsetId`) and `return` early when it is `false`, same as today's
+      `if (!saved) return;` check.
+- [x] 2.2 Replace the `toolsetId` argument in `initiateOAuthLogin(auth, toolsetId)` with
+      `savedToolsetId`.
+- [x] 2.3 Replace the `toolsetId` argument in the Cancelled-result recheck `getToolset(toolsetId)`
+      with `savedToolsetId`.
+- [x] 2.4 Replace both the `url: toolsetId` field in the API-key `ToolsetLoginBodyDto` and the
+      `loginToolset(toolsetId, body)` call with `savedToolsetId`.
+- [x] 2.5 Leave every other use of the `toolsetId` prop in `AuthSection.tsx` (e.g. `isEditMode`,
+      `handleConfirmLogout`) unchanged — they run before or independent of the persist step and
+      are not stale.
+
+## 3. Tests
+
+- [x] 3.1 In `apps/chat/src/pages/ToolsetEditor/EditorForm/tests/AuthSection.spec.tsx`, add a
+      case: `onEnsureSaved` resolves to a freshly created id (distinct from the `toolsetId` prop
+      passed in, simulating a brand-new toolset), clicking "Log In" (OAuth path) calls
+      `initiateOAuthLogin` with that returned id, not the stale prop.
+- [x] 3.2 Add the equivalent case for the API-key login path: `loginToolset` is called with the
+      id `onEnsureSaved` resolved to.
+- [x] 3.3 Add a case confirming that when `onEnsureSaved` resolves to `false`, `handleLogIn`
+      returns without calling `initiateOAuthLogin` / `loginToolset` (existing failure-path
+      behavior preserved) — already covered by the pre-existing "does not open a popup when
+      saving unsaved changes fails" and "does not attempt to log in when saving unsaved changes
+      fails" tests; no new test needed.
+- [x] 3.4 In `apps/chat/src/pages/ToolsetEditor/tests/ToolsetEditor.spec.tsx`, verify
+      `handleEnsureSaved`/`onEnsureSaved` resolves to the id `persistFormIfChanged` returns
+      (covering both the create-new-toolset case and the unchanged-form short-circuit case),
+      not just a boolean. Added an `invoke-ensure-saved` hook to the mocked `ToolsetEditorView`
+      to exercise `onEnsureSaved` directly and render its resolved value for assertions.
+
+## 4. Verify
+
+- [x] 4.1 `npm exec nx test chat -- src/pages/ToolsetEditor` passes: 5 test files, 72 tests, all
+      green (includes 2 new `AuthSection.spec.tsx` cases and 2 new `ToolsetEditor.spec.tsx`
+      cases).
+- [x] 4.2 `npm exec nx lint chat` passes with 0 errors (20 pre-existing warnings unrelated to
+      this change remain, e.g. non-null-assertion warnings in `apply-chunk.spec.ts`).
+- [x] 4.3 Manually verify in the running app: create a brand-new toolset, fill in OAuth or
+      API-key settings, click "Log In" once — login succeeds on the first click.

--- a/openspec/specs/toolset-authentication/spec.md
+++ b/openspec/specs/toolset-authentication/spec.md
@@ -51,7 +51,13 @@ persisted — using the same persist logic as advancing past the General step. I
 not changed since it was last persisted, no create/update request SHALL be sent. If persisting
 fails, the system SHALL show an error notification and SHALL NOT proceed to submit credentials
 or open the OAuth authorization popup, so login never runs against a stale endpoint or
-authentication configuration.
+authentication configuration. The persist step SHALL return the toolset id it just resolved
+(the newly created id, the updated id, or the already-persisted id when nothing changed), and
+every subsequent call in the same login attempt — initiating the OAuth popup, re-checking
+sign-in status after a Cancelled OAuth result, and the API-key login request — SHALL use that
+returned id rather than any toolset id value captured before the persist step ran, so the very
+first login for a brand-new toolset targets the id that was just created instead of an empty or
+stale id.
 
 #### Scenario: Log in persists unsaved endpoint/auth changes first
 - **WHEN** a user edits the endpoint or authentication fields on the Settings step without
@@ -68,6 +74,13 @@ authentication configuration.
 - **WHEN** persisting unsaved changes before login fails
 - **THEN** the system shows an error notification and does not submit credentials or open the
   OAuth authorization popup
+
+#### Scenario: First login for a brand-new toolset uses the freshly created id
+- **WHEN** a user fills in a new toolset's settings and clicks "Log in" for the very first time,
+  before the toolset has ever been persisted
+- **THEN** the persist step creates the toolset and the login call (OAuth popup initiation or
+  API-key login request) uses the id the create call just returned, not an empty or otherwise
+  stale id, so the very first click succeeds
 
 ### Requirement: OAuth redirect and callback handshake
 For OAuth login with config, the system SHALL save the OAuth configuration (Editor) or use the


### PR DESCRIPTION
…suring correct login for new toolsets

## Description of changes

- Fixes a bug where clicking "Log In" for a brand-new toolset failed on the first click and only succeeded on retry.
- AuthSection.handleLogIn was authenticating against the toolsetId prop captured at click time, which is still empty for a toolset that hasn't been created yet — onEnsureSaved() creates it and updates state, but that update only lands on the next render.
- onEnsureSaved now resolves to the actual persisted id (string | false) instead of a plain boolean, and handleLogIn uses that returned id for the OAuth popup, the Cancelled-result recheck, and the API-key login call.

## Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #<ISSUE_ID>

## UI changes

<Please, provide Screenshots or Figma links>

## Checklist

- [ ] the pull request name ends with `(Issue #<ISSUE_ID>)` (comma-separated list of issues)
- [ ] I confirm that I don't share any confidential information like API keys or any other secrets and private URLs

<details>
  <summary>PR title cheatsheet</summary>

`<type>[optional scope]: <description>`

1. type (required)
    - `feat` - A new feature
    - `fix` - A bug fix
    - `docs` - Documentation only changes
    - `test` - Adding missing tests or correcting existing tests
    - `ci` - Changes to our CI configuration files and scripts
    - `chore` - Other changes that are minor and/or not user-facing
2. scope (optional, current repo suggestions below)
    - `chat`
    - `overlay`
    - `shared`
    - `sandbox-overlay`
    - `visualizer-connector`

</details>
