### PR TITLE
fix: Fix unexpected errors, Issue #8057

### DIFF
--- a/apps/chat/src/hooks/conversation-sources/useConversationSources.ts
+++ b/apps/chat/src/hooks/conversation-sources/useConversationSources.ts
@@ -22,16 +22,26 @@ export const useConversationSources = (
     const generated: DisplayAttachment[] = [];
     const sources: QuotationSource[] = [];
     const seenUrls = new Set<string>();
+    const seenUploadedIds = new Set<string | undefined>();
+    const seenGeneratedIds = new Set<string | undefined>();
 
     for (const msg of messages) {
       const dtos = msg.custom_content?.attachments;
       if (msg.role === MessageRole.User) {
-        uploaded.push(...attachmentDtosToDisplayAttachments(dtos));
+        for (const att of attachmentDtosToDisplayAttachments(dtos)) {
+          if (seenUploadedIds.has(att.id)) continue;
+          seenUploadedIds.add(att.id);
+          uploaded.push(att);
+        }
       } else if (msg.role === MessageRole.Assistant) {
         const regularDtos = dtos?.filter(
           (dto) => !isReferenceOnlyAttachment(dto),
         );
-        generated.push(...attachmentDtosToDisplayAttachments(regularDtos));
+        for (const att of attachmentDtosToDisplayAttachments(regularDtos)) {
+          if (seenGeneratedIds.has(att.id)) continue;
+          seenGeneratedIds.add(att.id);
+          generated.push(att);
+        }
 
         for (const dto of dtos ?? []) {
           if (!isReferenceOnlyAttachment(dto)) continue;

--- a/libs/attachment-canvas/src/components/AttachmentCanvas/AttachmentCanvas.tsx
+++ b/libs/attachment-canvas/src/components/AttachmentCanvas/AttachmentCanvas.tsx
@@ -159,6 +159,15 @@ const AttachmentCanvasBase: FC<AttachmentCanvasProps> = ({
       COPY_RESET_MS,
     );
   }, [onCopyJson]);
+
+  useEffect(() => {
+    return () => {
+      if (copyTextResetRef.current != null) clearTimeout(copyTextResetRef.current);
+      if (copyResetRef.current != null) clearTimeout(copyResetRef.current);
+      if (copyJsonResetRef.current != null) clearTimeout(copyJsonResetRef.current);
+    };
+  }, []);
+
   const {
     colors,
     typography,

--- a/libs/attachment-canvas/src/components/PdfContent/PdfContent.tsx
+++ b/libs/attachment-canvas/src/components/PdfContent/PdfContent.tsx
@@ -16,12 +16,22 @@ import {
 import { fetchBlobFromUrl } from '../../utils/download';
 import styles from './PdfContent.module.scss';
 
+const THUMBNAIL_OVERSCAN = 5;
+/* Conservative fallback used until the first item is measured. Overestimates
+ * to avoid rendering too many items before the real height is known. */
+const THUMBNAIL_HEIGHT_FALLBACK = 200;
+
 /** Props for the `PdfContent` component. */
 export interface PdfContentProps {
+  /** URL of the PDF file to display. */
   url: string;
+  /** Highlight annotations to overlay on the document. */
   highlights: InputHighlightData[];
+  /** ID of the highlight that should be scrolled into view on mount. */
   selectedHighlightId?: string;
+  /** Custom fetcher for the PDF blob; falls back to a plain `fetch` wrapper. */
   loadPdf?: (url: string) => Promise<Blob>;
+  /** File name shown in the canvas header. */
   fileName?: string;
 }
 
@@ -40,8 +50,20 @@ export const PdfContent: FC<PdfContentProps> = ({
     const match = highlights.find((h) => h.id === selectedHighlightId);
     return match?.bboxes[0]?.page ?? 1;
   });
+
   const viewerApiRef = useRef<PdfViewerApi | null>(null);
   const thumbnailNodeRefs = useRef<Map<number, HTMLDivElement>>(new Map());
+  const thumbnailObserverRef = useRef<IntersectionObserver | null>(null);
+  const [requestedThumbnailPages, setRequestedThumbnailPages] = useState<
+    number[]
+  >([]);
+
+  /* Virtual sidebar state — avoid mounting 200+ PageThumbnail instances at once. */
+  const sidebarRef = useRef<HTMLDivElement>(null);
+  const itemHeightRef = useRef(THUMBNAIL_HEIGHT_FALLBACK);
+  const [itemHeight, setItemHeight] = useState(THUMBNAIL_HEIGHT_FALLBACK);
+  const [scrollTop, setScrollTop] = useState(0);
+  const [sidebarHeight, setSidebarHeight] = useState(600);
 
   useEffect(() => {
     if (!selectedHighlightId) return;
@@ -50,16 +72,92 @@ export const PdfContent: FC<PdfContentProps> = ({
     if (page != null) setSelectedPage(page);
   }, [selectedHighlightId, highlights]);
 
+  /* Scroll to the selected page thumbnail. When it is outside the virtual
+   * window and not yet mounted, scroll the container to its approximate
+   * position — the element will mount on the next render and become visible. */
   useEffect(() => {
-    thumbnailNodeRefs.current.get(selectedPage)?.scrollIntoView({
-      block: 'center',
-      behavior: 'smooth',
-    });
+    const el = thumbnailNodeRefs.current.get(selectedPage);
+    if (el) {
+      el.scrollIntoView({ block: 'center', behavior: 'smooth' });
+    } else if (sidebarRef.current) {
+      sidebarRef.current.scrollTo({
+        top: (selectedPage - 1) * itemHeightRef.current,
+        behavior: 'smooth',
+      });
+    }
   }, [selectedPage, totalPages]);
 
-  const thumbnailPageNumbers = useMemo(
+  const allPageNumbers = useMemo(
     () => (isMobile ? [] : Array.from({ length: totalPages }, (_, i) => i + 1)),
     [isMobile, totalPages],
+  );
+
+  /*
+   * Request thumbnail renders only for pages visible (or within 300 px of)
+   * the sidebar viewport. Passing all page numbers at once causes the library
+   * to queue every render upfront; when the canvas closes mid-queue the PDF.js
+   * instance is already destroyed before later batches start, producing
+   * "No PDF document loaded" errors.
+   */
+  useEffect(() => {
+    setRequestedThumbnailPages([]);
+
+    if (allPageNumbers.length === 0) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const newPages = entries
+          .filter((e) => e.isIntersecting)
+          .map((e) => Number((e.target as HTMLElement).dataset.page))
+          .filter((n) => n > 0);
+        if (newPages.length === 0) return;
+        setRequestedThumbnailPages((prev) => {
+          const seen = new Set(prev);
+          const toAdd = newPages.filter((p) => !seen.has(p));
+          return toAdd.length === 0 ? prev : [...prev, ...toAdd];
+        });
+      },
+      { rootMargin: '300px 0px' },
+    );
+
+    thumbnailObserverRef.current = observer;
+    thumbnailNodeRefs.current.forEach((el) => observer.observe(el));
+
+    return () => {
+      observer.disconnect();
+      thumbnailObserverRef.current = null;
+    };
+  }, [allPageNumbers]);
+
+  /* Track sidebar scroll position and height for virtual windowing. */
+  useEffect(() => {
+    const el = sidebarRef.current;
+    if (!el) return;
+
+    setSidebarHeight(el.clientHeight);
+
+    const ro = new ResizeObserver(() => setSidebarHeight(el.clientHeight));
+    ro.observe(el);
+
+    const handleScroll = () => setScrollTop(el.scrollTop);
+    el.addEventListener('scroll', handleScroll, { passive: true });
+
+    return () => {
+      ro.disconnect();
+      el.removeEventListener('scroll', handleScroll);
+    };
+  }, [totalPages]);
+
+  /*
+   * Pass only pages whose thumbnail has not yet been rendered. The library's
+   * effect restarts from page 1 whenever `thumbnailPageNumbers` changes — if
+   * we pass the full accumulated list, every scroll event re-renders every
+   * previously-loaded thumbnail. Filtering to pending pages means the library
+   * only ever renders new work.
+   */
+  const pendingThumbnailPages = useMemo(
+    () => requestedThumbnailPages.filter((p) => !thumbnails.has(p)),
+    [requestedThumbnailPages, thumbnails],
   );
 
   const handleThumbnailsLoaded = useCallback((map: Map<number, string>) => {
@@ -75,27 +173,70 @@ export const PdfContent: FC<PdfContentProps> = ({
     viewerApiRef.current?.navigateToPage(pageNum);
   }, []);
 
+  /* Virtual window: only mount PageThumbnail components near the visible area.
+   * Padding spacers preserve total scroll height so the scrollbar stays accurate. */
+  const startIdx = Math.max(
+    0,
+    Math.floor(scrollTop / itemHeight) - THUMBNAIL_OVERSCAN,
+  );
+  const endIdx = Math.min(
+    allPageNumbers.length - 1,
+    Math.ceil((scrollTop + sidebarHeight) / itemHeight) +
+      THUMBNAIL_OVERSCAN -
+      1,
+  );
+  const paddingTop = startIdx * itemHeight;
+  const paddingBottom = Math.max(
+    0,
+    (allPageNumbers.length - 1 - endIdx) * itemHeight,
+  );
+
+  if (!url) return null;
+
   return (
     <div className="flex h-full overflow-hidden">
       {totalPages > 0 && (
-        <div className="w-30 me-1 shrink-0 overflow-auto pe-0.5 mobile:hidden">
-          {thumbnailPageNumbers.map((pageNum) => (
-            <div
-              key={pageNum}
-              ref={(el) => {
-                if (el) thumbnailNodeRefs.current.set(pageNum, el);
-                else thumbnailNodeRefs.current.delete(pageNum);
-              }}
-            >
-              <PageThumbnail
-                pageNum={pageNum}
-                onSelectPage={handleSelectPage}
-                isSelected={selectedPage === pageNum}
-                isLoading={!thumbnails.has(pageNum)}
-                thumbnailUrl={thumbnails.get(pageNum) ?? null}
-              />
-            </div>
-          ))}
+        <div
+          ref={sidebarRef}
+          className="w-30 me-1 shrink-0 overflow-auto pe-0.5 mobile:hidden"
+        >
+          <div style={{ paddingTop, paddingBottom }}>
+            {allPageNumbers.slice(startIdx, endIdx + 1).map((pageNum, sliceIdx) => (
+              <div
+                key={pageNum}
+                data-page={pageNum}
+                ref={(el) => {
+                  if (el) {
+                    /* Measure real item height from the first rendered element so
+                     * the virtual window calculation stays accurate. */
+                    if (
+                      sliceIdx === 0 &&
+                      startIdx === 0 &&
+                      itemHeightRef.current === THUMBNAIL_HEIGHT_FALLBACK
+                    ) {
+                      const h = el.getBoundingClientRect().height;
+                      if (h > 0) {
+                        itemHeightRef.current = h;
+                        setItemHeight(h);
+                      }
+                    }
+                    thumbnailNodeRefs.current.set(pageNum, el);
+                    thumbnailObserverRef.current?.observe(el);
+                  } else {
+                    thumbnailNodeRefs.current.delete(pageNum);
+                  }
+                }}
+              >
+                <PageThumbnail
+                  pageNum={pageNum}
+                  onSelectPage={handleSelectPage}
+                  isSelected={selectedPage === pageNum}
+                  isLoading={!thumbnails.has(pageNum)}
+                  thumbnailUrl={thumbnails.get(pageNum) ?? null}
+                />
+              </div>
+            ))}
+          </div>
         </div>
       )}
       <div
@@ -108,7 +249,7 @@ export const PdfContent: FC<PdfContentProps> = ({
           selectedHighlightId={selectedHighlightId}
           showOccurrences={false}
           onTotalPagesChange={setTotalPages}
-          thumbnailPageNumbers={thumbnailPageNumbers}
+          thumbnailPageNumbers={pendingThumbnailPages}
           onThumbnailsLoaded={handleThumbnailsLoaded}
           onViewerReady={handleViewerReady}
         />

--- a/libs/attachment-canvas/src/context/AttachmentCanvasContext.tsx
+++ b/libs/attachment-canvas/src/context/AttachmentCanvasContext.tsx
@@ -86,6 +86,7 @@ export const AttachmentCanvasProvider = ({
   );
 
   const closeCanvas = useCallback(() => {
+    setContent(EMPTY_CONTENT);
     setIsOpen(false);
     setIsLoading(false);
   }, []);

--- a/libs/attachment-canvas/src/context/tests/AttachmentCanvasContext.spec.tsx
+++ b/libs/attachment-canvas/src/context/tests/AttachmentCanvasContext.spec.tsx
@@ -72,6 +72,23 @@ describe('AttachmentCanvasProvider', () => {
     expect(URL.revokeObjectURL).not.toHaveBeenCalled();
   });
 
+  it('revokes the current blob URL when the canvas is closed', () => {
+    const { result } = renderCanvas();
+
+    act(() => {
+      result.current.openCanvas({
+        type: AttachmentContentType.Pdf,
+        url: 'blob:mock-close-url',
+      });
+    });
+
+    act(() => {
+      result.current.closeCanvas();
+    });
+
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:mock-close-url');
+  });
+
   it('does not revoke content types with no url (e.g. PlainText)', () => {
     const { result, unmount } = renderCanvas();
 

--- a/libs/attachment-input/src/components/AttachmentGroup/AttachmentGroup.tsx
+++ b/libs/attachment-input/src/components/AttachmentGroup/AttachmentGroup.tsx
@@ -151,8 +151,8 @@ export const AttachmentGroup: FC<AttachmentGroupProps> = ({
             : 'flex flex-wrap',
         )}
       >
-        {visibleAttachments.map((attachment) => (
-          <div key={attachment.id} role="listitem">
+        {visibleAttachments.map((attachment, index) => (
+          <div key={`${attachment.id}-${index}`} role="listitem">
             <AttachmentCard
               attachment={attachment}
               onClick={onAttachmentClick}

--- a/libs/attachment-input/src/utils/attachment.ts
+++ b/libs/attachment-input/src/utils/attachment.ts
@@ -55,6 +55,7 @@ export const generateAttachmentId = (): string =>
 
 /** Returns the name without its trailing file extension. */
 export const getNameWithoutExtension = (name: string): string => {
+  if (name == null) return '';
   const dotIndex = name.lastIndexOf('.');
   return dotIndex > 0 ? name.slice(0, dotIndex) : name;
 };

--- a/libs/attachment-input/src/utils/attachment.ts
+++ b/libs/attachment-input/src/utils/attachment.ts
@@ -53,7 +53,7 @@ import {
 export const generateAttachmentId = (): string =>
   `${Date.now()}-${Math.random().toString(36).slice(2)}`;
 
-/** Returns the name without its trailing file extension. */
+/** Returns the name without its trailing file extension. Returns an empty string when `name` is nullish. */
 export const getNameWithoutExtension = (name: string): string => {
   if (name == null) return '';
   const dotIndex = name.lastIndexOf('.');

--- a/libs/attachment-input/src/utils/tests/name-without-extension.spec.ts
+++ b/libs/attachment-input/src/utils/tests/name-without-extension.spec.ts
@@ -21,4 +21,12 @@ describe('getNameWithoutExtension', () => {
   it('removes trailing dot', () => {
     expect(getNameWithoutExtension('name.')).toBe('name');
   });
+
+  it('returns an empty string for null', () => {
+    expect(getNameWithoutExtension(null as unknown as string)).toBe('');
+  });
+
+  it('returns an empty string for undefined', () => {
+    expect(getNameWithoutExtension(undefined as unknown as string)).toBe('');
+  });
 });

--- a/libs/chat-shared/src/utils/message-attachment-to-display.ts
+++ b/libs/chat-shared/src/utils/message-attachment-to-display.ts
@@ -112,10 +112,20 @@ export const messageAttachmentToDisplayAttachment = (
   };
 };
 
-/** Maps a list of {@link MessageAttachment} DTOs to display-only attachment models. */
+/** Maps a list of {@link MessageAttachment} DTOs to display-only attachment models. Entries with duplicate `id` values are deduplicated — first occurrence wins. */
 export const messageAttachmentsToDisplayAttachments = (
   dtos: MessageAttachment[] | undefined,
   resolvers: AttachmentDisplayResolvers = {},
-): DisplayAttachment[] =>
-  dtos?.map((dto) => messageAttachmentToDisplayAttachment(dto, resolvers)) ??
-  [];
+): DisplayAttachment[] => {
+  const seen = new Set<string | undefined>();
+  return (
+    dtos?.reduce<DisplayAttachment[]>((acc, dto) => {
+      const att = messageAttachmentToDisplayAttachment(dto, resolvers);
+      if (!seen.has(att.id)) {
+        seen.add(att.id);
+        acc.push(att);
+      }
+      return acc;
+    }, []) ?? []
+  );
+};

--- a/libs/conversation-input/src/components/Input/Input.tsx
+++ b/libs/conversation-input/src/components/Input/Input.tsx
@@ -240,6 +240,7 @@ export const Input: FC<InputProps> = ({
       await onSend?.(currentMessage, currentAttachments);
       currentAttachments.forEach((a) => {
         if (a.previewUrl) URL.revokeObjectURL(a.previewUrl);
+        if (a.playUrl) URL.revokeObjectURL(a.playUrl);
       });
       resetAttachments([]);
     } catch {

--- a/libs/conversation-input/src/hooks/useAttachments.ts
+++ b/libs/conversation-input/src/hooks/useAttachments.ts
@@ -209,8 +209,8 @@ export const useAttachments = ({
           baseAttachmentsAmount + attachmentsRef.current.length + toAdd.length;
         if (count > maximumAttachmentsAmount) {
           toAdd.forEach((attachment) => {
-            if (attachment.previewUrl)
-              URL.revokeObjectURL(attachment.previewUrl);
+            if (attachment.previewUrl) URL.revokeObjectURL(attachment.previewUrl);
+            if (attachment.playUrl) URL.revokeObjectURL(attachment.playUrl);
           });
           onAttachmentsLimitExceeded?.(count, maximumAttachmentsAmount);
           return;

--- a/libs/source-panel/src/components/FilesSection/FilesSection.tsx
+++ b/libs/source-panel/src/components/FilesSection/FilesSection.tsx
@@ -39,9 +39,9 @@ const FilesSection: FC<FilesSectionProps> = ({
         role="list"
         className="grid grid-cols-[repeat(auto-fill,minmax(84px,1fr))] gap-3"
       >
-        {attachments.map((att) => (
+        {attachments.map((att, index) => (
           <div
-            key={att.id}
+            key={`${att.id}-${index}`}
             role="listitem"
             className={
               att.type === AttachmentType.Audio ? 'col-span-full' : undefined


### PR DESCRIPTION
## Description of changes

Fixes the following error: TypeError: Cannot read properties of undefined (reading 'lastIndexOf')

Fixed PDF freezes in PdfContent.tsx: virtual sidebar rendering (only ~15 components instead of 209) and lazy thumbnail loading (no redundant re-renders on scroll).

Also fixed several memory leaks

## Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #8057

## UI changes

<Please, provide Screenshots or Figma links>

## Checklist

- [X] the pull request name ends with `(Issue #<ISSUE_ID>)` (comma-separated list of issues)
- [X] I confirm that I don't share any confidential information like API keys or any other secrets and private URLs

<details>
  <summary>PR title cheatsheet</summary>

`<type>[optional scope]: <description>`

1. type (required)
    - `feat` - A new feature
    - `fix` - A bug fix
    - `docs` - Documentation only changes
    - `test` - Adding missing tests or correcting existing tests
    - `ci` - Changes to our CI configuration files and scripts
    - `chore` - Other changes that are minor and/or not user-facing
2. scope (optional, current repo suggestions below)
    - `chat`
    - `overlay`
    - `shared`
    - `sandbox-overlay`
    - `visualizer-connector`

</details>
