### PR TITLE
fix: Fix how sources in the sidebar are shown, Issue #6904 

### DIFF
--- a/apps/chat/src/hooks/conversation-sources/useConversationSources.ts
+++ b/apps/chat/src/hooks/conversation-sources/useConversationSources.ts
@@ -4,6 +4,7 @@ import type { QuotationSource } from '@epam/ai-dial-source-panel';
 import { useMemo } from 'react';
 import { resolveMessageAnnotations } from '../../utils/annotation';
 import { attachmentDtosToDisplayAttachments } from '../../utils/attachment-dto-to-display';
+import { isReferenceOnlyAttachment } from '../../utils/reference-attachment';
 
 /**
  * Derives uploaded (user), generated (assistant) attachment lists, and quotation sources
@@ -23,13 +24,27 @@ export const useConversationSources = (
     const seenUrls = new Set<string>();
 
     for (const msg of messages) {
-      const attachments = attachmentDtosToDisplayAttachments(
-        msg.custom_content?.attachments,
-      );
+      const dtos = msg.custom_content?.attachments;
       if (msg.role === MessageRole.User) {
-        uploaded.push(...attachments);
+        uploaded.push(...attachmentDtosToDisplayAttachments(dtos));
       } else if (msg.role === MessageRole.Assistant) {
-        generated.push(...attachments);
+        const regularDtos = dtos?.filter(
+          (dto) => !isReferenceOnlyAttachment(dto),
+        );
+        generated.push(...attachmentDtosToDisplayAttachments(regularDtos));
+
+        for (const dto of dtos ?? []) {
+          if (!isReferenceOnlyAttachment(dto)) continue;
+          const url = dto.reference_url as string;
+          if (seenUrls.has(url)) continue;
+          seenUrls.add(url);
+          sources.push({
+            url,
+            title: dto.title ?? url,
+            contentType: dto.reference_type ?? dto.type ?? '',
+            quote: dto.data,
+          });
+        }
 
         for (const annotation of resolveMessageAnnotations(msg)) {
           const att = annotation?.body?.source?.attachment;

--- a/apps/chat/src/pages/AppsEditor/tests/AppEditorIframe.spec.tsx
+++ b/apps/chat/src/pages/AppsEditor/tests/AppEditorIframe.spec.tsx
@@ -319,7 +319,10 @@ describe('AppEditorIframe — ready-to-save readiness', () => {
   it('re-gates logged-out to false when the iframe reloads for a different app', () => {
     const onLoggedOutChange = vi.fn();
     const { rerender } = render(
-      <AppEditorIframe {...DEFAULT_PROPS} onLoggedOutChange={onLoggedOutChange} />,
+      <AppEditorIframe
+        {...DEFAULT_PROPS}
+        onLoggedOutChange={onLoggedOutChange}
+      />,
     );
 
     fireEvent(

--- a/libs/source-panel/src/components/SourcesSection/SourcesSection.tsx
+++ b/libs/source-panel/src/components/SourcesSection/SourcesSection.tsx
@@ -1,6 +1,7 @@
 import {
   buildCssVars,
   Highlight,
+  MarkdownRenderer,
   mergeClasses,
 } from '@epam/ai-dial-chat-shared';
 import {
@@ -117,15 +118,15 @@ const SourcesSection: FC<SourcesSectionProps> = ({
               />
             </div>
             {source.quote && (
-              <p
+              <div
                 className={mergeClasses(
                   quoteClassName,
                   styles.quote,
-                  'line-clamp-5 max-h-[80px] overflow-hidden',
+                  'line-clamp-5 [&>div>*+*]:mt-1',
                 )}
               >
-                {source.quote}
-              </p>
+                <MarkdownRenderer content={source.quote} />
+              </div>
             )}
           </li>
         ))}

--- a/openspec/specs/conversation-sources-sidebar/spec.md
+++ b/openspec/specs/conversation-sources-sidebar/spec.md
@@ -244,20 +244,30 @@ For both states:
 `apps/chat/src/hooks/conversation-sources/useConversationSources.ts` SHALL export `useConversationSources(messages: Message[])` returning `{ uploaded: DisplayAttachment[]; generated: DisplayAttachment[]; sources: QuotationSource[] }`. The hook SHALL:
 
 - Walk `messages` once in a single loop.
-- Partition attachments by `MessageRole.User` (`uploaded`) vs `MessageRole.Assistant` (`generated`) using `attachmentDtosToDisplayAttachments` from `apps/chat/src/utils/attachment-dto-to-display.ts`.
-- For assistant messages, also walk `msg.custom_content?.annotations ?? []`. For each annotation where `annotation?.body?.source?.attachment?.url` is present, append a `QuotationSource` to `sources`:
-  - `url` — `annotation.body.source.attachment.url`
-  - `title` — `annotation.body.title ?? url`
-  - `quote` — `annotation.body.quote` (optional)
-- Deduplicate `sources` by `url` (first occurrence wins); skip subsequent annotations with the same URL.
+- For user messages: push all attachments into `uploaded` via `attachmentDtosToDisplayAttachments`.
+- For assistant messages:
+  - Split `msg.custom_content?.attachments` into **reference-only** dtos (`isReferenceOnlyAttachment` from `apps/chat/src/utils/reference-attachment.ts` returns `true`) and **regular** dtos (all others).
+  - Push only the regular dtos into `generated` via `attachmentDtosToDisplayAttachments`.
+  - For each reference-only dto, if `dto.reference_url` has not been seen before, append a `QuotationSource` to `sources`:
+    - `url` — `dto.reference_url`
+    - `title` — `dto.title ?? dto.reference_url`
+    - `contentType` — `dto.reference_type ?? dto.type ?? ''`
+    - `quote` — `dto.data` (optional)
+  - Also walk `msg.custom_content?.annotations ?? []`. For each annotation where `annotation?.body?.source?.attachment?.url` is present and not already seen, append a `QuotationSource` to `sources`:
+    - `url` — `annotation.body.source.attachment.url`
+    - `title` — `annotation.body.title ?? url`
+    - `contentType` — `annotation.body.source.attachment.type ?? ''`
+    - `quote` — `annotation.body.quote` (optional)
+- Deduplicate `sources` by `url` across both reference-only attachments and annotations (first occurrence wins), using a shared `seenUrls` set.
 - Tolerate `null`/`undefined` annotation items without throwing.
 - Return the three lists wrapped in `useMemo`, keyed on the `messages` reference.
 
-`QuotationSource` is defined in `apps/chat/src/models/quotation-source.ts` as:
+`QuotationSource` is defined in `libs/source-panel/src/models/quotation-source.ts` as:
 ```ts
 interface QuotationSource {
   url: string;
   title: string;
+  contentType: string;
   quote?: string;
 }
 ```
@@ -273,15 +283,21 @@ interface QuotationSource {
 - **THEN** all derived attachments appear in `uploaded` in message order
 - **AND** `generated` and `sources` are empty
 
-#### Scenario: Only assistant attachments
+#### Scenario: Only assistant attachments without reference_url
 
-- **WHEN** every message in the input has `role: MessageRole.Assistant` and one attachment each
+- **WHEN** every message in the input has `role: MessageRole.Assistant` and one regular (url-bearing) attachment each
 - **THEN** all derived attachments appear in `generated` in message order
-- **AND** `uploaded` is empty
+- **AND** `uploaded` and `sources` are empty
+
+#### Scenario: Reference-only attachment goes to sources, not generated
+
+- **WHEN** an assistant message has one attachment with `reference_url` set and no `url`
+- **THEN** `generated` receives no entry from that attachment
+- **AND** `sources` contains one `QuotationSource` with `url = dto.reference_url`, `title = dto.title`, `contentType = dto.reference_type ?? dto.type ?? ''`, and `quote = dto.data`
 
 #### Scenario: Mixed roles
 
-- **WHEN** a user message with one attachment is followed by an assistant message with two attachments
+- **WHEN** a user message with one attachment is followed by an assistant message with two regular attachments
 - **THEN** `uploaded` has one entry from the user message and `generated` has two entries from the assistant message
 
 #### Scenario: Message without custom_content
@@ -294,10 +310,10 @@ interface QuotationSource {
 - **WHEN** an assistant message has `custom_content.annotations` containing two annotations each with `body.source.attachment.url`
 - **THEN** both appear in `sources` in annotation order
 
-#### Scenario: Duplicate source URLs are deduplicated
+#### Scenario: Duplicate source URLs are deduplicated across reference attachments and annotations
 
-- **WHEN** two annotations reference the same `url`
-- **THEN** `sources` contains only the first occurrence
+- **WHEN** a reference-only attachment and a subsequent annotation both reference the same `url`
+- **THEN** `sources` contains only the first occurrence (the reference attachment)
 
 #### Scenario: Annotations without a source URL are skipped
 
@@ -328,9 +344,9 @@ For `SourcesSection`:
 - When `sources.length === 0`: return `null` (no title or empty message rendered).
 - When `sources.length > 0`: render a `<ul>` where each `<li>` contains two rows:
   - **Row 1** (flex, `items-center`, `justify-between`): an `<a href={source.url} target="_blank" rel="noopener noreferrer">` showing `source.title` with `truncate`; and a `DialGhostIconButton` with `IconCopy` that calls `navigator.clipboard.writeText(source.url)` on click, `aria-label={copyLabel}`.
-  - **Row 2** (only when `source.quote` is present): a `<p>` with `line-clamp-5` and `max-h-[80px] overflow-hidden` rendering `source.quote`.
+  - **Row 2** (only when `source.quote` is present): a `<div>` with `quoteClassName` (typography), `styles.quote` (color token), `line-clamp-5`, and `[&>div>*+*]:mt-1` (spacing between block elements), containing a `MarkdownRenderer` rendering `source.quote`. The `[&>div>*+*]:mt-1` selector targets the block-level children of `MarkdownRenderer`'s root `<div>` to add consistent vertical spacing between headings, paragraphs, and lists.
 
-`SourcesSection` is located at `apps/chat/src/components/ConversationSourcesPanel/sections/SourcesSection/SourcesSection.tsx`.
+`SourcesSection` is located at `libs/source-panel/src/components/SourcesSection/SourcesSection.tsx`.
 
 #### Scenario: Uploaded Files section with attachments
 
@@ -367,10 +383,10 @@ For `SourcesSection`:
 - **WHEN** a `QuotationSource` has no `quote` field
 - **THEN** no second row is rendered for that item
 
-#### Scenario: Quote row is clamped to five lines
+#### Scenario: Quote is rendered as markdown and clamped to five lines
 
 - **WHEN** a `QuotationSource` has a `quote` value
-- **THEN** the quote paragraph has `line-clamp-5` and `max-h-[80px]` applied
+- **THEN** the quote is rendered via `MarkdownRenderer` inside a wrapper div that has `line-clamp-5` applied, so markdown formatting is visible and the block is clamped at five lines with spacing between block elements
 
 #### Scenario: Read-only attachment cards without handler
 


### PR DESCRIPTION
## Description of changes

The quotations were shown as MD files instead as sources

## Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #6904 

## UI changes

<img width="1919" height="1011" alt="image" src="https://github.com/user-attachments/assets/db9f13bb-f6a2-45cc-952f-3c224bdf2603" />


## Checklist

- [X] the pull request name ends with `(Issue #<ISSUE_ID>)` (comma-separated list of issues)
- [X] I confirm that I don't share any confidential information like API keys or any other secrets and private URLs

<details>
  <summary>PR title cheatsheet</summary>

`<type>[optional scope]: <description>`

1. type (required)
    - `feat` - A new feature
    - `fix` - A bug fix
    - `docs` - Documentation only changes
    - `test` - Adding missing tests or correcting existing tests
    - `ci` - Changes to our CI configuration files and scripts
    - `chore` - Other changes that are minor and/or not user-facing
2. scope (optional, current repo suggestions below)
    - `chat`
    - `overlay`
    - `shared`
    - `sandbox-overlay`
    - `visualizer-connector`

</details>
