### PR TITLE
fix(chat): fix starters description positioning on wide screens (Issue #7994)

### DIFF
--- a/apps/chat/src/components/Chat/Chat.tsx
+++ b/apps/chat/src/components/Chat/Chat.tsx
@@ -930,14 +930,18 @@ const ChatView = memo(({ isPreview, customViewer }: ChatViewProps) => {
                       />
                     ) : (
                       <>
-                        {shouldShowIntroText && (
-                          <IntroText
-                            isWideLayout={isWideLayout}
-                            modelId={selectedConversations[0].model.id}
-                          />
-                        )}
+                        {!isWideLayout && (
+                          <>
+                            {shouldShowIntroText && (
+                              <IntroText
+                                isWideLayout={isWideLayout}
+                                modelId={selectedConversations[0].model.id}
+                              />
+                            )}
 
-                        {!isWideLayout && <ChatStarters />}
+                            <ChatStarters />
+                          </>
+                        )}
 
                         {!isPlayback && (
                           <ChatInput
@@ -977,7 +981,18 @@ const ChatView = memo(({ isPreview, customViewer }: ChatViewProps) => {
                           />
                         )}
 
-                        {isWideLayout && <ChatStarters />}
+                        {isWideLayout && (
+                          <div className="flex flex-col gap-4">
+                            {shouldShowIntroText && (
+                              <IntroText
+                                isWideLayout={isWideLayout}
+                                modelId={selectedConversations[0].model.id}
+                              />
+                            )}
+
+                            <ChatStarters />
+                          </div>
+                        )}
                       </>
                     )}
                   </div>


### PR DESCRIPTION
## Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #7994 

## Checklist

- [x] the pull request name ends with `(Issue #<ISSUE_ID>)` (comma-separated list of issues)
- [x] I confirm that I don't share any confidential information like API keys or any other secrets and private URLs
