### PR TITLE
fix: upload archive into it's own folder (#7912)

### DIFF
--- a/apps/chat/src/hooks/files/tests/upload/useDialFileUploadBatch.spec.tsx
+++ b/apps/chat/src/hooks/files/tests/upload/useDialFileUploadBatch.spec.tsx
@@ -150,14 +150,58 @@ describe('useDialFileUploadBatch', () => {
 
       expect(validation).toEqual({ valid: true });
     });
+
+    it('routes an archive conflict fallback back through archive upload', async () => {
+      const { result, invalidateFolders } = renderUploadBatch();
+      const file = new File(['zip'], 'archive.zip');
+
+      act(() => {
+        result.current.onUploadFiles(
+          [{ name: 'archive', fileContent: file }],
+          '/My files/reports',
+        );
+      });
+
+      await waitFor(() =>
+        expect(mockUploadArchive).toHaveBeenCalledWith(
+          file,
+          BUCKET,
+          'reports/archive/',
+        ),
+      );
+      expect(mockUploadFile).not.toHaveBeenCalled();
+      expect(invalidateFolders).toHaveBeenCalledWith(['reports/']);
+    });
+
+    it('keeps ordinary ZIP file uploads on the normal file-upload path', async () => {
+      const { result } = renderUploadBatch();
+      const file = new File(['zip'], 'archive.zip');
+
+      act(() => {
+        result.current.onUploadFiles(
+          [{ name: 'archive.zip', fileContent: file }],
+          '/My files/reports',
+        );
+      });
+
+      await waitFor(() =>
+        expect(mockUploadFile).toHaveBeenCalledWith(
+          BUCKET,
+          'reports/archive.zip',
+          file,
+          expect.objectContaining({ uploadMode: 'create-only' }),
+        ),
+      );
+      expect(mockUploadArchive).not.toHaveBeenCalled();
+    });
   });
 
   describe('onUploadArchive', () => {
     it('invalidates the destination cache and shows no toast on full success', async () => {
       mockUploadArchive.mockResolvedValue({
         results: [
-          { path: 'reports/a.txt', success: true },
-          { path: 'reports/b.txt', success: true },
+          { path: 'reports/archive/a.txt', success: true },
+          { path: 'reports/archive/b.txt', success: true },
         ],
       });
 
@@ -167,7 +211,7 @@ describe('useDialFileUploadBatch', () => {
       act(() => {
         result.current.onUploadArchive(
           new File(['zip'], 'archive.zip'),
-          'archive.zip',
+          'archive',
           '/My files/reports',
         );
       });
@@ -191,7 +235,7 @@ describe('useDialFileUploadBatch', () => {
       act(() => {
         result.current.onUploadArchive(
           new File(['zip'], 'archive.zip'),
-          'archive.zip',
+          'archive',
           '/My files/reports',
         );
       });
@@ -218,7 +262,7 @@ describe('useDialFileUploadBatch', () => {
       act(() => {
         result.current.onUploadArchive(
           new File(['zip'], 'archive.zip'),
-          'archive.zip',
+          'archive',
           '/My files/reports',
         );
       });
@@ -241,7 +285,7 @@ describe('useDialFileUploadBatch', () => {
       act(() => {
         result.current.onUploadArchive(
           new File(['zip'], 'archive.zip'),
-          'archive.zip',
+          'archive',
           '/My files/reports',
         );
       });
@@ -256,25 +300,21 @@ describe('useDialFileUploadBatch', () => {
       );
     });
 
-    it('resolves bucket and destinationPath relative to the destination folder', async () => {
+    it('resolves bucket and destinationPath to an archive-named child folder', async () => {
       mockUploadArchive.mockResolvedValue({ results: [] });
 
       const { result } = renderUploadBatch();
 
       const file = new File(['zip'], 'archive.zip');
       act(() => {
-        result.current.onUploadArchive(
-          file,
-          'archive.zip',
-          '/My files/reports',
-        );
+        result.current.onUploadArchive(file, 'archive', '/My files/reports');
       });
 
       await waitFor(() =>
         expect(mockUploadArchive).toHaveBeenCalledWith(
           file,
           BUCKET,
-          'reports/',
+          'reports/archive/',
         ),
       );
     });

--- a/apps/chat/src/hooks/files/useDialFileUploadBatch.ts
+++ b/apps/chat/src/hooks/files/useDialFileUploadBatch.ts
@@ -44,6 +44,27 @@ const formatArchiveFailedEntries = (
   return hiddenCount > 0 ? `${visible}${getRestLabel(hiddenCount)}` : visible;
 };
 
+const buildArchiveDestinationPath = (
+  destinationApiPath: string,
+  archiveName: string,
+): string => `${destinationApiPath}${archiveName}/`;
+
+const hasZipExtension = (name: string): boolean => /\.zip$/i.test(name);
+
+const getArchiveConflictUploadFallback = (
+  files: DialUploadFileItem[],
+): DialUploadFileItem | undefined => {
+  const [file] = files;
+
+  if (files.length !== 1 || file == null) {
+    return undefined;
+  }
+
+  return hasZipExtension(file.fileContent.name) && !hasZipExtension(file.name)
+    ? file
+    : undefined;
+};
+
 export interface UseDialFileUploadBatchOptions {
   bucket: string;
   rootLabel: string;
@@ -104,9 +125,86 @@ export const useDialFileUploadBatch = ({
     useState<FileUploadBatchState | null>(null);
   const uploadAbortControllerRef = useRef<AbortController | null>(null);
 
+  const uploadArchiveToFolder = useCallback(
+    (file: File, name: string, destinationFolder: string) => {
+      const destinationApiPath = virtualPathToApiPath(
+        destinationFolder,
+        rootLabel,
+      );
+
+      setUploadBatchState({
+        files: [
+          {
+            id: `${Date.now()}-archive`,
+            name,
+            status: FileUploadStatus.Uploading,
+          },
+        ],
+        isOpen: true,
+      });
+
+      const run = async (): Promise<void> => {
+        try {
+          const { results } = await uploadArchive(
+            file,
+            bucket,
+            buildArchiveDestinationPath(destinationApiPath, name),
+          );
+          const successCount = results.filter((r) => r.success).length;
+          const failedResults = results.filter((r) => !r.success);
+          const failedCount = failedResults.length;
+          const failedFiles = formatArchiveFailedEntries(
+            failedResults,
+            (count) => t(DialFileManagerI18nKeys.AndOtherItems, { count }),
+          );
+
+          if (results.length > 0 && successCount === 0) {
+            onNotification?.({
+              variant: NotificationVariant.Error,
+              message: t(DialFileManagerI18nKeys.UploadArchiveFilesError, {
+                count: failedCount,
+                files: failedFiles,
+              }),
+            });
+          } else if (failedCount > 0) {
+            onNotification?.({
+              variant: NotificationVariant.Error,
+              message: t(DialFileManagerI18nKeys.UploadArchivePartialError, {
+                count: failedCount,
+                files: failedFiles,
+              }),
+            });
+          }
+        } catch {
+          onNotification?.({
+            variant: NotificationVariant.Error,
+            message: t(DialFileManagerI18nKeys.UploadArchiveError),
+          });
+        } finally {
+          invalidateFolders([destinationApiPath]);
+          bumpRetry();
+          setUploadBatchState(null);
+        }
+      };
+
+      void run();
+    },
+    [bucket, rootLabel, onNotification, t, invalidateFolders, bumpRetry],
+  );
+
   const onUploadFiles = useCallback(
     (files: DialUploadFileItem[], destinationFolder: string) => {
       if (files.length === 0) return;
+
+      const archiveConflictFile = getArchiveConflictUploadFallback(files);
+      if (archiveConflictFile != null) {
+        uploadArchiveToFolder(
+          archiveConflictFile.fileContent,
+          archiveConflictFile.name,
+          destinationFolder,
+        );
+        return;
+      }
 
       const controller = new AbortController();
       uploadAbortControllerRef.current = controller;
@@ -242,74 +340,15 @@ export const useDialFileUploadBatch = ({
       sharedRootMetaRef,
       invalidateFolders,
       bumpRetry,
+      uploadArchiveToFolder,
     ],
   );
 
   const onUploadArchive = useCallback(
     (file: File, name: string, destinationFolder: string) => {
-      const destinationApiPath = virtualPathToApiPath(
-        destinationFolder,
-        rootLabel,
-      );
-
-      setUploadBatchState({
-        files: [
-          {
-            id: `${Date.now()}-archive`,
-            name,
-            status: FileUploadStatus.Uploading,
-          },
-        ],
-        isOpen: true,
-      });
-
-      const run = async (): Promise<void> => {
-        try {
-          const { results } = await uploadArchive(
-            file,
-            bucket,
-            destinationApiPath,
-          );
-          const successCount = results.filter((r) => r.success).length;
-          const failedResults = results.filter((r) => !r.success);
-          const failedCount = failedResults.length;
-          const failedFiles = formatArchiveFailedEntries(
-            failedResults,
-            (count) => t(DialFileManagerI18nKeys.AndOtherItems, { count }),
-          );
-
-          if (results.length > 0 && successCount === 0) {
-            onNotification?.({
-              variant: NotificationVariant.Error,
-              message: t(DialFileManagerI18nKeys.UploadArchiveFilesError, {
-                count: failedCount,
-                files: failedFiles,
-              }),
-            });
-          } else if (failedCount > 0) {
-            onNotification?.({
-              variant: NotificationVariant.Error,
-              message: t(DialFileManagerI18nKeys.UploadArchivePartialError, {
-                count: failedCount,
-                files: failedFiles,
-              }),
-            });
-          }
-        } catch {
-          onNotification?.({
-            variant: NotificationVariant.Error,
-            message: t(DialFileManagerI18nKeys.UploadArchiveError),
-          });
-        } finally {
-          invalidateFolders([destinationApiPath]);
-          bumpRetry();
-          setUploadBatchState(null);
-        }
-      };
-
-      void run();
+      uploadArchiveToFolder(file, name, destinationFolder);
     },
-    [bucket, rootLabel, onNotification, t, invalidateFolders, bumpRetry],
+    [uploadArchiveToFolder],
   );
 
   const onValidateUpload = useCallback(

--- a/openspec/specs/file-manager-upload-archive/spec.md
+++ b/openspec/specs/file-manager-upload-archive/spec.md
@@ -10,11 +10,11 @@ The BFF SHALL expose `POST /api/v1/files/upload-archive` (multipart/form-data) t
 
 **Rate limit**: `@Throttle({ default: { limit: 5, ttl: 60000 } })` — matching `/download-archive`'s stricter limit (archive operations are heavier than single-file operations).
 
-**Caching**: no NestJS cache read/write. Frontend-side folder-listing cache for the destination folder is invalidated by the hook on completion.
+**Caching**: no NestJS cache read/write. Frontend-side folder-listing cache for the parent destination folder is invalidated by the hook on completion so the archive-named child folder appears in the refreshed listing.
 
 #### Request
 
-Multipart fields: `file` (the ZIP, binary), `bucket` (string), `destinationPath` (string, relative path within bucket — the folder entries are extracted into).
+Multipart fields: `file` (the ZIP, binary), `bucket` (string), `destinationPath` (string, relative path within bucket — the final folder entries are extracted into). The frontend SHALL pass an archive-named child folder as `destinationPath`; for example, uploading `archive.zip` from `reports/` calls the endpoint with `destinationPath: "reports/archive/"`, using the ui-kit's prepared archive name without the `.zip` extension.
 
 **`UploadArchiveDto`** (`apps/chat-api/src/files/dto/upload-archive.dto.ts`, describes the non-file fields for Swagger/validation):
 
@@ -79,8 +79,8 @@ uploadArchive(
 ```json
 {
   "results": [
-    { "path": "reports/q1.pdf", "success": true },
-    { "path": "reports/q2 (1).pdf", "success": true }
+    { "path": "reports/archive/q1.pdf", "success": true },
+    { "path": "reports/archive/q2 (1).pdf", "success": true }
   ]
 }
 ```
@@ -118,14 +118,14 @@ uploadArchive(
 #### Scenario: Conflicting entry is uploaded with a deduplicated name
 
 - **WHEN** one entry's destination path already exists and DIAL Core returns 412 for that entry's `create-only` upload
-- **THEN** the service retries the same entry using the next available deduplicated sibling name, such as `reports/q1 (1).pdf`
-- **AND** the entry's result is `{ "path": "reports/q1 (1).pdf", "success": true }`
+- **THEN** the service retries the same entry using the next available deduplicated sibling name, such as `reports/archive/q1 (1).pdf`
+- **AND** the entry's result is `{ "path": "reports/archive/q1 (1).pdf", "success": true }`
 - **AND** the remaining entries are still processed
 
 #### Scenario: Deduplicated name also conflicts
 
 - **WHEN** an entry's original path and first deduplicated path both already exist
-- **THEN** the service continues retrying with incremented suffixes, such as `reports/q1 (2).pdf`, until an available name is created
+- **THEN** the service continues retrying with incremented suffixes, such as `reports/archive/q1 (2).pdf`, until an available name is created
 
 ---
 
@@ -184,22 +184,33 @@ Every archive entry SHALL be rejected (recorded as a failed result, not extracte
 
 ### Requirement: onUploadArchive wired on useDialFileManager
 
-`useDialFileManager` SHALL expose `onUploadArchive(file: File, name: string, destinationFolder: string)`, wired to ui-kit's `DialFileManager.onUploadArchive` prop, that resolves `destinationFolder` to `{ bucket, destinationPath }` (same resolution as `onUploadFiles`) and calls the new `uploadArchive` server-api wrapper.
+`useDialFileManager` SHALL expose `onUploadArchive(file: File, name: string, destinationFolder: string)`, wired to ui-kit's `DialFileManager.onUploadArchive` prop, that resolves `destinationFolder` to the parent API folder path (same resolution as `onUploadFiles`), appends the provided archive `name` as a trailing-slashed child folder, and calls the new `uploadArchive` server-api wrapper with that archive-named `destinationPath`.
+
+If the ui-kit's archive conflict resolver falls back to `onUploadFiles` because the browser reports a ZIP with an empty or non-standard MIME type, `useDialFileManager` SHALL detect the single-file shape `{ fileContent.name: "*.zip", name: "<archive-folder-name>" }` and route it back through the archive upload path instead of uploading the ZIP as a normal file.
 
 **State ownership**: `onUploadArchive` reuses the hook's existing `uploadBatchState` (no new progress-state shape is introduced) to represent the in-flight archive upload as a single indeterminate item, since the BFF returns one aggregated result rather than per-entry progress events.
 
-**Cache invalidation**: on completion, the hook invalidates the cache entry for the destination folder and increments `retryCounter`, matching `onUploadFiles`.
+**Cache invalidation**: on completion, the hook invalidates the cache entry for the parent destination folder and increments `retryCounter`, matching `onUploadFiles`. The archive-named child folder's contents are fetched only after the user opens that folder.
 
-**Notifications**: request-level failure (network/validation error, non-ZIP, oversized archive, timeout) surfaces via `onNotification(NotificationVariant.Error, ...)` with the generic archive-upload error because no per-entry result list is available. If the request succeeds but every entry in `results` failed, the hook surfaces an all-failed archive-entry message containing the failed file list. Partial failure (some entries failed) surfaces via a distinct partial-failure message containing the failed count and failed file list, matching the `CopyPartialError`/`MovePartialError` convention while adding actionable file names. Full success shows no toast — the extracted files appearing in the refreshed listing is the confirmation.
+**Notifications**: request-level failure (network/validation error, non-ZIP, oversized archive, timeout) surfaces via `onNotification(NotificationVariant.Error, ...)` with the generic archive-upload error because no per-entry result list is available. If the request succeeds but every entry in `results` failed, the hook surfaces an all-failed archive-entry message containing the failed file list. Partial failure (some entries failed) surfaces via a distinct partial-failure message containing the failed count and failed file list, matching the `CopyPartialError`/`MovePartialError` convention while adding actionable file names. Full success shows no toast — the archive-named child folder appearing in the refreshed parent listing is the confirmation.
 
 The failed file list SHALL be built from failed `UploadArchiveEntryResultDto` entries as `path` or `path (error)` when an entry includes an error. The list SHALL display at most five entries and append the existing `dialFileManager.andOtherItems` label for the remaining count.
 
-**Memoisation**: `onUploadArchive` SHALL be a `useCallback` with dependencies that include `bucket`, `rootLabel`, `onNotification`, and `t`.
+**Memoisation**: archive upload handling SHALL be memoised with dependencies that include `bucket`, `rootLabel`, `onNotification`, and `t`; `onUploadArchive` MAY delegate to that memoised handler.
 
-#### Scenario: Successful archive upload refreshes the destination folder
+#### Scenario: Successful archive upload refreshes the parent destination folder
 
-- **WHEN** `onUploadArchive` completes with all entries successful
-- **THEN** the destination folder's cache entry is cleared, `retryCounter` increments, and no toast is shown
+- **WHEN** `onUploadArchive` receives `name: "archive"` and `destinationFolder: "/My files/reports"` and completes with all entries successful
+- **THEN** `uploadArchive` is called with `destinationPath: "reports/archive/"`
+- **AND** the parent destination folder's cache entry (`reports/`) is cleared, `retryCounter` increments, and no toast is shown
+
+#### Scenario: Archive conflict fallback does not create a normal ZIP file
+
+- **GIVEN** the selected archive file is `archive.zip`
+- **AND** the ui-kit resolves an archive-name conflict and calls `onUploadFiles` with one item named `archive` or `archive (1)`
+- **WHEN** `useDialFileManager` handles that callback
+- **THEN** it calls `uploadArchive` with `destinationPath: "reports/archive/"` or `destinationPath: "reports/archive (1)/"`
+- **AND** it does not call the normal single-file upload wrapper
 
 #### Scenario: Partial archive upload failure shows a toast with failed files
 
@@ -222,14 +233,14 @@ The failed file list SHALL be built from failed `UploadArchiveEntryResultDto` en
 
 Archive entry name collisions SHALL NOT depend on the ui-kit's upload conflict popup. The ui-kit can only compare the selected archive file's prepared name against the currently loaded destination folder items before calling `onUploadArchive`; it does not inspect the ZIP contents. Therefore, conflicts for files inside the archive SHALL be resolved by the BFF during extraction/upload using the DIAL Core create-only response as the source of truth.
 
-If the ui-kit opens its conflict popup during archive selection, that popup concerns only the selected archive name prepared by the ui-kit and SHALL NOT be treated as resolution for entries inside the archive. When the user proceeds from that popup, `onUploadArchive` SHALL send the selected archive and destination folder to the BFF, and the BFF SHALL perform per-entry deduplication. If the user cancels the popup, no archive upload request is made.
+If the ui-kit opens its conflict popup during archive selection, that popup concerns only the selected archive name prepared by the ui-kit and SHALL NOT be treated as resolution for entries inside the archive. When the user proceeds from that popup, `onUploadArchive` SHALL send the selected archive and archive-named destination path to the BFF, and the BFF SHALL perform per-entry deduplication. If the user cancels the popup, no archive upload request is made.
 
 #### Scenario: Existing file inside archive destination does not require a popup
 
-- **GIVEN** the destination folder contains `reports/q1.pdf`
+- **GIVEN** the archive-named destination folder contains `reports/archive/reports/q1.pdf`
 - **AND** the selected archive contains `reports/q1.pdf`
 - **WHEN** the archive upload runs
-- **THEN** the BFF uploads the entry as `reports/q1 (1).pdf` or the next available deduplicated name
+- **THEN** the BFF uploads the entry as `reports/archive/reports/q1 (1).pdf` or the next available deduplicated name
 - **AND** no frontend replace/duplicate decision is required for that archive entry
 
 ---


### PR DESCRIPTION
## Description of changes

Update archive upload so extracted files are placed inside a folder named after the archive instead of directly in the selected destination. Also handle archive-name conflicts correctly, so duplicate/replace resolution continues through archive extraction rather than uploading the ZIP as a regular file.

## Applicable issues

- https://github.com/epam/ai-dial-chat/issues/7912

## Checklist

- [X] the pull request name ends with `(Issue #<ISSUE_ID>)` (comma-separated list of issues)
- [X] I confirm that I don't share any confidential information like API keys or any other secrets and private URLs
