### PR TITLE
fix(chat): fix attach link edit disable (#1301)

### DIFF
--- a/apps/chat/src/components/Chat/ChatMessage/ChatMessageContent/UserMessage.tsx
+++ b/apps/chat/src/components/Chat/ChatMessage/ChatMessageContent/UserMessage.tsx
@@ -223,6 +223,11 @@ export const UserMessage = memo(function UserMessage({
     return mappedUserEditableAttachments.map(({ id }) => id);
   }, [mappedUserEditableAttachments]);
 
+  const mappedUserDialLinks = useMemo(
+    () => getDialLinksFromAttachments(message.custom_content?.attachments),
+    [message.custom_content?.attachments],
+  );
+
   const [newEditableAttachmentsIds, setNewEditableAttachmentsIds] = useState<
     string[]
   >(mappedUserEditableAttachmentsIds);
@@ -284,10 +289,17 @@ export const UserMessage = memo(function UserMessage({
     [newEditableAttachments],
   );
 
+  const isDialLinksChanged = useMemo(
+    () => !isEqual(mappedUserDialLinks, selectedDialLinks),
+    [mappedUserDialLinks, selectedDialLinks],
+  );
+
   const isContentEmptyAndNoAttachments = useMemo(
     () =>
-      messageContent.trim().length <= 0 && newEditableAttachments.length <= 0,
-    [messageContent, newEditableAttachments],
+      messageContent.trim().length <= 0 &&
+      newEditableAttachments.length <= 0 &&
+      !isDialLinksChanged,
+    [messageContent, newEditableAttachments, isDialLinksChanged],
   );
 
   const selectedFileIds = useMemo(
@@ -780,6 +792,11 @@ export const UserMessage = memo(function UserMessage({
               onClick={() => {
                 setMessageContent(message.content);
                 setNewEditableAttachmentsIds(mappedUserEditableAttachmentsIds);
+                setSelectedDialLinks(
+                  getDialLinksFromAttachments(
+                    message.custom_content?.attachments,
+                  ),
+                );
                 if (isRecording) {
                   stopRecording();
                 }


### PR DESCRIPTION
## Description of changes

[Attach link] While editing user-message: Cancel doesn't remove added link. Save& Submit stays disabled if to add new link

## Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #1301

## Checklist

- [x] the pull request name ends with `(Issue #<ISSUE_ID>)` (comma-separated list of issues)
- [x] I confirm that I don't share any confidential information like API keys or any other secrets and private URLs

<details>
  <summary>PR title cheatsheet</summary>

`<type>[optional scope]: <description>`

1. type (required)
    - `feat` - A new feature
    - `fix` - A bug fix
    - `docs` - Documentation only changes
    - `test` - Adding missing tests or correcting existing tests
    - `ci` - Changes to our CI configuration files and scripts
    - `chore` - Other changes that are minor and/or not user-facing
2. scope (optional, current repo suggestions below)
    - `chat`
    - `overlay`
    - `shared`
    - `sandbox-overlay`
    - `visualizer-connector`

</details>
