### PR TITLE
fix(chat): save Quick App 2.0 orchestrator temperature when set to 0 (Issue #8104)

### DIFF
--- a/apps/chat/src/components/AppsEditor/__tests__/form.test.ts
+++ b/apps/chat/src/components/AppsEditor/__tests__/form.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+
+import { MarketplaceEntity } from '@/src/types/marketplace';
+import { DialAIEntityModel } from '@/src/types/models';
+import { QuickApp2Config } from '@/src/types/quick-apps';
+
+import {
+  AppsEditorFormType,
+  AppsEditorSchemaTypes,
+  getApplicationPayload,
+} from '../form';
+
+const MODEL_ID = 'gpt-4';
+
+const buildEntitiesMap = (allowsTemperature: boolean) =>
+  ({
+    [MODEL_ID]: {
+      id: MODEL_ID,
+      features: { temperature: allowsTemperature },
+    } as DialAIEntityModel,
+  }) as Record<string, MarketplaceEntity>;
+
+const buildFormData = (temperature: number): AppsEditorFormType =>
+  ({
+    type: AppsEditorSchemaTypes.QuickApp2,
+    name: 'Test app',
+    iconUrl: '',
+    description: '',
+    version: '0.0.1',
+    topics: [],
+    model: MODEL_ID,
+    temperature,
+    instructions: 'Do the thing',
+    documentRelativeUrl: [],
+    agentsAndToolsets: [],
+    agentsAndToolsetsJson: '[]',
+    isJsonView: false,
+    codeInterpreter: false,
+    inputAttachmentTypes: [],
+    chatMessageInputDisabled: false,
+    autoSubmit: false,
+    starters: [],
+    agentSkills: [],
+    timestamp: false,
+    fileTools: false,
+    processLargeFiles: false,
+  }) as unknown as AppsEditorFormType;
+
+const getOrchestratorParameters = (
+  temperature: number,
+  allowsTemperature = true,
+) =>
+  (
+    getApplicationPayload({
+      data: buildFormData(temperature),
+      allEntitiesMap: buildEntitiesMap(allowsTemperature),
+    }).applicationProperties as QuickApp2Config
+  ).orchestrator.deployment.parameters;
+
+describe('getApplicationPayload - Quick App 2.0 orchestrator temperature', () => {
+  it('saves a temperature of 0', () => {
+    expect(getOrchestratorParameters(0)).toEqual({ temperature: 0 });
+  });
+
+  it('saves a non-zero temperature', () => {
+    expect(getOrchestratorParameters(0.7)).toEqual({ temperature: 0.7 });
+  });
+
+  it('omits parameters when the model does not support temperature', () => {
+    expect(getOrchestratorParameters(0.7, false)).toBeUndefined();
+  });
+});

--- a/apps/chat/src/components/AppsEditor/form.ts
+++ b/apps/chat/src/components/AppsEditor/form.ts
@@ -988,10 +988,9 @@ export const getApplicationPayload = ({
 
     case AppsEditorSchemaTypes.QuickApp2: {
       const model = allEntitiesMap[data.model] as DialAIEntityModel | undefined;
-      const temperatureToUse =
-        model && doesModelAllowTemperature(model)
-          ? data.temperature
-          : undefined;
+      const temperatureToUse = data.temperature;
+      const shouldSendTemperature = model && doesModelAllowTemperature(model);
+
       const starters = data.starters
         .filter((starter) => starter.text.trim() && starter.title.trim())
         .map(({ title, text }) => ({ title, text }));
@@ -1009,7 +1008,7 @@ export const getApplicationPayload = ({
           orchestrator: {
             deployment: {
               deployment_id: model?.id ?? data.model,
-              ...(temperatureToUse && {
+              ...(shouldSendTemperature && {
                 parameters: { temperature: temperatureToUse },
               }),
             },

--- a/apps/chat/src/components/Chat/Publish/PublicationHandler/ReviewApplicationDialog/ReviewQuickApp2Section.tsx
+++ b/apps/chat/src/components/Chat/Publish/PublicationHandler/ReviewApplicationDialog/ReviewQuickApp2Section.tsx
@@ -205,7 +205,7 @@ const ReviewQuickApp2SectionView = ({
         value={orchestratorName}
         valueClassName="max-w-[414px] break-all text-primary"
       />
-      {config.orchestrator.deployment.parameters?.temperature && (
+      {config.orchestrator.deployment.parameters?.temperature !== undefined && (
         <MarketplaceEntityInfoRow
           label={t(ChatI18nKeys.Temperature)}
           value={config.orchestrator.deployment.parameters.temperature}


### PR DESCRIPTION


A falsy guard treated a temperature of 0 as "no value", so the parameter was omitted from the saved payload. The publication review dialog hid the row for the same reason.

## Description of changes

<!-- Please explain the changes you made right below this line. -->

## Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #8104 

## UI changes

<Please, provide Screenshots or Figma links>

## Checklist

- [x] the pull request name ends with `(Issue #<ISSUE_ID>)` (comma-separated list of issues)
- [x] I confirm that I don't share any confidential information like API keys or any other secrets and private URLs

<details>
  <summary>PR title cheatsheet</summary>

`<type>[optional scope]: <description>`

1. type (required)
    - `feat` - A new feature
    - `fix` - A bug fix
    - `docs` - Documentation only changes
    - `test` - Adding missing tests or correcting existing tests
    - `ci` - Changes to our CI configuration files and scripts
    - `chore` - Other changes that are minor and/or not user-facing
2. scope (optional, current repo suggestions below)
    - `chat`
    - `overlay`
    - `shared`
    - `sandbox-overlay`
    - `visualizer-connector`

</details>
