### PR TITLE
fix: Composer action bar drops to its own row when only a file is attached, Issue #7907

### DIFF
--- a/libs/conversation-input/src/components/Input/Input.tsx
+++ b/libs/conversation-input/src/components/Input/Input.tsx
@@ -227,16 +227,12 @@ export const Input: FC<InputProps> = ({
     onToolToggle != null;
   /*
    * Stacked layout: textarea on its own row above the action bar. Used when the
-   * caller opts in (edit mode), whenever attachments are present, when the
+   * caller opts in (edit mode), whenever the
    * message spans multiple visual lines, or when one or more tools are selected
    * (chips need the row between textarea and buttons).
    */
   const isStackedLayout =
-    isStacked ||
-    attachments.length > 0 ||
-    message.includes('\n') ||
-    isMultiLine ||
-    hasSelectedTools;
+    isStacked || message.includes('\n') || isMultiLine || hasSelectedTools;
   const hasModelSelected =
     deployments === undefined || selectedDeploymentId != null;
 

--- a/libs/conversation-input/src/models/Input.ts
+++ b/libs/conversation-input/src/models/Input.ts
@@ -167,7 +167,7 @@ export interface InputProps {
   /**
    * When `true`, the textarea always renders on its own row above the action bar
    * (attach button at the start, footer actions at the end), instead of the
-   * compact single-row layout used when no attachments are present. Used by the
+   * compact single-row layout. Used by the
    * edit-message UI, which always wants the stacked layout.
    */
   isStacked?: boolean;


### PR DESCRIPTION
## Description of changes

<!-- Please explain the changes you made right below this line. -->

## Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #7907

## UI changes

<Please, provide Screenshots or Figma links>

## Checklist

- [X] the pull request name ends with `(Issue #<ISSUE_ID>)` (comma-separated list of issues)
- [X] I confirm that I don't share any confidential information like API keys or any other secrets and private URLs

<details>
  <summary>PR title cheatsheet</summary>

`<type>[optional scope]: <description>`

1. type (required)
    - `feat` - A new feature
    - `fix` - A bug fix
    - `docs` - Documentation only changes
    - `test` - Adding missing tests or correcting existing tests
    - `ci` - Changes to our CI configuration files and scripts
    - `chore` - Other changes that are minor and/or not user-facing
2. scope (optional, current repo suggestions below)
    - `chat`
    - `overlay`
    - `shared`
    - `sandbox-overlay`
    - `visualizer-connector`

</details>
