### PR TITLE
fix: enforce presence of authSettings in ToolsetBodyDto validation

### DIFF
--- a/apps/chat-api/src/toolsets/dto/toolset-body.dto.ts
+++ b/apps/chat-api/src/toolsets/dto/toolset-body.dto.ts
@@ -2,6 +2,7 @@
 import { Type } from 'class-transformer';
 import {
   IsArray,
+  IsDefined,
   IsEnum,
   IsNotEmpty,
   IsOptional,
@@ -169,6 +170,7 @@ export class ToolsetBodyDto {
   reference?: string;
 
   @ApiProperty({ type: () => ToolsetAuthSettingsBodyDto })
+  @IsDefined()
   @ValidateNested()
   @Type(() => ToolsetAuthSettingsBodyDto)
   authSettings!: ToolsetAuthSettingsBodyDto;

--- a/apps/chat-api/src/toolsets/tests/toolset-body.dto.spec.ts
+++ b/apps/chat-api/src/toolsets/tests/toolset-body.dto.spec.ts
@@ -64,3 +64,16 @@ describe('ToolsetBodyDto — endpoint', () => {
     expect(errors.some((e) => e.property === 'endpoint')).toBe(true);
   });
 });
+
+describe('ToolsetBodyDto — authSettings', () => {
+  it('rejects when authSettings is missing', async () => {
+    const { authSettings: _omitted, ...noAuthSettings } = BASE_BODY;
+    const errors = await validateDto(noAuthSettings);
+    expect(errors.some((e) => e.property === 'authSettings')).toBe(true);
+  });
+
+  it('rejects when authSettings is an empty object', async () => {
+    const errors = await validateDto({ ...BASE_BODY, authSettings: {} });
+    expect(errors.some((e) => e.property === 'authSettings')).toBe(true);
+  });
+});

--- a/apps/chat-api/src/toolsets/tests/toolsets.controller.spec.ts
+++ b/apps/chat-api/src/toolsets/tests/toolsets.controller.spec.ts
@@ -223,6 +223,15 @@ describe('ToolsetsController — write operations (integration)', () => {
         .expect(400);
     });
 
