### PR TITLE
feat: add account Usage page with summary card and by-model table

### DIFF
--- a/apps/chat/src/app/app.tsx
+++ b/apps/chat/src/app/app.tsx
@@ -84,6 +84,9 @@ const ConversationSharedInvitationPage = lazy(
     import('../pages/ConversationSharedInvitation/ConversationSharedInvitation'),
 );
 const NotFoundPage = lazy(() => import('../pages/NotFound/NotFound'));
+const ProfileUsagePage = lazy(
+  () => import('../pages/ProfileUsage/ProfileUsage'),
+);
 
 // Start loading the module immediately so the Suspense fallback is skipped on first navigation.
 const conversationPageModule = import('../pages/Conversation/Conversation');
@@ -411,6 +414,16 @@ const App: FC = () => {
                 <RouteErrorBoundary>
                   <Suspense fallback={<RouteFallback />}>
                     <ToolsetEditorPage />
+                  </Suspense>
+                </RouteErrorBoundary>
+              }
+            />
+            <Route
+              path={ROUTES.ProfileUsage}
+              element={
+                <RouteErrorBoundary>
+                  <Suspense fallback={<RouteFallback />}>
+                    <ProfileUsagePage />
                   </Suspense>
                 </RouteErrorBoundary>
               }

--- a/apps/chat/src/components/Navigation/UserMenu.tsx
+++ b/apps/chat/src/components/Navigation/UserMenu.tsx
@@ -15,10 +15,12 @@ import {
   IconLanguage,
   IconLogout,
   IconMoon,
+  IconSettings,
   IconSun,
 } from '@tabler/icons-react';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router-dom';
 import {
   AuthI18nKeys,
   ButtonsI18nKeys,
@@ -39,6 +41,7 @@ import { useThemeOptions } from '../../hooks/theme/useThemeOptions';
 import { useUserProfile } from '../../hooks/user-profile/useUserProfile';
 import { useUiFeature } from '../../hooks/useUiFeature';
 import { AuthStatus } from '../../types/auth-status';
+import { ROUTES } from '../../types/routes';
 import { ThemeId } from '../../types/theme-id';
 import LogoutConfirmationModal from '../LogoutConfirmation/LogoutConfirmationModal';
 import AvatarInitials from './AvatarInitials';
@@ -47,6 +50,7 @@ import MenuItemLabel from './MenuItemLabel';
 export const UserMenu = memo(() => {
   const { status, user } = useUser();
   const { t } = useTranslation();
+  const navigate = useNavigate();
   const { hasDark, hasLight, selectedTheme, setTheme } = useThemeOptions();
   const { preference, setPreference } = useKeyboardShortcutPreference();
   const { language, changeLanguage } = useLanguage();
@@ -201,6 +205,16 @@ export const UserMenu = memo(() => {
           },
         ]
       : []),
+    {
+      key: 'settings',
+      label: (
+        <span className="dial-small-text">
+          {t(SettingsI18nKeys.NavSectionLabel)}
+        </span>
+      ),
+      icon: <IconSettings size={DIAL_ICON_SIZE.SM} aria-hidden />,
+      onClick: () => navigate(ROUTES.ProfileUsage),
+    },
     { key: 'divider-1', type: DropdownItemType.Divider },
     {
       key: 'logout',

--- a/apps/chat/src/components/ProfileSettingsNav/ProfileSettingsNav.tsx
+++ b/apps/chat/src/components/ProfileSettingsNav/ProfileSettingsNav.tsx
@@ -1,0 +1,80 @@
+import { mergeClasses } from '@epam/ai-dial-chat-shared';
+import { BASE_ICON_SIZE } from '@epam/ai-dial-ui-kit';
+import {
+  IconAdjustmentsHorizontal,
+  IconTable,
+  IconUser,
+} from '@tabler/icons-react';
+import { type FC, memo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Link, useLocation } from 'react-router-dom';
+import { SettingsI18nKeys } from '../../constants/translation-keys';
+import { ROUTES } from '../../types/routes';
+
+interface Props {
+  className?: string;
+}
+
+/**
+ * Left sub-navigation for account settings pages (General · Preferences · Usage).
+ * General and Preferences have no page yet and render as inert rows; Usage links
+ * to the real route and gets the active-state highlight when visited.
+ */
+const ProfileSettingsNav: FC<Props> = ({ className }) => {
+  const { t } = useTranslation();
+  const { pathname } = useLocation();
+  const isUsageActive = pathname === ROUTES.ProfileUsage;
+
+  const rowClassName =
+    'flex items-center gap-2.5 rounded-[9px] px-2.5 py-2 dial-small-text';
+
+  return (
+    <nav
+      aria-label={t(SettingsI18nKeys.NavAriaLabel)}
+      className={mergeClasses(
+        'hidden w-[210px] shrink-0 flex-col border-e border-tertiary bg-layer-0 px-3 py-5 desktop:flex',
+        className,
+      )}
+    >
+      <div className="dial-tiny-semi-text px-2.5 pb-3 uppercase tracking-wider text-secondary">
+        {t(SettingsI18nKeys.NavSectionLabel)}
+      </div>
+
+      <div
+        aria-disabled="true"
+        className={mergeClasses(rowClassName, 'cursor-default text-secondary')}
+      >
+        <IconUser size={BASE_ICON_SIZE} stroke={1.75} aria-hidden />
+        {t(SettingsI18nKeys.General)}
+      </div>
+
+      <div
+        aria-disabled="true"
+        className={mergeClasses(rowClassName, 'cursor-default text-secondary')}
+      >
+        <IconAdjustmentsHorizontal
+          size={BASE_ICON_SIZE}
+          stroke={1.75}
+          aria-hidden
+        />
+        {t(SettingsI18nKeys.Preferences)}
+      </div>
+
+      <Link
+        to={ROUTES.ProfileUsage}
+        aria-current={isUsageActive ? 'page' : undefined}
+        className={mergeClasses(
+          rowClassName,
+          isUsageActive
+            ? 'bg-accent-primary-alpha font-semibold text-accent-primary'
+            : 'text-secondary hover:bg-layer-6',
+        )}
+      >
+        <IconTable size={BASE_ICON_SIZE} stroke={1.75} aria-hidden />
+        {t(SettingsI18nKeys.Usage)}
+      </Link>
+    </nav>
+  );
+};
+
+export default memo(ProfileSettingsNav);

--- a/apps/chat/src/constants/translation-keys.ts
+++ b/apps/chat/src/constants/translation-keys.ts
@@ -452,6 +452,8 @@ export enum SettingsI18nKeys {
   Usage = 'settings.usage',
   UsagePageSubtitle = 'settings.usagePageSubtitle',
   UsageByModel = 'settings.usageByModel',
+  UsageLoadError = 'settings.usageLoadError',
+  UsageLoading = 'settings.usageLoading',
 }
 
 export enum ConversationPanelI18nKeys {

--- a/apps/chat/src/constants/translation-keys.ts
+++ b/apps/chat/src/constants/translation-keys.ts
@@ -445,6 +445,13 @@ export enum SettingsI18nKeys {
   KeyboardShortcuts = 'settings.keyboardShortcuts',
   ShortcutEnter = 'settings.shortcutEnter',
   ShortcutMetaEnter = 'settings.shortcutMetaEnter',
+  NavSectionLabel = 'settings.navSectionLabel',
+  NavAriaLabel = 'settings.navAriaLabel',
+  General = 'settings.general',
+  Preferences = 'settings.preferences',
+  Usage = 'settings.usage',
+  UsagePageSubtitle = 'settings.usagePageSubtitle',
+  UsageByModel = 'settings.usageByModel',
 }
 
 export enum ConversationPanelI18nKeys {

--- a/apps/chat/src/hooks/useAccountUsage.ts
+++ b/apps/chat/src/hooks/useAccountUsage.ts
@@ -1,0 +1,70 @@
+import type { ModelUsageRowData, UsageWindowData } from '@epam/ai-dial-kit';
+import { useCallback, useEffect, useState } from 'react';
+import {
+  MOCK_USAGE_ROWS,
+  MOCK_USAGE_WINDOWS,
+} from '../pages/ProfileUsage/mock-usage-data';
+
+export interface UseAccountUsageResult {
+  /** Daily/monthly budget windows for the summary card. */
+  windows: UsageWindowData[];
+  /** Per-model usage rows for the by-model table. */
+  rows: ModelUsageRowData[];
+  /** `true` while a fetch is in flight. */
+  isLoading: boolean;
+  /** `true` after the most recent fetch rejected. */
+  hasError: boolean;
+  /** Re-fetches account usage when no request is in flight. */
+  refresh: () => void;
+}
+
+/**
+ * Account-wide usage/budget summary and by-model breakdown for the Usage settings page.
+ *
+ * No account usage/budget endpoint exists yet, so this returns the same fixture data as
+ * a resolved fetch. Swapping in the real call once it lands only requires replacing the
+ * body of `fetchUsage` below — `ProfileUsage` already consumes this hook's loading/error
+ * contract and needs no changes.
+ */
+export const useAccountUsage = (): UseAccountUsageResult => {
+  const [windows, setWindows] = useState<UsageWindowData[]>([]);
+  const [rows, setRows] = useState<ModelUsageRowData[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [hasError, setHasError] = useState(false);
+  const [refreshCounter, setRefreshCounter] = useState(0);
+
+  const refresh = useCallback(() => {
+    setRefreshCounter((counter) => counter + 1);
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const fetchUsage = async () => {
+      setIsLoading(true);
+      setHasError(false);
+
+      try {
+        // TODO: replace with the real account usage/budget fetch once that API lands.
+        if (cancelled) return;
+        setWindows(MOCK_USAGE_WINDOWS);
+        setRows(MOCK_USAGE_ROWS);
+      } catch {
+        if (cancelled) return;
+        setHasError(true);
+      } finally {
+        if (!cancelled) {
+          setIsLoading(false);
+        }
+      }
+    };
+
+    void fetchUsage();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [refreshCounter]);
+
+  return { windows, rows, isLoading, hasError, refresh };
+};

--- a/apps/chat/src/i18n/locales/en.json
+++ b/apps/chat/src/i18n/locales/en.json
@@ -386,7 +386,14 @@
     "themeSystem": "System",
     "keyboardShortcuts": "Keyboard shortcuts",
     "shortcutEnter": "Enter — send message, Shift+Enter — new line",
-    "shortcutMetaEnter": "{{modifier}}+Enter — send message, Enter — new line"
+    "shortcutMetaEnter": "{{modifier}}+Enter — send message, Enter — new line",
+    "navSectionLabel": "Settings",
+    "navAriaLabel": "Settings navigation",
+    "general": "General",
+    "preferences": "Preferences",
+    "usage": "Usage",
+    "usagePageSubtitle": "Per-model figures below sum to the totals · settle after each response · times in your timezone · set by your organization.",
+    "usageByModel": "By model"
   },
   "attachments": {
     "downloadFile": "Download file",

--- a/apps/chat/src/i18n/locales/en.json
+++ b/apps/chat/src/i18n/locales/en.json
@@ -393,7 +393,9 @@
     "preferences": "Preferences",
     "usage": "Usage",
     "usagePageSubtitle": "Per-model figures below sum to the totals · settle after each response · times in your timezone · set by your organization.",
-    "usageByModel": "By model"
+    "usageByModel": "By model",
+    "usageLoadError": "Could not load your usage data. Please try again.",
+    "usageLoading": "Loading usage data"
   },
   "attachments": {
     "downloadFile": "Download file",

--- a/apps/chat/src/pages/ProfileUsage/ProfileUsage.tsx
+++ b/apps/chat/src/pages/ProfileUsage/ProfileUsage.tsx
@@ -1,14 +1,19 @@
 import { UsageModelTable, UsageSummaryCard } from '@epam/ai-dial-kit';
+import { DialSpinner, NeutralButton } from '@epam/ai-dial-ui-kit';
 import { type FC, memo } from 'react';
 import { useTranslation } from 'react-i18next';
 import ProfileSettingsNav from '../../components/ProfileSettingsNav/ProfileSettingsNav';
-import { SettingsI18nKeys } from '../../constants/translation-keys';
-import { MOCK_USAGE_ROWS, MOCK_USAGE_WINDOWS } from './mock-usage-data';
+import {
+  ButtonsI18nKeys,
+  SettingsI18nKeys,
+} from '../../constants/translation-keys';
+import { useAccountUsage } from '../../hooks/useAccountUsage';
 
 type Props = Record<string, never>;
 
 const ProfileUsage: FC<Props> = () => {
   const { t } = useTranslation();
+  const { windows, rows, isLoading, hasError, refresh } = useAccountUsage();
 
   return (
     <div className="flex h-full min-h-0 w-full">
@@ -21,18 +26,47 @@ const ProfileUsage: FC<Props> = () => {
             {t(SettingsI18nKeys.UsagePageSubtitle)}
           </p>
 
-          <UsageSummaryCard windows={MOCK_USAGE_WINDOWS} className="mb-10" />
+          {isLoading && (
+            <div className="flex items-center justify-center py-16">
+              <DialSpinner />
+              <span role="status" aria-live="polite" className="sr-only">
+                {t(SettingsI18nKeys.UsageLoading)}
+              </span>
+            </div>
+          )}
 
-          <div className="mb-5 flex items-baseline gap-2.5">
-            <span className="dial-h3-text">
-              {t(SettingsI18nKeys.UsageByModel)}
-            </span>
-            <span className="dial-small-semi-text text-secondary">
-              {MOCK_USAGE_ROWS.length}
-            </span>
-          </div>
+          {!isLoading && hasError && (
+            <div
+              role="status"
+              aria-live="polite"
+              className="flex flex-col items-start gap-3 py-16"
+            >
+              <p className="dial-body-text">
+                {t(SettingsI18nKeys.UsageLoadError)}
+              </p>
+              <NeutralButton
+                label={t(ButtonsI18nKeys.Retry)}
+                onClick={refresh}
+              />
+            </div>
+          )}
 
-          <UsageModelTable rows={MOCK_USAGE_ROWS} />
+          {!isLoading && !hasError && (
+            <>
+              <UsageSummaryCard windows={windows} className="mb-10" />
+
+              <div className="mb-5 flex items-baseline gap-2.5">
+                <span className="dial-h3-text">
+                  {t(SettingsI18nKeys.UsageByModel)}
+                </span>
+                <span className="dial-small-semi-text text-secondary">
+                  {rows.length}
+                </span>
+              </div>
+
+              <UsageModelTable rows={rows} />
+            </>
+          )}
         </div>
       </div>
     </div>

--- a/apps/chat/src/pages/ProfileUsage/ProfileUsage.tsx
+++ b/apps/chat/src/pages/ProfileUsage/ProfileUsage.tsx
@@ -1,0 +1,42 @@
+import { UsageModelTable, UsageSummaryCard } from '@epam/ai-dial-kit';
+import { type FC, memo } from 'react';
+import { useTranslation } from 'react-i18next';
+import ProfileSettingsNav from '../../components/ProfileSettingsNav/ProfileSettingsNav';
+import { SettingsI18nKeys } from '../../constants/translation-keys';
+import { MOCK_USAGE_ROWS, MOCK_USAGE_WINDOWS } from './mock-usage-data';
+
+type Props = Record<string, never>;
+
+const ProfileUsage: FC<Props> = () => {
+  const { t } = useTranslation();
+
+  return (
+    <div className="flex h-full min-h-0 w-full">
+      <ProfileSettingsNav />
+
+      <div className="min-w-0 flex-1 overflow-auto p-6 desktop:p-10">
+        <div className="mx-auto flex max-w-[1000px] flex-col">
+          <h1 className="dial-display2-text">{t(SettingsI18nKeys.Usage)}</h1>
+          <p className="dial-tiny-text mb-6 mt-2 max-w-[640px] text-secondary">
+            {t(SettingsI18nKeys.UsagePageSubtitle)}
+          </p>
+
+          <UsageSummaryCard windows={MOCK_USAGE_WINDOWS} className="mb-10" />
+
+          <div className="mb-5 flex items-baseline gap-2.5">
+            <span className="dial-h3-text">
+              {t(SettingsI18nKeys.UsageByModel)}
+            </span>
+            <span className="dial-small-semi-text text-secondary">
+              {MOCK_USAGE_ROWS.length}
+            </span>
+          </div>
+
+          <UsageModelTable rows={MOCK_USAGE_ROWS} />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default memo(ProfileUsage);

--- a/apps/chat/src/pages/ProfileUsage/mock-usage-data.ts
+++ b/apps/chat/src/pages/ProfileUsage/mock-usage-data.ts
@@ -1,0 +1,57 @@
+import type { ModelUsageRowData, UsageWindowData } from '@epam/ai-dial-kit';
+
+// TODO: replace with real account usage data once the usage/budget API lands.
+export const MOCK_USAGE_WINDOWS: UsageWindowData[] = [
+  {
+    title: 'Daily limit',
+    scope: 'All models',
+    used: 3.6,
+    limit: 4,
+    resetLabel: 'Resets 00:00 · in 6h 12m',
+  },
+  {
+    title: 'Monthly limit',
+    scope: 'All models',
+    used: 41,
+    limit: 120,
+    resetLabel: 'Resets 1 Aug · in 12 days',
+  },
+];
+
+export const MOCK_USAGE_ROWS: ModelUsageRowData[] = [
+  {
+    id: 'claude-opus',
+    name: 'Claude Opus',
+    version: '4.8',
+    today: { used: 2, limit: 2, resetLabel: 'Resets in 4h' },
+    thisMonth: { used: 12, limit: 30, resetLabel: 'Resets 1 Aug' },
+  },
+  {
+    id: 'deepseek-flash',
+    name: 'ali.deepseek-v4-flash',
+    version: '4.0.1',
+    today: { used: 0.4, limit: null },
+    thisMonth: { used: 17, limit: 20, resetLabel: 'Resets 1 Aug' },
+  },
+  {
+    id: 'glm',
+    name: 'GLM-5.2',
+    version: '5.2.1',
+    today: { used: 0.5, limit: null },
+    thisMonth: { used: 6.2, limit: 40, resetLabel: 'Resets 1 Aug' },
+  },
+  {
+    id: 'gpt-4o',
+    name: 'GPT-4o',
+    version: '2024-11',
+    today: { used: 0.2, limit: null },
+    thisMonth: { used: 4.1, limit: null },
+  },
+  {
+    id: 'deepseek-pro',
+    name: 'ali.deepseek-v4-pro',
+    version: '4.0.0',
+    today: { used: 0.1, limit: null },
+    thisMonth: { used: 1.7, limit: null },
+  },
+];

--- a/apps/chat/src/types/routes.ts
+++ b/apps/chat/src/types/routes.ts
@@ -21,4 +21,5 @@ export enum ROUTES {
   FileManager = '/files',
   ScheduledTasks = '/scheduled-tasks',
   ScheduledTaskCreate = '/scheduled-tasks/new',
+  ProfileUsage = '/profile/usage',
 }

--- a/libs/ai-dial-kit/src/components/UsageModelTable/UsageModelRow.tsx
+++ b/libs/ai-dial-kit/src/components/UsageModelTable/UsageModelRow.tsx
@@ -1,0 +1,229 @@
+import { InitialsAvatar, mergeClasses } from '@epam/ai-dial-chat-shared';
+import { type FC } from 'react';
+import {
+  type ModelUsagePeriod,
+  type UsageModelTableLabels,
+  UsageLimitState,
+  UsageRowScope,
+} from '../../types/usage-limit';
+import { DEFAULT_USAGE_STATE_COLORS } from '../../utils/usage-colors';
+import {
+  formatUsageAmount,
+  getModelRowState,
+  getUsageLimitState,
+  getUsagePercentage,
+} from '../../utils/usage-limit';
+
+/** Props for `UsageModelRow`. */
+export interface UsageModelRowProps {
+  /** Model display name. */
+  name: string;
+  /** Version suffix shown next to the name. */
+  version?: string;
+  /** Today's spend and optional cap. */
+  today: ModelUsagePeriod;
+  /** This month's spend and optional cap. */
+  thisMonth: ModelUsagePeriod;
+  /** ISO 4217 currency code used to format amounts. */
+  currency: string;
+  /** Fraction of remaining budget at/below which a period becomes `Warning`. */
+  warningThreshold?: number;
+  /** Resolved copy for this table. */
+  labels: UsageModelTableLabels;
+  /** Typography class for the model name. Defaults to `'dial-small-semi-text'`. */
+  nameClassName?: string;
+  /** Typography class for muted secondary text (version, cap denominator, reset subline, mobile cell labels). Defaults to `'dial-tiny-text text-secondary'`. */
+  secondaryTextClassName?: string;
+  /** Typography class for usage cell values. Defaults to `'dial-small-semi-text'`. */
+  valueClassName?: string;
+  /** Typography class for the eyebrow "Model" label above the name. Matches the Catalog browse-card entity-type label style by default. */
+  eyebrowClassName?: string;
+  /** Typography class for a row's status text when its worse period is `Normal`. Defaults to `'text-secondary'` (muted, not colored — only Warning/Blocked get colored text). */
+  normalStatusTextClassName?: string;
+  /** Typography class for the status text when neither period has a cap. Defaults to `'text-secondary'`. */
+  noCapStatusTextClassName?: string;
+}
+
+const renderPeriodCell = (
+  period: ModelUsagePeriod,
+  currency: string,
+  warningThreshold: number | undefined,
+  valueClassName: string,
+  secondaryTextClassName: string,
+  labels: UsageModelTableLabels,
+  columnLabel: string,
+) => {
+  const mobileLabel = (
+    <div
+      className={mergeClasses(
+        'mb-1 block desktop:hidden',
+        secondaryTextClassName,
+      )}
+    >
+      {columnLabel}
+    </div>
+  );
+
+  if (period.limit == null) {
+    return (
+      <div>
+        {mobileLabel}
+        <div className={valueClassName}>
+          {formatUsageAmount(period.used, currency)}
+        </div>
+      </div>
+    );
+  }
+
+  const state = getUsageLimitState(period.used, period.limit, warningThreshold);
+  const colors = DEFAULT_USAGE_STATE_COLORS[state];
+  const percentage = getUsagePercentage(period.used, period.limit);
+
+  return (
+    <div>
+      {mobileLabel}
+      <div className={valueClassName}>
+        {labels.capValueLabel(
+          formatUsageAmount(period.used, currency),
+          formatUsageAmount(period.limit, currency),
+        )}
+      </div>
+      <div
+        role="progressbar"
+        aria-valuenow={period.used}
+        aria-valuemin={0}
+        aria-valuemax={period.limit}
+        aria-label={columnLabel}
+        className="mt-1.5 h-1 max-w-[130px] overflow-hidden rounded-full bg-layer-4"
+      >
+        <div
+          className={mergeClasses(
+            'h-full rounded-full transition-[width] duration-300',
+            colors.fillClassName,
+          )}
+          style={{
+            width: `${percentage}%`,
+            backgroundColor: colors.fillClassName
+              ? undefined
+              : colors.fillColorValue,
+          }}
+        />
+      </div>
+    </div>
+  );
+};
+
+/** One row of `UsageModelTable`: a model tile, today/this-month usage cells, and a status indicator. */
+export const UsageModelRow: FC<UsageModelRowProps> = ({
+  name,
+  version,
+  today,
+  thisMonth,
+  currency,
+  warningThreshold,
+  labels,
+  nameClassName = 'dial-small-semi-text',
+  secondaryTextClassName = 'dial-tiny-text text-secondary',
+  valueClassName = 'dial-small-semi-text',
+  eyebrowClassName = 'dial-caption-text font-semibold uppercase tracking-[0.06em] text-accent-primary',
+  normalStatusTextClassName = 'text-secondary',
+  noCapStatusTextClassName = 'text-secondary',
+}) => {
+  const { state, scope } = getModelRowState(
+    { today, thisMonth },
+    warningThreshold,
+  );
+  const colors = DEFAULT_USAGE_STATE_COLORS[state];
+  const hasCap = scope != null;
+  const resetLabel =
+    scope === UsageRowScope.Daily ? today.resetLabel : thisMonth.resetLabel;
+
+  const statusLabel =
+    state === UsageLimitState.Blocked
+      ? labels.capReachedLabel(scope as UsageRowScope)
+      : state === UsageLimitState.Warning
+        ? labels.nearCapLabel(scope as UsageRowScope)
+        : state === UsageLimitState.Normal
+          ? labels.withinLimitsLabel
+          : labels.noLimitLabel;
+
+  // Only Warning/Blocked color the status text itself; Normal stays muted (the dot alone
+  // carries the "OK" green), and the no-cap case gets its own quiet, uncolored tone.
+  const isUrgent =
+    state === UsageLimitState.Warning || state === UsageLimitState.Blocked;
+  const statusTextClassName = !hasCap
+    ? noCapStatusTextClassName
+    : isUrgent
+      ? colors.textClassName
+      : normalStatusTextClassName;
+
+  return (
+    <div className="grid grid-cols-2 items-start gap-x-4 gap-y-3 border-b border-tertiary px-3 py-4 last:border-b-0 hover:bg-layer-6 desktop:grid-cols-[minmax(200px,1fr)_1fr_1fr_1fr] desktop:gap-4">
+      <div className="col-span-2 flex min-w-0 items-center gap-3 desktop:col-span-1">
+        <InitialsAvatar
+          name={name}
+          size={40}
+          className="shrink-0 rounded-[11px]"
+        />
+        <div className="min-w-0">
+          <div className={eyebrowClassName}>{labels.modelEyebrowLabel}</div>
+          <div className={mergeClasses(nameClassName, 'truncate')}>
+            {name}
+            {version && (
+              <span className={mergeClasses('ms-1', secondaryTextClassName)}>
+                {version}
+              </span>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {renderPeriodCell(
+        today,
+        currency,
+        warningThreshold,
+        valueClassName,
+        secondaryTextClassName,
+        labels,
+        labels.todayColumnLabel,
+      )}
+      {renderPeriodCell(
+        thisMonth,
+        currency,
+        warningThreshold,
+        valueClassName,
+        secondaryTextClassName,
+        labels,
+        labels.monthColumnLabel,
+      )}
+
+      <div className="col-span-2 flex flex-col items-start gap-1 desktop:col-span-1 desktop:justify-self-start">
+        <div
+          className={mergeClasses(
+            'dial-tiny-semi-text flex items-center gap-2',
+            statusTextClassName,
+          )}
+        >
+          {hasCap && (
+            <span
+              aria-hidden
+              className={mergeClasses(
+                'size-1.5 shrink-0 rounded-full',
+                colors.fillClassName,
+              )}
+              style={
+                colors.fillClassName
+                  ? undefined
+                  : { backgroundColor: colors.fillColorValue }
+              }
+            />
+          )}
+          {statusLabel}
+        </div>
+        {hasCap && resetLabel && (
+          <div className={secondaryTextClassName}>{resetLabel}</div>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/libs/ai-dial-kit/src/components/UsageModelTable/UsageModelTable.tsx
+++ b/libs/ai-dial-kit/src/components/UsageModelTable/UsageModelTable.tsx
@@ -1,0 +1,95 @@
+import { mergeClasses } from '@epam/ai-dial-chat-shared';
+import { DialNoDataContent } from '@epam/ai-dial-ui-kit';
+import { type FC } from 'react';
+import {
+  type ModelUsageRowData,
+  type UsageModelTableLabels,
+  UsageRowScope,
+} from '../../types/usage-limit';
+import { UsageModelRow } from './UsageModelRow';
+
+/** English default copy for `UsageModelTable`. The consuming app overrides these with translated strings. */
+const DEFAULT_LABELS: UsageModelTableLabels = {
+  modelColumnLabel: 'Model',
+  todayColumnLabel: 'Today',
+  monthColumnLabel: 'This month',
+  statusColumnLabel: 'Status',
+  modelEyebrowLabel: 'Model',
+  capValueLabel: (formattedUsed, formattedLimit) =>
+    `${formattedUsed} / ${formattedLimit}`,
+  capReachedLabel: (scope) =>
+    scope === UsageRowScope.Daily ? 'Daily cap reached' : 'Monthly cap reached',
+  nearCapLabel: (scope) =>
+    scope === UsageRowScope.Daily ? 'Near daily cap' : 'Near monthly cap',
+  withinLimitsLabel: 'Within limits',
+  noLimitLabel: 'No limit · rolls up',
+  emptyTitle: 'No usage yet',
+  emptyDescription: 'Model usage will appear here once you start chatting.',
+};
+
+/** Props for `UsageModelTable`. */
+export interface UsageModelTableProps {
+  /** The rows to render, one per model. */
+  rows: ModelUsageRowData[];
+  /** ISO 4217 currency code used to format amounts. Defaults to `'USD'`. */
+  currency?: string;
+  /** Fraction of remaining budget at/below which a period becomes `Warning`. Defaults to `0.15` (85% used). */
+  warningThreshold?: number;
+  /** Extra classes applied to the table's root element. */
+  className?: string;
+  /** Class for the column header row text. Defaults to the app's uppercase, tracked-out section-header style, in a WCAG AA-safe shade. */
+  headerClassName?: string;
+  /** User-visible copy overrides. Merged over English defaults — pass translated strings here. */
+  labels?: Partial<UsageModelTableLabels>;
+}
+
+/**
+ * Cardless by-model usage table: a header rule followed by hairline-divided rows, each
+ * showing a model tile, today/this-month spend (with a mini meter once capped), and a
+ * left-aligned status indicator. Renders an empty state when there are no rows.
+ */
+export const UsageModelTable: FC<UsageModelTableProps> = ({
+  rows,
+  currency = 'USD',
+  warningThreshold,
+  className,
+  headerClassName = 'dial-tiny-semi-text uppercase tracking-wider text-secondary',
+  labels,
+}) => {
+  const text = { ...DEFAULT_LABELS, ...labels };
+
+  if (rows.length === 0) {
+    return (
+      <DialNoDataContent
+        title={text.emptyTitle}
+        description={text.emptyDescription}
+      />
+    );
+  }
+
+  return (
+    <div className={mergeClasses('flex flex-col', className)}>
+      <div className="hidden grid-cols-[minmax(200px,1fr)_1fr_1fr_1fr] gap-4 border-b border-tertiary px-3 pb-3 desktop:grid">
+        <span className={headerClassName}>{text.modelColumnLabel}</span>
+        <span className={headerClassName}>{text.todayColumnLabel}</span>
+        <span className={headerClassName}>{text.monthColumnLabel}</span>
+        <span className={mergeClasses(headerClassName, 'justify-self-start')}>
+          {text.statusColumnLabel}
+        </span>
+      </div>
+
+      {rows.map((row) => (
+        <UsageModelRow
+          key={row.id}
+          name={row.name}
+          version={row.version}
+          today={row.today}
+          thisMonth={row.thisMonth}
+          currency={currency}
+          warningThreshold={warningThreshold}
+          labels={text}
+        />
+      ))}
+    </div>
+  );
+};

--- a/libs/ai-dial-kit/src/components/UsageModelTable/tests/UsageModelTable.spec.tsx
+++ b/libs/ai-dial-kit/src/components/UsageModelTable/tests/UsageModelTable.spec.tsx
@@ -1,0 +1,144 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { UsageModelTable } from '../UsageModelTable';
+
+describe('UsageModelTable', () => {
+  it('renders the empty state when there are no rows', () => {
+    render(<UsageModelTable rows={[]} />);
+    expect(screen.getByText('No usage yet')).toBeTruthy();
+  });
+
+  it('renders a no-cap model as a normal row, not muted, with a rolls-up status', () => {
+    render(
+      <UsageModelTable
+        rows={[
+          {
+            id: 'gpt-4o',
+            name: 'GPT-4o',
+            version: '2024-11',
+            today: { used: 0.2, limit: null },
+            thisMonth: { used: 4.1, limit: null },
+          },
+        ]}
+      />,
+    );
+    expect(screen.getByText('GPT-4o')).toBeTruthy();
+    expect(screen.getByText('$0.20')).toBeTruthy();
+    expect(screen.getByText('$4.10')).toBeTruthy();
+    expect(screen.getByText('No limit · rolls up')).toBeTruthy();
+    // No reset subline for an uncapped row.
+    expect(screen.queryByText(/Resets/)).toBeNull();
+    // Name keeps full-strength styling — not de-emphasised.
+    expect(screen.getByText('GPT-4o').className).not.toContain('text-tertiary');
+    expect(screen.getByText('GPT-4o').className).not.toContain(
+      'text-secondary',
+    );
+  });
+
+  it('shows "Within limits" (muted text, green dot) for a row comfortably under cap', () => {
+    const { container } = render(
+      <UsageModelTable
+        rows={[
+          {
+            id: 'glm',
+            name: 'GLM-5.2',
+            version: '5.2.1',
+            today: { used: 0.5, limit: null },
+            thisMonth: { used: 6.2, limit: 40, resetLabel: 'Resets 1 Aug' },
+          },
+        ]}
+      />,
+    );
+    const status = screen.getByText('Within limits');
+    expect(status.className).toContain('text-secondary');
+    expect(status.className).not.toContain('text-accent-secondary');
+    expect(screen.getByText('Resets 1 Aug')).toBeTruthy();
+    const dot = container.querySelector('.bg-accent-secondary');
+    expect(dot).toBeTruthy();
+  });
+
+  it('shows "Near monthly cap" (colored text) for a row past the warning threshold', () => {
+    render(
+      <UsageModelTable
+        rows={[
+          {
+            id: 'deepseek-flash',
+            name: 'ali.deepseek-v4-flash',
+            version: '4.0.1',
+            today: { used: 0.4, limit: null },
+            thisMonth: { used: 17, limit: 20, resetLabel: 'Resets 1 Aug' },
+          },
+        ]}
+      />,
+    );
+    const status = screen.getByText('Near monthly cap');
+    // Status text uses `text-warning` (dark, AA-safe) — the dot alone carries the
+    // lighter decorative orange fill.
+    expect(status.className).toContain('text-warning');
+    expect(screen.getByText('$17.00 / $20.00')).toBeTruthy();
+  });
+
+  it('shows "Daily cap reached" when the daily scope is worse than a fine monthly scope', () => {
+    render(
+      <UsageModelTable
+        rows={[
+          {
+            id: 'claude-opus',
+            name: 'Claude Opus',
+            version: '4.8',
+            today: { used: 2, limit: 2, resetLabel: 'Resets in 4h' },
+            thisMonth: { used: 12, limit: 30, resetLabel: 'Resets 1 Aug' },
+          },
+        ]}
+      />,
+    );
+    expect(screen.getByText('Daily cap reached')).toBeTruthy();
+    expect(screen.getByText('Resets in 4h')).toBeTruthy();
+    // The (better) monthly reset line is not the one shown in the status subline.
+    expect(screen.queryByText('Resets 1 Aug')).toBeNull();
+    expect(screen.getByText('$2.00 / $2.00')).toBeTruthy();
+    expect(screen.getByText('$12.00 / $30.00')).toBeTruthy();
+  });
+
+  it('left-aligns the status cell', () => {
+    render(
+      <UsageModelTable
+        rows={[
+          {
+            id: 'claude-opus',
+            name: 'Claude Opus',
+            today: { used: 2, limit: 2, resetLabel: 'Resets in 4h' },
+            thisMonth: { used: 12, limit: 30 },
+          },
+        ]}
+      />,
+    );
+    const status = screen.getByText('Daily cap reached');
+    const statusCell = status.parentElement;
+    expect(statusCell?.className).toContain('items-start');
+    expect(statusCell?.className).toContain('justify-self-start');
+  });
+
+  it('renders multiple rows in order', () => {
+    render(
+      <UsageModelTable
+        rows={[
+          {
+            id: 'a',
+            name: 'Model A',
+            today: { used: 1, limit: null },
+            thisMonth: { used: 1, limit: null },
+          },
+          {
+            id: 'b',
+            name: 'Model B',
+            today: { used: 1, limit: null },
+            thisMonth: { used: 1, limit: null },
+          },
+        ]}
+      />,
+    );
+    expect(screen.getByText('Model A')).toBeTruthy();
+    expect(screen.getByText('Model B')).toBeTruthy();
+  });
+});

--- a/libs/ai-dial-kit/src/components/UsageSummaryCard/UsageSummaryCard.tsx
+++ b/libs/ai-dial-kit/src/components/UsageSummaryCard/UsageSummaryCard.tsx
@@ -1,0 +1,191 @@
+import { mergeClasses } from '@epam/ai-dial-chat-shared';
+import { IconClock } from '@tabler/icons-react';
+import { type FC } from 'react';
+import {
+  type UsageSummaryCardLabels,
+  type UsageWindowData,
+  UsageLimitState,
+} from '../../types/usage-limit';
+import { DEFAULT_USAGE_STATE_COLORS } from '../../utils/usage-colors';
+import {
+  formatUsageAmount,
+  getUsageLimitState,
+  getUsagePercentage,
+} from '../../utils/usage-limit';
+
+/** English default copy for `UsageSummaryCard`. The consuming app overrides these with translated strings. */
+const DEFAULT_LABELS: UsageSummaryCardLabels = {
+  leftOfLabel: 'left of',
+  runningLowLabel: 'Running low',
+  limitReachedLabel: 'Limit reached',
+  unlimitedHeading: 'No limit set',
+  percentUsedLabel: (percent) => `${percent}% used`,
+};
+
+/** Props for `UsageSummaryCard`. */
+export interface UsageSummaryCardProps {
+  /** The windows to render side by side (e.g. daily + monthly). */
+  windows: UsageWindowData[];
+  /** ISO 4217 currency code used to format amounts. Defaults to `'USD'`. */
+  currency?: string;
+  /** Fraction of remaining budget at/below which a window becomes `Warning`. Defaults to `0.15` (85% used). */
+  warningThreshold?: number;
+  /** Extra classes applied to the card's root element. */
+  className?: string;
+  /** Typography class for window titles and the unlimited heading. Defaults to `'dial-h3-text'`. */
+  titleClassName?: string;
+  /** Typography class for muted secondary text (scope, figure suffix, reset line, percentage). Defaults to `'dial-tiny-text text-secondary'`. */
+  secondaryTextClassName?: string;
+  /** Typography class for the headline figure amount. Defaults to `'dial-display1-text'`. */
+  figureClassName?: string;
+  /** Classes for the pill shown when a window is `Warning`. Defaults to amber DS tokens. */
+  warningPillClassName?: string;
+  /** Classes for the pill shown when a window is `Blocked`. Defaults to red DS tokens. */
+  blockedPillClassName?: string;
+  /** User-visible copy overrides. Merged over English defaults — pass translated strings here. */
+  labels?: Partial<UsageSummaryCardLabels>;
+}
+
+/**
+ * Account-level usage summary card. Renders one panel per window (e.g. daily/monthly limit)
+ * with a title, remaining-amount figure, meter, percentage used, reset line, and a state pill
+ * once a window is running low or fully used.
+ */
+export const UsageSummaryCard: FC<UsageSummaryCardProps> = ({
+  windows,
+  currency = 'USD',
+  warningThreshold,
+  className,
+  titleClassName = 'dial-h3-text',
+  secondaryTextClassName = 'dial-tiny-text text-secondary',
+  figureClassName = 'dial-display1-text',
+  warningPillClassName = 'border-warning bg-warning text-warning',
+  blockedPillClassName = 'border-error bg-error text-error',
+  labels,
+}) => {
+  const text = { ...DEFAULT_LABELS, ...labels };
+
+  return (
+    <div
+      className={mergeClasses(
+        'grid grid-cols-1 divide-y divide-tertiary overflow-hidden rounded-[20px] border border-tertiary bg-layer-0 desktop:grid-cols-2 desktop:divide-x desktop:divide-y-0',
+        className,
+      )}
+      // Matches the Catalog browse-card shadow exactly (`CardGrid.module.scss` `.card`) — a
+      // two-layer shadow with commas inside `rgba()`, which this app's Tailwind setup does not
+      // reliably turn into CSS when expressed as an arbitrary-value class.
+      style={{
+        boxShadow:
+          '0 1px 3px rgba(16, 24, 40, 0.04), 0 6px 20px rgba(16, 24, 40, 0.05)',
+      }}
+    >
+      {windows.map((window) => {
+        const state = getUsageLimitState(
+          window.used,
+          window.limit,
+          warningThreshold,
+        );
+        const colors = DEFAULT_USAGE_STATE_COLORS[state];
+        const percentage = getUsagePercentage(window.used, window.limit);
+        const remaining =
+          window.limit == null ? null : Math.max(0, window.limit - window.used);
+        const showPill =
+          state === UsageLimitState.Warning ||
+          state === UsageLimitState.Blocked;
+
+        return (
+          <div key={window.title} className="flex flex-col gap-4 p-[22px]">
+            <div className="flex items-start justify-between gap-2">
+              <div>
+                <div className={titleClassName}>{window.title}</div>
+                <div className={secondaryTextClassName}>{window.scope}</div>
+              </div>
+              {showPill && (
+                <span
+                  className={mergeClasses(
+                    'dial-tiny-semi-text shrink-0 whitespace-nowrap rounded-full border px-2 py-1',
+                    state === UsageLimitState.Blocked
+                      ? blockedPillClassName
+                      : warningPillClassName,
+                  )}
+                >
+                  {state === UsageLimitState.Blocked
+                    ? text.limitReachedLabel
+                    : text.runningLowLabel}
+                </span>
+              )}
+            </div>
+
+            {state === UsageLimitState.Unlimited ? (
+              <div className={titleClassName}>{text.unlimitedHeading}</div>
+            ) : (
+              <>
+                <div
+                  className={mergeClasses(
+                    figureClassName,
+                    colors.textClassName,
+                  )}
+                >
+                  {formatUsageAmount(
+                    state === UsageLimitState.Blocked ? 0 : (remaining ?? 0),
+                    currency,
+                  )}{' '}
+                  <span className={secondaryTextClassName}>
+                    {text.leftOfLabel}{' '}
+                    {formatUsageAmount(window.limit ?? 0, currency)}
+                  </span>
+                </div>
+
+                <div className="flex items-center gap-3">
+                  <div
+                    role="progressbar"
+                    aria-valuenow={window.used}
+                    aria-valuemin={0}
+                    aria-valuemax={window.limit ?? undefined}
+                    aria-label={window.title}
+                    className="h-1.5 flex-1 overflow-hidden rounded-full bg-layer-4"
+                  >
+                    <div
+                      className={mergeClasses(
+                        'h-full rounded-full transition-[width] duration-300',
+                        colors.fillClassName,
+                      )}
+                      style={{
+                        width: `${percentage}%`,
+                        backgroundColor: colors.fillClassName
+                          ? undefined
+                          : colors.fillColorValue,
+                      }}
+                    />
+                  </div>
+                  <span
+                    className={mergeClasses(
+                      'dial-tiny-semi-text shrink-0',
+                      colors.textClassName,
+                    )}
+                  >
+                    {text.percentUsedLabel(Math.round(percentage))}
+                  </span>
+                </div>
+              </>
+            )}
+
+            <div
+              className={mergeClasses(
+                'flex items-center gap-1.5',
+                secondaryTextClassName,
+              )}
+            >
+              <IconClock
+                size={12}
+                className="shrink-0 opacity-70"
+                aria-hidden
+              />
+              {window.resetLabel}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+};

--- a/libs/ai-dial-kit/src/components/UsageSummaryCard/tests/UsageSummaryCard.spec.tsx
+++ b/libs/ai-dial-kit/src/components/UsageSummaryCard/tests/UsageSummaryCard.spec.tsx
@@ -1,0 +1,93 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { UsageSummaryCard } from '../UsageSummaryCard';
+
+const dailyWithin = {
+  title: 'Daily limit',
+  scope: 'All models',
+  used: 1,
+  limit: 4,
+  resetLabel: 'Resets 00:00 · in 6h 12m',
+};
+
+const monthlyWithin = {
+  title: 'Monthly limit',
+  scope: 'All models',
+  used: 41,
+  limit: 120,
+  resetLabel: 'Resets 1 Aug · in 12 days',
+};
+
+describe('UsageSummaryCard', () => {
+  it('renders a window within limits without a pill', () => {
+    render(<UsageSummaryCard windows={[dailyWithin]} />);
+    expect(screen.getByText('Daily limit')).toBeTruthy();
+    expect(screen.getByText('$3.00', { exact: false })).toBeTruthy();
+    expect(screen.getByText('25% used')).toBeTruthy();
+    expect(screen.queryByText('Running low')).toBeNull();
+  });
+
+  it('shows the Running low pill once a window crosses the warning threshold', () => {
+    render(
+      <UsageSummaryCard windows={[{ ...dailyWithin, used: 3.6, limit: 4 }]} />,
+    );
+    expect(screen.getByText('Running low')).toBeTruthy();
+    expect(screen.getByText('90% used')).toBeTruthy();
+  });
+
+  it('reads $0.00 left and shows a Limit reached pill once the window is fully used', () => {
+    render(
+      <UsageSummaryCard windows={[{ ...dailyWithin, used: 4, limit: 4 }]} />,
+    );
+    expect(screen.getByText('$0.00', { exact: false })).toBeTruthy();
+    expect(screen.getByText('100% used')).toBeTruthy();
+    expect(screen.getByText('Limit reached')).toBeTruthy();
+    expect(screen.queryByText('Running low')).toBeNull();
+  });
+
+  it('shows the unlimited heading and hides the meter/pill when there is no limit', () => {
+    render(<UsageSummaryCard windows={[{ ...dailyWithin, limit: null }]} />);
+    expect(screen.getByText('No limit set')).toBeTruthy();
+    expect(screen.queryByRole('progressbar')).toBeNull();
+    expect(screen.queryByText('Running low')).toBeNull();
+  });
+
+  it('always shows the reset line regardless of state', () => {
+    render(<UsageSummaryCard windows={[dailyWithin]} />);
+    expect(screen.getByText('Resets 00:00 · in 6h 12m')).toBeTruthy();
+  });
+
+  it('renders two windows side by side', () => {
+    render(<UsageSummaryCard windows={[dailyWithin, monthlyWithin]} />);
+    expect(screen.getByText('Daily limit')).toBeTruthy();
+    expect(screen.getByText('Monthly limit')).toBeTruthy();
+  });
+
+  it('uses green for a Normal window and the AA-safe dark warning color for a Warning window', () => {
+    render(
+      <UsageSummaryCard
+        windows={[
+          { ...dailyWithin, used: 1, limit: 4 },
+          { ...monthlyWithin, used: 102, limit: 120 },
+        ]}
+      />,
+    );
+    const normalFigure = screen.getByText('$3.00', { exact: false });
+    expect(normalFigure.className).toContain('text-accent-secondary');
+
+    // Warning text uses `text-warning` (dark, AA-safe) — never the light decorative
+    // orange fill color, which only meets the lower non-text contrast bar.
+    const warningFigure = screen.getByText('$18.00', { exact: false });
+    expect(warningFigure.className).toContain('text-warning');
+    expect(warningFigure.className).not.toContain('text-accent-secondary');
+    expect(warningFigure.className).not.toContain('text-error');
+  });
+
+  it('uses red for a Blocked window', () => {
+    render(
+      <UsageSummaryCard windows={[{ ...dailyWithin, used: 4, limit: 4 }]} />,
+    );
+    const figure = screen.getByText('$0.00', { exact: false });
+    expect(figure.className).toContain('text-error');
+  });
+});

--- a/libs/ai-dial-kit/src/index.ts
+++ b/libs/ai-dial-kit/src/index.ts
@@ -27,3 +27,29 @@ export { Textarea } from './components/Textarea/Textarea';
 export type { TextareaProps } from './components/Textarea/Textarea';
 export { TagInput } from './components/TagInput/TagInput';
 export type { TagInputProps } from './components/TagInput/TagInput';
+export { UsageSummaryCard } from './components/UsageSummaryCard/UsageSummaryCard';
+export type { UsageSummaryCardProps } from './components/UsageSummaryCard/UsageSummaryCard';
+export { UsageModelTable } from './components/UsageModelTable/UsageModelTable';
+export type { UsageModelTableProps } from './components/UsageModelTable/UsageModelTable';
+export { UsageModelRow } from './components/UsageModelTable/UsageModelRow';
+export type { UsageModelRowProps } from './components/UsageModelTable/UsageModelRow';
+export { UsageLimitState, UsageRowScope } from './types/usage-limit';
+export type {
+  UsageLimitStateColors,
+  UsageWindowData,
+  ModelUsagePeriod,
+  ModelUsageRowData,
+  UsageSummaryCardLabels,
+  UsageModelTableLabels,
+} from './types/usage-limit';
+export {
+  DEFAULT_USAGE_WARNING_THRESHOLD,
+  formatUsageAmount,
+  getUsageLimitState,
+  getUsagePercentage,
+  getModelRowState,
+} from './utils/usage-limit';
+export {
+  DEFAULT_USAGE_STATE_COLORS,
+  USAGE_WARNING_FILL_COLOR_VALUE,
+} from './utils/usage-colors';

--- a/libs/ai-dial-kit/src/types/usage-limit.ts
+++ b/libs/ai-dial-kit/src/types/usage-limit.ts
@@ -1,0 +1,113 @@
+/** Account-level usage/budget status derived from `used` vs `limit`. */
+export enum UsageLimitState {
+  /** Remaining budget is above the warning threshold. */
+  Normal = 'normal',
+  /** Remaining budget is at or below the warning threshold. */
+  Warning = 'warning',
+  /** Usage has reached or exceeded the limit. */
+  Blocked = 'blocked',
+  /** No limit is configured for this scope. */
+  Unlimited = 'unlimited',
+}
+
+/** Which capped scope a model row's displayed status was derived from. */
+export enum UsageRowScope {
+  Daily = 'daily',
+  Monthly = 'monthly',
+}
+
+/** Colors applied to a meter/text/dot for one `UsageLimitState`. Provide either the `*ClassName`
+ * fields (existing Tailwind utilities) or `colorValue` (a raw CSS `var()` expression, applied via
+ * inline style) for DS tokens with no matching utility class.
+ *
+ * `textClassName` must always resolve to a token that passes WCAG AA (≥4.5:1) as text — it is
+ * never a decorative-only color. `fillClassName`/`fillColorValue` are for the meter/dot fill,
+ * which is decorative (paired with the AA-safe text) and does not carry the 4.5:1 requirement. */
+export interface UsageLimitStateColors {
+  /** Class applied to the colored text (amount, status label). Always AA-safe as text. */
+  textClassName: string;
+  /** Class applied to the meter/dot fill background. */
+  fillClassName?: string;
+  /** Raw CSS color (or `var(--token, fallback)` expression) for the fill, used via inline style when `fillClassName` is omitted. */
+  fillColorValue?: string;
+}
+
+/** One usage/budget window (e.g. daily or monthly) shown in the summary card. */
+export interface UsageWindowData {
+  /** Window title, e.g. `'Daily limit'`. */
+  title: string;
+  /** Scope shown under the title, e.g. `'All models'`. */
+  scope: string;
+  /** Amount already spent this window, in `currency`. */
+  used: number;
+  /** Budget for this window. `null` means no limit is configured. */
+  limit: number | null;
+  /** Pre-formatted reset line, e.g. `'Resets 00:00 · in 6h 12m'`. */
+  resetLabel: string;
+}
+
+/** Spend and (optional) cap for one scope (daily or monthly) of a single model row. */
+export interface ModelUsagePeriod {
+  /** Amount spent this period, in `currency`. */
+  used: number;
+  /** Cap for this period. `null` means no limit is configured (spend still rolls up to totals). */
+  limit: number | null;
+  /** Pre-formatted reset line shown only when `limit` is set, e.g. `'Resets in 4h'`. */
+  resetLabel?: string;
+}
+
+/** One row of the by-model usage table. */
+export interface ModelUsageRowData {
+  /** Stable identifier for the row (e.g. deployment id). */
+  id: string;
+  /** Model display name, e.g. `'Claude Opus'`. */
+  name: string;
+  /** Version suffix shown next to the name, e.g. `'4.8'`. */
+  version?: string;
+  /** Today's (daily) spend and optional cap. */
+  today: ModelUsagePeriod;
+  /** This month's (monthly) spend and optional cap. */
+  thisMonth: ModelUsagePeriod;
+}
+
+/** All user-visible strings rendered by `UsageSummaryCard`. English defaults — the consuming app supplies translations. */
+export interface UsageSummaryCardLabels {
+  /** Suffix appended after the formatted remaining/zero amount, e.g. `'left of'`. */
+  leftOfLabel: string;
+  /** Label on the pill shown when a window is in the `Warning` state, e.g. `'Running low'`. */
+  runningLowLabel: string;
+  /** Label on the pill shown when a window is in the `Blocked` state, e.g. `'Limit reached'`. */
+  limitReachedLabel: string;
+  /** Heading shown instead of the figure/meter when a window has no limit. */
+  unlimitedHeading: string;
+  /** Computes the muted "`X`% used" caption from a rounded percentage. */
+  percentUsedLabel: (percent: number) => string;
+}
+
+/** All user-visible strings rendered by `UsageModelTable`. English defaults — the consuming app supplies translations. */
+export interface UsageModelTableLabels {
+  /** "Model" column header. */
+  modelColumnLabel: string;
+  /** "Today" column header. */
+  todayColumnLabel: string;
+  /** "This month" column header. */
+  monthColumnLabel: string;
+  /** "Status" column header. */
+  statusColumnLabel: string;
+  /** Eyebrow label shown above each model's name, e.g. `'Model'`. */
+  modelEyebrowLabel: string;
+  /** Computes the "`used` / `limit`" cell text from formatted amounts. */
+  capValueLabel: (formattedUsed: string, formattedLimit: string) => string;
+  /** Status text for a row whose worse scope is `Blocked`, given which scope it came from. */
+  capReachedLabel: (scope: UsageRowScope) => string;
+  /** Status text for a row whose worse scope is `Warning`, given which scope it came from. */
+  nearCapLabel: (scope: UsageRowScope) => string;
+  /** Status text for a row whose worse scope is `Normal`. */
+  withinLimitsLabel: string;
+  /** Status text for a row with no cap on either scope. */
+  noLimitLabel: string;
+  /** Title shown when there are no rows to display. */
+  emptyTitle: string;
+  /** Description shown under the empty-state title. */
+  emptyDescription: string;
+}

--- a/libs/ai-dial-kit/src/utils/tests/usage-limit.spec.ts
+++ b/libs/ai-dial-kit/src/utils/tests/usage-limit.spec.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from 'vitest';
+import { UsageLimitState, UsageRowScope } from '../../types/usage-limit';
+import {
+  formatUsageAmount,
+  getModelRowState,
+  getUsageLimitState,
+  getUsagePercentage,
+} from '../usage-limit';
+
+describe('getUsageLimitState', () => {
+  it('returns Unlimited when limit is null', () => {
+    expect(getUsageLimitState(500, null)).toBe(UsageLimitState.Unlimited);
+  });
+
+  it('returns Blocked when used equals limit', () => {
+    expect(getUsageLimitState(120, 120)).toBe(UsageLimitState.Blocked);
+  });
+
+  it('returns Blocked when used exceeds limit', () => {
+    expect(getUsageLimitState(130, 120)).toBe(UsageLimitState.Blocked);
+  });
+
+  it('returns Warning when remaining fraction is at the threshold', () => {
+    expect(getUsageLimitState(90, 120, 0.25)).toBe(UsageLimitState.Warning);
+  });
+
+  it('returns Normal when remaining fraction is above the threshold', () => {
+    expect(getUsageLimitState(41, 120, 0.25)).toBe(UsageLimitState.Normal);
+  });
+
+  it('uses the default warning threshold (85% used) when none is provided', () => {
+    expect(getUsageLimitState(85, 100)).toBe(UsageLimitState.Warning);
+    expect(getUsageLimitState(84, 100)).toBe(UsageLimitState.Normal);
+  });
+});
+
+describe('getUsagePercentage', () => {
+  it('returns 100 when limit is null', () => {
+    expect(getUsagePercentage(50, null)).toBe(100);
+  });
+
+  it('computes the used/limit ratio as a percentage', () => {
+    expect(getUsagePercentage(30, 120)).toBe(25);
+  });
+
+  it('clamps above 100 when used exceeds limit', () => {
+    expect(getUsagePercentage(200, 120)).toBe(100);
+  });
+
+  it('clamps below 0 for a negative used amount', () => {
+    expect(getUsagePercentage(-10, 120)).toBe(0);
+  });
+});
+
+describe('formatUsageAmount', () => {
+  it('formats a whole-dollar amount with two decimal places by default', () => {
+    expect(formatUsageAmount(79, 'USD')).toBe('$79.00');
+  });
+
+  it('formats with zero fraction digits when requested', () => {
+    expect(formatUsageAmount(79.4, 'USD', 0)).toBe('$79');
+  });
+});
+
+describe('getModelRowState', () => {
+  it('picks Blocked from daily over Normal on monthly (Claude Opus case)', () => {
+    const result = getModelRowState({
+      today: { used: 2, limit: 2 },
+      thisMonth: { used: 12, limit: 30 },
+    });
+    expect(result).toEqual({
+      state: UsageLimitState.Blocked,
+      scope: UsageRowScope.Daily,
+    });
+  });
+
+  it('picks Warning from monthly when daily has no cap (deepseek-flash case)', () => {
+    const result = getModelRowState({
+      today: { used: 0.4, limit: null },
+      thisMonth: { used: 17, limit: 20 },
+    });
+    expect(result).toEqual({
+      state: UsageLimitState.Warning,
+      scope: UsageRowScope.Monthly,
+    });
+  });
+
+  it('picks Normal from monthly when daily has no cap (GLM case)', () => {
+    const result = getModelRowState({
+      today: { used: 0.5, limit: null },
+      thisMonth: { used: 6.2, limit: 40 },
+    });
+    expect(result).toEqual({
+      state: UsageLimitState.Normal,
+      scope: UsageRowScope.Monthly,
+    });
+  });
+
+  it('resolves to Unlimited with no scope when neither period has a cap', () => {
+    const result = getModelRowState({
+      today: { used: 0.2, limit: null },
+      thisMonth: { used: 4.1, limit: null },
+    });
+    expect(result).toEqual({ state: UsageLimitState.Unlimited, scope: null });
+  });
+
+  it('prefers daily on a tie between equal non-unlimited states', () => {
+    const result = getModelRowState({
+      today: { used: 50, limit: 100 },
+      thisMonth: { used: 500, limit: 1000 },
+    });
+    expect(result).toEqual({
+      state: UsageLimitState.Normal,
+      scope: UsageRowScope.Daily,
+    });
+  });
+
+  it('picks Blocked when both scopes are capped and blocked', () => {
+    const result = getModelRowState({
+      today: { used: 10, limit: 10 },
+      thisMonth: { used: 200, limit: 200 },
+    });
+    expect(result.state).toBe(UsageLimitState.Blocked);
+  });
+});

--- a/libs/ai-dial-kit/src/utils/usage-colors.ts
+++ b/libs/ai-dial-kit/src/utils/usage-colors.ts
@@ -1,0 +1,41 @@
+import {
+  type UsageLimitStateColors,
+  UsageLimitState,
+} from '../types/usage-limit';
+
+/**
+ * Orange DS token with no named Tailwind utility in this app. Used only for the decorative
+ * meter/dot fill (applied via inline style, since this app's Tailwind setup does not reliably
+ * generate rules for bracketed `var(--x,#fallback)` classes) — never for text, since at ~3:1
+ * against light backgrounds it fails WCAG AA as a text color. `text-warning` (darker) is used
+ * for text in the `Warning` state instead.
+ */
+export const USAGE_WARNING_FILL_COLOR_VALUE = 'var(--bg-orange-400, #D97C27)';
+
+/**
+ * Shared meter/text/dot colors per `UsageLimitState`: green (`accent-secondary`) under the
+ * warning threshold, orange at/above it, red once the cap is reached. Reused by every usage
+ * component so the whole feature reads as one consistent color language. Every `textClassName`
+ * here is verified to pass WCAG AA (≥4.5:1) against this app's page and card backgrounds.
+ */
+export const DEFAULT_USAGE_STATE_COLORS: Record<
+  UsageLimitState,
+  UsageLimitStateColors
+> = {
+  [UsageLimitState.Normal]: {
+    textClassName: 'text-accent-secondary',
+    fillClassName: 'bg-accent-secondary',
+  },
+  [UsageLimitState.Warning]: {
+    textClassName: 'text-warning',
+    fillColorValue: USAGE_WARNING_FILL_COLOR_VALUE,
+  },
+  [UsageLimitState.Blocked]: {
+    textClassName: 'text-error',
+    fillClassName: 'bg-controls-error',
+  },
+  [UsageLimitState.Unlimited]: {
+    textClassName: 'text-secondary',
+    fillClassName: 'bg-layer-4',
+  },
+};

--- a/libs/ai-dial-kit/src/utils/usage-limit.ts
+++ b/libs/ai-dial-kit/src/utils/usage-limit.ts
@@ -1,0 +1,91 @@
+import {
+  type ModelUsageRowData,
+  UsageLimitState,
+  UsageRowScope,
+} from '../types/usage-limit';
+
+/** Default fraction of remaining budget at/below which the state becomes `Warning` (85% used). */
+export const DEFAULT_USAGE_WARNING_THRESHOLD = 0.15;
+
+/**
+ * Derives the `UsageLimitState` for one scope from raw usage numbers.
+ * `limit === null` means no budget is configured, which always resolves to `Unlimited`.
+ */
+export const getUsageLimitState = (
+  used: number,
+  limit: number | null,
+  warningThreshold: number = DEFAULT_USAGE_WARNING_THRESHOLD,
+): UsageLimitState => {
+  if (limit == null) {
+    return UsageLimitState.Unlimited;
+  }
+  if (used >= limit) {
+    return UsageLimitState.Blocked;
+  }
+  const remainingFraction = (limit - used) / limit;
+  if (remainingFraction <= warningThreshold) {
+    return UsageLimitState.Warning;
+  }
+  return UsageLimitState.Normal;
+};
+
+/** Formats an amount as a currency string using the runtime's `Intl` support. */
+export const formatUsageAmount = (
+  amount: number,
+  currency: string,
+  maximumFractionDigits?: number,
+): string =>
+  new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency,
+    maximumFractionDigits,
+  }).format(amount);
+
+/** Percentage (0–100) of the budget consumed so far, for driving a meter. `Unlimited` scopes render a full meter. */
+export const getUsagePercentage = (
+  used: number,
+  limit: number | null,
+): number => {
+  if (limit == null || limit <= 0) {
+    return 100;
+  }
+  return Math.min(100, Math.max(0, (used / limit) * 100));
+};
+
+const STATE_PRIORITY: Record<UsageLimitState, number> = {
+  [UsageLimitState.Unlimited]: 0,
+  [UsageLimitState.Normal]: 1,
+  [UsageLimitState.Warning]: 2,
+  [UsageLimitState.Blocked]: 3,
+};
+
+/**
+ * Picks the overall status for a model row from its daily and monthly scopes: whichever
+ * scope is in the worse state wins (`Blocked` > `Warning` > `Normal` > `Unlimited`). A row
+ * with no cap on either scope resolves to `Unlimited` with no scope. Ties prefer `daily`,
+ * since it is the more time-sensitive scope.
+ */
+export const getModelRowState = (
+  row: Pick<ModelUsageRowData, 'today' | 'thisMonth'>,
+  warningThreshold: number = DEFAULT_USAGE_WARNING_THRESHOLD,
+): { state: UsageLimitState; scope: UsageRowScope | null } => {
+  const dailyState = getUsageLimitState(
+    row.today.used,
+    row.today.limit,
+    warningThreshold,
+  );
+  const monthlyState = getUsageLimitState(
+    row.thisMonth.used,
+    row.thisMonth.limit,
+    warningThreshold,
+  );
+
+  if (STATE_PRIORITY[dailyState] >= STATE_PRIORITY[monthlyState]) {
+    return {
+      state: dailyState,
+      scope:
+        dailyState === UsageLimitState.Unlimited ? null : UsageRowScope.Daily,
+    };
+  }
+  return { state: monthlyState, scope: UsageRowScope.Monthly };
+};


### PR DESCRIPTION
## Summary
- Adds a Usage settings page: daily/monthly limit summary card + by-model usage table, reusing existing DS components and tokens
- Adds a Settings sub-nav (`ProfileSettingsNav`) and a Settings entry point in the user menu
- Adds `useAccountUsage` hook so `ProfileUsage` fetches through a loading/error/refresh-shaped seam — no account usage/budget API exists yet, so it currently resolves to fixture data; swapping in the real call later only touches the hook body

## Test plan
- [x] `nx run chat:typecheck` passes
- [x] `nx run chat:lint` passes (0 errors)
- [x] `nx run ai-dial-kit:test` passes (37/37, incl. `UsageSummaryCard`, `UsageModelTable`, `usage-limit` utils)
- [ ] Manual check of `/profile/usage` in the running app

🤖 Generated with [Claude Code](https://claude.com/claude-code)