### PR TITLE
fix: enhance OAuth popup handling and update related documentation

### DIFF
--- a/apps/chat-api/src/config/csp.ts
+++ b/apps/chat-api/src/config/csp.ts
@@ -19,11 +19,16 @@ export const buildFrameAncestorsDirective = (
  * Disables `frameguard` (which sends `X-Frame-Options: SAMEORIGIN` by
  * default) only once at least one origin is allowlisted, relying solely on
  * CSP `frame-ancestors` for framing control in that case; the empty-allowlist
- * default-deny posture (frameguard enabled) is otherwise unchanged.
+ * default-deny posture (frameguard enabled) is otherwise unchanged. Uses
+ * `same-origin-allow-popups` for COOP so navigating an OAuth popup to an
+ * external identity provider does not sever the opener's WindowProxy and
+ * make an active popup look closed. The popup clears its own `window.opener`
+ * before that navigation, preserving reverse-tabnabbing protection.
  */
 export const createHelmetOptions = (
   allowedIframeOrigins: string[],
 ): HelmetOptions => ({
+  crossOriginOpenerPolicy: { policy: 'same-origin-allow-popups' },
   contentSecurityPolicy: {
     directives: {
       defaultSrc: ["'self'"],

--- a/apps/chat-api/src/config/tests/csp.spec.ts
+++ b/apps/chat-api/src/config/tests/csp.spec.ts
@@ -62,6 +62,17 @@ describe('Helmet security headers', () => {
     app = undefined;
   });
 
+  it('keeps cross-origin OAuth popup references observable by the opener', async () => {
+    app = await createTestApp([]);
+    const response = await request(app.getHttpServer())
+      .get('/ping')
+      .expect(200);
+
+    expect(response.headers['cross-origin-opener-policy']).toBe(
+      'same-origin-allow-popups',
+    );
+  });
+
   it("sends frame-ancestors 'none' and keeps X-Frame-Options when the allowlist is empty", async () => {
     app = await createTestApp([]);
     const response = await request(app.getHttpServer())

--- a/apps/chat-api/src/deployments/deployments.service.ts
+++ b/apps/chat-api/src/deployments/deployments.service.ts
@@ -127,6 +127,7 @@ const mapToolsetAuthSettings = (
 
   return {
     authenticationType: getString(raw, 'authentication_type'),
+    dynamicallyRegistered: getBoolean(raw, 'dynamically_registered'),
     globalAuthStatus: getString(raw, 'global_auth_status'),
     appLevelAuthStatus: getString(raw, 'app_level_auth_status'),
     userLevelAuthStatus: getString(raw, 'user_level_auth_status'),

--- a/apps/chat-api/src/deployments/dto/deployment-details.dto.ts
+++ b/apps/chat-api/src/deployments/dto/deployment-details.dto.ts
@@ -257,6 +257,13 @@ export class ToolsetAuthSettingsDto {
 
   @ApiPropertyOptional({
     description:
+      'Whether DIAL Core dynamically registered the OAuth client instead of using user-provided client configuration',
+    example: true,
+  })
+  dynamicallyRegistered?: boolean;
+
+  @ApiPropertyOptional({
+    description:
       'Whether the toolset has global (shared) credentials signed in',
     enum: ['SIGNED_IN', 'SIGNED_OUT'],
   })

--- a/apps/chat-api/src/deployments/tests/deployments.service.spec.ts
+++ b/apps/chat-api/src/deployments/tests/deployments.service.spec.ts
@@ -1343,6 +1343,7 @@ describe('DeploymentsService', () => {
           features: { mcp: true, tools: false, cache: false },
           auth_settings: {
             authentication_type: 'OAUTH',
+            dynamically_registered: true,
             client_id: 'public-client-id',
             client_secret: 'super-secret',
             code_verifier: 'super-secret-verifier',
@@ -1390,6 +1391,7 @@ describe('DeploymentsService', () => {
           }),
           authSettings: {
             authenticationType: 'OAUTH',
+            dynamicallyRegistered: true,
             clientId: 'public-client-id',
             codeChallenge: 'challenge-value',
             codeChallengeMethod: 'S256',

--- a/apps/chat-api/src/openapi/openapi-response.dto.ts
+++ b/apps/chat-api/src/openapi/openapi-response.dto.ts
@@ -318,6 +318,13 @@ export class DialToolsetAuthSettingsDto {
   @ApiProperty({ example: 'OAUTH', enum: ['OAUTH', 'API_KEY', 'NONE'] })
   authenticationType!: string;
 
+  @ApiPropertyOptional({
+    description:
+      'Whether DIAL Core dynamically registered the OAuth client instead of using user-provided client configuration',
+    example: true,
+  })
+  dynamicallyRegistered?: boolean;
+
   @ApiPropertyOptional({ example: 'X-Api-Key' })
   apiKeyHeader?: string;
 

--- a/apps/chat-api/src/toolsets/tests/toolsets.service.spec.ts
+++ b/apps/chat-api/src/toolsets/tests/toolsets.service.spec.ts
@@ -633,6 +633,7 @@ describe('ToolsetsService', () => {
             transport: 'SSE',
             authSettings: {
               authentication_type: 'OAUTH',
+              dynamically_registered: true,
               client_id: 'client-from-custom-resource',
               client_secret: 'secret-value',
               authorization_endpoint: 'https://auth.example.com/authorize',
@@ -675,6 +676,7 @@ describe('ToolsetsService', () => {
       });
       expect(result.authSettings).toMatchObject({
         authenticationType: 'OAUTH',
+        dynamicallyRegistered: true,
         clientId: 'client-from-custom-resource',
         authorizationEndpoint: 'https://auth.example.com/authorize',
         tokenEndpoint: 'https://auth.example.com/token',

--- a/apps/chat-api/src/toolsets/toolsets.service.ts
+++ b/apps/chat-api/src/toolsets/toolsets.service.ts
@@ -390,6 +390,7 @@ const mapAuthSettings = (
 
   return {
     authenticationType,
+    dynamicallyRegistered: getBoolean(raw, 'dynamically_registered'),
     apiKeyHeader: getString(raw, 'api_key_header'),
     clientId: getString(raw, 'client_id'),
     redirectUri: getString(raw, 'redirect_uri'),
@@ -662,7 +663,6 @@ export class ToolsetsService {
       accessToken,
       toolsetName,
     );
-
     return mergeCustomToolsetDetails(
       result.data as unknown as RawDialToolset,
       toolsetName,

--- a/apps/chat/src/hooks/toolsets/useToolsetLogin.ts
+++ b/apps/chat/src/hooks/toolsets/useToolsetLogin.ts
@@ -160,12 +160,10 @@ export const useToolsetLogin = (): {
       }
 
       /*
-       * Cancelled: the callback popup posts its result and closes itself
-       * back-to-back — the opener can observe `popup.closed` before the
-       * `BroadcastChannel` message arrives, so a login that actually
-       * succeeded server-side can still surface as Cancelled here.
-       * Re-checking the toolset's real status avoids reporting a false
-       * cancel for a login that already went through.
+       * Treat the backend as the final authority if popup tracking or
+       * cross-process message delivery ever still reports a false cancel.
+       * This avoids reporting cancellation for a login that actually
+       * completed server-side.
        */
       try {
         const refreshed = await getToolset(toolsetId);

--- a/apps/chat/src/pages/AppsEditor/AppEditorIframe.tsx
+++ b/apps/chat/src/pages/AppsEditor/AppEditorIframe.tsx
@@ -247,13 +247,10 @@ const AppEditorIframe = forwardRef<AppEditorIframeHandle, Props>(
         }
 
         /*
-         * Cancelled: the callback popup posts its result and closes itself
-         * back-to-back — under load the opener can observe `popup.closed`
-         * before the `BroadcastChannel` message arrives, so a login that
-         * actually succeeded server-side can still surface as Cancelled
-         * here. Re-fetching the toolset's real status (same recheck
-         * `CatalogView`/`AuthSection` already do) avoids reporting a false
-         * failure to the iframe for a login that already went through.
+         * Treat the backend as the final authority if popup tracking or
+         * cross-process message delivery ever still reports a false cancel.
+         * This avoids reporting a failed login to the iframe after it
+         * actually completed server-side.
          */
         try {
           const refreshed = await getToolset(encodedToolsetId);

--- a/apps/chat/src/pages/ToolsetAuthCallback/ToolsetAuthCallback.tsx
+++ b/apps/chat/src/pages/ToolsetAuthCallback/ToolsetAuthCallback.tsx
@@ -39,22 +39,14 @@ const readRedirectState = (): ToolsetRedirectState | null => {
 };
 
 /**
- * Safety-net delay before this popup closes itself after posting a result,
- * used only if the opener never closes it (e.g. the opener tab was closed or
- * navigated away before it could process the message). In the common case
- * the opener's `waitForToolsetOAuthResult` closes this popup right after
- * receiving the message, well before this fires.
- */
-const SELF_CLOSE_FALLBACK_MS = 4000;
-
-/**
  * Reports the OAuth result to the flow-scoped `BroadcastChannel` the opener
  * is waiting on. This popup does not close itself immediately afterwards —
  * the opener closes it once the message is received, so the popup is never
- * observed closed before the message has arrived. A bounded fallback timer
- * closes the popup here too, in case the opener can't (e.g. it was closed or
- * navigated away). With no `flowId` there is nothing for an opener to
- * receive, so the popup closes itself right away instead.
+ * observed closed before the message has arrived. `postMessage` determines
+ * the eligible destination channels and queues their delivery tasks before
+ * returning, so closing only this sender afterwards does not cancel the
+ * queued messages. With no `flowId` there is nothing for an opener to
+ * receive, so the popup closes itself right away.
  */
 const reportResult = (
   flowId: string | undefined,
@@ -67,7 +59,6 @@ const reportResult = (
   const channel = new BroadcastChannel(getToolsetOAuthChannelName(flowId));
   channel.postMessage(message);
   channel.close();
-  setTimeout(() => window.close(), SELF_CLOSE_FALLBACK_MS);
 };
 
 /**

--- a/apps/chat/src/pages/ToolsetAuthCallback/tests/ToolsetAuthCallback.spec.tsx
+++ b/apps/chat/src/pages/ToolsetAuthCallback/tests/ToolsetAuthCallback.spec.tsx
@@ -157,8 +157,8 @@ describe('ToolsetAuthCallback', () => {
     expect(mockClose).not.toHaveBeenCalled();
   });
 
-  it('closes the window itself if the opener never does, once the safety-net delay elapses', async () => {
-    vi.useFakeTimers();
+  it('closes its sending channel after queuing the result', async () => {
+    const closeChannelSpy = vi.spyOn(BroadcastChannel.prototype, 'close');
     try {
       setRedirectState({
         toolsetId: 'toolsets/b/my__1.0.0',
@@ -172,11 +172,9 @@ describe('ToolsetAuthCallback', () => {
 
       await resultPromise;
       expect(mockClose).not.toHaveBeenCalled();
-
-      await vi.advanceTimersByTimeAsync(4000);
-      expect(mockClose).toHaveBeenCalledOnce();
+      expect(closeChannelSpy).toHaveBeenCalledTimes(2);
     } finally {
-      vi.useRealTimers();
+      closeChannelSpy.mockRestore();
     }
   });
 

--- a/apps/chat/src/pages/ToolsetEditor/EditorForm/AuthSection.tsx
+++ b/apps/chat/src/pages/ToolsetEditor/EditorForm/AuthSection.tsx
@@ -156,12 +156,10 @@ const AuthSection: FC<Props> = ({
         });
       } else if (result.type === ToolsetOAuthResultType.Cancelled) {
         /*
-         * The callback popup posts its result and closes itself back-to-back
-         * — under load the opener can observe `popup.closed` before the
-         * `BroadcastChannel` message arrives, so a login that actually
-         * succeeded server-side can still surface as Cancelled here.
-         * Re-checking the toolset's real status avoids leaving the form
-         * stuck showing "logged out" for a login that already went through.
+         * Treat the backend as the final authority if popup tracking or
+         * cross-process message delivery ever still reports a false cancel.
+         * This keeps the form from showing "logged out" after a login that
+         * actually completed server-side.
          */
         try {
           const refreshed = await getToolset(savedToolsetId);

--- a/apps/chat/src/pages/ToolsetEditor/ToolsetEditor.tsx
+++ b/apps/chat/src/pages/ToolsetEditor/ToolsetEditor.tsx
@@ -186,8 +186,18 @@ const ToolsetEditor: FC = () => {
         }
         return next;
       });
+
+      /*
+       * AuthSection only reports isLoggedIn=true after the login request has
+       * succeeded (or a successful OAuth login has been recovered).
+       * Keep the shared toolset list in sync with that confirmed status so
+       * returning to the Catalog does not expose the pre-auth snapshot.
+       */
+      if (patch.isLoggedIn === true) {
+        void refetchToolsets();
+      }
     },
-    [],
+    [refetchToolsets],
   );
 
   const setEditorStep = useCallback(

--- a/apps/chat/src/pages/ToolsetEditor/tests/ToolsetEditor.spec.tsx
+++ b/apps/chat/src/pages/ToolsetEditor/tests/ToolsetEditor.spec.tsx
@@ -196,6 +196,12 @@ vi.mock('../ToolsetEditorView', () => ({
         >
           fill-invalid-oauth-toolset
         </button>
+        <button
+          type="button"
+          onClick={() => onAuthChange({ isLoggedIn: true })}
+        >
+          report-login-success
+        </button>
       </div>
     );
   },
@@ -486,6 +492,18 @@ describe('ToolsetEditor', () => {
     await user.click(
       screen.getByRole('button', {
         name: 'save-toolset',
+      }),
+    );
+
+    await waitFor(() => expect(mockRefetchToolsets).toHaveBeenCalledOnce());
+  });
+
+  it('refetches toolsets after the auth section reports a successful login', async () => {
+    renderEditor();
+
+    await user.click(
+      await screen.findByRole('button', {
+        name: 'report-login-success',
       }),
     );
 

--- a/apps/chat/src/utils/tests/toolsets.spec.ts
+++ b/apps/chat/src/utils/tests/toolsets.spec.ts
@@ -522,6 +522,7 @@ describe('toolsetDtoToForm', () => {
       allowedTools: ['tool1'],
       authSettings: {
         authenticationType: 'OAUTH',
+        dynamicallyRegistered: false,
         clientId: 'client',
         authorizationEndpoint: 'https://auth.example.com/authorize',
         tokenEndpoint: 'https://auth.example.com/token',
@@ -551,6 +552,27 @@ describe('toolsetDtoToForm', () => {
       codeChallengeMethod: 'S256',
     });
     expect(form.auth.clientSecret).toBeUndefined();
+  });
+
+  it('restores WithLogin for a dynamically registered OAuth client', () => {
+    const dto: DialToolsetDto = {
+      id: 'toolsets/b/My%20toolset__0.0.1',
+      toolset: 'toolsets/b/My%20toolset__0.0.1',
+      displayName: 'My toolset',
+      endpoint: 'https://my-toolset.example.com/mcp',
+      authSettings: {
+        authenticationType: 'OAUTH',
+        dynamicallyRegistered: true,
+        clientId: 'dynamically-registered-client',
+        authorizationEndpoint: 'https://auth.example.com/authorize',
+        tokenEndpoint: 'https://auth.example.com/token',
+      },
+    };
+
+    const form = toolsetDtoToForm(dto);
+
+    expect(form.auth.withLogin).toBe(WithLogin.WithLogin);
+    expect(form.auth.clientId).toBe('dynamically-registered-client');
   });
 
   it('repairs encoded endpoint URLs returned from the API before showing them in the editor', () => {

--- a/apps/chat/src/utils/toolsets.ts
+++ b/apps/chat/src/utils/toolsets.ts
@@ -398,8 +398,13 @@ export const toolsetDtoToForm = (dto: DialToolsetDto): ToolsetFormData => {
     withLogin = WithLogin.WithoutLogin;
   } else if (
     authenticationType === ToolsetAuthTypes.OAuth &&
-    authSettings?.clientId
+    authSettings?.dynamicallyRegistered === false
   ) {
+    /*
+     * A public client id exists for both dynamically registered and manually
+     * configured OAuth clients. Core's explicit registration flag is the
+     * reliable way to restore the editor mode.
+     */
     withLogin = WithLogin.WithConfig;
   }
 

--- a/docs/auth/auth-bff-encrypted-cookie.md
+++ b/docs/auth/auth-bff-encrypted-cookie.md
@@ -155,6 +155,14 @@ _Source: [`auth-diagrams/08-toolset-signin-interrupt.mmd`](./auth-diagrams/08-to
 - The assigned channel id travels with subsequent completion requests (`X-DIAL-CLIENT-CHANNEL-ID`), so Core can correlate a `toolset/signin` event back to the specific blocked tool call.
 - A `toolset/signin` event surfaces a global dialog; the user logs in with the existing toolset API-key/OAuth mechanics (unchanged from the Catalog/Toolset-Editor flows), and the result is reported back on the same channel (`POST /api/v1/client-channel/report`) so Core can resume or terminate the tool call.
 - Gated behind the `liveChatInteraction` feature flag (`apps/chat-api/src/app-config/config-registry/config-registry.constants.ts`); unsubscribes on logout, tab close, or the flag flipping off.
+- Toolset OAuth opens an external-provider popup and tracks it from the initiating Chat tab. The
+  Chat response therefore uses `Cross-Origin-Opener-Policy: same-origin-allow-popups` (rather
+  than Helmet's `same-origin` default), preventing provider navigation from severing the
+  opener's `WindowProxy` and producing a false `popup.closed` cancellation. Before navigating
+  externally, the popup still sets its own `window.opener` to `null` to prevent reverse tabnabbing.
+  After the callback posts its result, it closes only its sending `BroadcastChannel`; the
+  initiating tab closes the popup after receiving the already-queued message, with no
+  timer-based handoff.
 
 ---
 

--- a/docs/environment-variables-migration-guide.md
+++ b/docs/environment-variables-migration-guide.md
@@ -7,17 +7,17 @@ directly — all runtime config is served by the API (see `AppConfigContext`).
 
 ## Auth / session
 
-| Variable                        | Required                                       | Default            | Description                                                                                                                         |
-| ------------------------------- | ---------------------------------------------- | ------------------ | ----------------------------------------------------------------------------------------------------------------------------------- |
-| `AUTH_SESSION_SECRET`           | Yes                                            | —                  | 64-char hex (32-byte) session encryption key                                                                                        |
-| `AUTH_SESSION_PREV_SECRET`      | No                                             | —                  | Previous secret, accepted during key rotation                                                                                       |
-| `AUTH_SESSION_COOKIE_NAME`      | No                                             | `__Host-chat.sess` | Session cookie name                                                                                                                 |
-| `AUTH_TRANSACTION_COOKIE_NAME`  | No                                             | `__Host-chat.tx`   | Login transaction cookie name                                                                                                       |
-| `AUTH_COOKIE_SECURE`            | No                                             | `true`             | Set `false` only for local HTTP smoke testing; drops `__Host-` prefix when disabled                                                 |
-| `AUTH_CALLBACK_BASE_URL`        | Yes                                            | —                  | Public API base URL used for OIDC redirect URIs                                                                                     |
-| `AUTH_POST_LOGOUT_REDIRECT_URI` | If any provider is configured (new-style only) | —                  | Where the browser lands after IdP logout; applied to every configured provider                                                      |
-| `ADMIN_ROLE_NAMES`              | No                                             | `admin`            | Comma-separated fallback admin role names, used when a provider sets no override                                                    |
-| `DIAL_ROLES_FIELD`              | No                                             | `dial_roles`       | Fallback dot-separated roles-claim path, used when a provider sets no override                                                      |
+| Variable                        | Required                                       | Default            | Description                                                                         |
+| ------------------------------- | ---------------------------------------------- | ------------------ | ----------------------------------------------------------------------------------- |
+| `AUTH_SESSION_SECRET`           | Yes                                            | —                  | 64-char hex (32-byte) session encryption key                                        |
+| `AUTH_SESSION_PREV_SECRET`      | No                                             | —                  | Previous secret, accepted during key rotation                                       |
+| `AUTH_SESSION_COOKIE_NAME`      | No                                             | `__Host-chat.sess` | Session cookie name                                                                 |
+| `AUTH_TRANSACTION_COOKIE_NAME`  | No                                             | `__Host-chat.tx`   | Login transaction cookie name                                                       |
+| `AUTH_COOKIE_SECURE`            | No                                             | `true`             | Set `false` only for local HTTP smoke testing; drops `__Host-` prefix when disabled |
+| `AUTH_CALLBACK_BASE_URL`        | Yes                                            | —                  | Public API base URL used for OIDC redirect URIs                                     |
+| `AUTH_POST_LOGOUT_REDIRECT_URI` | If any provider is configured (new-style only) | —                  | Where the browser lands after IdP logout; applied to every configured provider      |
+| `ADMIN_ROLE_NAMES`              | No                                             | `admin`            | Comma-separated fallback admin role names, used when a provider sets no override    |
+| `DIAL_ROLES_FIELD`              | No                                             | `dial_roles`       | Fallback dot-separated roles-claim path, used when a provider sets no override      |
 
 ### Auth providers
 

--- a/libs/chat-api-client/openapi.json
+++ b/libs/chat-api-client/openapi.json
@@ -1348,8 +1348,14 @@
           "200": {
             "description": "SSE stream of client-channel RPC events"
           },
+          "400": {
+            "description": "The reconnect channel id header is present but invalid"
+          },
           "401": {
             "description": "Not authenticated"
+          },
+          "403": {
+            "description": "The liveChatInteraction feature is not enabled for this user"
           },
           "502": {
             "description": "DIAL Core rejected or failed the subscription"
@@ -1396,6 +1402,9 @@
           },
           "401": {
             "description": "Not authenticated"
+          },
+          "403": {
+            "description": "The liveChatInteraction feature is not enabled for this user"
           },
           "429": {
             "description": "Rate limit exceeded"
@@ -4595,6 +4604,11 @@
             "description": "Type of authentication",
             "enum": ["OAUTH", "API_KEY", "NONE"]
           },
+          "dynamicallyRegistered": {
+            "type": "boolean",
+            "description": "Whether DIAL Core dynamically registered the OAuth client instead of using user-provided client configuration",
+            "example": true
+          },
           "globalAuthStatus": {
             "type": "string",
             "description": "Whether the toolset has global (shared) credentials signed in",
@@ -5219,6 +5233,11 @@
             "type": "string",
             "example": "OAUTH",
             "enum": ["OAUTH", "API_KEY", "NONE"]
+          },
+          "dynamicallyRegistered": {
+            "type": "boolean",
+            "description": "Whether DIAL Core dynamically registered the OAuth client instead of using user-provided client configuration",
+            "example": true
           },
           "apiKeyHeader": {
             "type": "string",

--- a/libs/chat-api-client/src/generated/src/models/index.ts
+++ b/libs/chat-api-client/src/generated/src/models/index.ts
@@ -2387,6 +2387,12 @@ export interface DialToolsetAuthSettingsDto {
    */
   authenticationType: DialToolsetAuthSettingsDtoAuthenticationTypeEnum;
   /**
+   * Whether DIAL Core dynamically registered the OAuth client instead of using user-provided client configuration
+   * @type {boolean}
+   * @memberof DialToolsetAuthSettingsDto
+   */
+  dynamicallyRegistered?: boolean;
+  /**
    *
    * @type {string}
    * @memberof DialToolsetAuthSettingsDto
@@ -4353,6 +4359,12 @@ export interface ToolsetAuthSettingsDto {
    * @memberof ToolsetAuthSettingsDto
    */
   authenticationType?: ToolsetAuthSettingsDtoAuthenticationTypeEnum;
+  /**
+   * Whether DIAL Core dynamically registered the OAuth client instead of using user-provided client configuration
+   * @type {boolean}
+   * @memberof ToolsetAuthSettingsDto
+   */
+  dynamicallyRegistered?: boolean;
   /**
    * Whether the toolset has global (shared) credentials signed in
    * @type {string}

--- a/openspec/specs/chat-api-backend/spec.md
+++ b/openspec/specs/chat-api-backend/spec.md
@@ -1,3 +1,8 @@
+## Purpose
+
+Define the Chat API application's bootstrap, security, validation, health, rate-limiting, and
+theme-service requirements.
+
 ## Requirements
 
 ---
@@ -82,12 +87,23 @@ The application SHALL expose `GET /api/health` returning HTTP 200 with a JSON bo
 
 ### Requirement: Security headers via Helmet
 
-The application SHALL apply `helmet()` middleware in `main.ts` to set standard HTTP security headers (CSP, HSTS, X-Frame-Options, etc.) on all responses.
+The application SHALL apply `helmet()` middleware in `main.ts` to set standard HTTP security
+headers (CSP, HSTS, X-Frame-Options, etc.) on all responses. The configured
+Cross-Origin-Opener-Policy SHALL be `same-origin-allow-popups` so cross-origin OAuth provider
+navigation does not sever the initiating Chat tab's popup reference; OAuth popups SHALL
+independently clear their own `window.opener` before external navigation to retain
+reverse-tabnabbing protection.
 
 #### Scenario: Security headers present on API responses
 
 - **WHEN** any API endpoint is called
 - **THEN** the response includes `X-Content-Type-Options: nosniff` and `X-Frame-Options`
+
+#### Scenario: OAuth-compatible opener policy
+
+- **WHEN** any Chat page is served through the API application
+- **THEN** its `Cross-Origin-Opener-Policy` response header is
+  `same-origin-allow-popups`
 
 ---
 

--- a/openspec/specs/toolset-authentication/spec.md
+++ b/openspec/specs/toolset-authentication/spec.md
@@ -94,14 +94,18 @@ authorize URL SHALL include `code_challenge`/`code_challenge_method` query param
 toolset's stored OAuth configuration includes them. A shared callback route, loaded inside that
 new window, SHALL read the persisted state and complete login by submitting the authorization
 `code`, `redirectUri`, and the stored `credentialsLevel`, then post the outcome to the opener over
-the flow's `BroadcastChannel` and wait, without closing itself. The opener SHALL close the
-callback window itself immediately after receiving that message, so the window never closes
-before its result has been delivered. The callback window SHALL additionally carry its own
-bounded safety-net auto-close timer, started once the outcome has been posted, that closes the
-window if the opener has not already done so by the time it fires — covering the case where the
-opener tab was itself closed or navigated away before it could process the message. The page that
-initiated login (Toolset Editor or Catalog) is never navigated away and does not automatically
-refresh; the user reopens it to see updated status.
+the flow's `BroadcastChannel`, close its sending channel, and wait without closing itself. Per the
+BroadcastChannel delivery contract, `postMessage` SHALL determine the eligible destinations and
+queue their delivery before the sender is closed. The opener SHALL close the callback window
+itself immediately after receiving that message, so the window never closes before its result
+has been delivered and the handoff requires no timer. The environment SHALL serve Chat with
+`Cross-Origin-Opener-Policy: same-origin-allow-popups`, not Helmet's `same-origin` default, so
+navigation to an external OAuth provider does not sever the opener's popup reference and make an
+active login appear manually cancelled; the popup SHALL still clear its own `window.opener`
+before external navigation. The page that initiated login (Toolset Editor or Catalog) SHALL
+never be navigated away and, after receiving a successful result, SHALL show a success
+notification and refetch the shared toolset list so the updated authentication status is visible
+without a second login attempt or page reload.
 
 #### Scenario: Initiate OAuth login from the editor
 - **WHEN** a user saves an OAuth toolset in login-with-config mode from the Toolset Editor, or
@@ -131,18 +135,24 @@ refresh; the user reopens it to see updated status.
   login
 - **THEN** the system reads the stored redirect state, calls the login endpoint with the code,
   redirect URI, and the stored `credentialsLevel`, and posts the outcome to the opener over the
-  flow's `BroadcastChannel` without closing itself
+  flow's `BroadcastChannel`, closes the sending channel after delivery has been queued, and leaves
+  the callback window open for the opener to close
+
+#### Scenario: External provider navigation preserves popup tracking
+- **WHEN** the OAuth popup navigates from Chat to a cross-origin identity provider
+- **THEN** Chat's `same-origin-allow-popups` COOP policy keeps the popup reference observable by
+  the opener, while the popup's cleared `window.opener` prevents the provider from navigating the
+  Chat tab
 
 #### Scenario: Opener closes the callback window on receiving the result
 - **WHEN** the opener's `BroadcastChannel` listener receives the callback window's posted result
 - **THEN** the opener resolves the login outcome and closes the callback window itself, so the
   window is never observed closed before its message was delivered
 
-#### Scenario: Callback window self-closes if the opener never does
-- **WHEN** the callback window has posted its result but the opener has not closed it before the
-  window's own safety-net timer elapses (e.g. because the opener tab was closed or navigated
-  away)
-- **THEN** the callback window closes itself
+#### Scenario: Successful OAuth login refreshes the initiating page
+- **WHEN** the opener receives a successful OAuth login result
+- **THEN** it shows a success notification and refetches the shared toolset list so the updated
+  authentication status is immediately available in the initiating tab
 
 #### Scenario: Callback without stored state
 - **WHEN** the callback route is reached with no valid stored redirect state
@@ -279,15 +289,14 @@ neither `API_KEY` nor `OAUTH`, the request SHALL fail with `400 Bad Request`.
 - **THEN** the server uses the supplied value directly and does not perform the stored-toolset
   lookup
 
-### Requirement: API-key login success notification
+### Requirement: API-key login success feedback and refresh
 
-When an API-key login succeeds, the system SHALL show a success notification, matching the
-notification already shown for a successful OAuth login, regardless of whether the login was
-initiated from the Toolset Editor's Auth section or the Catalog Details Panel.
+When an API-key login succeeds, the system SHALL show a success notification and refetch the
+shared toolset list, matching the behavior of a successful OAuth login, regardless of whether
+the login was initiated from the Toolset Editor's Auth section or the Catalog Details Panel.
 
 #### Scenario: API-key login success notification in the Toolset Editor
 - **WHEN** a user submits a valid API key in the Toolset Editor's Auth section and the login
   request succeeds
-- **THEN** the system shows a success notification in addition to marking the toolset as logged
-  in
-
+- **THEN** the system shows a success notification, marks the toolset as logged in, and refetches
+  the shared toolset list

--- a/openspec/specs/toolset-authentication/spec.md
+++ b/openspec/specs/toolset-authentication/spec.md
@@ -44,6 +44,15 @@ and whether a login is triggered on save.
 - **THEN** the configuration can be saved without submitting credentials and without
   triggering a login
 
+#### Scenario: Reopen an OAuth toolset with dynamic client registration
+- **WHEN** the editor loads a saved OAuth toolset that Core marks as dynamically registered
+- **THEN** the login mode is restored as "with login", even though the returned OAuth settings
+  contain the dynamically assigned client ID and endpoints
+
+#### Scenario: Reopen an OAuth toolset with manual client configuration
+- **WHEN** the editor loads a saved OAuth toolset that Core marks as not dynamically registered
+- **THEN** the login mode is restored as "with login & config"
+
 ### Requirement: Persist unsaved changes before login
 Clicking "Log in" (API Key or OAuth) SHALL first persist any unsaved editor changes — creating
 the toolset if it has no id yet, or updating it if the form has changed since it was last


### PR DESCRIPTION
## Summary

- Fix first-attempt toolset login handling by preserving OAuth popup tracking, removing timer-based callback closing, and refreshing toolset data after successful login.
- Add consistent success notifications for OAuth and API-key login flows.
- Map Core’s `dynamically_registered` field to restore the correct OAuth editor mode.
- Update tests, OpenAPI client, documentation, and specifications.

## Applicable issues

 #7777
## UI changes

<Please, provide Screenshots or Figma links>

## Checklist

- [ ] the pull request name ends with `(Issue #<ISSUE_ID>)` (comma-separated list of issues)
- [ ] I confirm that I don't share any confidential information like API keys or any other secrets and private URLs

<details>
  <summary>PR title cheatsheet</summary>

`<type>[optional scope]: <description>`

1. type (required)
    - `feat` - A new feature
    - `fix` - A bug fix
    - `docs` - Documentation only changes
    - `test` - Adding missing tests or correcting existing tests
    - `ci` - Changes to our CI configuration files and scripts
    - `chore` - Other changes that are minor and/or not user-facing
2. scope (optional, current repo suggestions below)
    - `chat`
    - `overlay`
    - `shared`
    - `sandbox-overlay`
    - `visualizer-connector`

</details>