+    it('returns 400 when authSettings is omitted, and does not call the service', async () => {
+      const { authSettings: _omitted, ...noAuthSettings } = validBody;
+      await request(app.getHttpServer())
+        .post('/api/v1/toolsets')
+        .send(noAuthSettings)
+        .expect(400);
+      expect(service.createToolset).not.toHaveBeenCalled();
+    });
+
     it('returns 400 for an unknown extra property (forbidNonWhitelisted)', async () => {
       await request(app.getHttpServer())
         .post('/api/v1/toolsets')

--- a/openspec/changes/archive/2026-08-03-fix-toolset-create-missing-auth-settings-validation/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-03-fix-toolset-create-missing-auth-settings-validation/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-03

--- a/openspec/changes/archive/2026-08-03-fix-toolset-create-missing-auth-settings-validation/design.md
+++ b/openspec/changes/archive/2026-08-03-fix-toolset-create-missing-auth-settings-validation/design.md
@@ -1,0 +1,51 @@
+## Context
+
+`ToolsetBodyDto` (`apps/chat-api/src/toolsets/dto/toolset-body.dto.ts`) is shared by
+`POST /api/v1/toolsets` (create) and `PATCH /api/v1/toolsets/:toolsetName` (update). Its
+`authSettings` field uses `@ValidateNested()` + `@Type(() => ToolsetAuthSettingsBodyDto)`
+with no decorator asserting the property is present. class-validator's `@ValidateNested()`
+only validates a value that exists; an omitted key produces no error. `ToolsetsService`
+assumes `authSettings` is always a defined object when it builds the DIAL Core payload
+(`toDialAuthSettings`), so an omitted field throws a `TypeError` that is caught generically
+and mapped to a 503, masking the real problem (a bad request) as an upstream outage.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Reject a `POST /api/v1/toolsets` (and `PATCH`) request whose body omits `authSettings`
+  with a 400 that names the missing field, before any service/DIAL Core code runs.
+- Keep the existing behavior for `authSettings: {}` (400 naming `authenticationType`)
+  unchanged.
+
+**Non-Goals:**
+- Changing whether `authSettings` is required on update (`PATCH`) semantics beyond making
+  omission consistently a 400 — no behavior change is proposed for partial-update semantics
+  since the same DTO scenario already requires the field.
+- Any change to `ToolsetsService`'s DIAL Core call shape, caching, or error-mapping logic for
+  genuine DIAL Core failures.
+
+## Decisions
+
+- **Add `@IsDefined()` to `authSettings`, ahead of `@ValidateNested()`.** class-validator
+  runs decorators in declaration order and short-circuits nested validation only when the
+  base decorator already reports failure for that property is not automatic — but
+  `@IsDefined()` reports its own violation independently while `@ValidateNested()` still
+  simply no-ops on `undefined`. Both are cheap to keep, and `@IsDefined()` gives an explicit
+  "authSettings should not be null or undefined" message rather than relying on incidental
+  side effects of `@ValidateNested()`. Alternative considered: `@IsNotEmptyObject()` — rejected
+  because it would also need to tolerate a partially-specified object mid-validation, which
+  `@ValidateNested()` already handles; `@IsDefined()` is the minimal, precise fix for "key
+  missing entirely."
+- **No `catch` added in `ToolsetsService.createToolset`/`toDialAuthSettings` for
+  `authSettings` being `undefined`.** Once the DTO guarantees presence, defensive handling in
+  the service for an impossible state would be dead code. This matches the project's
+  guidance against validating conditions that cannot occur past the DTO boundary.
+
+## Risks / Trade-offs
+
+- [Risk] `PATCH` requests that legitimately omit `authSettings` to leave it unchanged (if any
+  such usage exists) would start failing. → Mitigation: confirmed via
+  `openspec/specs/toolset-write-api/spec.md` and `ToolsetBodyDto`'s `@ApiProperty` (not
+  `@ApiPropertyOptional`) that `authSettings` is already documented/typed as required on this
+  shared DTO; no partial-update contract currently permits omitting it, so no legitimate
+  caller is affected.

--- a/openspec/changes/archive/2026-08-03-fix-toolset-create-missing-auth-settings-validation/proposal.md
+++ b/openspec/changes/archive/2026-08-03-fix-toolset-create-missing-auth-settings-validation/proposal.md
@@ -1,0 +1,40 @@
+## Why
+
+`POST /api/v1/toolsets` (and the equivalent `PATCH` update path) validates `authSettings`
+with `@ValidateNested()` + `@Type(() => ToolsetAuthSettingsBodyDto)` but no decorator that
+asserts the property itself is present. class-validator only recurses into
+`@ValidateNested()` when the value exists, so an entirely omitted `authSettings` passes DTO
+validation silently. The request then reaches `ToolsetsService`, which reads
+`authSettings.authenticationType` on `undefined`, throws a `TypeError`, and that error is
+caught and mapped by `handleDialFetchError` to a `503 DIAL Core is currently unavailable` —
+a misleading response, since DIAL Core was never called. This was reported against issue
+#7570 while automating its QA coverage and violates the existing `toolset-write-api` spec
+scenario "Invalid create body", which requires a 400 (not a 503) whenever the body fails DTO
+validation.
+
+## What Changes
+
+- Add a presence-validation decorator (`@IsDefined()` or equivalent) to `authSettings` on
+  `ToolsetBodyDto` so an omitted `authSettings` fails DTO validation and responds 400 instead
+  of reaching `ToolsetsService`.
+- Add a regression scenario to the `toolset-write-api` spec covering an omitted
+  `authSettings` field, mirroring the existing "Missing endpoint field" scenario.
+- Add/extend unit tests for `ToolsetBodyDto` and the `createToolset` controller/service path
+  to cover the omitted-`authSettings` case.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `toolset-write-api`: the "Create toolset endpoint" requirement gains an explicit rule that
+  `authSettings` must be present in the request body, with a new scenario asserting the 400
+  response when it is omitted.
+
+## Impact
+
+- `apps/chat-api/src/toolsets/dto/toolset-body.dto.ts` — add the presence decorator to
+  `authSettings`.
+- `apps/chat-api/src/toolsets/tests/` — new/updated unit tests.
+- `openspec/specs/toolset-write-api/spec.md` — new scenario via delta spec.
+- No API contract or OpenAPI shape change: `authSettings` was already documented as required
+  via `@ApiProperty`; this only makes runtime validation match that contract.

--- a/openspec/changes/archive/2026-08-03-fix-toolset-create-missing-auth-settings-validation/specs/toolset-write-api/spec.md
+++ b/openspec/changes/archive/2026-08-03-fix-toolset-create-missing-auth-settings-validation/specs/toolset-write-api/spec.md
@@ -1,0 +1,57 @@
+## MODIFIED Requirements
+
+### Requirement: Create toolset endpoint
+The backend SHALL expose `POST /api/v1/toolsets` that creates a toolset by proxying DIAL
+Core using the caller's session access token. The request body SHALL be validated via a DTO,
+including an optional `intro` string field limited to 90 characters, the per-user toolset
+list cache SHALL be invalidated on success, and DIAL Core error statuses SHALL be mapped to
+typed HTTP responses. When `intro` is provided, it SHALL be forwarded to DIAL Core as part of
+the create request body. The `endpoint` field SHALL be required to be present but MAY be an
+empty string — an empty string is accepted so the toolset editor can create a draft toolset
+right after its General step, before the endpoint is collected on the Settings step; when
+non-empty, `endpoint` SHALL still be validated as a well-formed `http(s)://` or `sse://` URL.
+The `authSettings` field SHALL be required to be present in the request body — an entirely
+omitted `authSettings` SHALL fail DTO validation and SHALL NOT reach the DIAL Core call,
+regardless of whether its nested `authenticationType` is itself valid.
+
+#### Scenario: Successful create with a draft (empty) endpoint
+- **WHEN** an authenticated user POSTs a toolset body with `endpoint` set to an empty string
+- **THEN** the service proxies the create to DIAL Core and returns the created toolset
+  identifier
+
+#### Scenario: Missing endpoint field
+- **WHEN** an authenticated user POSTs a toolset body with the `endpoint` field omitted
+  entirely
+- **THEN** the endpoint responds with a 400 and does not call DIAL Core
+
+#### Scenario: Missing authSettings field
+- **WHEN** an authenticated user POSTs a toolset body with the `authSettings` field omitted
+  entirely
+- **THEN** the endpoint responds with a 400 naming `authSettings` and does not call DIAL Core
+
+#### Scenario: Successful create
+- **WHEN** an authenticated user POSTs a valid toolset body
+- **THEN** the service proxies the create to DIAL Core, invalidates the user's toolset list
+  cache, and returns the created toolset identifier
+
+#### Scenario: Successful create with intro
+- **WHEN** an authenticated user POSTs a valid toolset body including an `intro` of 90
+  characters or fewer
+- **THEN** the service includes `intro` in the DIAL Core create request and the create
+  succeeds
+
+#### Scenario: Successful create without intro
+- **WHEN** an authenticated user POSTs a valid toolset body with `intro` omitted or empty
+- **THEN** the create succeeds and no `intro` value is sent to DIAL Core
+
+#### Scenario: Invalid create body
+- **WHEN** the request body fails DTO validation
+- **THEN** the endpoint responds with a 400 and does not call DIAL Core
+
+#### Scenario: Intro exceeds the character limit
+- **WHEN** an authenticated user POSTs a toolset body with `intro` longer than 90 characters
+- **THEN** the endpoint responds with a 400 validation error and does not call DIAL Core
+
+#### Scenario: DIAL Core create error
+- **WHEN** DIAL Core returns an error status during create
+- **THEN** the endpoint maps it to the corresponding typed HTTP error (e.g. 502/503)

--- a/openspec/changes/archive/2026-08-03-fix-toolset-create-missing-auth-settings-validation/tasks.md
+++ b/openspec/changes/archive/2026-08-03-fix-toolset-create-missing-auth-settings-validation/tasks.md
@@ -1,0 +1,30 @@
+## 1. DTO fix
+
+- [x] 1.1 Add `@IsDefined()` to `authSettings` on `ToolsetBodyDto`
+      (`apps/chat-api/src/toolsets/dto/toolset-body.dto.ts`), ordered before
+      `@ValidateNested()` / `@Type(() => ToolsetAuthSettingsBodyDto)`.
+- [x] 1.2 Confirm the Swagger `@ApiProperty` metadata for `authSettings` still reflects a
+      required field (no change expected, verify only).
+
+## 2. Tests
+
+- [x] 2.1 Add a unit test for `ToolsetBodyDto` validation asserting an omitted `authSettings`
+      produces a validation error naming `authSettings`.
+- [x] 2.2 Add/extend a `ToolsetsController`/`ToolsetsService` test (e.g. supertest against
+      `POST /api/v1/toolsets`) asserting an omitted `authSettings` body returns 400 and that
+      `ToolsetsService`/DIAL Core is never invoked (e.g. via a spy assertion).
+- [x] 2.3 Confirm the existing `authSettings: {}` case (400 naming `authenticationType`) and
+      the existing "Missing endpoint field" test still pass unchanged.
+
+## 3. Verification
+
+- [x] 3.1 Run `npm exec nx test chat-api` and `npm exec nx lint chat-api`. (One
+      unrelated flaky failure in `scheduled-tasks.controller.spec.ts` reproduced in
+      isolation as passing — pre-existing, untouched by this change.)
+- [x] 3.2 Verify the repro from issue #7570 — `POST /api/v1/toolsets` with
+      `{"name": "<any>", "endpoint": "https://example.com/mcp", "transport": "HTTP"}` now
+      returns 400 (not 503). Exercised via the `toolsets.controller.spec.ts` supertest
+      integration test (real `ValidationPipe` config, stubbed session — the route's auth
+      guard would reject an unauthenticated live request before validation runs, so a
+      live-server manual repro can't isolate this case any better than the integration test
+      already does).

--- a/openspec/specs/toolset-write-api/spec.md
+++ b/openspec/specs/toolset-write-api/spec.md
@@ -13,6 +13,9 @@ the create request body. The `endpoint` field SHALL be required to be present bu
 empty string — an empty string is accepted so the toolset editor can create a draft toolset
 right after its General step, before the endpoint is collected on the Settings step; when
 non-empty, `endpoint` SHALL still be validated as a well-formed `http(s)://` or `sse://` URL.
+The `authSettings` field SHALL be required to be present in the request body — an entirely
+omitted `authSettings` SHALL fail DTO validation and SHALL NOT reach the DIAL Core call,
+regardless of whether its nested `authenticationType` is itself valid.
 
 #### Scenario: Successful create with a draft (empty) endpoint
 - **WHEN** an authenticated user POSTs a toolset body with `endpoint` set to an empty string
@@ -23,6 +26,11 @@ non-empty, `endpoint` SHALL still be validated as a well-formed `http(s)://` or 
 - **WHEN** an authenticated user POSTs a toolset body with the `endpoint` field omitted
   entirely
 - **THEN** the endpoint responds with a 400 and does not call DIAL Core
+
+#### Scenario: Missing authSettings field
+- **WHEN** an authenticated user POSTs a toolset body with the `authSettings` field omitted
+  entirely
+- **THEN** the endpoint responds with a 400 naming `authSettings` and does not call DIAL Core
 
 #### Scenario: Successful create
 - **WHEN** an authenticated user POSTs a valid toolset body


### PR DESCRIPTION
## Description of changes

<!-- Please explain the changes you made right below this line. -->

## Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #7570
## UI changes

<Please, provide Screenshots or Figma links>

## Checklist

- [ ] the pull request name ends with `(Issue #<ISSUE_ID>)` (comma-separated list of issues)
- [ ] I confirm that I don't share any confidential information like API keys or any other secrets and private URLs

<details>
  <summary>PR title cheatsheet</summary>

`<type>[optional scope]: <description>`

1. type (required)
    - `feat` - A new feature
    - `fix` - A bug fix
    - `docs` - Documentation only changes
    - `test` - Adding missing tests or correcting existing tests
    - `ci` - Changes to our CI configuration files and scripts
    - `chore` - Other changes that are minor and/or not user-facing
2. scope (optional, current repo suggestions below)
    - `chat`
    - `overlay`
    - `shared`
    - `sandbox-overlay`
    - `visualizer-connector`

</details>
