### PR TITLE
fix(chat): fix nasted folder limitation (#5613)

### DIFF
--- a/apps/chat/src/components/Chat/ChangePathDialog.tsx
+++ b/apps/chat/src/components/Chat/ChangePathDialog.tsx
@@ -9,10 +9,10 @@ import { useTranslation } from '@/src/hooks/useTranslation';
 
 import {
   getFolderIdFromEntityId,
+  getFolderNestingLevel,
   updateMovedFolderId,
 } from '@/src/utils/app/folders';
 import {
-  getOrganizationPublishPathDepth,
   organizationFolderIdToPublishPathSuffix,
   publishToUrlToOrganizationFolderId,
   remapPublicFolderToFilesNamespace,
@@ -35,7 +35,10 @@ import {
   ToolsetSelectors,
 } from '@/src/store/selectors';
 
-import { MAX_CONVERSATION_AND_PROMPT_FOLDERS_DEPTH } from '@/src/constants/folders';
+import {
+  MAX_NESTED_FOLDERS,
+  MAX_NEW_FOLDER_PATH_SEGMENTS,
+} from '@/src/constants/folders';
 import {
   ChatI18nKeys,
   CommonI18nKeys,
@@ -377,6 +380,8 @@ export const ChangePathDialog = ({
     gridOptions,
     navigationPanelOptions,
     handleRenameValidation,
+    isMaxFolderDepthReached,
+    showMaxDepthError,
     resetGridEditing,
     emptyStateTitle,
     emptyStateDescription,
@@ -395,6 +400,7 @@ export const ChangePathDialog = ({
       folders: additionalOrganizationFolders,
     },
     gridEditingOptions,
+    folderDepthOffset: depth,
   });
 
   const publishedFolderIds = useMemo(
@@ -606,13 +612,12 @@ export const ChangePathDialog = ({
 
   const handleCreateFolderValidate = useCallback(
     (name: string, parentFolder: DialFile) => {
-      const pathDepth = getOrganizationPublishPathDepth(parentFolder.id);
-      if (pathDepth + 1 + depth > MAX_CONVERSATION_AND_PROMPT_FOLDERS_DEPTH) {
+      if (isMaxFolderDepthReached(parentFolder.id)) {
         return t(ChatI18nKeys.NotAllowedMoreNestedFolders);
       }
       return handleRenameValidation(name, parentFolder);
     },
-    [depth, handleRenameValidation, t],
+    [handleRenameValidation, isMaxFolderDepthReached, t],
   );
 
   const itemsToRender = useMemo(() => {
@@ -635,9 +640,8 @@ export const ChangePathDialog = ({
   const handleConfirm = useCallback(() => {
     const folderId = currentPath ?? resolvedInitialFolderId;
     const suffix = organizationFolderIdToPublishPathSuffix(folderId);
-    const pathDepth = getOrganizationPublishPathDepth(folderId);
 
-    if (pathDepth + depth > MAX_CONVERSATION_AND_PROMPT_FOLDERS_DEPTH) {
+    if (getFolderNestingLevel(folderId) + depth > MAX_NESTED_FOLDERS) {
       dispatch(
         UIActions.showErrorToast({
           message: t(ChatI18nKeys.NotAllowedMoreNestedFolders),
@@ -1010,6 +1014,8 @@ export const ChangePathDialog = ({
         onCreateFolder={handleCreateOrganizationFolder}
         onMoveToFiles={handleOrganizationMoveFiles}
         onCreateFolderValidate={handleCreateFolderValidate}
+        maxNewFolderDepth={MAX_NEW_FOLDER_PATH_SEGMENTS - depth}
+        onNewFolderDepthExceeded={showMaxDepthError}
         onRenameValidate={handleOrganizationRenameValidation}
         onDeleteFiles={handleDeleteTempFolders}
         deleteConfirmationOptions={deleteConfirmationOptions}

--- a/apps/chat/src/components/Chatbar/ChatFolders.tsx
+++ b/apps/chat/src/components/Chatbar/ChatFolders.tsx
@@ -33,7 +33,7 @@ import {
   UISelectors,
 } from '@/src/store/selectors';
 
-import { MAX_CONVERSATION_AND_PROMPT_FOLDERS_DEPTH } from '@/src/constants/folders';
+import { MAX_FOLDERS_DEPTH } from '@/src/constants/folders';
 import { ChatI18nKeys } from '@/src/constants/i18n';
 import { CHAT_PANEL_PUBLICATION_FEATURE_TYPES } from '@/src/constants/publication';
 import {
@@ -292,7 +292,7 @@ const ChatFolderTemplate = ({
         denyDrop={shouldDenyDrop}
       />
       <Folder
-        maxDepth={MAX_CONVERSATION_AND_PROMPT_FOLDERS_DEPTH}
+        maxDepth={MAX_FOLDERS_DEPTH}
         readonly={readonly || isConversationsStreaming}
         searchTerm={searchTerm}
         currentFolder={folder}

--- a/apps/chat/src/components/Common/CodeEditor/Sidebar/CodeEditorFileTree.tsx
+++ b/apps/chat/src/components/Common/CodeEditor/Sidebar/CodeEditorFileTree.tsx
@@ -17,7 +17,7 @@ import { CodeEditorActions, FilesActions } from '@/src/store/actions';
 import { useAppDispatch, useAppSelector } from '@/src/store/hooks';
 import { CodeEditorSelectors, FilesSelectors } from '@/src/store/selectors';
 
-import { MAX_CONVERSATION_AND_PROMPT_FOLDERS_DEPTH } from '@/src/constants/folders';
+import { MAX_FOLDERS_DEPTH } from '@/src/constants/folders';
 
 import { CloseButtonSmall } from '@/src/components/Common/CloseButtons';
 import { Loader } from '@/src/components/Common/Loader';
@@ -148,7 +148,7 @@ export const CodeEditorFileTree = ({
     <>
       {rootFolders.map((folder) => (
         <Folder
-          maxDepth={MAX_CONVERSATION_AND_PROMPT_FOLDERS_DEPTH}
+          maxDepth={MAX_FOLDERS_DEPTH}
           key={folder.id}
           searchTerm=""
           onFileUpload={handleFileUpload}

--- a/apps/chat/src/components/Common/SelectFolder/SelectFolderList.tsx
+++ b/apps/chat/src/components/Common/SelectFolder/SelectFolderList.tsx
@@ -12,7 +12,7 @@ import { DialFile } from '@/src/types/files';
 import { FolderInterface } from '@/src/types/folder';
 import { Prompt } from '@/src/types/prompt';
 
-import { MAX_CONVERSATION_AND_PROMPT_FOLDERS_DEPTH } from '@/src/constants/folders';
+import { MAX_FOLDERS_DEPTH } from '@/src/constants/folders';
 
 import { CollapsibleSection } from '@/src/components/Common/CollapsibleSection';
 import { NoData } from '@/src/components/Common/NoData';
@@ -136,7 +136,7 @@ export const SelectFolderList = <T extends Conversation | Prompt | DialFile>({
                               : FeatureType.Prompt
                         }
                         skipFolderRenameValidation
-                        maxDepth={MAX_CONVERSATION_AND_PROMPT_FOLDERS_DEPTH}
+                        maxDepth={MAX_FOLDERS_DEPTH}
                         currentFolder={folder}
                         highlightedFolders={highlightedFolders}
                         highlightTemporaryFolders={highlightTemporaryFolders}

--- a/apps/chat/src/components/FileManager/FileManager.tsx
+++ b/apps/chat/src/components/FileManager/FileManager.tsx
@@ -11,6 +11,7 @@ import { FilesActions } from '@/src/store/actions';
 import { useAppDispatch, useAppSelector } from '@/src/store/hooks';
 import { SettingsSelectors } from '@/src/store/selectors';
 
+import { MAX_NEW_FOLDER_PATH_SEGMENTS } from '@/src/constants/folders';
 import { SideBarI18nKeys } from '@/src/constants/i18n';
 
 import { FilesUploadingModal } from './FilesUploadingModal';
@@ -79,6 +80,8 @@ export const FileManager: React.FC = () => {
     handleOpenUnshareFilesDialog,
     handleOpenRemoveFilesAccessDialog,
     handleRenameValidation,
+    handleCreateFolderValidate,
+    showMaxDepthError,
 
     sharedWithMeIds,
 
@@ -162,7 +165,9 @@ export const FileManager: React.FC = () => {
           onUnshareFiles={handleOpenUnshareFilesDialog}
           onRemoveFilesAccess={handleOpenRemoveFilesAccessDialog}
           onRenameValidate={handleRenameValidation}
-          onCreateFolderValidate={handleRenameValidation}
+          onCreateFolderValidate={handleCreateFolderValidate}
+          maxNewFolderDepth={MAX_NEW_FOLDER_PATH_SEGMENTS}
+          onNewFolderDepthExceeded={showMaxDepthError}
           sharedWithMeIds={sharedWithMeIds}
           uploadEnabled={uploadEnabled}
           clearSearchResults={handleClearSearch}

--- a/apps/chat/src/components/FileManager/hooks/useFileManager.tsx
+++ b/apps/chat/src/components/FileManager/hooks/useFileManager.tsx
@@ -19,7 +19,11 @@ import {
   filterFoldersByFilters,
 } from '@/src/utils/app/file-manager-adapter';
 import { dispatchOpenFileManagerUnshareDialog } from '@/src/utils/app/file-manager-unshare-dispatch';
-import { getFolderIdFromEntityId } from '@/src/utils/app/folders';
+import {
+  getFolderIdFromEntityId,
+  getFolderNestingLevel,
+  getFoldersDepth,
+} from '@/src/utils/app/folders';
 import { getFileRootId, getRootId, isRootId } from '@/src/utils/app/id';
 import {
   PublishedWithMeFilter,
@@ -41,7 +45,11 @@ import { DialFile as LocalDialFileType } from '@/src/types/files';
 import type { RootState } from '@/src/types/store';
 import { Translation } from '@/src/types/translation';
 
-import { PublicationActions, ShareActions } from '@/src/store/actions';
+import {
+  PublicationActions,
+  ShareActions,
+  UIActions,
+} from '@/src/store/actions';
 import { FilesActions } from '@/src/store/files/files.reducers';
 import { FilesSelectors } from '@/src/store/files/files.selectors';
 import { useAppDispatch, useAppSelector } from '@/src/store/hooks';
@@ -52,6 +60,7 @@ import {
   REVIEW_FILES_SECTION,
   SHARED_WITH_ME_FILES_SECTION,
 } from '@/src/constants/fileManager';
+import { MAX_NESTED_FOLDERS } from '@/src/constants/folders';
 import {
   ChatI18nKeys,
   CommonI18nKeys,
@@ -177,6 +186,7 @@ interface UseFileManagerOptions {
     folders?: FolderInterface[];
   };
   gridEditingOptions?: UseGridEditingScrollOptions;
+  folderDepthOffset?: number;
 }
 
 export const useFileManager = ({
@@ -188,6 +198,7 @@ export const useFileManager = ({
   initialPath,
   additionalFilesAndFolders,
   gridEditingOptions: gridEditingOptionsConfig,
+  folderDepthOffset = 0,
 }: UseFileManagerOptions = {}) => {
   const dispatch = useAppDispatch();
   const router = useRouter();
@@ -759,6 +770,21 @@ export const useFileManager = ({
     [t, sharedByMeFileNames],
   );
 
+  const isMaxFolderDepthReached = useCallback(
+    (parentFolderId: string | undefined) =>
+      getFolderNestingLevel(parentFolderId) + folderDepthOffset >=
+      MAX_NESTED_FOLDERS,
+    [folderDepthOffset],
+  );
+
+  const showMaxDepthError = useCallback(() => {
+    dispatch(
+      UIActions.showErrorToast({
+        message: translateChat(ChatI18nKeys.NotAllowedMoreNestedFolders),
+      }),
+    );
+  }, [dispatch, translateChat]);
+
   const handleMoveFiles = useCallback(
     (
       movedItems: DialCopiedItem[],
@@ -766,6 +792,22 @@ export const useFileManager = ({
       destinationFolder: string,
     ) => {
       if (movedItems.length === 0) return;
+
+      const exceedsMaxDepth = movedItems.some((item) => {
+        if (item.nodeType !== DialFileNodeType.FOLDER) return false;
+
+        const movedFolder = folders.find((f) => f.id === item.sourceUrl);
+        const subtreeLevels = movedFolder
+          ? getFoldersDepth(movedFolder, folders) - 1
+          : 0;
+
+        return (
+          getFolderNestingLevel(item.destinationUrl) + subtreeLevels >
+          MAX_NESTED_FOLDERS
+        );
+      });
+
+      if (exceedsMaxDepth) return;
 
       movingFilesCountRef.current = movedItems.length;
       isRenamingRef.current = sourceFolder === destinationFolder;
@@ -788,7 +830,7 @@ export const useFileManager = ({
         setCurrentPath(movedCurrentOrParent.destinationUrl);
       }
     },
-    [dispatch, currentPath],
+    [dispatch, currentPath, folders],
   );
 
   const handleSearchFiles = useCallback(
@@ -1443,6 +1485,12 @@ export const useFileManager = ({
   const handleCreateFolder = useCallback(
     (file: DialUploadFileItem, folderPath: string, fileId: string) => {
       if (deduplicatedFileIdsRef.current.has(fileId)) return;
+
+      if (isMaxFolderDepthReached(getFolderIdFromEntityId(folderPath))) {
+        showMaxDepthError();
+        return;
+      }
+
       deduplicatedFileIdsRef.current.add(fileId);
 
       dispatch(
@@ -1452,12 +1500,18 @@ export const useFileManager = ({
         }),
       );
     },
-    [dispatch],
+    [dispatch, isMaxFolderDepthReached, showMaxDepthError],
   );
 
   const handleUploadArchive = useCallback(
     (archiveFile: File | null, name: string, destinationUrl: string) => {
       if (!archiveFile) return;
+
+      if (isMaxFolderDepthReached(destinationUrl)) {
+        showMaxDepthError();
+        return;
+      }
+
       dispatch(
         FilesActions.uploadArchive({
           archive: archiveFile,
@@ -1466,7 +1520,7 @@ export const useFileManager = ({
         }),
       );
     },
-    [dispatch],
+    [dispatch, isMaxFolderDepthReached, showMaxDepthError],
   );
 
   const handleOpenUnshareFilesDialog = useCallback(
@@ -1519,6 +1573,14 @@ export const useFileManager = ({
       }
     },
     [router.locale, t],
+  );
+
+  const handleCreateFolderValidate = useCallback(
+    (name: string, parentFolder: DialFile) =>
+      isMaxFolderDepthReached(parentFolder.id)
+        ? translateChat(ChatI18nKeys.NotAllowedMoreNestedFolders)
+        : handleRenameValidation(name, parentFolder),
+    [handleRenameValidation, isMaxFolderDepthReached, translateChat],
   );
 
   const emptyStateTitle = useMemo(() => {
@@ -1584,6 +1646,9 @@ export const useFileManager = ({
     handleOpenUnshareFilesDialog,
     handleOpenRemoveFilesAccessDialog,
     handleRenameValidation,
+    handleCreateFolderValidate,
+    isMaxFolderDepthReached,
+    showMaxDepthError,
     sharedWithMeIds,
 
     uploadEnabled,

--- a/apps/chat/src/components/Files/FileManagerModal.tsx
+++ b/apps/chat/src/components/Files/FileManagerModal.tsx
@@ -27,6 +27,7 @@ import { FilesSelectors } from '@/src/store/files/files.selectors';
 import { useAppDispatch, useAppSelector } from '@/src/store/hooks';
 import { ConversationsSelectors } from '@/src/store/selectors';
 
+import { MAX_NEW_FOLDER_PATH_SEGMENTS } from '@/src/constants/folders';
 import { ChatI18nKeys } from '@/src/constants/i18n';
 import { OUTSIDE_PRESS_AND_MOUSE_EVENT } from '@/src/constants/modal';
 
@@ -368,6 +369,8 @@ export const FileManagerModal = memo(
       handleUploadArchive,
       handleMoveFiles,
       handleRenameValidation,
+      handleCreateFolderValidate,
+      showMaxDepthError,
       sharedWithMeIds,
 
       uploadEnabled,
@@ -513,7 +516,9 @@ export const FileManagerModal = memo(
               onUploadArchive={handleUploadArchive}
               onMoveToFiles={handleMoveFiles}
               onRenameValidate={handleRenameValidation}
-              onCreateFolderValidate={handleRenameValidation}
+              onCreateFolderValidate={handleCreateFolderValidate}
+              maxNewFolderDepth={MAX_NEW_FOLDER_PATH_SEGMENTS}
+              onNewFolderDepthExceeded={showMaxDepthError}
               sharedWithMeIds={sharedWithMeIds}
               uploadEnabled={uploadEnabled}
               getDisabledTooltip={getDisabledTooltip}

--- a/apps/chat/src/components/Promptbar/components/PromptFolders.tsx
+++ b/apps/chat/src/components/Promptbar/components/PromptFolders.tsx
@@ -29,7 +29,7 @@ import {
   UISelectors,
 } from '@/src/store/selectors';
 
-import { MAX_CONVERSATION_AND_PROMPT_FOLDERS_DEPTH } from '@/src/constants/folders';
+import { MAX_FOLDERS_DEPTH } from '@/src/constants/folders';
 import { ChatI18nKeys } from '@/src/constants/i18n';
 import { PROMPT_PANEL_PUBLICATION_FEATURE_TYPES } from '@/src/constants/publication';
 import {
@@ -272,7 +272,7 @@ const PromptFolderTemplate = ({
         denyDrop={isExternal || isSelectMode}
       />
       <Folder
-        maxDepth={MAX_CONVERSATION_AND_PROMPT_FOLDERS_DEPTH}
+        maxDepth={MAX_FOLDERS_DEPTH}
         searchTerm={searchTerm}
         currentFolder={folder}
         itemComponent={PromptComponent}

--- a/apps/chat/src/constants/folders.ts
+++ b/apps/chat/src/constants/folders.ts
@@ -1,4 +1,6 @@
-export const MAX_CONVERSATION_AND_PROMPT_FOLDERS_DEPTH = 3;
+export const MAX_FOLDERS_DEPTH = 3;
+export const MAX_NESTED_FOLDERS = MAX_FOLDERS_DEPTH + 1;
+export const MAX_NEW_FOLDER_PATH_SEGMENTS = MAX_NESTED_FOLDERS + 2;
 
 export const FOLDER_ATTACHMENT_CONTENT_TYPE =
   'application/vnd.dial.metadata+json';

--- a/apps/chat/src/store/files/files.epics.ts
+++ b/apps/chat/src/store/files/files.epics.ts
@@ -36,6 +36,7 @@ import {
 } from '@/src/utils/app/file';
 import {
   getFolderFromId,
+  getFolderNestingLevel,
   getGeneratedFolderId,
   updateMovedEntityId,
 } from '@/src/utils/app/folders';
@@ -69,6 +70,7 @@ import {
 } from '@/src/store/selectors';
 
 import { MAX_VISIBLE_NOTIFICATION_ITEMS } from '@/src/constants/file';
+import { MAX_NESTED_FOLDERS } from '@/src/constants/folders';
 import {
   ChatI18nKeys,
   CommonI18nKeys,
@@ -76,7 +78,17 @@ import {
 } from '@/src/constants/i18n';
 
 import { UploadStatus } from '@epam/ai-dial-shared';
-import { DialFileNodeType } from '@epam/ai-dial-ui-kit';
+import { DialCopiedItem, DialFileNodeType } from '@epam/ai-dial-ui-kit';
+
+const exceedsMaxNesting = (folderId: string) =>
+  getFolderNestingLevel(folderId) > MAX_NESTED_FOLDERS;
+
+const maxNestingErrorToast = () =>
+  UIActions.showErrorToast({
+    message: translate(ChatI18nKeys.NotAllowedMoreNestedFolders, {
+      ns: Translation.Chat,
+    }),
+  });
 
 const initEpic: AppEpic = (action$, state$) =>
   action$.pipe(
@@ -678,6 +690,16 @@ const moveFilesEpic: AppEpic = (action$) =>
   action$.pipe(
     ofType(FilesActions.moveFiles.type),
     switchMap(({ payload }) => {
+      const landsTooDeep = payload.files.some(
+        (file: DialCopiedItem) =>
+          file.nodeType === DialFileNodeType.FOLDER &&
+          exceedsMaxNesting(file.destinationUrl),
+      );
+
+      if (landsTooDeep) {
+        return of(FilesActions.moveFilesFail({ files: payload.files }));
+      }
+
       const abortController = new AbortController();
 
       return concat(
@@ -961,6 +983,11 @@ const uploadArchiveEpic: AppEpic = (action$) =>
     ofType(FilesActions.uploadArchive.type),
     switchMap(({ payload }) => {
       const destinationUrl = `${payload.destinationUrl}/${payload.name}`;
+
+      if (exceedsMaxNesting(destinationUrl)) {
+        return of(maxNestingErrorToast(), FilesActions.uploadArchiveFail());
+      }
+
       return FileService.uploadArchive({
         file: payload.archive,
         destinationUrl,
@@ -1214,6 +1241,10 @@ const createNewFolderEpic: AppEpic = (action$) =>
   action$.pipe(
     ofType(FilesActions.createNewFolder.type),
     mergeMap(({ payload }) => {
+      if (exceedsMaxNesting(payload.destinationUrl)) {
+        return of(maxNestingErrorToast());
+      }
+
       return concat(
         of(
           FilesActions.uploadFiles({

--- a/apps/chat/src/utils/app/__tests__/folders.test.ts
+++ b/apps/chat/src/utils/app/__tests__/folders.test.ts
@@ -3,11 +3,18 @@ import { describe, expect, it } from 'vitest';
 
 import {
   getEmptyLeafFolderIds,
+  getFolderNestingLevel,
+  getFoldersDepth,
   getPartialAndFullyChosenFolders,
   getSelectedEntitiesByFolderId,
   updateMovedEntityId,
   updateMovedFolderId,
 } from '@/src/utils/app/folders';
+
+import {
+  MAX_NESTED_FOLDERS,
+  MAX_NEW_FOLDER_PATH_SEGMENTS,
+} from '@/src/constants/folders';
 
 import { FeatureType } from '@epam/ai-dial-shared';
 import type { FolderInterface, ShareEntity } from '@epam/ai-dial-shared';
@@ -278,5 +285,68 @@ describe('getPartialAndFullyChosenFolders with folder/prompt id collision', () =
     );
 
     expect(fullyChosenFolderIds).toContain(`${folderPath}/`);
+  });
+});
+
+describe('getFolderNestingLevel', () => {
+  it.each([
+    [undefined, 0],
+    ['', 0],
+    ['files/bucket', 0],
+    ['files/bucket/folder1', 1],
+    ['files/bucket/folder1/folder2', 2],
+    ['files/bucket/folder1/folder2/folder3', 3],
+    ['files/bucket/folder1/folder2/folder3/folder4', 4],
+  ])('returns %s -> %s', (folderId, expected) => {
+    expect(getFolderNestingLevel(folderId)).toBe(expected);
+  });
+
+  it('ignores a trailing slash', () => {
+    expect(getFolderNestingLevel('files/bucket/folder1/')).toBe(1);
+  });
+
+  it.each([
+    ['files/bucket', true],
+    ['files/bucket/f1', true],
+    ['files/bucket/f1/f2', true],
+    ['files/bucket/f1/f2/f3', true],
+    ['files/bucket/f1/f2/f3/f4', false],
+  ])('allows creating inside %s -> %s', (parentId, allowed) => {
+    expect(getFolderNestingLevel(parentId) < MAX_NESTED_FOLDERS).toBe(allowed);
+  });
+});
+
+describe('getFoldersDepth', () => {
+  const bucket = 'files/bucket';
+  const folders = [
+    testFolder(`${bucket}/src`, bucket),
+    testFolder(`${bucket}/src/child`, `${bucket}/src`),
+    testFolder(`${bucket}/leaf`, bucket),
+  ];
+
+  it('counts the folder itself, so a leaf is 1', () => {
+    expect(getFoldersDepth(folders[2], folders)).toBe(1);
+  });
+
+  it('counts the deepest nested child', () => {
+    expect(getFoldersDepth(folders[0], folders)).toBe(2);
+  });
+});
+
+describe('MAX_NEW_FOLDER_PATH_SEGMENTS', () => {
+  it.each([
+    'files/bucket',
+    'files/bucket/f1',
+    'files/bucket/f1/f2',
+    'files/bucket/f1/f2/f3',
+    'files/bucket/f1/f2/f3/f4',
+  ])('matches the app-side check for %s', (parentId) => {
+    const vetoedByUiKit =
+      parentId.split('/').filter(Boolean).length >
+      MAX_NEW_FOLDER_PATH_SEGMENTS - 1;
+
+    expect(vetoedByUiKit).toBe(
+      getFolderNestingLevel(parentId) >= MAX_NESTED_FOLDERS,
+    );
   });
 });

--- a/apps/chat/src/utils/app/folders.ts
+++ b/apps/chat/src/utils/app/folders.ts
@@ -41,7 +41,7 @@ import {
   prepareEntityName,
   truncateToUtf8Bytes,
 } from './common';
-import { isRootEntity } from './id';
+import { getIdWithoutRootPathSegments, isRootEntity } from './id';
 import { hasWritePermission } from './share';
 import { isReplayConversation, splitEntityId } from './shared-utils';
 
@@ -73,6 +73,11 @@ export const getFoldersDepth = (
 
   return 1 + maxDepth;
 };
+
+export const getFolderNestingLevel = (folderId: string | undefined): number =>
+  folderId
+    ? getIdWithoutRootPathSegments(folderId).split('/').filter(Boolean).length
+    : 0;
 
 export const getParentAndCurrentFoldersById = (
   folders: FolderInterface[],

--- a/apps/chat/src/utils/app/publications.ts
+++ b/apps/chat/src/utils/app/publications.ts
@@ -132,14 +132,6 @@ export const organizationFolderIdToPublishPathSuffix = (
   return getIdWithoutRootPathSegments(folderId) || undefined;
 };
 
-export const getOrganizationPublishPathDepth = (
-  folderId: string | undefined,
-): number => {
-  const relative = folderId ? getIdWithoutRootPathSegments(folderId) : '';
-  const segments = relative.split('/').filter(Boolean);
-  return segments.length === 0 ? 0 : segments.length - 1;
-};
-
 export const remapPublicFolderToFilesNamespace = (
   folder: FolderInterface,
 ): FolderInterface => {


### PR DESCRIPTION
## Description of changes

If user try to create more than 4 nested folders then error toast should be displayed

## Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #5613

## UI changes

<Please, provide Screenshots or Figma links>

## Checklist

- [x] the pull request name ends with `(Issue #<ISSUE_ID>)` (comma-separated list of issues)
- [x] I confirm that I don't share any confidential information like API keys or any other secrets and private URLs

<details>
  <summary>PR title cheatsheet</summary>

`<type>[optional scope]: <description>`

1. type (required)
    - `feat` - A new feature
    - `fix` - A bug fix
    - `docs` - Documentation only changes
    - `test` - Adding missing tests or correcting existing tests
    - `ci` - Changes to our CI configuration files and scripts
    - `chore` - Other changes that are minor and/or not user-facing
2. scope (optional, current repo suggestions below)
    - `chat`
    - `overlay`
    - `shared`
    - `sandbox-overlay`
    - `visualizer-connector`

</details>
