### PR TITLE
fix: [Quick App] Preview does not reset after Settings changes, Issue #7996

### DIFF
--- a/apps/chat/src/pages/AppsEditor/AppEditorIframe.tsx
+++ b/apps/chat/src/pages/AppsEditor/AppEditorIframe.tsx
@@ -20,6 +20,8 @@ import { getToolset, logoutToolset } from '../../server-api/toolsets';
 import type {
   ToolsetLoginResultPayload,
   ToolsetLogoutResultPayload,
+  TriggerSaveGeneralPayload,
+  TriggerSaveMessage,
 } from '../../types/apps-editor';
 import { AppsEditorEvent } from '../../types/apps-editor';
 import {
@@ -41,7 +43,7 @@ import {
 } from '../../utils/toolsets';
 
 export interface AppEditorIframeHandle {
-  triggerSave: () => void;
+  triggerSave: (general?: TriggerSaveGeneralPayload) => void;
 }
 
 interface Props {
@@ -399,10 +401,14 @@ const AppEditorIframe = forwardRef<AppEditorIframeHandle, Props>(
     useImperativeHandle(
       ref,
       () => ({
-        triggerSave: () => {
+        triggerSave: (general?: TriggerSaveGeneralPayload) => {
           if (!schema.editorUrl) return;
+          const message: TriggerSaveMessage = {
+            type: AppsEditorEvent.TriggerSave,
+            general,
+          };
           iframeRef.current?.contentWindow?.postMessage(
-            { type: AppsEditorEvent.TriggerSave },
+            message,
             new URL(schema.editorUrl).origin,
           );
         },

--- a/apps/chat/src/pages/AppsEditor/AppEditorIframe.tsx
+++ b/apps/chat/src/pages/AppsEditor/AppEditorIframe.tsx
@@ -50,7 +50,12 @@ interface Props {
   schema: ApplicationSchemaSummaryDto;
   appId: string;
   onUpdated?: () => void;
-  onSaveSuccess?: () => void;
+  /**
+   * Called when the embedded editor's `SaveSuccess` message resolves, with
+   * `hasChanges` normalized to a strict boolean (a missing/non-boolean field
+   * on the message is treated as `false`) — see `SaveSuccessMessage`.
+   */
+  onSaveSuccess?: (hasChanges: boolean) => void;
   onSaveError?: (error: string) => void;
   /**
    * Notifies the host whenever the iframe's readiness to save changes.
@@ -60,11 +65,26 @@ interface Props {
    * component's own loading-spinner overlay.
    */
   onReadyChange?: (isReady: boolean) => void;
+  /**
+   * Notifies the host whenever the iframe reports the user is logged out
+   * (`AppsEditorEvent.LoggedOut`). Since `ReadyToSave` will never arrive in
+   * that case, the host uses this to distinguish an expected "not
+   * authenticated" state from a genuine readiness failure.
+   */
+  onLoggedOutChange?: (isLoggedOut: boolean) => void;
 }
 
 const AppEditorIframe = forwardRef<AppEditorIframeHandle, Props>(
   function AppEditorIframe(
-    { schema, appId, onUpdated, onSaveSuccess, onSaveError, onReadyChange },
+    {
+      schema,
+      appId,
+      onUpdated,
+      onSaveSuccess,
+      onSaveError,
+      onReadyChange,
+      onLoggedOutChange,
+    },
     ref,
   ) {
     const { t } = useTranslation();
@@ -73,6 +93,7 @@ const AppEditorIframe = forwardRef<AppEditorIframeHandle, Props>(
 
     const [isUiLoading, setIsUiLoading] = useState(true);
     const [isReadyToSave, setIsReadyToSave] = useState(false);
+    const [isLoggedOut, setIsLoggedOut] = useState(false);
     const iframeRef = useRef<HTMLIFrameElement>(null);
 
     const iframeUrl = useMemo(() => {
@@ -330,11 +351,14 @@ const AppEditorIframe = forwardRef<AppEditorIframeHandle, Props>(
           case `${displayName}/${AppsEditorEvent.ReadyToSave}`:
             setIsReadyToSave(true);
             break;
+          case `${displayName}/${AppsEditorEvent.LoggedOut}`:
+            setIsLoggedOut(true);
+            break;
           case `${displayName}/${AppsEditorEvent.UpdatedSuccess}`:
             onUpdated?.();
             break;
           case AppsEditorEvent.SaveSuccess:
-            onSaveSuccess?.();
+            onSaveSuccess?.(event.data?.hasChanges === true);
             break;
           case AppsEditorEvent.SaveError:
             onSaveError?.(event.data?.error ?? '');
@@ -387,16 +411,22 @@ const AppEditorIframe = forwardRef<AppEditorIframeHandle, Props>(
       };
     }, [iframeUrl]);
 
-    /* Re-gates readiness-to-save whenever the iframe reloads for a different
-     * app/schema, so a stale `true` from the previous app doesn't leak into
-     * the newly loaded one — the new iframe must send its own ReadyToSave. */
+    /* Re-gates readiness-to-save (and the logged-out flag) whenever the
+     * iframe reloads for a different app/schema, so stale values from the
+     * previous app don't leak into the newly loaded one — the new iframe
+     * must send its own ReadyToSave/LoggedOut. */
     useEffect(() => {
       setIsReadyToSave(false);
+      setIsLoggedOut(false);
     }, [iframeUrl]);
 
     useEffect(() => {
       onReadyChange?.(isReadyToSave);
     }, [isReadyToSave, onReadyChange]);
+
+    useEffect(() => {
+      onLoggedOutChange?.(isLoggedOut);
+    }, [isLoggedOut, onLoggedOutChange]);
 
     useImperativeHandle(
       ref,

--- a/apps/chat/src/pages/AppsEditor/AppsEditor.tsx
+++ b/apps/chat/src/pages/AppsEditor/AppsEditor.tsx
@@ -62,6 +62,21 @@ const AppsEditor: FC = () => {
   >(null);
   const [isPreviewing, setIsPreviewing] = useState(false);
   const [isSettingsReady, setIsSettingsReady] = useState(false);
+  /**
+   * Whether the embedded Settings-step editor reported the user is logged
+   * out (`AppsEditorEvent.LoggedOut`). In that case `ReadyToSave` will never
+   * arrive, so the readiness timeout below must not surface its generic
+   * "not ready" error — being logged out is an expected state, not a
+   * readiness failure.
+   */
+  const [isLoggedOut, setIsLoggedOut] = useState(false);
+  /**
+   * Bumped whenever a Settings-step save reports a real configuration
+   * change (`SaveSuccessMessage.hasChanges === true`). Passed to
+   * `SettingsStep` as `AppPreviewChat`'s `key`, so the preview pane
+   * remounts and starts a fresh session the next time it is shown.
+   */
+  const [previewResetKey, setPreviewResetKey] = useState(0);
 
   const generalFormRef = useRef<GeneralFormHandle>(null);
   const settingsStepRef = useRef<SettingsStepHandle>(null);
@@ -168,15 +183,37 @@ const AppsEditor: FC = () => {
     if (settingsReadyKeyRef.current === key) return;
     settingsReadyKeyRef.current = key;
     setIsSettingsReady(false);
+    setIsLoggedOut(false);
   }, [schema, appIdForSettings]);
+
+  /* Read inside the readiness-timeout callback below so a LoggedOut signal
+   * that arrives at any point before the timeout fires is honored, without
+   * having to re-arm the timeout every time isLoggedOut changes. */
+  const isLoggedOutRef = useRef(isLoggedOut);
+  useEffect(() => {
+    isLoggedOutRef.current = isLoggedOut;
+  }, [isLoggedOut]);
+
+  /* Clears an already-surfaced readiness-timeout error once the Settings
+   * step reports the user is logged out — that explains why ReadyToSave
+   * never arrived, so the generic "not ready" error is misleading. */
+  useEffect(() => {
+    if (!isLoggedOut) return;
+    setSaveError((prev) =>
+      prev === t(AppsEditorI18nKeys.ErrorSettingsNotReady) ? '' : prev,
+    );
+  }, [isLoggedOut, t]);
 
   /* Safety net for the initial ReadyToSave signal itself (see
    * SETTINGS_READY_TIMEOUT_MS above) — armed whenever the Settings step is
    * visible and not yet ready, and re-armed whenever schema/appId change (a
-   * fresh iframe load). Cleared as soon as isSettingsReady flips true. */
+   * fresh iframe load). Cleared as soon as isSettingsReady flips true. Skips
+   * surfacing the error if the Settings step reported the user is logged
+   * out, since ReadyToSave is then expected to never arrive. */
   useEffect(() => {
     if (isGeneralStep || isSettingsReady) return;
     const timeoutId = setTimeout(() => {
+      if (isLoggedOutRef.current) return;
       setSaveError(t(AppsEditorI18nKeys.ErrorSettingsNotReady));
     }, SETTINGS_READY_TIMEOUT_MS);
     return () => clearTimeout(timeoutId);
@@ -198,30 +235,36 @@ const AppsEditor: FC = () => {
     void refetchDeployments(false);
   }, [refetchDeployments]);
 
-  const handleSaveSuccess = useCallback(() => {
-    clearSaveTimeout();
-    if (isPreviewing) return;
+  const handleSaveSuccess = useCallback(
+    (hasChanges: boolean) => {
+      clearSaveTimeout();
+      if (isPreviewing) return;
 
-    const completeSave = async () => {
-      await refetchDeployments().catch(() => undefined);
-      setIsSaving(false);
-      if (pendingSaveAction === 'preview') {
-        setIsPreviewing(true);
-      } else {
-        navigate(returnUrl);
-      }
-      setPendingSaveAction(null);
-    };
+      const completeSave = async () => {
+        await refetchDeployments().catch(() => undefined);
+        setIsSaving(false);
+        if (hasChanges) {
+          setPreviewResetKey((prev) => prev + 1);
+        }
+        if (pendingSaveAction === 'preview') {
+          setIsPreviewing(true);
+        } else {
+          navigate(returnUrl);
+        }
+        setPendingSaveAction(null);
+      };
 
-    void completeSave();
-  }, [
-    clearSaveTimeout,
-    isPreviewing,
-    pendingSaveAction,
-    refetchDeployments,
-    navigate,
-    returnUrl,
-  ]);
+      void completeSave();
+    },
+    [
+      clearSaveTimeout,
+      isPreviewing,
+      pendingSaveAction,
+      refetchDeployments,
+      navigate,
+      returnUrl,
+    ],
+  );
 
   const handleSaveError = useCallback(
     (error: string) => {
@@ -360,6 +403,8 @@ const AppsEditor: FC = () => {
               onSaveSuccess={handleSaveSuccess}
               onSaveError={handleSaveError}
               onReadyChange={setIsSettingsReady}
+              onLoggedOutChange={setIsLoggedOut}
+              previewResetKey={previewResetKey}
             />
           )}
         </div>

--- a/apps/chat/src/pages/AppsEditor/AppsEditor.tsx
+++ b/apps/chat/src/pages/AppsEditor/AppsEditor.tsx
@@ -203,28 +203,6 @@ const AppsEditor: FC = () => {
     if (isPreviewing) return;
 
     const completeSave = async () => {
-      try {
-        /*
-         * The embedded Settings-step editor persists straight to DIAL Core
-         * from its own iframe and holds its own in-memory copy of the
-         * General-step fields (name/description/...) from whenever it last
-         * loaded the app. If General were persisted *before* triggering this
-         * save, the iframe's own save would overwrite those fields right
-         * back to its stale copy. Persisting General *after* the Settings
-         * save succeeds means the General PATCH's GET-then-merge reads the
-         * just-saved document and layers the new General values on top of
-         * it, so neither side clobbers the other.
-         */
-        if (pendingSaveAction === 'save' && hasExistingAppOnMountRef.current) {
-          await generalFormRef.current?.persist();
-        }
-      } catch {
-        setIsSaving(false);
-        setSaveError(t(AppsEditorI18nKeys.ErrorSaveFailed));
-        setPendingSaveAction(null);
-        return;
-      }
-
       await refetchDeployments().catch(() => undefined);
       setIsSaving(false);
       if (pendingSaveAction === 'preview') {
@@ -243,7 +221,6 @@ const AppsEditor: FC = () => {
     refetchDeployments,
     navigate,
     returnUrl,
-    t,
   ]);
 
   const handleSaveError = useCallback(
@@ -276,7 +253,10 @@ const AppsEditor: FC = () => {
     setIsSaving(true);
     setPendingSaveAction('save');
     startSaveTimeout();
-    settingsStepRef.current?.triggerSave();
+    const general = hasExistingAppOnMountRef.current
+      ? generalFormRef.current?.getValues()
+      : undefined;
+    settingsStepRef.current?.triggerSave(general);
   }, [isGeneralStep, startSaveTimeout]);
 
   const handlePreview = useCallback(() => {

--- a/apps/chat/src/pages/AppsEditor/GeneralForm.tsx
+++ b/apps/chat/src/pages/AppsEditor/GeneralForm.tsx
@@ -25,21 +25,17 @@ import {
   BasicI18nKeys,
   EditorI18nKeys,
 } from '../../constants/translation-keys';
-import {
-  createApplication,
-  updateApplication,
-} from '../../server-api/applications';
+import { createApplication } from '../../server-api/applications';
+import type { TriggerSaveGeneralPayload } from '../../types/apps-editor';
 import { isQuickAppSchema } from '../../utils/application-schema';
 
 export interface GeneralFormHandle {
   submit: () => Promise<void>;
   /**
-   * Persists the current form values to the update-application endpoint when they
-   * differ from the values the form was initially seeded with. Resolves without a
-   * network call when nothing changed. Rejects on failure so the caller can surface
-   * an error before proceeding.
+   * Current in-memory General-step values, normalized the same way values used to be
+   * trimmed before being sent to `update-application`. Excludes `version`.
    */
-  persist: () => Promise<void>;
+  getValues: () => TriggerSaveGeneralPayload;
 }
 
 export interface GeneralFormInitialValues {
@@ -92,14 +88,11 @@ const GeneralForm = forwardRef<GeneralFormHandle, Props>(function GeneralForm(
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState('');
   const hasSeededInitialValuesRef = useRef(false);
-  const seededValuesRef = useRef<DeploymentCreationFormValues>(EMPTY_VALUES);
 
   useEffect(() => {
     if (hasSeededInitialValuesRef.current || !initialValues) return;
     hasSeededInitialValuesRef.current = true;
-    const seededValues = normalizeFormValues(initialValues);
-    seededValuesRef.current = seededValues;
-    setValues(seededValues);
+    setValues(normalizeFormValues(initialValues));
   }, [initialValues]);
 
   const labels: DeploymentCreationFormLabels = useMemo(
@@ -210,40 +203,21 @@ const GeneralForm = forwardRef<GeneralFormHandle, Props>(function GeneralForm(
     }
   }, [isSubmitting, values, appId, t, onCreated, schemaId]);
 
-  const handlePersist = useCallback(async () => {
-    if (!appId) return;
-
-    const seededValues = seededValuesRef.current;
-    const trimmedName = values.name.trim();
-    const trimmedDescription = values.description.trim();
-    const trimmedIconUrl = values.iconUrl.trim();
-    const trimmedIntro = values.intro.trim();
-    const isTopicsEqual =
-      values.topics.length === seededValues.topics.length &&
-      values.topics.every((topic) => seededValues.topics.includes(topic));
-    const isDirty =
-      trimmedName !== seededValues.name.trim() ||
-      trimmedDescription !== seededValues.description.trim() ||
-      trimmedIconUrl !== seededValues.iconUrl.trim() ||
-      trimmedIntro !== seededValues.intro.trim() ||
-      !isTopicsEqual;
-
-    if (!isDirty) return;
-
-    await updateApplication(appId, {
-      name: trimmedName,
-      description: trimmedDescription || undefined,
-      iconUrl: trimmedIconUrl || undefined,
+  const getValues = useCallback(
+    (): TriggerSaveGeneralPayload => ({
+      name: values.name.trim(),
+      description: values.description.trim() || undefined,
+      iconUrl: values.iconUrl.trim() || undefined,
       topics: values.topics.length > 0 ? values.topics : undefined,
-      intro: trimmedIntro || undefined,
-    });
-  }, [appId, values]);
-
-  useImperativeHandle(
-    ref,
-    () => ({ submit: handleSubmit, persist: handlePersist }),
-    [handleSubmit, handlePersist],
+      intro: values.intro.trim() || undefined,
+    }),
+    [values],
   );
+
+  useImperativeHandle(ref, () => ({ submit: handleSubmit, getValues }), [
+    handleSubmit,
+    getValues,
+  ]);
 
   const previewItem = useMemo<CatalogItem>(
     () => ({

--- a/apps/chat/src/pages/AppsEditor/SettingsStep.tsx
+++ b/apps/chat/src/pages/AppsEditor/SettingsStep.tsx
@@ -3,12 +3,13 @@ import type { ApplicationSchemaSummaryDto } from '@epam/chat-api-client';
 import { forwardRef, memo, useImperativeHandle, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { AppsEditorI18nKeys } from '../../constants/translation-keys';
+import type { TriggerSaveGeneralPayload } from '../../types/apps-editor';
 import type { AppEditorIframeHandle } from './AppEditorIframe';
 import AppEditorIframe from './AppEditorIframe';
 import AppPreviewChat from './AppPreviewChat';
 
 export interface SettingsStepHandle {
-  triggerSave: () => void;
+  triggerSave: (general?: TriggerSaveGeneralPayload) => void;
 }
 
 interface Props {
@@ -45,7 +46,8 @@ const SettingsStep = forwardRef<SettingsStepHandle, Props>(
     useImperativeHandle(
       ref,
       () => ({
-        triggerSave: () => iframeRef.current?.triggerSave(),
+        triggerSave: (general?: TriggerSaveGeneralPayload) =>
+          iframeRef.current?.triggerSave(general),
       }),
       [],
     );

--- a/apps/chat/src/pages/AppsEditor/SettingsStep.tsx
+++ b/apps/chat/src/pages/AppsEditor/SettingsStep.tsx
@@ -19,10 +19,19 @@ interface Props {
   appIconUrl?: string;
   isPreviewing?: boolean;
   onUpdated?: () => void;
-  onSaveSuccess?: () => void;
+  onSaveSuccess?: (hasChanges: boolean) => void;
   onSaveError?: (error: string) => void;
   /** Notifies the host whenever the embedded editor's readiness to save changes (`AppsEditorEvent.ReadyToSave`), not merely UI-rendered readiness. */
   onReadyChange?: (isReady: boolean) => void;
+  /** Notifies the host whenever the embedded editor reports the user is logged out (`AppsEditorEvent.LoggedOut`). */
+  onLoggedOutChange?: (isLoggedOut: boolean) => void;
+  /**
+   * Bumped by the host whenever a save reports a real configuration change
+   * (`SaveSuccessMessage.hasChanges === true`). Passed as `AppPreviewChat`'s
+   * `key`, so it remounts — discarding the previous preview conversation and
+   * composer state — the next time the preview pane is shown.
+   */
+  previewResetKey?: number;
 }
 
 const SettingsStep = forwardRef<SettingsStepHandle, Props>(
@@ -37,6 +46,8 @@ const SettingsStep = forwardRef<SettingsStepHandle, Props>(
       onSaveSuccess,
       onSaveError,
       onReadyChange,
+      onLoggedOutChange,
+      previewResetKey,
     },
     ref,
   ) {
@@ -64,6 +75,7 @@ const SettingsStep = forwardRef<SettingsStepHandle, Props>(
               onSaveSuccess={onSaveSuccess}
               onSaveError={onSaveError}
               onReadyChange={onReadyChange}
+              onLoggedOutChange={onLoggedOutChange}
             />
           </div>
           {appId && (
@@ -74,6 +86,7 @@ const SettingsStep = forwardRef<SettingsStepHandle, Props>(
               )}
             >
               <AppPreviewChat
+                key={previewResetKey}
                 appId={appId}
                 appDisplayName={appDisplayName ?? schema.displayName}
                 appIconUrl={appIconUrl ?? schema.iconUrl}

--- a/apps/chat/src/pages/AppsEditor/tests/AppEditorIframe.spec.tsx
+++ b/apps/chat/src/pages/AppsEditor/tests/AppEditorIframe.spec.tsx
@@ -1,6 +1,7 @@
 import type { DialToolsetDto } from '@epam/chat-api-client';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import type { ComponentProps } from 'react';
+import type { ComponentProps, Ref } from 'react';
+import { createRef } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { TOOLSET_REDIRECT_STATE_KEY } from '../../../constants/toolsets';
 import * as UserContextModule from '../../../context/auth/UserContext';
@@ -10,6 +11,7 @@ import * as toolsetsApi from '../../../server-api/toolsets';
 import { AppsEditorEvent } from '../../../types/apps-editor';
 import { AuthStatus } from '../../../types/auth-status';
 import { getToolsetOAuthChannelName } from '../../../utils/toolsets';
+import type { AppEditorIframeHandle } from '../AppEditorIframe';
 import AppEditorIframe from '../AppEditorIframe';
 
 vi.mock('../../../context/auth/UserContext');
@@ -46,7 +48,8 @@ const DEFAULT_PROPS = {
 
 const renderIframe = (
   props?: Partial<ComponentProps<typeof AppEditorIframe>>,
-) => render(<AppEditorIframe {...DEFAULT_PROPS} {...props} />);
+  ref?: Ref<AppEditorIframeHandle>,
+) => render(<AppEditorIframe {...DEFAULT_PROPS} {...props} ref={ref} />);
 
 describe('AppEditorIframe', () => {
   beforeEach(() => {
@@ -238,6 +241,61 @@ describe('AppEditorIframe — ready-to-save readiness', () => {
     );
 
     expect(onReadyChange).not.toHaveBeenCalledWith(true);
+  });
+});
+
+describe('AppEditorIframe — triggerSave', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseUser.mockReturnValue({
+      status: AuthStatus.Authenticated,
+      user: { sub: 'u1', providerId: 'local', claims: {}, isAdmin: false },
+      refresh: vi.fn(),
+      reset: vi.fn(),
+    });
+    mockUseTheme.mockReturnValue({
+      currentTheme: 'dark',
+      selectedTheme: 'dark',
+      setTheme: vi.fn(),
+      isLoading: false,
+    });
+  });
+
+  it('posts TriggerSave with the given general payload', () => {
+    const ref = createRef<AppEditorIframeHandle>();
+    renderIframe({}, ref);
+    const iframe = screen.getByTitle('QuickApp') as HTMLIFrameElement;
+    const postMessageSpy = vi.spyOn(
+      iframe.contentWindow as Window,
+      'postMessage',
+    );
+
+    ref.current?.triggerSave({ name: 'My App', description: 'desc' });
+
+    expect(postMessageSpy).toHaveBeenCalledWith(
+      {
+        type: AppsEditorEvent.TriggerSave,
+        general: { name: 'My App', description: 'desc' },
+      },
+      'https://editor.example.com',
+    );
+  });
+
+  it('posts TriggerSave with no general payload when none is passed', () => {
+    const ref = createRef<AppEditorIframeHandle>();
+    renderIframe({}, ref);
+    const iframe = screen.getByTitle('QuickApp') as HTMLIFrameElement;
+    const postMessageSpy = vi.spyOn(
+      iframe.contentWindow as Window,
+      'postMessage',
+    );
+
+    ref.current?.triggerSave();
+
+    expect(postMessageSpy).toHaveBeenCalledWith(
+      { type: AppsEditorEvent.TriggerSave, general: undefined },
+      'https://editor.example.com',
+    );
   });
 });
 

--- a/apps/chat/src/pages/AppsEditor/tests/AppEditorIframe.spec.tsx
+++ b/apps/chat/src/pages/AppsEditor/tests/AppEditorIframe.spec.tsx
@@ -118,6 +118,45 @@ describe('AppEditorIframe', () => {
     expect(onUpdated).toHaveBeenCalledOnce();
   });
 
+  it('calls onSaveSuccess with hasChanges: true when the SaveSuccess message carries it', () => {
+    const onSaveSuccess = vi.fn();
+    renderIframe({ onSaveSuccess });
+    fireEvent(
+      window,
+      new MessageEvent('message', {
+        data: { type: AppsEditorEvent.SaveSuccess, hasChanges: true },
+        origin: 'https://editor.example.com',
+      }),
+    );
+    expect(onSaveSuccess).toHaveBeenCalledWith(true);
+  });
+
+  it('calls onSaveSuccess with hasChanges: false when the SaveSuccess message carries it', () => {
+    const onSaveSuccess = vi.fn();
+    renderIframe({ onSaveSuccess });
+    fireEvent(
+      window,
+      new MessageEvent('message', {
+        data: { type: AppsEditorEvent.SaveSuccess, hasChanges: false },
+        origin: 'https://editor.example.com',
+      }),
+    );
+    expect(onSaveSuccess).toHaveBeenCalledWith(false);
+  });
+
+  it('normalizes a missing hasChanges field on SaveSuccess to false', () => {
+    const onSaveSuccess = vi.fn();
+    renderIframe({ onSaveSuccess });
+    fireEvent(
+      window,
+      new MessageEvent('message', {
+        data: { type: AppsEditorEvent.SaveSuccess },
+        origin: 'https://editor.example.com',
+      }),
+    );
+    expect(onSaveSuccess).toHaveBeenCalledWith(false);
+  });
+
   it('ignores messages from a different origin', () => {
     const onUpdated = vi.fn();
     renderIframe({ onUpdated });
@@ -241,6 +280,69 @@ describe('AppEditorIframe — ready-to-save readiness', () => {
     );
 
     expect(onReadyChange).not.toHaveBeenCalledWith(true);
+  });
+
+  it('reports logged out once a loggedOut message arrives', () => {
+    const onLoggedOutChange = vi.fn();
+    renderIframe({ onLoggedOutChange });
+
+    fireEvent(
+      window,
+      new MessageEvent('message', {
+        data: {
+          type: `${SCHEMA.displayName}/${AppsEditorEvent.LoggedOut}`,
+        },
+        origin: 'https://editor.example.com',
+      }),
+    );
+
+    expect(onLoggedOutChange).toHaveBeenCalledWith(true);
+  });
+
+  it('ignores a loggedOut message from a different origin', () => {
+    const onLoggedOutChange = vi.fn();
+    renderIframe({ onLoggedOutChange });
+
+    fireEvent(
+      window,
+      new MessageEvent('message', {
+        data: {
+          type: `${SCHEMA.displayName}/${AppsEditorEvent.LoggedOut}`,
+        },
+        origin: 'https://evil.example.com',
+      }),
+    );
+
+    expect(onLoggedOutChange).not.toHaveBeenCalledWith(true);
+  });
+
+  it('re-gates logged-out to false when the iframe reloads for a different app', () => {
+    const onLoggedOutChange = vi.fn();
+    const { rerender } = render(
+      <AppEditorIframe {...DEFAULT_PROPS} onLoggedOutChange={onLoggedOutChange} />,
+    );
+
+    fireEvent(
+      window,
+      new MessageEvent('message', {
+        data: {
+          type: `${SCHEMA.displayName}/${AppsEditorEvent.LoggedOut}`,
+        },
+        origin: 'https://editor.example.com',
+      }),
+    );
+    expect(onLoggedOutChange).toHaveBeenCalledWith(true);
+    onLoggedOutChange.mockClear();
+
+    rerender(
+      <AppEditorIframe
+        {...DEFAULT_PROPS}
+        appId="different-app"
+        onLoggedOutChange={onLoggedOutChange}
+      />,
+    );
+
+    expect(onLoggedOutChange).toHaveBeenCalledWith(false);
   });
 });
 

--- a/apps/chat/src/pages/AppsEditor/tests/AppsEditor.spec.tsx
+++ b/apps/chat/src/pages/AppsEditor/tests/AppsEditor.spec.tsx
@@ -10,6 +10,7 @@ import {
   EditorI18nKeys,
 } from '../../../constants/translation-keys';
 import * as DeploymentsContextModule from '../../../context/DeploymentsContext';
+import type { TriggerSaveGeneralPayload } from '../../../types/apps-editor';
 import AppsEditor from '../AppsEditor';
 
 let latestSettingsStepProps: {
@@ -30,9 +31,10 @@ let latestGeneralFormProps: {
  * readiness-gating behavior itself flip this off before rendering. */
 let shouldSettingsAutoReady = true;
 
-const settingsStepTriggerSave = vi.fn();
+const settingsStepTriggerSave =
+  vi.fn<(general?: TriggerSaveGeneralPayload) => void>();
 const generalFormSubmit = vi.fn();
-const generalFormPersist = vi.fn();
+const generalFormGetValues = vi.fn<() => TriggerSaveGeneralPayload>();
 
 vi.mock('../SettingsStep', () => ({
   default: forwardRef(function MockSettingsStep(
@@ -76,7 +78,7 @@ vi.mock('../GeneralForm', () => ({
     latestGeneralFormProps = props;
     useImperativeHandle(ref, () => ({
       submit: generalFormSubmit,
-      persist: generalFormPersist,
+      getValues: generalFormGetValues,
     }));
     return <div>general-form</div>;
   }),
@@ -108,7 +110,7 @@ describe('AppsEditor', () => {
     latestSettingsStepProps = {};
     latestGeneralFormProps = null;
     shouldSettingsAutoReady = true;
-    generalFormPersist.mockReset().mockResolvedValue(undefined);
+    generalFormGetValues.mockReset().mockReturnValue({ name: 'My App' });
     mockUseDeployments.mockReturnValue({
       schemas: [SCHEMA],
       items: [],
@@ -347,9 +349,6 @@ describe('AppsEditor', () => {
 
     it('times out and re-enables Save with an error when no response arrives', () => {
       vi.useFakeTimers();
-      /* No appId: skips the persist step entirely so the save is triggered
-       * synchronously within the click handler, keeping the fake-timer
-       * assertions below deterministic. */
       renderEditor('step=settings&schema=quickapps2-schema');
 
       const saveButton = screen.getByRole('button', {
@@ -397,8 +396,12 @@ describe('AppsEditor', () => {
     });
   });
 
-  describe('Save & Exit persist sequencing', () => {
-    it('triggers the Settings step save before persisting General fields for an existing app', async () => {
+  describe('Save & Exit forwards General values to the Settings step', () => {
+    it('includes the current General values in triggerSave for an existing app', async () => {
+      generalFormGetValues.mockReturnValue({
+        name: 'Renamed App',
+        description: 'desc',
+      });
       renderEditor('step=general&schema=quickapps2-schema&appId=existing-app');
 
       act(() => {
@@ -409,49 +412,13 @@ describe('AppsEditor', () => {
         screen.getByRole('button', { name: EditorI18nKeys.SaveButton }),
       );
 
-      expect(settingsStepTriggerSave).toHaveBeenCalledOnce();
-      expect(generalFormPersist).not.toHaveBeenCalled();
-
-      await act(async () => {
-        latestSettingsStepProps.onSaveSuccess?.();
-        await Promise.resolve();
+      expect(settingsStepTriggerSave).toHaveBeenCalledWith({
+        name: 'Renamed App',
+        description: 'desc',
       });
-
-      await waitFor(() => expect(generalFormPersist).toHaveBeenCalledOnce());
-      const triggerOrder = settingsStepTriggerSave.mock.invocationCallOrder[0];
-      const persistOrder = generalFormPersist.mock.invocationCallOrder[0];
-      expect(triggerOrder).toBeLessThan(persistOrder);
     });
 
-    it('surfaces an error and does not exit when persist fails after the Settings step save succeeds', async () => {
-      generalFormPersist.mockRejectedValue(new Error('network error'));
-      renderEditor('step=general&schema=quickapps2-schema&appId=existing-app');
-
-      act(() => {
-        latestGeneralFormProps?.onCreated('existing-app', 'My App', undefined);
-      });
-
-      await userEvent.click(
-        screen.getByRole('button', { name: EditorI18nKeys.SaveButton }),
-      );
-
-      await act(async () => {
-        latestSettingsStepProps.onSaveSuccess?.();
-        await Promise.resolve();
-      });
-
-      await waitFor(() =>
-        expect(
-          screen.getByText(AppsEditorI18nKeys.ErrorSaveFailed),
-        ).toBeTruthy(),
-      );
-      const saveButton = screen.getByRole('button', {
-        name: EditorI18nKeys.SaveButton,
-      }) as HTMLButtonElement;
-      expect(saveButton.disabled).toBe(false);
-    });
-
-    it('skips persist entirely for a brand-new app', async () => {
+    it('does not include a general payload when saving a brand-new app created in this session', async () => {
       renderEditor('step=general&schema=quickapps2-schema');
 
       act(() => {
@@ -462,12 +429,36 @@ describe('AppsEditor', () => {
         screen.getByRole('button', { name: EditorI18nKeys.SaveButton }),
       );
 
+      expect(settingsStepTriggerSave).toHaveBeenCalledWith(undefined);
+    });
+
+    it('does not include a general payload when triggering Preview', async () => {
+      renderEditor('step=settings&schema=quickapps2-schema&appId=existing-app');
+
+      await userEvent.click(
+        screen.getByRole('button', { name: BasicI18nKeys.Preview }),
+      );
+
+      expect(settingsStepTriggerSave).toHaveBeenCalledWith();
+    });
+
+    it('does not call update-application-style persistence on save success', async () => {
+      renderEditor('step=general&schema=quickapps2-schema&appId=existing-app');
+
+      act(() => {
+        latestGeneralFormProps?.onCreated('existing-app', 'My App', undefined);
+      });
+
+      await userEvent.click(
+        screen.getByRole('button', { name: EditorI18nKeys.SaveButton }),
+      );
+
       await act(async () => {
         latestSettingsStepProps.onSaveSuccess?.();
         await Promise.resolve();
       });
 
-      expect(generalFormPersist).not.toHaveBeenCalled();
+      await waitFor(() => expect(refetchDeployments).toHaveBeenCalledOnce());
     });
   });
 });

--- a/apps/chat/src/pages/AppsEditor/tests/AppsEditor.spec.tsx
+++ b/apps/chat/src/pages/AppsEditor/tests/AppsEditor.spec.tsx
@@ -15,10 +15,12 @@ import AppsEditor from '../AppsEditor';
 
 let latestSettingsStepProps: {
   onUpdated?: () => void;
-  onSaveSuccess?: () => void;
+  onSaveSuccess?: (hasChanges: boolean) => void;
   onSaveError?: (error: string) => void;
   onReadyChange?: (isReady: boolean) => void;
+  onLoggedOutChange?: (isLoggedOut: boolean) => void;
   isPreviewing?: boolean;
+  previewResetKey?: number;
 } = {};
 
 let latestGeneralFormProps: {
@@ -40,10 +42,12 @@ vi.mock('../SettingsStep', () => ({
   default: forwardRef(function MockSettingsStep(
     props: {
       onUpdated?: () => void;
-      onSaveSuccess?: () => void;
+      onSaveSuccess?: (hasChanges: boolean) => void;
       onSaveError?: (error: string) => void;
       onReadyChange?: (isReady: boolean) => void;
+      onLoggedOutChange?: (isLoggedOut: boolean) => void;
       isPreviewing?: boolean;
+      previewResetKey?: number;
     },
     ref,
   ) {
@@ -56,7 +60,10 @@ vi.mock('../SettingsStep', () => ({
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
     return (
-      <div data-previewing={props.isPreviewing ? 'true' : 'false'}>
+      <div
+        data-previewing={props.isPreviewing ? 'true' : 'false'}
+        data-preview-reset-key={props.previewResetKey ?? 0}
+      >
         settings-step
       </div>
     );
@@ -145,7 +152,7 @@ describe('AppsEditor', () => {
       screen.getByRole('button', { name: BasicI18nKeys.Preview }),
     );
     act(() => {
-      latestSettingsStepProps.onSaveSuccess?.();
+      latestSettingsStepProps.onSaveSuccess?.(false);
     });
 
     expect(refetchDeployments).toHaveBeenCalledOnce();
@@ -169,7 +176,7 @@ describe('AppsEditor', () => {
       screen.getByRole('button', { name: BasicI18nKeys.Preview }),
     );
     act(() => {
-      latestSettingsStepProps.onSaveSuccess?.();
+      latestSettingsStepProps.onSaveSuccess?.(false);
     });
 
     expect(refetchDeployments).toHaveBeenCalledOnce();
@@ -232,7 +239,7 @@ describe('AppsEditor', () => {
       screen.getByRole('button', { name: EditorI18nKeys.SaveButton }),
     );
     act(() => {
-      latestSettingsStepProps.onSaveSuccess?.();
+      latestSettingsStepProps.onSaveSuccess?.(false);
     });
 
     await waitFor(() => expect(refetchDeployments).toHaveBeenCalledOnce());
@@ -250,7 +257,7 @@ describe('AppsEditor', () => {
       screen.getByRole('button', { name: BasicI18nKeys.Preview }),
     );
     act(() => {
-      latestSettingsStepProps.onSaveSuccess?.();
+      latestSettingsStepProps.onSaveSuccess?.(false);
     });
 
     expect(refetchDeployments).toHaveBeenCalledOnce();
@@ -347,6 +354,44 @@ describe('AppsEditor', () => {
       ).toBeNull();
     });
 
+    it('does not surface the readiness-timeout error when a logged-out signal arrives first', () => {
+      vi.useFakeTimers();
+      shouldSettingsAutoReady = false;
+      renderEditor('step=settings&schema=quickapps2-schema&appId=abc');
+
+      act(() => {
+        latestSettingsStepProps.onLoggedOutChange?.(true);
+      });
+      act(() => {
+        vi.advanceTimersByTime(60000);
+      });
+
+      expect(
+        screen.queryByText(AppsEditorI18nKeys.ErrorSettingsNotReady),
+      ).toBeNull();
+    });
+
+    it('clears an already-surfaced readiness-timeout error once a logged-out signal arrives', () => {
+      vi.useFakeTimers();
+      shouldSettingsAutoReady = false;
+      renderEditor('step=settings&schema=quickapps2-schema&appId=abc');
+
+      act(() => {
+        vi.advanceTimersByTime(60000);
+      });
+      expect(
+        screen.getByText(AppsEditorI18nKeys.ErrorSettingsNotReady),
+      ).toBeTruthy();
+
+      act(() => {
+        latestSettingsStepProps.onLoggedOutChange?.(true);
+      });
+
+      expect(
+        screen.queryByText(AppsEditorI18nKeys.ErrorSettingsNotReady),
+      ).toBeNull();
+    });
+
     it('times out and re-enables Save with an error when no response arrives', () => {
       vi.useFakeTimers();
       renderEditor('step=settings&schema=quickapps2-schema');
@@ -382,7 +427,7 @@ describe('AppsEditor', () => {
         saveButton.click();
       });
       await act(async () => {
-        latestSettingsStepProps.onSaveSuccess?.();
+        latestSettingsStepProps.onSaveSuccess?.(false);
         await Promise.resolve();
       });
 
@@ -454,11 +499,54 @@ describe('AppsEditor', () => {
       );
 
       await act(async () => {
-        latestSettingsStepProps.onSaveSuccess?.();
+        latestSettingsStepProps.onSaveSuccess?.(false);
         await Promise.resolve();
       });
 
       await waitFor(() => expect(refetchDeployments).toHaveBeenCalledOnce());
+    });
+  });
+
+  describe('Preview session reset on configuration change', () => {
+    it('bumps the preview reset key when a save reports hasChanges: true', async () => {
+      renderEditor('step=settings&schema=quickapps2-schema&appId=abc');
+      const keyBefore = Number(
+        screen.getByText('settings-step').dataset.previewResetKey,
+      );
+
+      await userEvent.click(
+        screen.getByRole('button', { name: BasicI18nKeys.Preview }),
+      );
+      await act(async () => {
+        latestSettingsStepProps.onSaveSuccess?.(true);
+        await Promise.resolve();
+      });
+
+      await waitFor(() =>
+        expect(
+          Number(screen.getByText('settings-step').dataset.previewResetKey),
+        ).toBe(keyBefore + 1),
+      );
+    });
+
+    it('does not bump the preview reset key when a save reports hasChanges: false', async () => {
+      renderEditor('step=settings&schema=quickapps2-schema&appId=abc');
+      const keyBefore = Number(
+        screen.getByText('settings-step').dataset.previewResetKey,
+      );
+
+      await userEvent.click(
+        screen.getByRole('button', { name: BasicI18nKeys.Preview }),
+      );
+      await act(async () => {
+        latestSettingsStepProps.onSaveSuccess?.(false);
+        await Promise.resolve();
+      });
+
+      await waitFor(() => expect(refetchDeployments).toHaveBeenCalledOnce());
+      expect(
+        Number(screen.getByText('settings-step').dataset.previewResetKey),
+      ).toBe(keyBefore);
     });
   });
 });

--- a/apps/chat/src/pages/AppsEditor/tests/GeneralForm.spec.tsx
+++ b/apps/chat/src/pages/AppsEditor/tests/GeneralForm.spec.tsx
@@ -7,16 +7,12 @@ import {
   AppsEditorI18nKeys,
   EditorI18nKeys,
 } from '../../../constants/translation-keys';
-import {
-  createApplication,
-  updateApplication,
-} from '../../../server-api/applications';
+import { createApplication } from '../../../server-api/applications';
 import type { GeneralFormHandle } from '../GeneralForm';
 import GeneralForm from '../GeneralForm';
 
 vi.mock('../../../server-api/applications', () => ({
   createApplication: vi.fn(),
-  updateApplication: vi.fn(),
 }));
 
 vi.mock('@epam/ai-dial-kit', () => ({
@@ -276,7 +272,6 @@ describe('GeneralForm', () => {
         undefined,
       ),
     );
-    expect(updateApplication).not.toHaveBeenCalled();
     expect(createApplication).not.toHaveBeenCalled();
   });
 
@@ -308,7 +303,6 @@ describe('GeneralForm', () => {
       await ref.current?.submit();
     });
 
-    expect(updateApplication).not.toHaveBeenCalled();
     expect(onCreated).toHaveBeenCalledWith(
       'users/u/apps/existing',
       'Renamed App',
@@ -317,8 +311,8 @@ describe('GeneralForm', () => {
     expect(createApplication).not.toHaveBeenCalled();
   });
 
-  describe('persist', () => {
-    it('does not call updateApplication when no field changed from the seeded initial values', async () => {
+  describe('getValues', () => {
+    it('returns the seeded initial values normalized, with no version field', () => {
       const ref = createRef<GeneralFormHandle>();
 
       renderForm(
@@ -329,29 +323,28 @@ describe('GeneralForm', () => {
         ref,
       );
 
-      await act(async () => {
-        await ref.current?.persist();
+      expect(ref.current?.getValues()).toEqual({
+        name: 'My App',
+        description: undefined,
+        iconUrl: undefined,
+        topics: ['a', 'b'],
+        intro: undefined,
       });
-
-      expect(updateApplication).not.toHaveBeenCalled();
     });
 
-    it('calls updateApplication with the current values when a field changed from the seeded initial values', async () => {
+    it('returns the current trimmed values after edits, excluding version', async () => {
       const ref = createRef<GeneralFormHandle>();
-      vi.mocked(updateApplication).mockResolvedValue({
-        id: 'users/u/apps/existing',
-      });
 
       renderForm(
         {
           appId: 'users/u/apps/existing',
-          initialValues: { name: 'My App' },
+          initialValues: { name: 'My App', version: '1.0.0' },
         },
         ref,
       );
 
       await user.clear(getNameInput());
-      await user.type(getNameInput(), 'Renamed App');
+      await user.type(getNameInput(), '  Renamed App  ');
       await user.type(
         screen.getByLabelText(EditorI18nKeys.DescriptionLabel),
         'New description',
@@ -361,42 +354,13 @@ describe('GeneralForm', () => {
         'New intro',
       );
 
-      await act(async () => {
-        await ref.current?.persist();
-      });
-
-      expect(updateApplication).toHaveBeenCalledWith('users/u/apps/existing', {
+      expect(ref.current?.getValues()).toEqual({
         name: 'Renamed App',
         description: 'New description',
         iconUrl: undefined,
         topics: undefined,
         intro: 'New intro',
       });
-    });
-
-    it('rejects and does not swallow the error when updateApplication fails', async () => {
-      const ref = createRef<GeneralFormHandle>();
-      vi.mocked(updateApplication).mockRejectedValue(
-        new Error('network error'),
-      );
-
-      renderForm(
-        {
-          appId: 'users/u/apps/existing',
-          initialValues: { name: 'My App' },
-        },
-        ref,
-      );
-
-      await user.clear(getNameInput());
-      await user.type(getNameInput(), 'Renamed App');
-
-      await expect(
-        act(async () => {
-          await ref.current?.persist();
-        }),
-      ).rejects.toThrow('network error');
-      expect(screen.queryByRole('alert')).toBeNull();
     });
   });
 

--- a/apps/chat/src/pages/AppsEditor/tests/SettingsStep.spec.tsx
+++ b/apps/chat/src/pages/AppsEditor/tests/SettingsStep.spec.tsx
@@ -1,13 +1,18 @@
 import { render, screen } from '@testing-library/react';
-import { forwardRef } from 'react';
+import type { Ref } from 'react';
+import { createRef, forwardRef, useImperativeHandle } from 'react';
 import { describe, expect, it, vi } from 'vitest';
+import type { SettingsStepHandle } from '../SettingsStep';
 import SettingsStep from '../SettingsStep';
+
+const mockTriggerSave = vi.fn();
 
 vi.mock('../AppEditorIframe', () => ({
   default: forwardRef(function MockAppEditorIframe(
     _props: unknown,
-    _ref: unknown,
+    ref: Ref<{ triggerSave: typeof mockTriggerSave }>,
   ) {
+    useImperativeHandle(ref, () => ({ triggerSave: mockTriggerSave }));
     return <div>iframe-content</div>;
   }),
 }));
@@ -64,5 +69,14 @@ describe('SettingsStep', () => {
     render(<SettingsStep schema={SCHEMA} appId="" isPreviewing={false} />);
 
     expect(screen.queryByText(/preview-chat-/)).toBeNull();
+  });
+
+  it('forwards the general payload from triggerSave to the embedded iframe', () => {
+    const ref = createRef<SettingsStepHandle>();
+    render(<SettingsStep schema={SCHEMA} appId="abc" ref={ref} />);
+
+    ref.current?.triggerSave({ name: 'My App' });
+
+    expect(mockTriggerSave).toHaveBeenCalledWith({ name: 'My App' });
   });
 });

--- a/apps/chat/src/pages/AppsEditor/tests/SettingsStep.spec.tsx
+++ b/apps/chat/src/pages/AppsEditor/tests/SettingsStep.spec.tsx
@@ -1,11 +1,18 @@
 import { render, screen } from '@testing-library/react';
 import type { Ref } from 'react';
-import { createRef, forwardRef, useImperativeHandle } from 'react';
-import { describe, expect, it, vi } from 'vitest';
+import {
+  createRef,
+  forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+} from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { SettingsStepHandle } from '../SettingsStep';
 import SettingsStep from '../SettingsStep';
 
 const mockTriggerSave = vi.fn();
+let previewChatMountCount = 0;
 
 vi.mock('../AppEditorIframe', () => ({
   default: forwardRef(function MockAppEditorIframe(
@@ -18,7 +25,19 @@ vi.mock('../AppEditorIframe', () => ({
 }));
 
 vi.mock('../AppPreviewChat', () => ({
-  default: ({ appId }: { appId: string }) => <div>preview-chat-{appId}</div>,
+  default: ({ appId }: { appId: string }) => {
+    /* Each mount increments the shared counter once, letting tests detect a
+     * remount (as opposed to a re-render of the same instance) triggered by
+     * the `key={previewResetKey}` this component is given in SettingsStep. */
+    const hasCountedRef = useRef(false);
+    useEffect(() => {
+      if (!hasCountedRef.current) {
+        hasCountedRef.current = true;
+        previewChatMountCount += 1;
+      }
+    }, []);
+    return <div>preview-chat-{appId}</div>;
+  },
 }));
 
 const SCHEMA = {
@@ -28,6 +47,10 @@ const SCHEMA = {
 };
 
 describe('SettingsStep', () => {
+  beforeEach(() => {
+    previewChatMountCount = 0;
+  });
+
   it('keeps both the iframe and the preview pane mounted regardless of isPreviewing', () => {
     const { rerender } = render(
       <SettingsStep schema={SCHEMA} appId="abc" isPreviewing={false} />,
@@ -78,5 +101,18 @@ describe('SettingsStep', () => {
     ref.current?.triggerSave({ name: 'My App' });
 
     expect(mockTriggerSave).toHaveBeenCalledWith({ name: 'My App' });
+  });
+
+  it('remounts the preview pane when previewResetKey changes', () => {
+    const { rerender } = render(
+      <SettingsStep schema={SCHEMA} appId="abc" previewResetKey={0} />,
+    );
+    expect(previewChatMountCount).toBe(1);
+
+    rerender(<SettingsStep schema={SCHEMA} appId="abc" previewResetKey={0} />);
+    expect(previewChatMountCount).toBe(1);
+
+    rerender(<SettingsStep schema={SCHEMA} appId="abc" previewResetKey={1} />);
+    expect(previewChatMountCount).toBe(2);
   });
 });

--- a/apps/chat/src/types/apps-editor.ts
+++ b/apps/chat/src/types/apps-editor.ts
@@ -67,3 +67,23 @@ export interface ToolsetLogoutResultPayload {
   reason?: string;
   credentials?: RefreshedToolsetCredentials;
 }
+
+/**
+ * Current General-step values carried on a `TriggerSave` message so the embedded
+ * QuickApps editor can merge them into the single save it already performs, instead of
+ * the host persisting them separately. Deliberately excludes `version` — Settings-step
+ * save must not alter the application's version.
+ */
+export interface TriggerSaveGeneralPayload {
+  name: string;
+  description?: string;
+  iconUrl?: string;
+  topics?: string[];
+  intro?: string;
+}
+
+/** Payload of a `TriggerSave` message posted to the embedded QuickApps iframe. */
+export interface TriggerSaveMessage {
+  type: AppsEditorEvent.TriggerSave;
+  general?: TriggerSaveGeneralPayload;
+}

--- a/apps/chat/src/types/apps-editor.ts
+++ b/apps/chat/src/types/apps-editor.ts
@@ -18,6 +18,15 @@ export enum AppsEditorEvent {
   /** Sent once the embedded QuickApps iframe's UI has rendered. Controls only the loading-spinner overlay — it does NOT indicate the iframe's data model is loaded/safe to save; see `ReadyToSave`. */
   ReadyToInteract = 'readyToInteract',
   /**
+   * Sent by the embedded QuickApps iframe once its session has resolved and
+   * the user is not authenticated (or the session errored). In this case the
+   * iframe never becomes safe to save (`ReadyToSave` will not arrive), so the
+   * host treats this as an expected non-ready state rather than a failure —
+   * see the "Settings step readiness gates Save and Preview" requirement in
+   * the `quick-app-authoring` spec.
+   */
+  LoggedOut = 'loggedOut',
+  /**
    * Sent by the embedded QuickApps iframe once its own internal application
    * model has finished loading and validating, and it is safe for the host
    * to send `TriggerSave`. Distinct from `ReadyToInteract` (UI rendered) —
@@ -86,4 +95,16 @@ export interface TriggerSaveGeneralPayload {
 export interface TriggerSaveMessage {
   type: AppsEditorEvent.TriggerSave;
   general?: TriggerSaveGeneralPayload;
+}
+
+/**
+ * Payload of a `SaveSuccess` message posted by the embedded QuickApps iframe once a
+ * `TriggerSave` completes successfully. `hasChanges` reflects whether any user-editable
+ * field (Settings-step configuration or a forwarded `general` field) actually changed as
+ * part of that save, excluding server-managed metadata such as `updatedAt`. Absent on
+ * embedded editors that predate this contract — treat as `false` in that case.
+ */
+export interface SaveSuccessMessage {
+  type: AppsEditorEvent.SaveSuccess;
+  hasChanges?: boolean;
 }

--- a/openspec/changes/archive/2026-07-23-quickapps-save-general-fields-via-iframe/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-23-quickapps-save-general-fields-via-iframe/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-22

--- a/openspec/changes/archive/2026-07-23-quickapps-save-general-fields-via-iframe/design.md
+++ b/openspec/changes/archive/2026-07-23-quickapps-save-general-fields-via-iframe/design.md
@@ -1,0 +1,195 @@
+## Context
+
+`AppsEditor.tsx` currently persists an existing Quick App's General-step fields
+(name/description/iconUrl/topics/intro — never `version`, see below) in two independent
+writes on Save & Exit:
+
+1. The embedded QuickApps Settings-step iframe saves the whole application document
+   itself, from its own in-memory copy of General fields (populated whenever it last
+   loaded the app — which may predate edits the user just made in the host's General
+   step).
+2. Once the iframe reports `SaveSuccess`, the host calls `update-application` with the
+   current General-step form values, relying on the backend's GET-then-merge PATCH
+   semantics to land on top of write (1) rather than being clobbered by it.
+
+This is two writes to one document ordered only by client-side sequencing (`await
+generalFormRef.current?.persist()` after `SaveSuccess`), an extra request per Save & Exit,
+and inherently racy if anything else touches the document between the two writes. The fix
+is to give QuickApps the current General values *before* it does its one save, via the
+`TriggerSave` message it already receives, so there is exactly one write.
+
+`version` is deliberately excluded from today's `update-application` call (per the
+existing `quick-app-authoring` requirement: "The update SHALL NOT alter that
+application's ... `version`") and stays excluded from the new payload for the same
+reason — Settings-step save must not silently change the app's version.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Collapse Save & Exit for an existing app into a single write performed by the embedded
+  QuickApps editor.
+- Remove the host's own `update-application` call and its GET-then-merge dependency for
+  this flow.
+- Preserve existing guarantees: General edits are only persisted on final Save & Exit
+  (not on `Next`, not on Preview), and `version`/settings-step configuration are
+  untouched by this path.
+
+**Non-Goals:**
+
+- Changing General-step field validation behavior (`Next`'s
+  `validateDeploymentCreationFields` call is unchanged; this change does not add
+  revalidation before Save & Exit for fields edited after `Next` was last clicked — that
+  gap, if any, is pre-existing and out of scope).
+- Changing the General-step persistence path for brand-new apps created in this session
+  (`createApplication` on `Next` already writes the initial General values; this change
+  does not alter when/whether *later* edits to General after creation get persisted for
+  a session-created app — this is unchanged pre-existing behavior gated by
+  `hasExistingAppOnMountRef`).
+- Any change to the embedded QuickApps app's own code — this repo only changes the
+  message contract it receives.
+
+## Decisions
+
+### 1. `TriggerSave` payload shape
+
+Add to `apps/chat/src/types/apps-editor.ts`:
+
+```ts
+export interface TriggerSaveGeneralPayload {
+  name: string;
+  description?: string;
+  iconUrl?: string;
+  topics?: string[];
+  intro?: string;
+}
+
+export interface TriggerSaveMessage {
+  type: AppsEditorEvent.TriggerSave;
+  general?: TriggerSaveGeneralPayload;
+}
+```
+
+`general` is optional and omitted entirely for: the General step's own `Next` action
+(doesn't touch Settings), Preview triggers, and any Save & Exit where the app didn't
+already exist when the editor session started (`hasExistingAppOnMountRef.current ===
+false`) — mirrors exactly the existing gating condition for when
+`generalFormRef.current?.persist()` used to run. `version` is intentionally never
+included, matching the current `update-application` call and the requirement that
+Settings-step save must not alter version.
+
+**Alternative considered:** always include `general` regardless of gating and let the
+dirty-check happen upstream. Rejected — it would change *when* General values reach the
+embedded editor for the brand-new-app-in-session case, which is explicitly out of scope
+(Non-Goals), and would widen the blast radius of this change beyond fixing the
+double-write.
+
+### 2. No more dirty-check gating on whether to send
+
+Today, `GeneralForm.handlePersist` compares current values against
+`seededValuesRef.current` and skips the `update-application` call entirely when nothing
+changed — because an unnecessary PATCH was extra cost worth avoiding. Under the new
+model there is no second write to skip: the values are merged into the one write
+QuickApps already performs, so sending unchanged values costs nothing extra. The
+dirty-check is removed rather than ported to the new payload path.
+
+**Alternative considered:** keep the dirty-check and only set `general` when values
+differ from the seeded ones. Rejected as unnecessary complexity — no cost being avoided,
+and it would require exposing seeded-value comparison across the ref boundary for no
+behavioral benefit.
+
+### 3. `GeneralFormHandle` gains a values accessor, loses `persist`
+
+```ts
+export interface GeneralFormHandle {
+  submit: () => Promise<void>;
+  /** Current in-memory General-step values, normalized the same way `persist` used to
+   * trim them before sending to `update-application`. */
+  getValues: () => TriggerSaveGeneralPayload;
+}
+```
+
+`handlePersist` and the `updateApplication` import/call in `GeneralForm.tsx` are removed.
+`getValues` is a synchronous read of component state — no network call, no async.
+
+**Alternative considered:** lift General-step form values into `AppsEditor` state (via
+`onChange` callback) instead of a ref-based pull. Rejected — `GeneralForm` already owns
+this state privately and pulling it up would mean `AppsEditor` re-rendering on every
+keystroke in the General step; a synchronous ref accessor read only at
+trigger-save-time avoids that and keeps `GeneralForm`'s state private, consistent with
+how `submit` already works.
+
+### 4. Threading the payload through `triggerSave()`
+
+`AppEditorIframe.triggerSave()`, `SettingsStepHandle.triggerSave()`, and
+`AppsEditor.handleSave`/`handlePreview` all gain a `general?: TriggerSaveGeneralPayload`
+parameter, passed through unchanged to the `postMessage` call:
+
+```ts
+iframeRef.current?.contentWindow?.postMessage(
+  { type: AppsEditorEvent.TriggerSave, general } satisfies TriggerSaveMessage,
+  new URL(schema.editorUrl).origin,
+);
+```
+
+`handleSave` computes the payload right before calling `triggerSave`:
+
+```ts
+const general =
+  pendingAction === 'save' && hasExistingAppOnMountRef.current
+    ? generalFormRef.current?.getValues()
+    : undefined;
+settingsStepRef.current?.triggerSave(general);
+```
+
+`handlePreview` always passes `undefined` (Preview never persists General, same as
+today).
+
+### 5. `handleSaveSuccess` simplification
+
+Remove the `completeSave` async wrapper's `generalFormRef.current?.persist()` branch and
+its try/catch (the only reason `completeSave` needed to be async/catchable). What
+remains — `refetchDeployments()`, clearing `isSaving`, navigating or entering preview —
+has no reason to fail in a way that needs its own error branch beyond what already
+exists, so `handleSaveSuccess` no longer needs its own dedicated error path for this
+step; `refetchDeployments().catch(() => undefined)` already swallows that failure as
+before.
+
+## Risks / Trade-offs
+
+- **[Cross-repo contract change]** The embedded QuickApps editor (external to this repo)
+  must start reading `general` off the `TRIGGER_SAVE` message and merging it into its own
+  save, or General edits will silently stop being persisted on Save & Exit. → Mitigation:
+  this is called out as a coordination dependency in the proposal; land it in lockstep
+  with (or gated until) the QuickApps-side change ships, and keep `general` optional so
+  an old QuickApps build that ignores the field fails safe (General edits just don't
+  persist, no crash) rather than failing hard.
+- **[Silent behavior change if QuickApps ignores the field]** Because `general` is
+  optional and additive to an existing message type, there's no way for the host to
+  detect whether the embedded editor actually consumed it. → Mitigation: out of scope to
+  add an acknowledgment protocol here; existing `SaveSuccess`/`SaveError` still confirms
+  the overall save happened, which is the same confirmation granularity as today.
+- **[Pre-existing validation gap carried forward]** A user can switch to the General tab,
+  edit the name to something that fails `validateDeploymentCreationFields`, switch back
+  to Settings without clicking `Next`, and hit Save & Exit — today that invalid value
+  reaches `update-application` unvalidated; after this change it reaches the iframe
+  payload unvalidated. Same risk, not introduced by this change. → Not mitigated here;
+  flagged as an Open Question below.
+
+## Migration Plan
+
+No data migration. This is a client-side message-contract change:
+
+1. Land the `TriggerSaveGeneralPayload`/`TriggerSaveMessage` type and the
+   `AppsEditor`/`AppEditorIframe`/`SettingsStep`/`GeneralForm` changes together (single
+   PR, per repo convention — this isn't a phased rollout of independently-shippable
+   pieces).
+2. Update/confirm the QuickApps editor's `TRIGGER_SAVE` handler consumes `general`
+   (tracked as an external coordination dependency, not a task in this change).
+3. Rollback is a plain revert — no persisted state format changes.
+
+## Open Questions
+
+- Should Save & Exit revalidate General-step fields (name pattern, intro length) before
+  including them in the `TriggerSave` payload, closing the pre-existing validation gap
+  noted above? Left as a follow-up; not addressed by this change.

--- a/openspec/changes/archive/2026-07-23-quickapps-save-general-fields-via-iframe/proposal.md
+++ b/openspec/changes/archive/2026-07-23-quickapps-save-general-fields-via-iframe/proposal.md
@@ -1,0 +1,67 @@
+## Why
+
+Save & Exit currently does two separate writes to the same application document: the
+embedded QuickApps Settings iframe saves the whole app itself (including its own
+in-memory, potentially stale copy of the General-step fields), and then, once that
+`SaveSuccess` arrives, the host separately PATCHes the General-step fields
+(name/description/iconUrl/topics/intro) via `update-application`. This depends on a
+GET-then-merge on the backend to avoid the second write clobbering the first, is racy
+by construction (two independent writes to one document, ordered only by client-side
+sequencing), and does an extra network round trip on every Save & Exit of an existing
+app. The two writes should collapse into the one write QuickApps already performs.
+
+## What Changes
+
+- The host stops calling `update-application` from `handleSaveSuccess` after the
+  Settings-step iframe reports success. The GET-then-merge-after-save comment/logic in
+  `apps/chat/src/pages/AppsEditor/AppsEditor.tsx` is removed.
+- **BREAKING** (internal protocol only): `AppsEditorEvent.TriggerSave` gains a payload
+  carrying the current General-step form values (name, description, iconUrl, version,
+  topics, intro), defined in `apps/chat/src/types/apps-editor.ts`. The embedded QuickApps
+  app is expected to merge these values into the app document it saves, instead of
+  relying on its own in-memory copy from whenever it last loaded the app.
+- `AppEditorIframe`'s `triggerSave()` handle accepts the General-step values and includes
+  them in the `postMessage` payload sent to the iframe.
+- `SettingsStep`'s `triggerSave()` handle forwards the same payload through to
+  `AppEditorIframe`.
+- `AppsEditor.tsx` sources the current General-step values to pass at trigger time.
+  `GeneralForm` exposes a way to read its current in-memory values (in addition to
+  `submit`/`persist`) so `AppsEditor` doesn't duplicate that state.
+- Save & Exit for an existing app becomes a single write (Settings-step save with General
+  values embedded) instead of a Settings-step save followed by a conditional
+  update-application call.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `quick-app-authoring`: the "Editing General step fields persists the changes on Save &
+  Exit" requirement changes from "host issues its own `update-application` PATCH after
+  Settings-step `SaveSuccess`" to "host includes current General-step values in the
+  `TriggerSave` payload sent to the embedded editor, which persists them as part of its
+  own single save." The dirty-check (skip when General is unchanged from its seeded
+  values) and the "does not alter settings-step configuration/version" guarantee are
+  preserved.
+
+## Impact
+
+- `apps/chat/src/pages/AppsEditor/AppsEditor.tsx` — remove post-`SaveSuccess`
+  `generalFormRef.current?.persist()` call and related dirty-check trigger point; read
+  current General values and pass them into `triggerSave()`.
+- `apps/chat/src/pages/AppsEditor/GeneralForm.tsx` — add a values accessor to
+  `GeneralFormHandle` (or otherwise expose current values); dirty-check logic may move to
+  the caller or stay internal depending on design.
+- `apps/chat/src/pages/AppsEditor/SettingsStep.tsx` — `triggerSave()` signature gains a
+  parameter.
+- `apps/chat/src/pages/AppsEditor/AppEditorIframe.tsx` — `triggerSave()` signature gains a
+  parameter; `TriggerSave` postMessage payload gains fields.
+- `apps/chat/src/types/apps-editor.ts` — define the `TriggerSave` payload shape.
+- Any embedded QuickApps editor contract/documentation describing the `TRIGGER_SAVE`
+  message shape (external to this repo) needs updating to consume the new payload fields
+  — out of scope for this repo's change but called out as a coordination dependency.
+- Existing tests in `apps/chat/src/pages/AppsEditor/tests/` covering `TriggerSave`,
+  `handleSaveSuccess`, and General-step persistence need updating.

--- a/openspec/changes/archive/2026-07-23-quickapps-save-general-fields-via-iframe/specs/quick-app-authoring/spec.md
+++ b/openspec/changes/archive/2026-07-23-quickapps-save-general-fields-via-iframe/specs/quick-app-authoring/spec.md
@@ -1,0 +1,58 @@
+## MODIFIED Requirements
+
+### Requirement: Editing General step fields persists the changes on Save & Exit
+
+Clicking "Next" on the General step of an existing app (an `appId` is already known) SHALL
+only validate the fields and advance to the Settings step — it SHALL NOT call any
+persistence API. The edited General step values SHALL be held in memory across the step
+transition. Persistence of General step edits SHALL happen only when the user performs the
+final "Save & Exit" action from the Settings step. At that point, if this editor session
+started against an app that already existed (as opposed to one created fresh in this
+session), the editor SHALL include the current General-step values — name, description,
+icon URL, and topics, and `intro` — as a `general` payload on the `TriggerSave` message
+posted to the embedded Settings-step editor, so the embedded editor persists them as part
+of the single save it already performs for the Settings step. The host SHALL NOT make a
+separate `update-application` (or any other) request to persist these values. The
+`general` payload SHALL NOT include `version`. Triggering a Preview action SHALL NOT
+include a `general` payload. The `TriggerSave` message's `general` payload SHALL NOT alter
+that application's settings-step configuration (`application_properties`, including
+orchestrator/tool set state) or its `version`. "Save & Exit" SHALL always additionally
+trigger the Settings step's own save (regardless of whether the Settings step step was
+itself touched), matching prior behavior for that step.
+
+#### Scenario: Next does not persist General edits
+- **WHEN** a user edits General step fields for an existing app and clicks "Next"
+- **THEN** no update-application (or create-application) request is sent, and the editor
+  advances to the Settings step with the edited values retained in memory
+
+#### Scenario: Save & Exit forwards edited General fields to the embedded editor
+- **WHEN** a user edits Topic, Description, Intro, Icon, or Name on the General step of an
+  existing Quick App, clicks Next, and then clicks Save & Exit on the Settings step
+- **THEN** the `TriggerSave` message posted to the embedded Settings-step editor includes
+  a `general` payload carrying the edited field values, and no `update-application`
+  request is made by the host
+
+#### Scenario: Save & Exit still forwards General fields when General is unchanged
+- **WHEN** a user does not edit any General step field for an existing app, clicks Next,
+  and then clicks Save & Exit on the Settings step without changing Settings either
+- **THEN** the `TriggerSave` message still includes a `general` payload carrying the
+  (unchanged) current values, no `update-application` request is made, and the Settings
+  step save is still triggered as it was before this behavior existed
+
+#### Scenario: Preview does not forward General fields
+- **WHEN** a user triggers Preview from the Settings step
+- **THEN** the `TriggerSave` message posted to the embedded editor has no `general`
+  payload
+
+#### Scenario: Save & Exit does not forward General fields for a session-created app
+- **WHEN** a user creates a new app in this editor session, advances to the Settings
+  step, and clicks Save & Exit
+- **THEN** the `TriggerSave` message posted to the embedded editor has no `general`
+  payload, matching the pre-existing behavior for apps created within the current
+  session
+
+#### Scenario: Save does not affect Settings-step configuration or version
+- **WHEN** the General step's edits are forwarded as part of Save & Exit for an existing
+  app that already has orchestrator or tool set configuration, or a `version`, from the
+  Settings step
+- **THEN** that configuration and version are unchanged after the save completes

--- a/openspec/changes/archive/2026-07-23-quickapps-save-general-fields-via-iframe/tasks.md
+++ b/openspec/changes/archive/2026-07-23-quickapps-save-general-fields-via-iframe/tasks.md
@@ -1,0 +1,73 @@
+## 1. Message contract
+
+- [x] 1.1 In `apps/chat/src/types/apps-editor.ts`, add `TriggerSaveGeneralPayload`
+      (`name: string`, `description?: string`, `iconUrl?: string`, `topics?: string[]`,
+      `intro?: string` — no `version`) and `TriggerSaveMessage` (`{ type:
+      AppsEditorEvent.TriggerSave; general?: TriggerSaveGeneralPayload }`).
+
+## 2. GeneralForm
+
+- [x] 2.1 In `apps/chat/src/pages/AppsEditor/GeneralForm.tsx`, add `getValues: () =>
+      TriggerSaveGeneralPayload` to `GeneralFormHandle`, returning the current trimmed
+      `values` normalized the same way `handlePersist` used to (trimmed name/description/
+      iconUrl/intro, `topics` as-is, omitting `version`).
+- [x] 2.2 Remove `handlePersist`, the `persist` entry from `GeneralFormHandle`, the
+      `updateApplication` import, and `seededValuesRef`'s dirty-check usage (keep
+      `seededValuesRef`/`hasSeededInitialValuesRef` only if still needed for seeding —
+      check whether anything else in the file still reads them before removing).
+- [x] 2.3 Update `apps/chat/src/pages/AppsEditor/tests/GeneralForm.spec.tsx`: remove
+      `persist`/dirty-check test cases, add coverage for `getValues()` returning current
+      trimmed form state.
+
+## 3. AppEditorIframe
+
+- [x] 3.1 In `apps/chat/src/pages/AppsEditor/AppEditorIframe.tsx`, change
+      `AppEditorIframeHandle.triggerSave` to `(general?: TriggerSaveGeneralPayload) =>
+      void` and update the `postMessage` call to send `{ type:
+      AppsEditorEvent.TriggerSave, general } satisfies TriggerSaveMessage`.
+- [x] 3.2 Update `apps/chat/src/pages/AppsEditor/tests/AppEditorIframe.spec.tsx` to assert
+      the posted message includes the passed `general` payload (and omits it when not
+      passed).
+
+## 4. SettingsStep
+
+- [x] 4.1 In `apps/chat/src/pages/AppsEditor/SettingsStep.tsx`, change
+      `SettingsStepHandle.triggerSave` to `(general?: TriggerSaveGeneralPayload) => void`
+      and forward the argument to `iframeRef.current?.triggerSave(general)`.
+- [x] 4.2 Update `apps/chat/src/pages/AppsEditor/tests/SettingsStep.spec.tsx` to assert
+      the argument is forwarded to the iframe handle.
+
+## 5. AppsEditor
+
+- [x] 5.1 In `apps/chat/src/pages/AppsEditor/AppsEditor.tsx`, update `handleSave` to
+      compute `general` (via `generalFormRef.current?.getValues()`) only when
+      `hasExistingAppOnMountRef.current` is true, and pass it to
+      `settingsStepRef.current?.triggerSave(general)`.
+- [x] 5.2 Update `handlePreview` to call `settingsStepRef.current?.triggerSave()` with no
+      `general` argument (Preview never persists General edits).
+- [x] 5.3 Simplify `handleSaveSuccess`: remove the `completeSave` async wrapper's
+      `generalFormRef.current?.persist()` call and its try/catch branch (the
+      `ErrorSaveFailed` catch tied specifically to that persist call); keep
+      `refetchDeployments()` + navigate/preview-mode logic, using
+      `refetchDeployments().catch(() => undefined)` as the sole failure handling for what
+      remains.
+- [x] 5.4 Remove `pendingSaveAction`/`hasExistingAppOnMountRef` usage that only existed to
+      gate the removed persist call, if any becomes dead after 5.1–5.3 — otherwise leave
+      as-is (both are still needed for the `general` gating and preview/save
+      distinction).
+
+## 6. Tests and verification
+
+- [x] 6.1 Update `apps/chat/src/pages/AppsEditor/tests/AppsEditor.spec.tsx`: replace
+      assertions on a post-`SaveSuccess` `update-application` call with assertions that
+      `triggerSave` (mocked `SettingsStepHandle`) is called with the expected `general`
+      payload for Save & Exit on an existing app, with `undefined`/no `general` for
+      Preview and for a session-created app.
+- [x] 6.2 Run `npm exec nx test chat` and fix any failures.
+- [x] 6.3 Run `npm exec nx lint chat` and fix any failures.
+- [x] 6.4 Manually verify in the running app (per CLAUDE.md UI-change guidance): edit
+      General fields on an existing Quick App, Save & Exit, and confirm the edited
+      values persist after reload — this depends on the embedded QuickApps editor
+      already consuming the new `general` payload (external coordination dependency
+      noted in design.md); if it doesn't yet, note that as a follow-up rather than
+      blocking this change's own tests.

--- a/openspec/specs/app-preview-chat/spec.md
+++ b/openspec/specs/app-preview-chat/spec.md
@@ -154,6 +154,51 @@ Selecting a starter with submit enabled SHALL create or append to the preview co
 - **WHEN** the user selects a preview starter whose normalized `submit` flag is true
 - **THEN** the preview conversation is created or appended using the starter text and the fixed application deployment id
 
+### Requirement: Preview session resets when the saved configuration actually changed
+
+A Settings-step save (triggered either by "Save & Exit" or by "Preview") completes with a
+`SaveSuccess` postMessage from the embedded Quick Apps editor. That message MAY carry a
+`hasChanges: boolean` field — see the `quick-app-authoring` spec's "SaveSuccess reports
+whether persisted data changed" requirement for what the embedded editor SHALL compute and
+send. `AppsEditor` SHALL treat `hasChanges` as `false` when the field is absent (an embedded
+editor build that predates this contract), preserving prior behavior until the embedded
+editor is updated.
+
+Whenever a `SaveSuccess` arrives with `hasChanges === true`, `AppsEditor` SHALL discard the
+current preview session before the next time the preview pane is shown: any preview
+conversation already created SHALL be deleted (the same best-effort, non-blocking deletion
+used when leaving the editor), and the in-memory preview state (conversation, messages, and
+any populated-but-unsent composer input) SHALL be reset so the preview pane renders its
+initial composer-only welcome state, reflecting the just-saved configuration, the next time
+it becomes visible. This reset happens at save time regardless of whether the preview pane is
+currently visible, since a Settings-step edit can only be made while the iframe (not the
+preview pane) is showing.
+
+When `hasChanges` is `false` (or absent), the existing preview conversation and its
+accumulated messages SHALL be left exactly as they are — this is the same "history survives
+toggling" behavior already required above, now scoped explicitly to saves that made no
+persisted change.
+
+#### Scenario: Preview starts fresh after a real configuration change
+- **WHEN** the user has an existing preview conversation, exits preview, changes a Settings
+  step or General step field, and the resulting save's `SaveSuccess` reports
+  `hasChanges: true`
+- **THEN** the previous preview conversation is deleted
+- **AND** the next time the preview pane is shown it renders the composer-only welcome state
+  (empty history, empty input) reflecting the latest configuration, not the prior
+  conversation
+
+#### Scenario: Preview retains history when nothing meaningful changed
+- **WHEN** the user has an existing preview conversation, exits preview, and saves again
+  (e.g. via Save & Exit staying on the page, or clicking Preview without editing anything)
+  with `SaveSuccess` reporting `hasChanges: false`
+- **THEN** the preview conversation and its messages are unchanged, matching the existing
+  "History survives toggling" scenario
+
+#### Scenario: Missing `hasChanges` field preserves prior behavior
+- **WHEN** the embedded Quick Apps editor posts `SaveSuccess` without a `hasChanges` field
+- **THEN** `AppsEditor` treats it as `false` and does not reset the preview session
+
 ### Requirement: Preview conversation is deleted when the editor is left
 The preview conversation, if one was created during the session, SHALL be deleted when the Apps editor Settings step (and therefore the component owning the preview conversation) unmounts — including when the user clicks Cancel, when a normal Save succeeds and navigates away, or when the user otherwise navigates away from `/apps-editor`. Deletion failures SHALL be logged and SHALL NOT block or surface an error during navigation.
 

--- a/openspec/specs/quick-app-authoring/spec.md
+++ b/openspec/specs/quick-app-authoring/spec.md
@@ -99,6 +99,57 @@ itself touched), matching prior behavior for that step.
   Settings step
 - **THEN** that configuration and version are unchanged after the save completes
 
+### Requirement: SaveSuccess reports whether persisted data changed
+
+The Settings step's embedded editor (the separate Quick Apps application loaded at
+`schema.editorUrl`, out of this repo's source tree) SHALL include a `hasChanges: boolean`
+field on the `AppsEditorEvent.SaveSuccess` message it posts back to the host after a
+`TriggerSave` completes successfully — for both a plain Settings-step save and one that also
+carried a `general` payload. `hasChanges` SHALL be computed by the embedded editor by
+comparing the record it is about to persist against the record as it existed before this
+save, and SHALL be `true` if any field the user can edit changed — Settings-step
+configuration (`application_properties`, including orchestrator/tool set state,
+conversation starters, chat-input-disabled state, etc.) or any forwarded `general` field
+(name, description, icon URL, topics, intro). It SHALL be `false` when none of those fields
+changed, even though the save still updates server-managed metadata such as `updatedAt`. A
+save that persists no user-editable field change but still touches only metadata (e.g. a
+no-op re-save) SHALL report `hasChanges: false`.
+
+This field is part of the cross-repo `postMessage` contract between this host
+(`apps/chat/src/pages/AppsEditor`) and the embedded Quick Apps editor; it requires a
+corresponding change in the Quick Apps editor's own save-completion code, not only in this
+repo. Until the embedded editor sends it, the host SHALL treat a `SaveSuccess` without the
+field as `hasChanges: false` (see the `app-preview-chat` spec's "Preview session resets when
+the saved configuration actually changed" requirement for how the host uses this value).
+
+On this repo's side, `apps/chat/src/types/apps-editor.ts` SHALL declare a
+`SaveSuccessMessage` interface (`{ type: AppsEditorEvent.SaveSuccess; hasChanges?: boolean }`)
+and `AppEditorIframe`'s message handler SHALL forward the received `hasChanges` value (or
+`undefined`) to its `onSaveSuccess` prop, which SHALL be widened from `() => void` to
+`(hasChanges: boolean) => void` (normalizing a missing/non-boolean field to `false` before
+calling it), threading it through `SettingsStep` to `AppsEditor`.
+
+#### Scenario: Settings-only change is reported
+- **WHEN** the user changes orchestrator/tool set configuration in the Settings step and
+  triggers a save
+- **THEN** the embedded editor's `SaveSuccess` message includes `hasChanges: true`
+
+#### Scenario: General-only change is reported
+- **WHEN** the user only edits a General step field (forwarded via the `general` payload) and
+  no Settings-step configuration changed, then triggers Save & Exit
+- **THEN** the embedded editor's `SaveSuccess` message includes `hasChanges: true`
+
+#### Scenario: No user-editable field changed
+- **WHEN** the user triggers a save (e.g. via Preview) without having changed any
+  Settings-step configuration or General field since the last save
+- **THEN** the embedded editor's `SaveSuccess` message includes `hasChanges: false`, even
+  though the persisted record's `updatedAt` still advances
+
+#### Scenario: Host forwards the flag to `onSaveSuccess`
+- **WHEN** `AppEditorIframe` receives a `SaveSuccess` message with `hasChanges: true`
+- **THEN** it calls `onSaveSuccess(true)` (not the no-argument call used before this
+  requirement)
+
 ### Requirement: Settings step readiness gates Save and Preview
 
 The Settings step's embedded editor runs in an iframe and communicates over
@@ -111,6 +162,26 @@ indefinitely with no recovery short of reloading the page. As a defense in depth
 any other case where no response arrives, a save or preview action that does not
 receive a response within a bounded timeout SHALL time out, reset the loading state, and
 surface an error, rather than leaving the buttons stuck disabled forever.
+
+The embedded editor MAY instead post a `LoggedOut` message once its session has resolved
+and the user is not authenticated (or the session errored). In that case `ReadyToInteract`
+was already sent (so the loading spinner clears) but `ReadyToSave` will never arrive, since
+the embedded editor cannot load its data model without an authenticated session. This is an
+expected state, not a readiness failure, so the host SHALL NOT surface the generic
+"Settings not ready" timeout error while, or after, a `LoggedOut` message has been received
+for the current Settings-step session — including suppressing an instance of that error
+already shown before `LoggedOut` arrived. The "Save & Exit" and "Preview" buttons SHALL
+remain disabled in this state, since `ReadyToSave` still gates them and will not arrive.
+
+#### Scenario: A logged-out signal suppresses the readiness-timeout error
+- **WHEN** the Settings step's iframe posts `LoggedOut` before the readiness timeout elapses
+- **THEN** the timeout does not surface the "Settings not ready" error once it elapses, and
+  the "Save & Exit" and "Preview" buttons remain disabled
+
+#### Scenario: A logged-out signal clears an already-surfaced readiness-timeout error
+- **WHEN** the readiness timeout has already surfaced the "Settings not ready" error and the
+  Settings step's iframe then posts `LoggedOut`
+- **THEN** the "Settings not ready" error is cleared
 
 #### Scenario: Save & Exit is disabled before the Settings step is ready
 - **WHEN** the Settings step's iframe has not yet sent `ReadyToInteract`

--- a/openspec/specs/quick-app-authoring/spec.md
+++ b/openspec/specs/quick-app-authoring/spec.md
@@ -48,39 +48,56 @@ Clicking "Next" on the General step of an existing app (an `appId` is already kn
 only validate the fields and advance to the Settings step — it SHALL NOT call any
 persistence API. The edited General step values SHALL be held in memory across the step
 transition. Persistence of General step edits SHALL happen only when the user performs the
-final "Save & Exit" action from the Settings step. At that point, if the General step
-values differ from the values the form was initially seeded with, the editor SHALL submit
-the current form values — name, description, icon URL, topics, and `intro` — to the
-dedicated update-application endpoint via the generated `@epam/chat-api-client`
-`ApplicationsApi`, through the `apps/chat/src/server-api/applications.ts` wrapper. If the
-General step values are unchanged from their initial values, the update-application
-endpoint SHALL NOT be called. The update SHALL NOT alter that application's settings-step
-configuration (`application_properties`, including orchestrator/tool set state) or its
-`version`. "Save & Exit" SHALL always additionally trigger the Settings step's own save
-(regardless of whether the Settings step step was itself touched), matching prior
-behavior for that step.
+final "Save & Exit" action from the Settings step. At that point, if this editor session
+started against an app that already existed (as opposed to one created fresh in this
+session), the editor SHALL include the current General-step values — name, description,
+icon URL, and topics, and `intro` — as a `general` payload on the `TriggerSave` message
+posted to the embedded Settings-step editor, so the embedded editor persists them as part
+of the single save it already performs for the Settings step. The host SHALL NOT make a
+separate `update-application` (or any other) request to persist these values. The
+`general` payload SHALL NOT include `version`. Triggering a Preview action SHALL NOT
+include a `general` payload. The `TriggerSave` message's `general` payload SHALL NOT alter
+that application's settings-step configuration (`application_properties`, including
+orchestrator/tool set state) or its `version`. "Save & Exit" SHALL always additionally
+trigger the Settings step's own save (regardless of whether the Settings step step was
+itself touched), matching prior behavior for that step.
 
 #### Scenario: Next does not persist General edits
 - **WHEN** a user edits General step fields for an existing app and clicks "Next"
 - **THEN** no update-application (or create-application) request is sent, and the editor
   advances to the Settings step with the edited values retained in memory
 
-#### Scenario: Save & Exit persists edited General fields for an existing app
+#### Scenario: Save & Exit forwards edited General fields to the embedded editor
 - **WHEN** a user edits Topic, Description, Intro, Icon, or Name on the General step of an
   existing Quick App, clicks Next, and then clicks Save & Exit on the Settings step
-- **THEN** the edited field values are submitted to the update-application endpoint for
-  that app as part of the Save & Exit action, and reopening the app shows the edited values
+- **THEN** the `TriggerSave` message posted to the embedded Settings-step editor includes
+  a `general` payload carrying the edited field values, and no `update-application`
+  request is made by the host
 
-#### Scenario: Save & Exit skips the update call when General is unchanged
+#### Scenario: Save & Exit still forwards General fields when General is unchanged
 - **WHEN** a user does not edit any General step field for an existing app, clicks Next,
   and then clicks Save & Exit on the Settings step without changing Settings either
-- **THEN** the update-application endpoint is not called, and the Settings step save is
-  still triggered as it was before this behavior existed
+- **THEN** the `TriggerSave` message still includes a `general` payload carrying the
+  (unchanged) current values, no `update-application` request is made, and the Settings
+  step save is still triggered as it was before this behavior existed
 
-#### Scenario: Save does not affect Settings-step configuration
-- **WHEN** the General step's edits are persisted as part of Save & Exit for an existing app
-  that already has orchestrator or tool set configuration from the Settings step
-- **THEN** that configuration is unchanged after the General-step update completes
+#### Scenario: Preview does not forward General fields
+- **WHEN** a user triggers Preview from the Settings step
+- **THEN** the `TriggerSave` message posted to the embedded editor has no `general`
+  payload
+
+#### Scenario: Save & Exit does not forward General fields for a session-created app
+- **WHEN** a user creates a new app in this editor session, advances to the Settings
+  step, and clicks Save & Exit
+- **THEN** the `TriggerSave` message posted to the embedded editor has no `general`
+  payload, matching the pre-existing behavior for apps created within the current
+  session
+
+#### Scenario: Save does not affect Settings-step configuration or version
+- **WHEN** the General step's edits are forwarded as part of Save & Exit for an existing
+  app that already has orchestrator or tool set configuration, or a `version`, from the
+  Settings step
+- **THEN** that configuration and version are unchanged after the save completes
 
 ### Requirement: Settings step readiness gates Save and Preview
 


### PR DESCRIPTION
## Description of changes

Fix - reset preview conversation if there were changes. Also small fix for logged out behavoir - it shouldn't show 'Ready to Save' error

## Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #7996 

## UI changes

<Please, provide Screenshots or Figma links>

## Checklist

- [X] the pull request name ends with `(Issue #<ISSUE_ID>)` (comma-separated list of issues)
- [X] I confirm that I don't share any confidential information like API keys or any other secrets and private URLs

<details>
  <summary>PR title cheatsheet</summary>

`<type>[optional scope]: <description>`

1. type (required)
    - `feat` - A new feature
    - `fix` - A bug fix
    - `docs` - Documentation only changes
    - `test` - Adding missing tests or correcting existing tests
    - `ci` - Changes to our CI configuration files and scripts
    - `chore` - Other changes that are minor and/or not user-facing
2. scope (optional, current repo suggestions below)
    - `chat`
    - `overlay`
    - `shared`
    - `sandbox-overlay`
    - `visualizer-connector`

</details>
