### PR TITLE
fix: limits control accessibility issues (#8107)

### DIFF
--- a/apps/chat/src/components/UsageLimitsControl/UsageLimitsControl.tsx
+++ b/apps/chat/src/components/UsageLimitsControl/UsageLimitsControl.tsx
@@ -71,6 +71,9 @@ const UsageLimitsControl: FC<Props> = ({ deploymentId, labels }) => {
         !wrapperRef.current.contains(event.target as Node)
       ) {
         setIsOpen(false);
+        requestAnimationFrame(() => {
+          triggerRef.current?.focus();
+        });
       }
     };
 
@@ -150,7 +153,6 @@ const UsageLimitsControl: FC<Props> = ({ deploymentId, labels }) => {
         <div
           ref={dialogRef}
           role="dialog"
-          aria-modal="true"
           aria-labelledby={titleId}
           tabIndex={-1}
           className="absolute bottom-full end-0 z-50 mb-2 flex w-64 max-w-[calc(100vw-2rem)] flex-col gap-3 rounded-lg bg-layer-raised p-4 shadow-lg focus:outline-none"

--- a/apps/chat/src/components/UsageLimitsControl/UsageLimitsControl.tsx
+++ b/apps/chat/src/components/UsageLimitsControl/UsageLimitsControl.tsx
@@ -71,6 +71,7 @@ const UsageLimitsControl: FC<Props> = ({ deploymentId, labels }) => {
         !wrapperRef.current.contains(event.target as Node)
       ) {
         setIsOpen(false);
+        /* Restore focus after the pointer event's default focus handling completes. */
         requestAnimationFrame(() => {
           triggerRef.current?.focus();
         });

--- a/apps/chat/src/components/UsageLimitsControl/tests/UsageLimitsControl.spec.tsx
+++ b/apps/chat/src/components/UsageLimitsControl/tests/UsageLimitsControl.spec.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useDeploymentUsageLimits } from '../../../hooks/useDeploymentUsageLimits';
@@ -169,7 +169,9 @@ describe('UsageLimitsControl', () => {
       }),
     );
 
-    expect(screen.getByRole('dialog')).toBeTruthy();
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toBeTruthy();
+    expect(dialog.getAttribute('aria-modal')).toBeNull();
     expect(screen.getByText('Usage Limit')).toBeTruthy();
     expect(screen.getAllByRole('progressbar')).toHaveLength(1);
     expect(
@@ -246,11 +248,10 @@ describe('UsageLimitsControl', () => {
         <UsageLimitsControl deploymentId="gpt-4o" labels={labels} />
       </>,
     );
-    await userEvent.click(
-      screen.getByRole('button', {
-        name: 'Monthly token usage: 25%',
-      }),
-    );
+    const trigger = screen.getByRole('button', {
+      name: 'Monthly token usage: 25%',
+    });
+    await userEvent.click(trigger);
 
     await userEvent.pointer({
       keys: '[MouseLeft]',
@@ -258,6 +259,9 @@ describe('UsageLimitsControl', () => {
     });
 
     expect(screen.queryByRole('dialog')).toBeNull();
+    await waitFor(() => {
+      expect(document.activeElement).toBe(trigger);
+    });
   });
 
   it('uses logical placement and mobile-safe dimensions', async () => {


### PR DESCRIPTION
## Description of changes

Fixed two accessibility issues in the **Usage Limits** popover:

- Restored focus to the usage trigger when the popover is dismissed by clicking outside.
- Removed the incorrect `aria-modal` attribute because the informational popover does not trap focus or block interaction with the page.

Added regression tests for both behaviors.

## Applicable issues

- https://github.com/epam/ai-dial-chat/issues/8107


## Checklist

- [X] the pull request name ends with `(Issue #<ISSUE_ID>)` (comma-separated list of issues)
- [X] I confirm that I don't share any confidential information like API keys or any other secrets and private URLs
