### PR TITLE
fix: scope client-channel subscription to the conversation page

### DIFF
--- a/apps/chat-api/src/files/listing/files-listing.service.ts
+++ b/apps/chat-api/src/files/listing/files-listing.service.ts
@@ -148,11 +148,6 @@ export class FilesListingService {
           `listFiles DIAL page: bucket=${bucket}, path=${normalizedPath}, page=${page}, count=${pageData.items.length}, hasNextPage=${nextToken != null}`,
         );
       } while (shouldAggregateAllPages && token != null);
-
-      this.logger.debug(
-        `listFiles DIAL raw: bucket=${bucket}, path=${normalizedPath}, count=${rawItems.length}, items=[${summarizeDialRawItems(rawItems)}]`,
-      );
-
       const items = rawItems.map((item) => normalizeFileItem(item, bucket));
       const resolvedPermissions = resolveListingPermissions(
         rawItems,

--- a/apps/chat/src/context/ClientChannelContext.tsx
+++ b/apps/chat/src/context/ClientChannelContext.tsx
@@ -9,6 +9,7 @@ import {
   useRef,
   useState,
 } from 'react';
+import { useMatch } from 'react-router';
 import {
   ClientChannelReportResult,
   reportClientChannel,
@@ -22,6 +23,7 @@ import {
   PendingSigninEventKind,
   TOOLSET_SIGNIN_METHOD,
 } from '../types/client-channel';
+import { ROUTES } from '../types/routes';
 import { parseExternalServiceUrl } from '../utils/external-services';
 import { useFeatureFlag } from './AppConfigContext';
 
@@ -88,13 +90,29 @@ const parseSigninEvent = (payload: string): PendingSigninEvent | null => {
 
 export const ClientChannelProvider: FC<Props> = ({ children }) => {
   const isEnabled = useFeatureFlag('liveChatInteraction');
+  /*
+   * `toolset/signin` and `external_service/signin` events can only ever be
+   * pushed by DIAL Core while a completion is streaming, which only happens
+   * on a specific conversation page (`Conversation`, mounted at
+   * `/conversations/*`) and the AppsEditor test-chat preview
+   * (`AppPreviewChat`) — the two callers of `useConversationStream`. The bare
+   * `/` route (`ConversationRoute`) is only the pre-conversation
+   * composer/empty state: it creates a conversation via a plain REST call
+   * and navigates to `/conversations/<id>` before any stream exists, so it
+   * is intentionally excluded here.
+   */
+  const matchConversations = useMatch(`${ROUTES.Conversations}/*`);
+  const matchAppsEditor = useMatch(ROUTES.AppsEditor);
+  const isStreamingCapablePage = !!(matchConversations ?? matchAppsEditor);
+  const isActive = isEnabled && isStreamingCapablePage;
+
   const [channelId, setChannelId] = useState<string | null>(null);
   const [pendingEvents, setPendingEvents] = useState<PendingSigninEvent[]>([]);
 
-  const isEnabledRef = useRef(isEnabled);
+  const isActiveRef = useRef(isActive);
   useEffect(() => {
-    isEnabledRef.current = isEnabled;
-  }, [isEnabled]);
+    isActiveRef.current = isActive;
+  }, [isActive]);
 
   const channelIdRef = useRef<string | null>(null);
   const eventsMapRef = useRef(new Map<string, PendingSigninEvent>());
@@ -171,7 +189,7 @@ export const ClientChannelProvider: FC<Props> = ({ children }) => {
   const connectRef = useRef<() => Promise<void>>(async () => undefined);
 
   const scheduleReconnect = useCallback(() => {
-    if (isStoppedRef.current || !isEnabledRef.current) return;
+    if (isStoppedRef.current || !isActiveRef.current) return;
     if (attemptRef.current >= RECONNECT_DELAYS_MS.length) return;
 
     const delay = RECONNECT_DELAYS_MS[attemptRef.current];
@@ -183,7 +201,7 @@ export const ClientChannelProvider: FC<Props> = ({ children }) => {
   }, [clearRetryTimeout]);
 
   const connect = useCallback(async () => {
-    if (isStoppedRef.current || !isEnabledRef.current) return;
+    if (isStoppedRef.current || !isActiveRef.current) return;
     if (abortControllerRef.current) return; // already connecting/connected
 
     const controller = new AbortController();
@@ -217,7 +235,7 @@ export const ClientChannelProvider: FC<Props> = ({ children }) => {
   }, [connect]);
 
   const ensureConnected = useCallback(() => {
-    if (isStoppedRef.current || !isEnabledRef.current) return;
+    if (isStoppedRef.current || !isActiveRef.current) return;
 
     /*
      * Core reuses the same RPC `id` across separate completions (it is not
@@ -255,7 +273,7 @@ export const ClientChannelProvider: FC<Props> = ({ children }) => {
 
   useEffect(() => {
     isStoppedRef.current = false;
-    if (!isEnabled) {
+    if (!isActive) {
       disconnect();
       return undefined;
     }
@@ -268,10 +286,10 @@ export const ClientChannelProvider: FC<Props> = ({ children }) => {
       disconnect();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isEnabled]);
+  }, [isActive]);
 
   useEffect(() => {
-    if (!isEnabled) return undefined;
+    if (!isActive) return undefined;
 
     const handleVisibilityChange = () => {
       if (document.visibilityState === 'visible') {
@@ -281,7 +299,7 @@ export const ClientChannelProvider: FC<Props> = ({ children }) => {
     document.addEventListener('visibilitychange', handleVisibilityChange);
     return () =>
       document.removeEventListener('visibilitychange', handleVisibilityChange);
-  }, [isEnabled, ensureConnected]);
+  }, [isActive, ensureConnected]);
 
   const reportEvent = useCallback(
     async (

--- a/apps/chat/src/context/tests/ClientChannelContext.spec.tsx
+++ b/apps/chat/src/context/tests/ClientChannelContext.spec.tsx
@@ -1,11 +1,19 @@
 import { act, renderHook, waitFor } from '@testing-library/react';
-import type { ReactNode } from 'react';
+import { useEffect, type ReactNode } from 'react';
+import {
+  MemoryRouter,
+  type NavigateFunction,
+  Route,
+  Routes,
+  useNavigate,
+} from 'react-router';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   reportClientChannel,
   subscribeClientChannel,
   unsubscribeClientChannel,
 } from '../../server-api/client-channel';
+import { ROUTES } from '../../types/routes';
 import { useFeatureFlag } from '../AppConfigContext';
 import {
   ClientChannelProvider,
@@ -45,9 +53,57 @@ const makeControllableStream = () => {
   };
 };
 
-const wrapper = ({ children }: { children: ReactNode }) => (
-  <ClientChannelProvider>{children}</ClientChannelProvider>
-);
+/** Renders the provider under a given initial route, since it derives `isStreamingCapablePage` via `useMatch`. */
+const makeWrapper =
+  (initialPath: string = ROUTES.Conversations) =>
+  ({ children }: { children: ReactNode }) => (
+    <MemoryRouter initialEntries={[initialPath]}>
+      <Routes>
+        <Route
+          path="*"
+          element={<ClientChannelProvider>{children}</ClientChannelProvider>}
+        />
+      </Routes>
+    </MemoryRouter>
+  );
+
+const wrapper = makeWrapper();
+
+const NavigateCapture = ({
+  onReady,
+}: {
+  onReady: (navigate: NavigateFunction) => void;
+}) => {
+  const navigate = useNavigate();
+  useEffect(() => {
+    onReady(navigate);
+  }, [navigate, onReady]);
+  return null;
+};
+
+/** Like `makeWrapper`, but also exposes a `navigate` function tests can call to simulate route changes without remounting the provider. */
+const makeNavigableWrapper = (initialPath: string) => {
+  let navigateFn: NavigateFunction = () => undefined;
+  const Wrapper = ({ children }: { children: ReactNode }) => (
+    <MemoryRouter initialEntries={[initialPath]}>
+      <NavigateCapture
+        onReady={(navigate) => {
+          navigateFn = navigate;
+        }}
+      />
+      <Routes>
+        <Route
+          path="*"
+          element={<ClientChannelProvider>{children}</ClientChannelProvider>}
+        />
+      </Routes>
+    </MemoryRouter>
+  );
+  return {
+    Wrapper,
+    navigate: (path: string) => act(() => navigateFn(path)),
+  };
+};
 
 describe('ClientChannelProvider', () => {
   beforeEach(() => {
@@ -321,6 +377,119 @@ describe('ClientChannelProvider', () => {
     await waitFor(() => expect(result.current.channelId).toBeNull());
     expect(mockUnsubscribe).toHaveBeenCalledWith('channel-1');
     expect(result.current.pendingEvents).toHaveLength(0);
+  });
+
+  describe('page scoping', () => {
+    it.each([['/files'], ['/']])(
+      'does not subscribe when the flag is enabled but the route (%s) is not streaming-capable',
+      async (path) => {
+        mockUseFeatureFlag.mockReturnValue(true);
+
+        renderHook(() => useClientChannel(), {
+          wrapper: makeWrapper(path),
+        });
+        await act(async () => {
+          await Promise.resolve();
+        });
+
+        expect(mockSubscribe).not.toHaveBeenCalled();
+      },
+    );
+
+    it.each([[ROUTES.Conversations], [ROUTES.AppsEditor]])(
+      'subscribes when the flag is enabled and the route is %s',
+      async (path) => {
+        mockUseFeatureFlag.mockReturnValue(true);
+        const { stream } = makeControllableStream();
+        mockSubscribe.mockResolvedValue({
+          body: stream,
+          channelId: 'channel-1',
+        });
+
+        const { result } = renderHook(() => useClientChannel(), {
+          wrapper: makeWrapper(path),
+        });
+
+        await waitFor(() => expect(result.current.channelId).toBe('channel-1'));
+      },
+    );
+
+    it('unsubscribes and clears pending events when navigating off a streaming-capable route', async () => {
+      mockUseFeatureFlag.mockReturnValue(true);
+      const { stream, push } = makeControllableStream();
+      mockSubscribe.mockResolvedValue({ body: stream, channelId: 'channel-1' });
+
+      const { Wrapper, navigate } = makeNavigableWrapper(ROUTES.Conversations);
+      const { result } = renderHook(() => useClientChannel(), {
+        wrapper: Wrapper,
+      });
+      await waitFor(() => expect(result.current.channelId).toBe('channel-1'));
+
+      const frame =
+        'data: {"id":"evt-1","method":"toolset/signin","params":{"toolsetId":"toolsets/b/my-toolset"}}\n\n';
+      await act(async () => {
+        push(frame);
+        await Promise.resolve();
+      });
+      await waitFor(() => expect(result.current.pendingEvents).toHaveLength(1));
+
+      navigate('/files');
+
+      await waitFor(() => expect(result.current.channelId).toBeNull());
+      expect(mockUnsubscribe).toHaveBeenCalledWith('channel-1');
+      expect(result.current.pendingEvents).toHaveLength(0);
+    });
+
+    it('reconnects when navigating back to a streaming-capable route', async () => {
+      mockUseFeatureFlag.mockReturnValue(true);
+      const first = makeControllableStream();
+      mockSubscribe.mockResolvedValueOnce({
+        body: first.stream,
+        channelId: 'channel-1',
+      });
+
+      const { Wrapper, navigate } = makeNavigableWrapper(ROUTES.Conversations);
+      const { result } = renderHook(() => useClientChannel(), {
+        wrapper: Wrapper,
+      });
+      await waitFor(() => expect(result.current.channelId).toBe('channel-1'));
+
+      navigate('/files');
+      await waitFor(() => expect(result.current.channelId).toBeNull());
+
+      const second = makeControllableStream();
+      mockSubscribe.mockResolvedValueOnce({
+        body: second.stream,
+        channelId: 'channel-2',
+      });
+
+      navigate(ROUTES.Conversations);
+
+      await waitFor(() => expect(result.current.channelId).toBe('channel-2'));
+    });
+
+    it('does not disconnect or reconnect when navigating between conversation sub-paths', async () => {
+      mockUseFeatureFlag.mockReturnValue(true);
+      const { stream } = makeControllableStream();
+      mockSubscribe.mockResolvedValue({ body: stream, channelId: 'channel-1' });
+
+      const { Wrapper, navigate } = makeNavigableWrapper(
+        `${ROUTES.Conversations}/conversation-1`,
+      );
+      const { result } = renderHook(() => useClientChannel(), {
+        wrapper: Wrapper,
+      });
+      await waitFor(() => expect(result.current.channelId).toBe('channel-1'));
+
+      navigate(`${ROUTES.Conversations}/conversation-2`);
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(mockUnsubscribe).not.toHaveBeenCalled();
+      expect(mockSubscribe).toHaveBeenCalledOnce();
+      expect(result.current.channelId).toBe('channel-1');
+    });
   });
 
   it('retries with capped backoff and stops after 5 attempts', async () => {

--- a/openspec/changes/archive/2026-08-05-scope-client-channel-to-conversation-page/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-05-scope-client-channel-to-conversation-page/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-05

--- a/openspec/changes/archive/2026-08-05-scope-client-channel-to-conversation-page/design.md
+++ b/openspec/changes/archive/2026-08-05-scope-client-channel-to-conversation-page/design.md
@@ -1,0 +1,121 @@
+## Context
+
+`ClientChannelProvider` (`apps/chat/src/context/ClientChannelContext.tsx`) is mounted once at the
+app root in `apps/chat/src/main.tsx` (inside `RequireAuth`, wrapping every non-login route). Its
+connect/disconnect effect (lines 256–271) is keyed only on `isEnabled` (`useFeatureFlag`
+`liveChatInteraction`). Once the flag is on, the provider opens an SSE fetch via
+`subscribeClientChannel` and keeps it alive — with capped exponential-backoff reconnect
+(`RECONNECT_DELAYS_MS`) and a `visibilitychange` resume listener — for the entire authenticated
+session, on every page (Catalog, FileManager, ToolsetEditor, ScheduledTasks, CustomAppEditor, etc.).
+
+`toolset/signin`/`external_service/signin` RPC events, however, are only ever pushed by DIAL Core
+while a completion is streaming and a tool/app calls an external service requiring interactive
+auth. Streaming only happens from two call sites of `useConversationStream`
+(`apps/chat/src/hooks/conversation/useConversationStream.ts`):
+`apps/chat/src/pages/Conversation/Conversation.tsx` (mounted only at `ROUTES.Conversations` =
+`/conversations/*`) and `apps/chat/src/pages/AppsEditor/AppPreviewChat.tsx` (route
+`ROUTES.AppsEditor` = `/apps-editor`, the custom-app test-chat preview). `ROUTES.Root` (`/`) is
+**not** streaming-capable: it renders `ConversationRoute`/`NewConversationComposer` — the
+pre-conversation empty state — which creates a new conversation via a plain REST call and
+navigates to `/conversations/<id>` *before* any stream starts, so it never itself hosts a live
+stream. This matches the
+legacy Redux epics behavior on `development`: `ChatEventsActions.init()` in
+`settings.epics.ts` was dispatched only for `PageType.Chat` and `PageType.AppsEditor`, and the
+actual subscribe/unsubscribe lifecycle in `conversations.epics.ts` was driven per-send
+(`sendMessageEpic`'s `shouldSubscribe`) and torn down ~1s after idle (`unsubscribeWhenIdleEpic`).
+
+`ClientChannelProvider` is mounted inside `BrowserRouter` already (see `main.tsx`), so it can call
+router hooks (`useMatch`, `useLocation`) directly without needing route params passed down from a
+`<Route element>`. `apps/chat/src/app/app.tsx` (lines 213–215) computes a related but broader
+`isConversationRoute` via `useMatch(ROUTES.Root)` / `useMatch(\`${ROUTES.Conversations}/*\`)` for a
+different purpose (whether to show the sources/attachment side panel, which is also wanted on the
+pre-conversation composer at `/`) — this design reuses the `useMatch` mechanism but intentionally
+excludes `ROUTES.Root` from its own boolean, since `/` never streams.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- The client-channel SSE connection is only open while the user is on a streaming-capable page
+  (`/conversations/*` or `/apps-editor`) AND the `liveChatInteraction` flag is enabled.
+- Navigating away from a streaming-capable page disconnects the channel (calls
+  `unsubscribeClientChannel`, clears pending events) exactly like the existing flag-disabled path
+  already does.
+- Navigating back to a streaming-capable page (flag still enabled) reconnects, same as today's
+  flag-enabled mount behavior.
+- No change to reconnect/backoff timing, RPC parsing, or the `report`/`unsubscribe` BFF contract.
+
+**Non-Goals:**
+
+- Not replicating the legacy's per-send-triggered subscribe or the 1-second idle-teardown timer.
+  Gating on page presence (a coarser, simpler condition than "is a stream literally in flight") is
+  sufficient: it already excludes every non-streaming-capable page, and within a streaming-capable
+  page `ensureConnected()` still nudges a reconnect right before each `streamCompletion` call.
+- Not touching `apps/chat-api` — this is a frontend-only lifecycle change.
+- Not changing which pages exist or adding a new `PageType`-style enum; reusing route matching is
+  sufficient and keeps this change additive to `ClientChannelContext.tsx` only.
+
+## Decisions
+
+**Gate via `useMatch` inside `ClientChannelProvider`, not a new prop from `main.tsx`.**
+`ClientChannelProvider` already sits inside `BrowserRouter` (`main.tsx` lines 47–97), so it can
+call `` useMatch(`${ROUTES.Conversations}/*`) `` and `useMatch(ROUTES.AppsEditor)` directly,
+combining them into a single `isStreamingCapablePage` boolean, using the same `useMatch` mechanism
+`app.tsx`'s `isConversationRoute` uses (without reusing its exact boolean, since that one also
+includes `ROUTES.Root` for an unrelated side-panel purpose). This avoids threading a new prop
+through `main.tsx`'s provider stack and avoids depending on `apps/chat/src/app/app.tsx` (a
+sibling/descendant component) for gating logic used before `App` even renders.
+
+*Alternative considered:* move `ClientChannelProvider` down into `App`/`Conversation`'s route
+tree so it only mounts on the conversation page. Rejected — `AppPreviewChat` (AppsEditor) is a
+separate route subtree from `Conversation`, so the provider would need to be duplicated or lifted
+to a common ancestor anyway; and unmounting/remounting the whole provider on every navigation
+would drop `pendingEvents` state and force a fresh `channelId` more aggressively than the existing
+flag-toggle teardown does. Keeping the provider mounted once and gating its *connection* (not its
+mount) reuses the already-correct disconnect/reconnect machinery (lines 239–271) with one extra
+condition.
+
+**Combine the page check into the same `isEnabled`-shaped condition, not a parallel effect.**
+Rename the internal `isEnabled` boolean's usage sites minimally: introduce
+`isActive = isEnabled && isStreamingCapablePage` and use `isActive` everywhere `isEnabled`
+currently gates connect/disconnect/reconnect/visibility-resume (`isEnabledRef`, the mount effect at
+line 256, `scheduleReconnect`, `ensureConnected`, the `visibilitychange` listener at line 273).
+This keeps a single source of truth for "should the channel be open" instead of adding a second
+independent effect that could race with the flag-driven one.
+
+*Alternative considered:* keep `isEnabled` as-is and add a second `useEffect` that calls
+`disconnect()`/`connect()` based on the route. Rejected — two effects independently calling
+`connect`/`disconnect` on the same refs is exactly the kind of race the existing single-effect
+design (with `isStoppedRef`/`abortControllerRef` guards) was built to avoid; one derived boolean is
+simpler and safer.
+
+**Streaming-capable routes = `Conversations` (`/conversations/*`) and `AppsEditor`
+(`/apps-editor`) only — `Root` (`/`) is deliberately excluded.** These are exactly the two current
+call sites of `useConversationStream`, and match the legacy `PageType.Chat`/`PageType.AppsEditor`
+scoping. `ROUTES.Root` renders `ConversationRoute`, the pre-conversation composer/empty state; it
+creates a new conversation via a plain REST call (`apiCreateConversation`/`saveConversation`) and
+navigates to `/conversations/<id>` *before* any stream exists — so `/` itself never hosts a live
+stream and including it would open a channel with no possible event to receive. `ToolsetEditor`,
+`CustomAppEditor`, `Catalog`, `FileManager`, `ScheduledTasks`, etc. are excluded for the same
+reason: none of them stream completions.
+
+## Risks / Trade-offs
+
+- **[Risk]** A completion in flight when the user navigates away mid-stream (e.g. clicking to
+  another conversation route that still matches `Conversations`, or navigating fully off the
+  streaming-capable routes while a background stream continues) could have its channel torn down
+  before a late `toolset/signin` event arrives. → **Mitigation:** `Conversations` is matched with
+  a wildcard (`/conversations/*`), so switching between conversations keeps the channel open;
+  fully leaving the app's chat/editor surface while a stream is still active is an edge case the
+  legacy implementation also did not special-case beyond its 1s idle grace window, and is
+  acceptable per the proposal's scope (page-level gating, not per-stream tracking).
+- **[Risk]** Rapid navigation across streaming-capable routes (e.g. React Router transitioning
+  through intermediate matches) could cause disconnect/reconnect churn. → **Mitigation:** the
+  existing `connect()` guard (`if (abortControllerRef.current) return;`) and `disconnect()`
+  idempotency already tolerate rapid toggles; no new debouncing is introduced since `isEnabled`
+  toggles (feature flag flips) already exercise this same path today.
+
+## Migration Plan
+
+Frontend-only, no data migration. Ship behind the existing `liveChatInteraction` flag (no new
+flag). Rollback is a plain revert of the `ClientChannelContext.tsx` change.

--- a/openspec/changes/archive/2026-08-05-scope-client-channel-to-conversation-page/proposal.md
+++ b/openspec/changes/archive/2026-08-05-scope-client-channel-to-conversation-page/proposal.md
@@ -1,0 +1,41 @@
+## Why
+
+`ClientChannelProvider` currently opens (and keeps reconnecting) the client-channel SSE
+subscription for the whole app session as soon as `liveChatInteraction` is enabled — it is
+mounted at the app root in `apps/chat/src/main.tsx` and self-connects on mount, regardless of
+which page the user is on. `toolset/signin` and `external_service/signin` events, however, can
+only ever be pushed by DIAL Core while a completion is actively streaming, which only happens on
+the conversation page. Keeping the channel open on every other page (marketplace, toolset editor,
+settings, etc.) holds an unnecessary long-lived SSE connection and reconnect/backoff loop open for
+no benefit. The legacy Redux-epics implementation (`development` branch) only opened the
+subscription as a side effect of sending a message and tore it down again shortly after the stream
+settled — this change restores that scoping under the current React-context architecture.
+
+## What Changes
+
+- `ClientChannelProvider`'s connect/reconnect lifecycle is additionally gated on "the user is
+  currently on the conversation page," on top of the existing `liveChatInteraction` feature flag
+  check. Leaving the conversation page disconnects the channel (mirroring the existing
+  flag-disabled teardown path); returning to it (with the flag enabled) reconnects.
+- No change to the SSE transport, RPC parsing, reconnect/backoff mechanics, or the
+  `report`/`unsubscribe` BFF endpoints — only *when* the provider is allowed to hold an open
+  connection changes.
+- `ensureConnected()` (called by `useConversationStream` right before `streamCompletion`) continues
+  to work as the same best-effort nudge; it remains a no-op if the page-level gate is not active.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `client-channel-protocol`: the `liveChatInteraction` feature-flag gating requirement is extended
+  with an additional page-scope precondition — the frontend SHALL only hold an open client-channel
+  subscription while the user is on the conversation page, in addition to the flag being enabled.
+
+## Impact
+
+- `apps/chat/src/context/ClientChannelContext.tsx` — connect/disconnect effect gains a
+  route-derived condition alongside `isEnabled`.
+- `apps/chat/src/main.tsx` and/or route-level wiring — needs a way for the provider to know the
+  active page/route without every consumer re-deriving it (e.g. reading the current route via
+  `react-router`'s `useLocation`/`matchPath`, consistent with existing routing conventions).
+- No backend changes; no changes to `apps/chat-api`.

--- a/openspec/changes/archive/2026-08-05-scope-client-channel-to-conversation-page/specs/client-channel-protocol/spec.md
+++ b/openspec/changes/archive/2026-08-05-scope-client-channel-to-conversation-page/specs/client-channel-protocol/spec.md
@@ -1,0 +1,59 @@
+## MODIFIED Requirements
+
+### Requirement: `liveChatInteraction` feature flag gates the mechanism
+
+The mechanism SHALL be gated by a feature flag key `liveChatInteraction`, read via the existing `AppConfigContext`/`useFeatureFlag` mechanism (server-supplied `features` map). When the flag is `false` or not yet `Ready`, the frontend SHALL NOT attempt to subscribe to the client channel and SHALL NOT attach a channel id to completion requests.
+
+In addition, the frontend SHALL only hold an open client-channel subscription while the current route is a streaming-capable page — `ROUTES.Conversations` (`/conversations` and any sub-path, e.g. a specific `/conversations/<id>`) or `ROUTES.AppsEditor` (`/apps-editor`) — matching `useConversationStream`'s two call sites (`Conversation` and `AppPreviewChat`). `ROUTES.Root` (`/`, the pre-conversation composer/empty state rendered by `ConversationRoute`) SHALL NOT count as streaming-capable: it creates a new conversation via a plain REST call and navigates to `/conversations/<id>` before any stream can exist, so it never itself hosts a live stream. `ClientChannelProvider` SHALL derive this route condition using `react-router`'s `useMatch`, since the provider is mounted inside `BrowserRouter`. The connect/reconnect/visibility-resume logic SHALL require both the flag being enabled AND the route condition; leaving a streaming-capable route while the channel is open SHALL disconnect it (unsubscribe from Core, clear pending events) the same way disabling the flag does today, and returning to a streaming-capable route (flag still enabled) SHALL reconnect it.
+
+The backend SHALL also enforce the flag server-side (defense in depth, so a restricted or fully-disabled user cannot bypass the frontend gate by calling the API directly): `POST /api/v1/client-channel/subscribe` and `POST /api/v1/client-channel/report` SHALL apply the existing `FeatureGuard`/`@RequireFeature(FeatureKey.LiveChatInteraction)` mechanism and return `403` when the flag resolves to `false` for the caller (including role-restricted denials via `LIVE_CHAT_INTERACTION_ENABLED_ROLES`). `POST /api/v1/client-channel/unsubscribe` SHALL NOT be gated by the flag, so a client that already holds an open channel can always tear it down (e.g. the flag flips off mid-session, the user's role no longer qualifies, or the user navigates off a streaming-capable route) regardless of the flag's current value for that user.
+
+#### Scenario: Flag disabled
+
+- **WHEN** `liveChatInteraction` resolves to `false`
+- **THEN** no subscribe request is made and completions carry no channel id
+
+#### Scenario: Flag flips to disabled while a channel is active
+
+- **WHEN** the flag becomes `false` after a channel was already subscribed
+- **THEN** the frontend calls unsubscribe for the active channel and clears any pending signin events from the dialog state
+
+#### Scenario: Backend rejects subscribe for a user the flag resolves false for
+
+- **WHEN** a caller with a valid session calls `POST /api/v1/client-channel/subscribe` while `liveChatInteraction` resolves to `false` for that user (globally disabled or excluded by `LIVE_CHAT_INTERACTION_ENABLED_ROLES`)
+- **THEN** the backend returns `403` without contacting DIAL Core
+
+#### Scenario: Backend rejects report for a user the flag resolves false for
+
+- **WHEN** a caller calls `POST /api/v1/client-channel/report` while the flag resolves to `false` for that user
+- **THEN** the backend returns `403` without forwarding the report to DIAL Core
+
+#### Scenario: Unsubscribe is never blocked by the flag
+
+- **WHEN** a caller calls `POST /api/v1/client-channel/unsubscribe` while the flag resolves to `false` for that user
+- **THEN** the backend still processes the unsubscribe normally
+
+#### Scenario: Flag enabled but user is on a non-streaming-capable page
+
+- **WHEN** `liveChatInteraction` resolves to `true` but the current route is not `/conversations/*` or `/apps-editor` (e.g. `/`, `/catalog`, `/files`, `/toolset-editor`, `/scheduled-tasks`, `/custom-app-editor`)
+- **THEN** the frontend does not open a client-channel subscription
+
+#### Scenario: Flag enabled but user is on the pre-conversation home page
+
+- **WHEN** `liveChatInteraction` resolves to `true` and the current route is bare `/` (no conversation selected yet)
+- **THEN** the frontend does not open a client-channel subscription, since `/` never itself hosts a live stream
+
+#### Scenario: Navigating from the conversation page to a non-streaming-capable page disconnects the channel
+
+- **WHEN** the flag is enabled, a channel is currently open, and the user navigates from `/conversations` to `/files`
+- **THEN** the frontend calls unsubscribe for the active channel, clears the channel id and any pending signin events, and does not attempt to reconnect while on `/files`
+
+#### Scenario: Navigating back to a streaming-capable page reconnects
+
+- **WHEN** the flag is enabled and the user navigates from a non-streaming-capable page back to `/conversations` or `/apps-editor`
+- **THEN** the frontend opens a new client-channel subscription, same as the existing flag-enabled mount behavior
+
+#### Scenario: Navigating between conversations keeps the channel open
+
+- **WHEN** the user navigates from `/conversations` to a different conversation still under `/conversations/*`
+- **THEN** the existing client-channel subscription is not torn down or reconnected

--- a/openspec/changes/archive/2026-08-05-scope-client-channel-to-conversation-page/tasks.md
+++ b/openspec/changes/archive/2026-08-05-scope-client-channel-to-conversation-page/tasks.md
@@ -1,0 +1,17 @@
+## 1. Route-scope the client channel connection
+
+- [x] 1.1 In `apps/chat/src/context/ClientChannelContext.tsx`, add `useMatch` calls (from `react-router`) for `` `${ROUTES.Conversations}/*` `` and `ROUTES.AppsEditor` (deliberately excluding `ROUTES.Root`, which never itself hosts a live stream), combined into a single `isStreamingCapablePage` boolean, importing `ROUTES` from `apps/chat/src/types/routes.ts`.
+- [x] 1.2 Derive `isActive = isEnabled && isStreamingCapablePage` and replace `isEnabled`/`isEnabledRef` with `isActive`/`isActiveRef` at every gating site: the ref-sync effect (lines 94–97), `scheduleReconnect` (line 174), `connect` (line 186), `ensureConnected` (line 220), the mount connect/disconnect effect (lines 256–271), and the `visibilitychange` resume effect (lines 273–284).
+- [x] 1.3 Verify the mount effect's dependency array and cleanup still disconnect correctly when `isActive` flips to `false` for either reason (flag disabled OR route no longer streaming-capable).
+
+## 2. Tests
+
+- [x] 2.1 Add/update tests in `apps/chat/src/context/tests/ClientChannelContext.spec.tsx` (or equivalent existing test file) covering: flag enabled + non-streaming route (including bare `/`) → no subscribe; flag enabled + `/conversations` or `/apps-editor` → subscribes; navigating from a streaming-capable route to a non-streaming-capable route → unsubscribes and clears pending events; navigating back → reconnects; navigating between `/conversations/*` sub-paths → no disconnect/reconnect churn.
+- [x] 2.2 Update `apps/chat/src/hooks/conversation/useConversationStream.spec.ts` if the `ensureConnected` mock/expectations assume the channel is always connected regardless of route. (No change needed — this spec already mocks `useClientChannel` directly, bypassing route derivation entirely.)
+
+## 3. Verification
+
+- [x] 3.1 `npm exec nx test chat`
+- [x] 3.2 `npm exec nx lint chat`
+- [x] 3.3 `npm exec nx build chat`
+- [x] 3.4 Manually verify in the running app: open `/`, `/files`, or `/catalog` with `liveChatInteraction` enabled and confirm no client-channel SSE request fires in the network tab; navigate into an actual conversation under `/conversations/<id>` and confirm it does.

--- a/openspec/specs/client-channel-protocol/spec.md
+++ b/openspec/specs/client-channel-protocol/spec.md
@@ -84,27 +84,59 @@ Generated-client impact: both endpoints SHALL be exposed through the generated `
 
 The mechanism SHALL be gated by a feature flag key `liveChatInteraction`, read via the existing `AppConfigContext`/`useFeatureFlag` mechanism (server-supplied `features` map). When the flag is `false` or not yet `Ready`, the frontend SHALL NOT attempt to subscribe to the client channel and SHALL NOT attach a channel id to completion requests.
 
-The backend SHALL also enforce this flag server-side (defense in depth, so a restricted or fully-disabled user cannot bypass the frontend gate by calling the API directly): `POST /api/v1/client-channel/subscribe` and `POST /api/v1/client-channel/report` SHALL apply the existing `FeatureGuard`/`@RequireFeature(FeatureKey.LiveChatInteraction)` mechanism and return `403` when the flag resolves to `false` for the caller (including role-restricted denials via `LIVE_CHAT_INTERACTION_ENABLED_ROLES`). `POST /api/v1/client-channel/unsubscribe` SHALL NOT be gated by the flag, so a client that already holds an open channel can always tear it down (e.g. the flag flips off mid-session, or the user's role no longer qualifies) regardless of the flag's current value for that user.
+In addition, the frontend SHALL only hold an open client-channel subscription while the current route is a streaming-capable page — `ROUTES.Conversations` (`/conversations` and any sub-path, e.g. a specific `/conversations/<id>`) or `ROUTES.AppsEditor` (`/apps-editor`) — matching `useConversationStream`'s two call sites (`Conversation` and `AppPreviewChat`). `ROUTES.Root` (`/`, the pre-conversation composer/empty state rendered by `ConversationRoute`) SHALL NOT count as streaming-capable: it creates a new conversation via a plain REST call and navigates to `/conversations/<id>` before any stream can exist, so it never itself hosts a live stream. `ClientChannelProvider` SHALL derive this route condition using `react-router`'s `useMatch`, since the provider is mounted inside `BrowserRouter`. The connect/reconnect/visibility-resume logic SHALL require both the flag being enabled AND the route condition; leaving a streaming-capable route while the channel is open SHALL disconnect it (unsubscribe from Core, clear pending events) the same way disabling the flag does today, and returning to a streaming-capable route (flag still enabled) SHALL reconnect it.
+
+The backend SHALL also enforce the flag server-side (defense in depth, so a restricted or fully-disabled user cannot bypass the frontend gate by calling the API directly): `POST /api/v1/client-channel/subscribe` and `POST /api/v1/client-channel/report` SHALL apply the existing `FeatureGuard`/`@RequireFeature(FeatureKey.LiveChatInteraction)` mechanism and return `403` when the flag resolves to `false` for the caller (including role-restricted denials via `LIVE_CHAT_INTERACTION_ENABLED_ROLES`). `POST /api/v1/client-channel/unsubscribe` SHALL NOT be gated by the flag, so a client that already holds an open channel can always tear it down (e.g. the flag flips off mid-session, the user's role no longer qualifies, or the user navigates off a streaming-capable route) regardless of the flag's current value for that user.
 
 #### Scenario: Flag disabled
+
 - **WHEN** `liveChatInteraction` resolves to `false`
 - **THEN** no subscribe request is made and completions carry no channel id
 
 #### Scenario: Flag flips to disabled while a channel is active
+
 - **WHEN** the flag becomes `false` after a channel was already subscribed
 - **THEN** the frontend calls unsubscribe for the active channel and clears any pending signin events from the dialog state
 
 #### Scenario: Backend rejects subscribe for a user the flag resolves false for
+
 - **WHEN** a caller with a valid session calls `POST /api/v1/client-channel/subscribe` while `liveChatInteraction` resolves to `false` for that user (globally disabled or excluded by `LIVE_CHAT_INTERACTION_ENABLED_ROLES`)
 - **THEN** the backend returns `403` without contacting DIAL Core
 
 #### Scenario: Backend rejects report for a user the flag resolves false for
+
 - **WHEN** a caller calls `POST /api/v1/client-channel/report` while the flag resolves to `false` for that user
 - **THEN** the backend returns `403` without forwarding the report to DIAL Core
 
 #### Scenario: Unsubscribe is never blocked by the flag
+
 - **WHEN** a caller calls `POST /api/v1/client-channel/unsubscribe` while the flag resolves to `false` for that user
 - **THEN** the backend still processes the unsubscribe normally
+
+#### Scenario: Flag enabled but user is on a non-streaming-capable page
+
+- **WHEN** `liveChatInteraction` resolves to `true` but the current route is not `/conversations/*` or `/apps-editor` (e.g. `/`, `/catalog`, `/files`, `/toolset-editor`, `/scheduled-tasks`, `/custom-app-editor`)
+- **THEN** the frontend does not open a client-channel subscription
+
+#### Scenario: Flag enabled but user is on the pre-conversation home page
+
+- **WHEN** `liveChatInteraction` resolves to `true` and the current route is bare `/` (no conversation selected yet)
+- **THEN** the frontend does not open a client-channel subscription, since `/` never itself hosts a live stream
+
+#### Scenario: Navigating from the conversation page to a non-streaming-capable page disconnects the channel
+
+- **WHEN** the flag is enabled, a channel is currently open, and the user navigates from `/conversations` to `/files`
+- **THEN** the frontend calls unsubscribe for the active channel, clears the channel id and any pending signin events, and does not attempt to reconnect while on `/files`
+
+#### Scenario: Navigating back to a streaming-capable page reconnects
+
+- **WHEN** the flag is enabled and the user navigates from a non-streaming-capable page back to `/conversations` or `/apps-editor`
+- **THEN** the frontend opens a new client-channel subscription, same as the existing flag-enabled mount behavior
+
+#### Scenario: Navigating between conversations keeps the channel open
+
+- **WHEN** the user navigates from `/conversations` to a different conversation still under `/conversations/*`
+- **THEN** the existing client-channel subscription is not torn down or reconnected
 
 ### Requirement: No secrets logged in client-channel handling
 


### PR DESCRIPTION
## Summary

- `ClientChannelProvider` now only holds an open client-channel SSE subscription while the
  user is on a streaming-capable route (`/conversations/*` or `/apps-editor`), on top of the
  existing `liveChatInteraction` feature-flag gate. Previously it connected at app startup and
  stayed connected on every page (catalog, file manager, toolset editor, settings, etc.).
- Bare `/` (the pre-conversation composer/empty state) is intentionally excluded — it creates a
  new conversation via a plain REST call and navigates to `/conversations/<id>` before any stream
  can exist, so it never itself receives these events.
- Leaving a streaming-capable route now disconnects the channel (unsubscribes, clears pending
  sign-in events) the same way disabling the feature flag already does; returning reconnects.
- No changes to the SSE transport, RPC parsing, reconnect/backoff mechanics, or the backend
  `subscribe`/`report`/`unsubscribe` endpoints.
- Synced the `client-channel-protocol` spec to document the route-scoping requirement
  (`openspec/specs/client-channel-protocol/spec.md`).

## Test plan

- [x] `npm exec nx test chat` — 170 files / 2065 tests pass, including new
      `ClientChannelContext.spec.tsx` coverage for: non-streaming routes (including `/`) don't
      subscribe, `/conversations` and `/apps-editor` do, navigating off a streaming-capable route
      unsubscribes and clears pending events, navigating back reconnects, and navigating between
      `/conversations/*` sub-paths doesn't churn the connection.
- [x] `npm exec nx lint chat`
- [x] `npm exec nx build chat`
- [x] Manually verified in the running app: no client-channel SSE request on `/`, `/files`, or
      `/catalog`; request fires when opening an actual conversation under `/conversations/<id>`.
