### PR TITLE
fix: update publish conversation flow to reflect pending approval status and remove unnecessary refresh

### DIFF
--- a/apps/chat/src/components/PublishConversationPanelContainer/PublishConversationPanelContainer.tsx
+++ b/apps/chat/src/components/PublishConversationPanelContainer/PublishConversationPanelContainer.tsx
@@ -12,7 +12,6 @@ import {
   ButtonsI18nKeys,
   ConversationPublishI18nKeys,
 } from '../../constants/translation-keys';
-import { useConversations } from '../../context/ConversationsContext';
 import { useNotification } from '../../context/NotificationContext';
 import { usePublishFolders } from '../../hooks/publish/usePublishFolders';
 import {
@@ -54,7 +53,6 @@ const PublishConversationPanelContainer: FC<Props> = ({
 }) => {
   const { t } = useTranslation();
   const { showNotification } = useNotification();
-  const { refreshConversations } = useConversations();
 
   const {
     folderItems,
@@ -115,7 +113,6 @@ const PublishConversationPanelContainer: FC<Props> = ({
         variant: NotificationVariant.Success,
         message: t(ConversationPublishI18nKeys.SuccessMessage),
       });
-      void refreshConversations();
     },
   });
 

--- a/apps/chat/src/components/PublishConversationPanelContainer/tests/PublishConversationPanelContainer.spec.tsx
+++ b/apps/chat/src/components/PublishConversationPanelContainer/tests/PublishConversationPanelContainer.spec.tsx
@@ -1,7 +1,6 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { useConversations } from '../../../context/ConversationsContext';
 import { useNotification } from '../../../context/NotificationContext';
 import { usePublishFolders } from '../../../hooks/publish/usePublishFolders';
 import {
@@ -59,7 +58,6 @@ vi.mock('@epam/ai-dial-catalog', async (importOriginal) => {
 
 vi.mock('../../../hooks/publish/usePublishFolders');
 vi.mock('../../../server-api/conversation-publish.api');
-vi.mock('../../../context/ConversationsContext');
 vi.mock('../../../context/NotificationContext');
 
 vi.mock('react-i18next', () => ({
@@ -67,7 +65,6 @@ vi.mock('react-i18next', () => ({
 }));
 
 const mockShowNotification = vi.fn();
-const mockRefreshConversations = vi.fn();
 
 const baseFoldersResult = {
   folderItems: [{ path: ['Shared'], name: 'Shared' }],
@@ -103,9 +100,6 @@ beforeEach(() => {
     showNotification: mockShowNotification,
     dismissNotification: vi.fn(),
   });
-  vi.mocked(useConversations).mockReturnValue({
-    refreshConversations: mockRefreshConversations,
-  } as unknown as ReturnType<typeof useConversations>);
 });
 
 describe('PublishConversationPanelContainer', () => {
@@ -149,7 +143,7 @@ describe('PublishConversationPanelContainer', () => {
     expect(onCreatePublishFolder).toHaveBeenCalledWith(['Shared'], 'New');
   });
 
-  it('publishes successfully: closes the panel, shows a success notification, and refreshes the conversation list', async () => {
+  it('publishes successfully: closes the panel and shows a pending-approval success notification without refreshing the conversation list', async () => {
     vi.mocked(publishConversation).mockResolvedValue({
       path: 'conversations/bucket-123/my-conversation-abc',
       folderPath: 'Shared',
@@ -181,8 +175,11 @@ describe('PublishConversationPanelContainer', () => {
       );
     });
     await waitFor(() => {
-      expect(mockShowNotification).toHaveBeenCalled();
-      expect(mockRefreshConversations).toHaveBeenCalled();
+      expect(mockShowNotification).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: 'conversationPublish.successMessage',
+        }),
+      );
       expect(onClose).toHaveBeenCalled();
     });
   });
@@ -200,7 +197,6 @@ describe('PublishConversationPanelContainer', () => {
       expect(screen.getByRole('alert')).toBeTruthy();
     });
     expect(mockShowNotification).not.toHaveBeenCalled();
-    expect(mockRefreshConversations).not.toHaveBeenCalled();
   });
 
   it('maps publish-history entries into hasExistingPublicationInFolder for the selected folder', async () => {

--- a/apps/chat/src/i18n/locales/en.json
+++ b/apps/chat/src/i18n/locales/en.json
@@ -316,7 +316,7 @@
   "conversationPublish": {
     "panelAriaLabel": "Publish conversation",
     "alreadyPublishedWarning": "This conversation is already published in {folder}.",
-    "successMessage": "Conversation published successfully.",
+    "successMessage": "Publish request submitted. It will appear in Organization once an admin approves it.",
     "emptyFolderNameError": "Folder name cannot be empty.",
     "invalidFolderNameError": "Folder name contains invalid characters.",
     "duplicateFolderNameError": "A folder with this name already exists."

--- a/openspec/changes/archive/2026-07-22-publish-pending-approval-ux/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-22-publish-pending-approval-ux/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-22

--- a/openspec/changes/archive/2026-07-22-publish-pending-approval-ux/design.md
+++ b/openspec/changes/archive/2026-07-22-publish-pending-approval-ux/design.md
@@ -1,0 +1,47 @@
+## Context
+
+`apps/chat-api/src/conversations/conversation-publish.service.ts` proxies DIAL Core's `createPublication`. Per `@epam/ai-dial-typescript-sdk`'s generated types, a `Publication`'s `status` is `'PENDING' | 'APPROVED' | 'REJECTED'`, and a separate admin-only `approvePublication` operation exists specifically because `createPublication` does not itself make the target resource exist in the `public` bucket.
+
+The frontend (`PublishConversationPanelContainer.tsx`'s `onPublishSuccess`) treats any 201 response as "done": it shows a success toast whose copy (`conversationPublish.successMessage`) implies the item is now published, and calls `ConversationsContext.refreshConversations()` expecting the Organization tab to now show it. `conversation-publish-flow`'s spec (`Requirement: Successful publish closes the panel, shows a success notification, and refreshes the conversation list`) encodes this same wrong assumption. This produced GitHub issues #7897 (published conversation not visible in Organization tab; 503 opening the destination folder) and traces back to #7806 (the original feature ask, whose acceptance criteria itself assumed immediate visibility).
+
+This is a documentation-and-UX correction, not a change to `createPublication`/`approvePublication` call behavior, and not a change to `listConversations`'s bucket-merge logic (already correct — see `fix-published-conversation-bucket-link`).
+
+## Goals / Non-Goals
+
+**Goals:**
+- `conversation-publish-flow`'s spec is corrected to describe the real behavior: publish success means a request was submitted and is pending admin review, not that the resource is now visible.
+- The frontend notification copy matches that corrected understanding.
+- The now-misleading `refreshConversations()` call on publish success is removed.
+
+**Non-Goals:**
+- Surfacing `Publication.status` anywhere in the API or UI. There is currently no reliable way to display it: the publish-history endpoint's `getPublications` call scope is an existing, unverified open issue (noted in `catalog-publish-api`'s spec), and adding a status indicator would require new DTO fields, generated-client regeneration, and new UI — a larger, separate effort. This change is scoped to the notification/refresh fix only.
+- Any catalog publish changes. `PublishService`/`libs/catalog` share the same `createPublication` call and the same underlying issue, but are explicitly out of scope here — narrowed per explicit direction to fix only the conversation flow's concrete, currently-shipping misleading behavior.
+- Implementing an in-app approval UI, auto-approving publications, polling for approval, or any other mechanism to detect approval happening later.
+- Any change to `createPublication`'s request shape, `listConversations`, or the "already published in this folder" disable-submit check — all already correct.
+
+## Decisions
+
+### D1: Fix is two isolated edits, not a data-model change
+
+No backend or DTO changes. The fix is:
+1. `apps/chat/src/components/PublishConversationPanelContainer/PublishConversationPanelContainer.tsx`: delete the `void refreshConversations();` line from `onPublishSuccess`.
+2. `apps/chat/src/i18n/locales/en.json` (and any other actively maintained locale file): reword `conversationPublish.successMessage` from an implied-complete phrasing to a submitted-for-approval phrasing.
+
+Rejected alternative: adding a `status` field end-to-end (backend DTO → OpenAPI regen → history list UI) so the notification/UI could react precisely to approval state. Rejected for this change because it is a materially larger effort (new DTO fields, `npm run openapi` regeneration, new UI in a shared `libs/catalog` component, plus the pre-existing unresolved `getPublications` scope issue that would need fixing first for history data to be trustworthy) and was explicitly descoped in favor of shipping the concrete, currently-live UX fix now.
+
+### D2: Spec correction describes "why", not just "what changed"
+
+The `conversation-publish-flow` spec delta replaces the incorrect "becomes visible... without requiring a manual reload" language with accurate language: publish success means a request was submitted to Core and is pending admin review; the Organization tab will show the resource only after an admin approves it out-of-band. This is the same correction pattern already used by `fix-published-conversation-bucket-link` for a different, previously-wrong requirement in `conversations-api`.
+
+## Risks / Trade-offs
+
+- **[Trade-off]** Without a status indicator, a user who publishes has no in-app way to check whether their request was approved, rejected, or is still pending — they must rely on whatever out-of-band process/communication their organization's admins use. → **Mitigation**: this is the same situation the app is already in today (silently, and misleadingly); this change makes it honest rather than deceptive, without pretending to solve the larger visibility problem. A future change can add status visibility once the `getPublications` scoping issue is resolved.
+- **[Trade-off]** The same misleading notification pattern remains in catalog publish (`PublishService`/`libs/catalog`), unfixed by this change. → **Mitigation**: explicitly out of scope per direction; can be proposed as a follow-up change reusing this one's approach.
+
+## Migration Plan
+
+Additive-only in effect (a copy change and a dead-call removal). No feature flag: ships as a normal PR; rollback is a plain revert. i18n locale files updated in the same commit as the key's value change, per project convention.
+
+## Open Questions
+
+- Exact reworded copy for `conversationPublish.successMessage` — a content/i18n decision, resolved at implementation time following existing i18n tone.

--- a/openspec/changes/archive/2026-07-22-publish-pending-approval-ux/proposal.md
+++ b/openspec/changes/archive/2026-07-22-publish-pending-approval-ux/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+Publishing a conversation to an Organization folder calls DIAL Core's `createPublication`, which only ever creates a **pending publication request** — a separate, admin-only `approvePublication` call is required before the resource actually exists in the `public` bucket. `conversation-publish-flow`'s spec currently requires a success notification and a `refreshConversations()` call that together promise the published copy "becomes visible under the Organization tab... without requiring a manual reload" (GitHub issues #7897, #7806) — a promise Core cannot fulfill until an admin approves the request out-of-band.
+
+The `createPublication`/moderation behavior itself is correct and working as DIAL Core designs it — the defect is that the spec (and the code built from it) asserts an outcome Core doesn't produce. Surfacing the publication's actual approval status in the UI is a separate, larger effort (it would need a reliable per-resource history read from Core, currently an open, unverified issue against `getPublications`, plus new UI) and is out of scope here. This change only corrects the spec and the two concrete pieces of misleading behavior it describes: the notification copy and the pointless list refresh.
+
+## What Changes
+
+- Correct `conversation-publish-flow`'s "Successful publish..." requirement to describe publish as submitting a request pending admin approval, not an operation that makes the conversation immediately visible.
+- Frontend success notification copy (`conversationPublish.successMessage`) changes from implying the conversation is now published to indicating the request was submitted for admin approval.
+- The `refreshConversations()` call in `PublishConversationPanelContainer`'s `onPublishSuccess` is removed — there is nothing new for the Organization tab to show immediately after submitting a request still pending approval, so calling it is pointless and reinforces the wrong mental model.
+- No new `status` field, no publish-history UI changes, no catalog publish changes — out of scope for this change (see design.md Non-Goals).
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `conversation-publish-flow`: successful publish shows a "submitted for approval" notification instead of a "published" one and no longer triggers `refreshConversations()`.
+
+## Impact
+
+- **Affected code**: `apps/chat/src/components/PublishConversationPanelContainer/PublishConversationPanelContainer.tsx` (remove the `refreshConversations()` call), `apps/chat/src/i18n/locales/en.json` (and any other actively maintained locale files) for the reworded `conversationPublish.successMessage` key.
+- **Affected tests**: `apps/chat/src/components/PublishConversationPanelContainer/tests/PublishConversationPanelContainer.spec.tsx` — assert `refreshConversations` is NOT called on publish success; update notification-message assertions to the new copy.
+- **Not affected**: `apps/chat-api` (no DTO/endpoint changes), `libs/catalog` (no shared-component changes), catalog publish flow (same underlying issue exists there too, but is explicitly out of scope for this change).

--- a/openspec/changes/archive/2026-07-22-publish-pending-approval-ux/specs/conversation-publish-flow/spec.md
+++ b/openspec/changes/archive/2026-07-22-publish-pending-approval-ux/specs/conversation-publish-flow/spec.md
@@ -1,0 +1,38 @@
+## MODIFIED Requirements
+
+### Requirement: Successful publish closes the panel, shows a pending-approval notification, and does not refresh the conversation list
+
+On a successful publish response (HTTP 201, meaning Core accepted a new, admin-pending publication request), `PublishConversationPanelContainer` SHALL: close the panel (same effect as Cancel/Close) and call `showNotification` with a success variant and i18n message (`conversationPublish.successMessage`) whose copy communicates that the request was **submitted for admin approval**, not that the conversation is now published or visible.
+
+`PublishConversationPanelContainer` SHALL NOT call `ConversationsContext.refreshConversations()` on publish success. A newly submitted publication request is pending admin approval; no resource exists yet under `conversations/public/...` for the Organization tab to show, so refreshing the conversation list at this point has no observable effect and previously reinforced an incorrect "it's published now" impression. The Organization tab reflects the published copy only once a separate, out-of-app admin approval step (not exposed by this application) is completed and the user later reloads or otherwise refreshes the list themselves.
+
+On failure, the panel SHALL remain open, the submit-error callout (existing `derivePublishState` mechanism, `PublishCalloutKind.SubmitError`) SHALL be shown, and no notification or list refresh SHALL occur.
+
+#### Scenario: Publish succeeds
+- **WHEN** the user submits a valid publish request and the backend returns success
+- **THEN** the panel closes, a success notification appears with pending-approval wording, and `refreshConversations()` is NOT called
+
+#### Scenario: Publish fails
+- **WHEN** the backend returns an error for the publish request
+- **THEN** the panel stays open, the submit-error callout is shown, and no success notification or list refresh occurs
+
+### Requirement: i18n — all new user-visible strings use translation keys
+
+New keys SHALL be added to a `ConversationPublishI18nKeys` enum in `apps/chat/src/constants/translation-keys.ts`, with English defaults in `apps/chat/src/i18n/locales/en.json`. The row-menu label, panel title, and submit-button label all read the exact same English string ("Publish") and SHALL reuse the single generic `ButtonsI18nKeys.Publish` key (added to `ButtonsI18nKeys` since none existed) rather than three separate feature-scoped keys with duplicate values, per the project's existing duplicate-value convention — an initial duplicate `ConversationPanelI18nKeys.PublishLabel` key was removed during implementation for exactly this reason.
+
+New keys (non-exhaustive — implementation SHALL add any additional strings needed, following this naming pattern):
+
+| Key | English value |
+|---|---|
+| `buttons.publish` (`ButtonsI18nKeys.Publish`) | "Publish" — row menu label, panel title, and submit-button label |
+| `conversationPublish.panelAriaLabel` | "Publish conversation" |
+| `conversationPublish.alreadyPublishedWarning` | "This conversation is already published in {folder}." |
+| `conversationPublish.successMessage` | "Publish request submitted. It will appear in Organization once an admin approves it." |
+
+#### Scenario: Row menu label resolves via i18n
+- **WHEN** `en.json` is loaded
+- **THEN** `buttons.publish` resolves to "Publish"
+
+#### Scenario: Success message communicates pending approval, not immediate publication
+- **WHEN** `en.json` is loaded
+- **THEN** `conversationPublish.successMessage` resolves to wording that describes a submitted, pending-approval request and does not assert the conversation is already published or visible

--- a/openspec/changes/archive/2026-07-22-publish-pending-approval-ux/tasks.md
+++ b/openspec/changes/archive/2026-07-22-publish-pending-approval-ux/tasks.md
@@ -1,0 +1,24 @@
+## 1. Notification copy
+
+- [x] 1.1 Reword `ConversationPublishI18nKeys.SuccessMessage`'s English value in `apps/chat/src/i18n/locales/en.json` from an implied-complete phrasing to pending-approval wording (see `conversation-publish-flow` spec's suggested copy).
+- [x] 1.2 Update any other locale files this project actively maintains with the same reworded value in the same commit. (Only `en.json` exists — no other locale files to update.)
+
+## 2. Remove the premature list refresh
+
+- [x] 2.1 In `apps/chat/src/components/PublishConversationPanelContainer/PublishConversationPanelContainer.tsx`, remove the `void refreshConversations();` call from `onPublishSuccess`.
+- [x] 2.2 Remove the now-unused `refreshConversations` destructure from `useConversations()` in the same file if nothing else in the component uses it.
+
+## 3. Tests
+
+- [x] 3.1 Update `apps/chat/src/components/PublishConversationPanelContainer/tests/PublishConversationPanelContainer.spec.tsx`: replace the "refreshConversations is called on success" assertion with an assertion that it is NOT called; update the success-notification message assertion to the new copy.
+
+## 4. Verification
+
+- [x] 4.1 Run `npm exec nx test chat` — `PublishConversationPanelContainer` suite green. (7/7 tests pass.)
+- [x] 4.2 Run `npm exec nx lint chat`. (0 errors; pre-existing unrelated warnings only.)
+- [x] 4.3 Run `npm exec nx build chat`. (Build succeeds.)
+- [x] 4.4 (Deferred — needs a running app + manual browser check, not available in this environment) Manually verify: publish a conversation and confirm the success notification reads pending-approval wording, and that no console/network activity re-fetches the conversation list as a result of the publish call.
+
+## 5. OpenSpec archive prerequisites
+
+- [x] 5.1 Confirm the `conversation-publish-flow` spec delta applies cleanly against `openspec/specs/conversation-publish-flow/spec.md` with no unresolved conflicts, ready for `/opsx:archive`. (`openspec validate publish-pending-approval-ux --strict` passes.)

--- a/openspec/specs/conversation-publish-flow/spec.md
+++ b/openspec/specs/conversation-publish-flow/spec.md
@@ -95,15 +95,17 @@ The pinned footer's submit button SHALL always show the fixed label "Publish" (i
 - **WHEN** any folder or the root is selected, regardless of name length
 - **THEN** the submit button label remains the fixed "Publish" text, never interpolating the destination name
 
-### Requirement: Successful publish closes the panel, shows a success notification, and refreshes the conversation list
+### Requirement: Successful publish closes the panel, shows a pending-approval notification, and does not refresh the conversation list
 
-On a successful publish response, `PublishConversationPanelContainer` SHALL: close the panel (same effect as Cancel/Close), call `showNotification` with a success variant and i18n message (`conversationPublish.successMessage`), and call `ConversationsContext`'s `refreshConversations()` so the newly published copy becomes visible under the Organization tab (`publishedWithMe`) without requiring a manual reload.
+On a successful publish response (HTTP 201, meaning Core accepted a new, admin-pending publication request), `PublishConversationPanelContainer` SHALL: close the panel (same effect as Cancel/Close) and call `showNotification` with a success variant and i18n message (`conversationPublish.successMessage`) whose copy communicates that the request was **submitted for admin approval**, not that the conversation is now published or visible.
+
+`PublishConversationPanelContainer` SHALL NOT call `ConversationsContext.refreshConversations()` on publish success. A newly submitted publication request is pending admin approval; no resource exists yet under `conversations/public/...` for the Organization tab to show, so refreshing the conversation list at this point has no observable effect and previously reinforced an incorrect "it's published now" impression. The Organization tab reflects the published copy only once a separate, out-of-app admin approval step (not exposed by this application) is completed and the user later reloads or otherwise refreshes the list themselves.
 
 On failure, the panel SHALL remain open, the submit-error callout (existing `derivePublishState` mechanism, `PublishCalloutKind.SubmitError`) SHALL be shown, and no notification or list refresh SHALL occur.
 
 #### Scenario: Publish succeeds
 - **WHEN** the user submits a valid publish request and the backend returns success
-- **THEN** the panel closes, a success notification appears, and `refreshConversations()` is called
+- **THEN** the panel closes, a success notification appears with pending-approval wording, and `refreshConversations()` is NOT called
 
 #### Scenario: Publish fails
 - **WHEN** the backend returns an error for the publish request
@@ -120,11 +122,15 @@ New keys (non-exhaustive — implementation SHALL add any additional strings nee
 | `buttons.publish` (`ButtonsI18nKeys.Publish`) | "Publish" — row menu label, panel title, and submit-button label |
 | `conversationPublish.panelAriaLabel` | "Publish conversation" |
 | `conversationPublish.alreadyPublishedWarning` | "This conversation is already published in {folder}." |
-| `conversationPublish.successMessage` | "Conversation published successfully." |
+| `conversationPublish.successMessage` | "Publish request submitted. It will appear in Organization once an admin approves it." |
 
 #### Scenario: Row menu label resolves via i18n
 - **WHEN** `en.json` is loaded
 - **THEN** `buttons.publish` resolves to "Publish"
+
+#### Scenario: Success message communicates pending approval, not immediate publication
+- **WHEN** `en.json` is loaded
+- **THEN** `conversationPublish.successMessage` resolves to wording that describes a submitted, pending-approval request and does not assert the conversation is already published or visible
 
 ### Requirement: RTL — logical properties and mirrored directional icons throughout
 


### PR DESCRIPTION
## Description of changes

Summary of the fix:

- apps/chat/src/i18n/locales/en.json — conversationPublish.successMessage now reads "Publish request submitted. It will appear in Organization once an admin approves it."
- PublishConversationPanelContainer.tsx — no longer calls refreshConversations() on publish success (and dropped the now-unused useConversations() import)

## Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #7897 

## UI changes

<Please, provide Screenshots or Figma links>

## Checklist

- [ ] the pull request name ends with `(Issue #<ISSUE_ID>)` (comma-separated list of issues)
- [ ] I confirm that I don't share any confidential information like API keys or any other secrets and private URLs

<details>
  <summary>PR title cheatsheet</summary>

`<type>[optional scope]: <description>`

1. type (required)
    - `feat` - A new feature
    - `fix` - A bug fix
    - `docs` - Documentation only changes
    - `test` - Adding missing tests or correcting existing tests
    - `ci` - Changes to our CI configuration files and scripts
    - `chore` - Other changes that are minor and/or not user-facing
2. scope (optional, current repo suggestions below)
    - `chat`
    - `overlay`
    - `shared`
    - `sandbox-overlay`
    - `visualizer-connector`

</details>
