### PR TITLE
fix: handle lost refresh-token races and improve session recovery (Issue #8150)

### DIFF
--- a/apps/chat-api/src/auth/refresh/refresh.service.spec.ts
+++ b/apps/chat-api/src/auth/refresh/refresh.service.spec.ts
@@ -79,13 +79,24 @@ describe('RefreshService', () => {
     expect(result.rt).toBe('new-rt');
   });
 
-  it('throws UnauthorizedException on invalid_grant', async () => {
-    const payload = makePayload();
+  it('throws UnauthorizedException on invalid_grant when the access token has already expired', async () => {
+    const now = Math.floor(Date.now() / 1000);
+    const payload = makePayload({ at_exp: now - 10 });
     mockClient.refresh.mockRejectedValue({ error: 'invalid_grant' });
 
     await expect(service.refresh(payload)).rejects.toThrow(
       UnauthorizedException,
     );
+  });
+
+  it('absorbs invalid_grant as a lost refresh-token race when the access token is still valid', async () => {
+    const now = Math.floor(Date.now() / 1000);
+    const payload = makePayload({ at_exp: now + 30 });
+    mockClient.refresh.mockRejectedValue({ error: 'invalid_grant' });
+
+    const result = await service.refresh(payload);
+
+    expect(result).toBe(payload);
   });
 
   it('throws UnauthorizedException on other refresh errors', async () => {

--- a/apps/chat-api/src/auth/refresh/refresh.service.ts
+++ b/apps/chat-api/src/auth/refresh/refresh.service.ts
@@ -33,6 +33,23 @@ export class RefreshService {
     } catch (err: unknown) {
       const oidcErr = err as { error?: string };
       if (oidcErr?.error === 'invalid_grant') {
+        /*
+         * A rotated refresh token that another pod (or another near-
+         * simultaneous request) already exchanged a moment ago also surfaces
+         * as invalid_grant here — there's no shared state to tell the two
+         * apart directly. But if this payload's access token hasn't actually
+         * expired yet, the session is still good; this pod just lost a race
+         * it didn't need to enter. Absorb it and let the next request pick
+         * up whichever cookie the browser currently holds instead of forcing
+         * a false logout.
+         */
+        const now = Math.floor(Date.now() / 1000);
+        if (payload.at_exp > now) {
+          this.logger.log(
+            `Absorbed a lost refresh-token race for sid ${payload.sid}; access token is still valid`,
+          );
+          return payload;
+        }
         throw new UnauthorizedException('Refresh token expired or revoked');
       }
       this.logger.error(

--- a/apps/chat-api/src/auth/session/session.guard.ts
+++ b/apps/chat-api/src/auth/session/session.guard.ts
@@ -61,20 +61,28 @@ export class SessionGuard implements CanActivate {
 
     const now = Math.floor(Date.now() / 1000);
     if (payload.at_exp < now + 60) {
-      payload = await this.refresh.refresh(payload);
-      const newToken = await this.session.encrypt(payload);
-      const cookieName = getSessionCookieName(this.config);
-      setCookieValue(
-        res,
-        cookieName,
-        newToken,
-        {
-          ...getCookieOptions(this.config),
-          maxAge: (payload.rt_exp - now) * 1000,
-        },
-        req.cookies as Record<string, string> | undefined,
-      );
-      res.setHeader('X-CSRF-Token', payload.csrf);
+      try {
+        payload = await this.refresh.refresh(payload);
+        const newToken = await this.session.encrypt(payload);
+        const cookieName = getSessionCookieName(this.config);
+        setCookieValue(
+          res,
+          cookieName,
+          newToken,
+          {
+            ...getCookieOptions(this.config),
+            maxAge: (payload.rt_exp - now) * 1000,
+          },
+          req.cookies as Record<string, string> | undefined,
+        );
+        res.setHeader('X-CSRF-Token', payload.csrf);
+      } catch (err) {
+        if (err instanceof UnauthorizedException) {
+          throw err;
+        }
+        this.logger.error('Unexpected error during token refresh', err);
+        throw new UnauthorizedException();
+      }
     }
 
     if (!payload.bucket) {

--- a/apps/chat-api/src/auth/session/tests/session.guard.spec.ts
+++ b/apps/chat-api/src/auth/session/tests/session.guard.spec.ts
@@ -159,6 +159,34 @@ describe('SessionGuard', () => {
     );
   });
 
+  it('rethrows a genuine UnauthorizedException from RefreshService as-is', async () => {
+    const now = Math.floor(Date.now() / 1000);
+    const payload = makePayload({ at_exp: now + 30 });
+    sessionService.decryptFromRequest.mockResolvedValue(payload);
+    refreshService.refresh.mockRejectedValue(
+      new UnauthorizedException('Refresh token expired or revoked'),
+    );
+
+    const { context } = makeContext({ cookieValue: 'valid-token' });
+    await expect(guard.canActivate(context)).rejects.toThrow(
+      UnauthorizedException,
+    );
+  });
+
+  it('converts an unexpected error from RefreshService into a clean UnauthorizedException', async () => {
+    const now = Math.floor(Date.now() / 1000);
+    const payload = makePayload({ at_exp: now + 30 });
+    sessionService.decryptFromRequest.mockResolvedValue(payload);
+    refreshService.refresh.mockRejectedValue(
+      new Error('unexpected provider registry failure'),
+    );
+
+    const { context } = makeContext({ cookieValue: 'valid-token' });
+    await expect(guard.canActivate(context)).rejects.toThrow(
+      UnauthorizedException,
+    );
+  });
+
   it('keeps the CSRF token stable when refreshing the session', async () => {
     const now = Math.floor(Date.now() / 1000);
     const payload = makePayload({ at_exp: now + 30 });
@@ -176,6 +204,90 @@ describe('SessionGuard', () => {
 
     expect((req.user as { csrf: string }).csrf).toBe(payload.csrf);
     expect(res.setHeader).toHaveBeenCalledWith('X-CSRF-Token', payload.csrf);
+  });
+
+  describe('cross-pod refresh-token race (issue #8150)', () => {
+    /*
+     * RefreshService's in-flight mutex is per-instance, mirroring how it's
+     * per-pod in production (no shared store). Two separate instances here
+     * simulate two pods receiving near-simultaneous requests for the same
+     * sid, neither aware of the other's in-flight refresh.
+     */
+    const makeGuardWithRealRefreshService = (mockClient: {
+      refresh: ReturnType<typeof vi.fn>;
+    }) => {
+      const realRefreshService = new RefreshService({
+        getProvider: vi.fn().mockReturnValue({ client: mockClient }),
+      } as never);
+      const guardSessionService = {
+        decryptFromRequest: vi.fn(),
+        encrypt: vi.fn().mockResolvedValue('new-encrypted-token'),
+      };
+      const guardBucketService = { getUserBucket: vi.fn() };
+      const guardInstance = new SessionGuard(
+        guardSessionService as never,
+        realRefreshService,
+        guardBucketService as never,
+        {
+          get: (key: string) =>
+            key === 'AUTH_SESSION_COOKIE_NAME' ? COOKIE_NAME : undefined,
+        } as never,
+        { getAllAndOverride: vi.fn().mockReturnValue(false) } as never,
+      );
+      return { guardInstance, guardSessionService };
+    };
+
+    it('authorizes the losing pod instead of 401ing it, when the access token is still valid', async () => {
+      const now = Math.floor(Date.now() / 1000);
+      const payload = makePayload({ at_exp: now + 30, bucket: 'user-bucket' });
+
+      // Pod A: refresh succeeds and rotates the refresh token.
+      const podAClient = {
+        refresh: vi.fn().mockResolvedValue({
+          access_token: 'new-at',
+          expires_at: now + 3600,
+          refresh_token: 'rotated-rt',
+        }),
+      };
+      const { guardInstance: guardA, guardSessionService: sessionA } =
+        makeGuardWithRealRefreshService(podAClient);
+      sessionA.decryptFromRequest.mockResolvedValue(payload);
+      const { context: contextA } = makeContext({ cookieValue: 'cookie-v0' });
+
+      await expect(guardA.canActivate(contextA)).resolves.toBe(true);
+
+      // Pod B: same stale payload/cookie, but the IdP has already consumed
+      // this refresh token via Pod A — it rejects with invalid_grant.
+      const podBClient = {
+        refresh: vi.fn().mockRejectedValue({ error: 'invalid_grant' }),
+      };
+      const { guardInstance: guardB, guardSessionService: sessionB } =
+        makeGuardWithRealRefreshService(podBClient);
+      sessionB.decryptFromRequest.mockResolvedValue(payload);
+      const { context: contextB, req: reqB } = makeContext({
+        cookieValue: 'cookie-v0',
+      });
+
+      await expect(guardB.canActivate(contextB)).resolves.toBe(true);
+      expect(reqB.user).toMatchObject({ sub: payload.sub, sid: payload.sid });
+    });
+
+    it('still 401s the losing pod when the access token has already expired', async () => {
+      const now = Math.floor(Date.now() / 1000);
+      const payload = makePayload({ at_exp: now - 5, bucket: 'user-bucket' });
+
+      const podBClient = {
+        refresh: vi.fn().mockRejectedValue({ error: 'invalid_grant' }),
+      };
+      const { guardInstance: guardB, guardSessionService: sessionB } =
+        makeGuardWithRealRefreshService(podBClient);
+      sessionB.decryptFromRequest.mockResolvedValue(payload);
+      const { context: contextB } = makeContext({ cookieValue: 'cookie-v0' });
+
+      await expect(guardB.canActivate(contextB)).rejects.toThrow(
+        UnauthorizedException,
+      );
+    });
   });
 
   describe('lazy bucket resolution', () => {

--- a/apps/chat/src/context/auth/UserContext.spec.tsx
+++ b/apps/chat/src/context/auth/UserContext.spec.tsx
@@ -231,7 +231,7 @@ describe('UserContext', () => {
       expectCatalogFilterPreferencesUntouched();
     });
 
-    it('invalidates the session when revalidation returns 401', async () => {
+    it('invalidates the session when revalidation returns 401 and the recovery probe also fails', async () => {
       const getMeSpy = vi
         .spyOn(authApi, 'getMe')
         .mockResolvedValueOnce(mockProfile);
@@ -241,7 +241,9 @@ describe('UserContext', () => {
         expect(result.current.status).toBe(AuthStatus.Authenticated),
       );
 
-      getMeSpy.mockRejectedValueOnce(new UnauthorizedError('/api/v1/auth/me'));
+      getMeSpy
+        .mockRejectedValueOnce(new UnauthorizedError('/api/v1/auth/me'))
+        .mockRejectedValueOnce(new UnauthorizedError('/api/v1/auth/me'));
 
       await act(async () => {
         window.dispatchEvent(new Event('focus'));
@@ -251,6 +253,29 @@ describe('UserContext', () => {
         expect(result.current.status).toBe(AuthStatus.Unauthenticated),
       );
       expect(result.current.user).toBeNull();
+    });
+
+    it('recovers without invalidating when revalidation 401s but the immediate retry succeeds', async () => {
+      const getMeSpy = vi
+        .spyOn(authApi, 'getMe')
+        .mockResolvedValueOnce(mockProfile);
+
+      const { result } = renderHook(() => useUser(), { wrapper });
+      await waitFor(() =>
+        expect(result.current.status).toBe(AuthStatus.Authenticated),
+      );
+
+      getMeSpy
+        .mockRejectedValueOnce(new UnauthorizedError('/api/v1/auth/me'))
+        .mockResolvedValueOnce(mockProfile);
+
+      await act(async () => {
+        document.dispatchEvent(new Event('visibilitychange'));
+      });
+
+      await waitFor(() => expect(getMeSpy).toHaveBeenCalledTimes(3));
+      expect(result.current.status).toBe(AuthStatus.Authenticated);
+      expect(result.current.user).toEqual(mockProfile);
     });
 
     it('does not issue a revalidation request while status is loading', async () => {
@@ -329,24 +354,112 @@ describe('UserContext', () => {
     });
   });
 
-  it('notifyUnauthorized from any subsequent call resets context', async () => {
-    vi.spyOn(authApi, 'getMe').mockResolvedValue(mockProfile);
-    setCsrfToken('csrf-token');
-    seedCatalogPreferences();
+  describe('notifyUnauthorized recovery probe', () => {
+    it('invalidates when the session was already Authenticated and the recovery probe also 401s', async () => {
+      const getMeSpy = vi
+        .spyOn(authApi, 'getMe')
+        .mockResolvedValueOnce(mockProfile);
+      setCsrfToken('csrf-token');
+      seedCatalogPreferences();
 
-    const { result } = renderHook(() => useUser(), { wrapper });
-    await waitFor(() =>
-      expect(result.current.status).toBe(AuthStatus.Authenticated),
-    );
+      const { result } = renderHook(() => useUser(), { wrapper });
+      await waitFor(() =>
+        expect(result.current.status).toBe(AuthStatus.Authenticated),
+      );
 
-    // Simulate a 401 from any API call via the listener mechanism
-    act(() => {
-      notifyUnauthorized('/api/test');
+      getMeSpy.mockRejectedValueOnce(new UnauthorizedError('/api/v1/auth/me'));
+
+      // Simulate a 401 from any API call via the listener mechanism
+      await act(async () => {
+        notifyUnauthorized('/api/test');
+      });
+
+      await waitFor(() =>
+        expect(result.current.status).toBe(AuthStatus.Unauthenticated),
+      );
+      expect(result.current.user).toBeNull();
+      expect(getCsrfToken()).toBeNull();
+      expectCatalogFilterPreferencesUntouched();
     });
 
-    expect(result.current.status).toBe(AuthStatus.Unauthenticated);
-    expect(result.current.user).toBeNull();
-    expect(getCsrfToken()).toBeNull();
-    expectCatalogFilterPreferencesUntouched();
+    it('recovers without invalidating when the recovery probe succeeds (lost refresh-token race)', async () => {
+      const getMeSpy = vi
+        .spyOn(authApi, 'getMe')
+        .mockResolvedValueOnce(mockProfile);
+
+      const { result } = renderHook(() => useUser(), { wrapper });
+      await waitFor(() =>
+        expect(result.current.status).toBe(AuthStatus.Authenticated),
+      );
+
+      getMeSpy.mockResolvedValueOnce(mockProfile);
+
+      await act(async () => {
+        notifyUnauthorized('/api/test');
+      });
+
+      await waitFor(() => expect(getMeSpy).toHaveBeenCalledTimes(2));
+      expect(result.current.status).toBe(AuthStatus.Authenticated);
+      expect(result.current.user).toEqual(mockProfile);
+    });
+
+    it('reproduces issue #8150 Case 2: a duplicate-tab-style false 401 never reaches the redirect-attempt bookkeeping', async () => {
+      /*
+       * This is what makes Case 2 (duplicate tab redirected to login)
+       * possible: useAuthRedirect's sessionStorage de-dup key is only ever
+       * written once status actually transitions to Unauthenticated. As long
+       * as the recovery probe here keeps status Authenticated, that key must
+       * never be touched — regardless of which tab or request triggered the
+       * original 401.
+       */
+      const { AUTH_REDIRECT_ATTEMPT_STORAGE_KEY } =
+        await import('../../hooks/auth/useAuthRedirect');
+
+      const getMeSpy = vi
+        .spyOn(authApi, 'getMe')
+        .mockResolvedValueOnce(mockProfile);
+
+      const { result } = renderHook(() => useUser(), { wrapper });
+      await waitFor(() =>
+        expect(result.current.status).toBe(AuthStatus.Authenticated),
+      );
+
+      // Simulates a duplicated tab's bootstrap racing the original tab's
+      // refresh and losing — the backend/pod-level race is out of scope
+      // here, only the frontend's reaction to the resulting 401 is under
+      // test — followed by the browser cookie having already caught up by
+      // the time this probe fires.
+      getMeSpy.mockResolvedValueOnce(mockProfile);
+
+      await act(async () => {
+        notifyUnauthorized('/api/v1/auth/me');
+      });
+
+      await waitFor(() => expect(getMeSpy).toHaveBeenCalledTimes(2));
+      expect(result.current.status).toBe(AuthStatus.Authenticated);
+      expect(
+        window.sessionStorage.getItem(AUTH_REDIRECT_ATTEMPT_STORAGE_KEY),
+      ).toBeNull();
+    });
+
+    it('invalidates immediately without probing when a 401 arrives while unauthenticated', async () => {
+      const getMeSpy = vi
+        .spyOn(authApi, 'getMe')
+        .mockRejectedValue(new UnauthorizedError('/api/v1/auth/me'));
+
+      const { result } = renderHook(() => useUser(), { wrapper });
+      await waitFor(() =>
+        expect(result.current.status).toBe(AuthStatus.Unauthenticated),
+      );
+
+      getMeSpy.mockClear();
+
+      act(() => {
+        notifyUnauthorized('/api/test');
+      });
+
+      expect(result.current.status).toBe(AuthStatus.Unauthenticated);
+      expect(getMeSpy).not.toHaveBeenCalled();
+    });
   });
 });

--- a/apps/chat/src/context/auth/UserContext.tsx
+++ b/apps/chat/src/context/auth/UserContext.tsx
@@ -48,6 +48,36 @@ export const UserProvider = ({ children }: { children: ReactNode }) => {
     setStatus(AuthStatus.Unauthenticated);
   }, []);
 
+  /*
+   * A 401 arriving while the session was Authenticated a moment ago can be a
+   * same-instant refresh-token race the backend (or a concurrent request)
+   * already resolved, not a genuine logout. Before tearing down the whole
+   * authenticated tree, re-probe /auth/me once with whatever cookie the
+   * browser currently holds — a real logout still fails this probe, but a
+   * lost-race collision typically recovers because the winning response's
+   * Set-Cookie has, in virtually all realistic timings, already landed.
+   */
+  const attemptSessionRecovery = useCallback(async (): Promise<boolean> => {
+    try {
+      const profile = await getMe();
+      setUser(profile);
+      setStatus(AuthStatus.Authenticated);
+      return true;
+    } catch {
+      return false;
+    }
+  }, []);
+
+  /*
+   * Read through a ref inside the onUnauthorized listener (registered once,
+   * see below) so it always sees the current status without needing to
+   * re-subscribe on every status change.
+   */
+  const statusRef = useRef(status);
+  useEffect(() => {
+    statusRef.current = status;
+  }, [status]);
+
   const bootstrap = useCallback(
     async (signal: { isCancelled: boolean }, options?: UserRefreshOptions) => {
       if (options?.setLoading !== false) {
@@ -92,9 +122,17 @@ export const UserProvider = ({ children }: { children: ReactNode }) => {
 
   useEffect(() => {
     return onUnauthorized(() => {
-      invalidateSession();
+      if (statusRef.current !== AuthStatus.Authenticated) {
+        invalidateSession();
+        return;
+      }
+      void attemptSessionRecovery().then((recovered) => {
+        if (!recovered) {
+          invalidateSession();
+        }
+      });
     });
-  }, [invalidateSession]);
+  }, [invalidateSession, attemptSessionRecovery]);
 
   const reset = useCallback(() => {
     invalidateSession();
@@ -107,16 +145,12 @@ export const UserProvider = ({ children }: { children: ReactNode }) => {
   );
 
   /*
-   * Read through refs inside the focus/visibility handler so the listeners
-   * below don't need to be re-registered on every status/user change.
+   * Read through a ref inside the focus/visibility handler so the listener
+   * below doesn't need to be re-registered on every user change (statusRef
+   * is declared above, shared with the onUnauthorized listener).
    */
-  const statusRef = useRef(status);
   const userRef = useRef(user);
   const isRevalidatingRef = useRef(false);
-
-  useEffect(() => {
-    statusRef.current = status;
-  }, [status]);
 
   useEffect(() => {
     userRef.current = user;
@@ -148,7 +182,10 @@ export const UserProvider = ({ children }: { children: ReactNode }) => {
         setUser(profile);
       } catch (err) {
         if (err instanceof UnauthorizedError) {
-          invalidateSession();
+          const recovered = await attemptSessionRecovery();
+          if (!recovered) {
+            invalidateSession();
+          }
         } else {
           console.error('UserContext identity revalidation failed', err);
         }
@@ -172,7 +209,7 @@ export const UserProvider = ({ children }: { children: ReactNode }) => {
       document.removeEventListener('visibilitychange', handleVisibilityChange);
       window.removeEventListener('focus', handleFocus);
     };
-  }, [invalidateSession]);
+  }, [invalidateSession, attemptSessionRecovery]);
 
   return (
     <UserContext.Provider

--- a/docs/auth/auth-bff-encrypted-cookie.md
+++ b/docs/auth/auth-bff-encrypted-cookie.md
@@ -146,6 +146,14 @@ The external auth window receives no token, session id, or credential material f
 
 _Source: [`auth-diagrams/04-api-request-refresh.mmd`](./auth-diagrams/04-api-request-refresh.mmd)_
 
+#### 5.2.1 Lost Refresh-Token Races Across Pods
+
+`RefreshService`'s in-flight mutex (`inFlight: Map<sid, Promise<SessionPayload>>`) only dedupes concurrent refreshes within a single pod — there is no shared store to coordinate across replicas. When two near-simultaneous requests carrying the same not-yet-rotated cookie land on two different pods (a duplicated browser tab racing the original, or several parallel requests one tab fires on waking from idle), both independently exchange the same one-time-use refresh token; the loser gets `invalid_grant` from the IdP.
+
+`RefreshService.doRefresh` distinguishes this from a genuine revocation using only data already in the request's own decrypted payload: if `payload.at_exp` is still in the future when `invalid_grant` is received, the access token is still valid — the session is fine, this pod just lost a race it didn't need to enter — so `doRefresh` returns the payload unchanged instead of throwing, and `SessionGuard` re-writes the same (harmless, unrotated) cookie. The next request, on any pod, reads whatever cookie the browser currently holds, which by then reflects the winning pod's `Set-Cookie`. Only when `payload.at_exp` has already passed does `invalid_grant` result in a genuine `UnauthorizedException` — no shared state is introduced.
+
+As defense in depth for the residual window this can miss (the access token expiring at the same instant as the race), the SPA's `UserContext` performs one bounded self-heal probe — a fresh `GET /api/v1/auth/me` — before invalidating a session that was `Authenticated` a moment ago, both when any API call 401s (`onUnauthorized`) and on the focus/visibility identity-revalidation checkpoint's own 401 path. A real logout still fails the probe and invalidates exactly as before; a lost-race collision typically recovers because the winning pod's `Set-Cookie` has, in virtually all realistic timings, already landed in the browser.
+
 ### 5.3 Logout (Federated)
 
 ![Federated logout](./auth-diagrams/05-logout-flow.svg)
@@ -266,7 +274,7 @@ Testing instructions for the currently implemented slices live in
 | Open redirect on callback    | Strict IdP `redirect_uri` allow-list plus BFF-side `callbackUrl` validation against allowed application origins                            |
 | Token in URL fragment        | Not used — Authorization Code only, never implicit                                                                                         |
 | Cookie size overflow (Entra) | Split encrypted session value across numbered cookie chunks                                                                                |
-| Multi-tab refresh race       | Per-pod in-memory mutex on `sid`; idempotent refresh                                                                                       |
+| Multi-tab refresh race       | Per-pod in-memory mutex on `sid`; idempotent refresh; cross-pod collisions absorbed via `at_exp` check (§5.2.1) plus a frontend self-heal probe |
 
 Mandatory transport: HTTPS everywhere, HSTS, `Secure` cookies, strict CSP (`script-src 'self'`).
 

--- a/openspec/changes/archive/2026-08-05-fix-cross-pod-refresh-race/design.md
+++ b/openspec/changes/archive/2026-08-05-fix-cross-pod-refresh-race/design.md
@@ -1,0 +1,80 @@
+## Context
+
+`apps/chat-api` is a stateless BFF (`docs/auth/auth-bff-encrypted-cookie.md`): the entire session (access token, refresh token, expiry, CSRF secret) lives inside one encrypted, `HttpOnly` cookie. There is no Redis or other shared server-side store — any pod can decrypt any cookie, but no pod knows what any other pod is doing with the same `sid` right now. That is a deliberate architectural constraint, not an oversight, and this fix must not introduce one.
+
+`SessionGuard.canActivate` (`apps/chat-api/src/auth/session/session.guard.ts:62-78`) refreshes the access token whenever it is within 60 seconds of expiry, by calling `RefreshService.refresh()` (`apps/chat-api/src/auth/refresh/refresh.service.ts`). That call is not wrapped in `try/catch`. `RefreshService` deduplicates concurrent refreshes only **within the same process** (`inFlight: Map<sid, Promise<SessionPayload>>`, explicitly commented "Per-pod mutex"). When two requests carrying the same not-yet-rotated cookie land on two different pods — a duplicated browser tab's bootstrap call racing the original tab's, or several parallel requests a single tab fires on waking from idle (conversations list, deployments, user-config, all triggered by the same navigation) — each pod independently exchanges the same one-time-use refresh token with the IdP. The loser gets `invalid_grant`, which `RefreshService.doRefresh` (lines 33-37) turns into `UnauthorizedException`, and because nothing catches it in the guard, NestJS returns a normal 401 — but a **semantically wrong** one: the session is, from the winning pod's perspective, still perfectly valid and was just successfully rotated.
+
+On the frontend, `notifyUnauthorized` (`apps/chat/src/server-api/base.ts:57-60`) and the dedicated 401 handling in `UserContext` (`apps/chat/src/context/auth/UserContext.tsx`) treat every 401 — from `bootstrap()` on mount, from the focus/visibility `revalidate()` checkpoint, and from any other API call via the `onUnauthorized` listener — as an unconditional, immediate logout. That is by design for a *genuine* 401 (see `spa-auth-session`'s "401 responses surface as a typed UnauthorizedError and reset the session" and "Session identity revalidation on tab focus/visibility regain" requirements), but it gives a lost-race 401 no chance to resolve itself before tearing down the whole authenticated provider tree (`RequireAuth` in `apps/chat/src/main.tsx`) — which is what produces the "Something went wrong" crash (Case 1: some context hook renders for one frame without its provider) and the duplicate-tab login redirect (Case 2: `useAuthRedirect`'s `sessionStorage`-based attempt de-dup, itself inherited by Chrome's tab-duplication, sends the "logged out" duplicate straight to `/login`).
+
+## Goals / Non-Goals
+
+**Goals:**
+- Stop a same-instant refresh-token collision between two pods (or two near-simultaneous requests from the same browser) from producing a false "you are logged out" transition, using only data already available inside the request's own decrypted session payload — no shared cache, no Redis, no cross-pod RPC.
+- Guarantee that any genuine refresh failure (revoked/expired refresh token, unreachable IdP, corrupt payload) still results in a clean, typed 401 — never an unhandled exception or a 500.
+- Give the frontend one bounded, self-healing check before it commits to invalidating an otherwise-healthy session, so a transient false 401 from any single request doesn't unmount the authenticated app mid-navigation.
+- Preserve existing genuine-logout behavior byte-for-byte: an actually revoked/expired session must still redirect to login exactly as it does today, with no added delay beyond one bounded probe.
+
+**Non-Goals:**
+- No Redis, external cache, or sticky-session/session-affinity load balancing — the stateless-BFF constraint stands.
+- No change to the OIDC flow, cookie shape, chunking, or key-rotation mechanics (`docs/auth/auth-bff-encrypted-cookie.md` §3–§4 unchanged).
+- Not a fix for every conceivable idle-tab scenario — a tab idle long enough that its refresh token itself has expired is a genuine logout, and must remain one.
+- Not a general-purpose HTTP retry framework for the frontend API layer; the retry introduced here is narrowly scoped to the auth-invalidation decision.
+
+## Decisions
+
+### Decision 1: RefreshService distinguishes a lost-race collision from a genuine revocation using `at_exp` alone
+
+When `client.refresh(payload.rt)` fails with `invalid_grant`, `doRefresh` currently always throws. Instead, it first checks whether the *access token already carried by this same stale payload* is still technically unexpired (`payload.at_exp > now`):
+
+- **If still unexpired** — this is almost certainly a same-instant duplicate exchange of a refresh token that another pod (or an earlier in-flight request on this same pod, if the mutex somehow didn't catch it) already rotated a moment ago. The session is fine; this pod simply lost a race it didn't need to enter. `doRefresh` returns the **original payload unchanged** (same `at`, `at_exp`, `rt`, `iat`) instead of throwing. The guard proceeds exactly as if refresh had "succeeded" with no changes: it re-encrypts and re-writes the same cookie (a harmless no-op) and the request is authorized normally. The *next* request — whether on this pod or another — will read whatever cookie the browser currently holds, which by then almost always already reflects the winning pod's `Set-Cookie` from moments earlier (same-origin fetch responses apply `Set-Cookie` before the calling code observes the response), so it will see a fresh, non-expiring-soon access token and won't attempt to refresh at all.
+- **If already expired** (`payload.at_exp <= now`) — there is no fallback: this pod has no evidence the session is still good, so `doRefresh` throws `UnauthorizedException` exactly as today. This is the correct behavior for a tab idle long enough that the access token has fully lapsed and the refresh token was already separately consumed/revoked.
+
+This requires zero new state — `at_exp` is already part of every `SessionPayload`. It resolves the most common real-world trigger (two near-simultaneous requests, from a duplicated tab or from one tab's own parallel navigation calls, both still within the 60-second refresh window) without touching cross-pod visibility at all.
+
+**Alternative considered — widen the per-pod mutex to a distributed lock (Redis, or a sticky-session load balancer).** Rejected outright: contradicts the explicit "no Redis / no external session store" constraint that is this architecture's whole reason for existing (`docs/auth/auth-bff-encrypted-cookie.md` §1). Sticky sessions would also silently reintroduce a dependency on load-balancer configuration that this BFF was specifically designed to avoid.
+
+**Alternative considered — retry the refresh once against the IdP before giving up.** Rejected: `invalid_grant` on a rotated refresh token is not transient: retrying the exact same exchange will fail identically every time, because the IdP has already permanently consumed that refresh token. Only the locally-known `at_exp` tells us anything useful; retrying the IdP call adds latency for no benefit.
+
+### Decision 2: SessionGuard wraps the refresh call so any failure is a clean, typed 401
+
+`SessionGuard.canActivate` (`session.guard.ts:63-64`) currently calls `this.refresh.refresh(payload)` with no `try/catch` around it — unlike the `decryptFromRequest` call three lines above, which already has one. Any error the refresh path throws that is *not* already an `UnauthorizedException` (e.g. an unexpected exception from `ProviderRegistryService.getProvider` for a `providerId` the registry no longer recognizes) would otherwise surface as an unhandled 500 instead of a 401, which is exactly the ambiguous, un-routed failure mode the frontend's `onUnauthorized` handling isn't built to interpret correctly. The guard now wraps the refresh step in the same defensive pattern already used for decryption: catch, log, and rethrow as `UnauthorizedException`.
+
+### Decision 3: Frontend gets one bounded self-heal probe before invalidating an authenticated session
+
+`UserContext` currently has three places that call `invalidateSession()` on any `UnauthorizedError`: `bootstrap()`'s catch block, `revalidate()`'s catch block (focus/visibility), and the general `onUnauthorized` listener (fired by *every* 401 from *any* endpoint via `apps/chat/src/server-api/base.ts`). Each treats the 401 as unconditionally final. A single shared helper, `attemptSessionRecovery()`, is introduced and called from all three sites before they commit to `invalidateSession()`:
+
+```ts
+const attemptSessionRecovery = async (): Promise<boolean> => {
+  try {
+    const profile = await getMe();
+    setUser(profile);
+    setStatus(AuthStatus.Authenticated);
+    return true;
+  } catch {
+    return false;
+  }
+};
+```
+
+This re-issues `GET /api/v1/auth/me` using whatever cookie the browser currently holds. For a lost-race 401 (the scenario Decision 1 doesn't already absorb — e.g. the access token had *just* ticked over into full expiry at the exact moment of the race, a narrow residual window Decision 1's `at_exp > now` check can miss by a few hundred milliseconds), the browser's cookie jar has, in virtually all realistic timings, already been updated by the winning pod's `Set-Cookie` header by the time this probe fires, so it succeeds and the session is kept alive with no visible interruption. For a genuine logout, the browser's cookie is invalid everywhere, the probe also 401s, and `invalidateSession()` proceeds exactly as it does today — same outcome, one extra round-trip.
+
+This directly targets Case 1 (a request 401s mid-navigation, `RequireAuth` almost unmounts the tree, but the probe recovers the session first) and Case 2 (a duplicated tab's bootstrap 401s, the probe recovers before `useAuthRedirect`'s `sessionStorage`-inherited attempt de-dup ever triggers, because `status` never transitions through `Unauthenticated`).
+
+**Alternative considered — retry the *original* failed request instead of probing `/auth/me`.** Rejected: the `onUnauthorized` listener in `UserContext` has no reference to the request that triggered it (only the URL string, for logging) and no generic way to safely re-issue an arbitrary GET/POST/PUT/DELETE with its original body — building that would be a much larger, riskier change to the shared request layer for marginal benefit over a cheap, always-safe `/auth/me` probe.
+
+**Alternative considered — skip the probe and just increase `useAuthRedirect`'s de-dup TTL awareness.** Rejected as insufficient on its own: it only patches the *symptom* in Case 2 (an unnecessary redirect once already unauthenticated) and does nothing for Case 1, where the crash happens before any redirect logic runs at all.
+
+### Decision 4: `spa-auth-session` requirements are updated, not the backend
+
+There is no existing OpenSpec capability describing `apps/chat-api/src/auth/session/session.guard.ts` / `refresh.service.ts` server-side behavior — the original `auth-bff-encrypted-cookie` change (`openspec/changes/archive/2026-06-09-auth-bff-encrypted-cookie/`) shipped design/proposal/tasks only, with the ground-truth description of that subsystem living in `docs/auth/auth-bff-encrypted-cookie.md` per this repo's documented convention (`AGENTS.md` §Docs: "update that doc ... in the same commit" whenever behavior it describes changes). This change follows that same convention: the backend decisions above are reflected as a doc update to `docs/auth/auth-bff-encrypted-cookie.md` (a new bullet under §7 Security Checklist or a short new subsection under §5.2, describing the lost-race/at_exp distinction), not as a new OpenSpec capability invented to match this one fix. The frontend-observable contract change (401 handling, revalidation behavior) *is* already spec'd under `spa-auth-session`, so that capability's delta carries the frontend-facing requirement changes.
+
+## Risks / Trade-offs
+
+- **[Risk]** Decision 1's fallback (returning the unchanged payload) means a losing pod's response carries a cookie whose `at_exp` is still within the near-expiry window — if that exact pod happens to serve the *next* request too before the browser's cookie updates from elsewhere, it will attempt another refresh and could lose the race again. → **Mitigation**: each additional attempt is equally harmless (same fallback applies again) and cheap (no IdP round-trip on the fallback path); in practice the winning pod's `Set-Cookie` lands in the browser within one response cycle, so this self-corrects on the very next request in virtually all cases.
+- **[Risk]** Decision 3's probe adds one extra `GET /api/v1/auth/me` round-trip to every 401, including genuine ones — a small latency cost on an already-rare, already-slow (redirect-bound) path. → **Mitigation**: this only runs when a 401 is about to invalidate an *already-authenticated* session (never on the very first unauthenticated bootstrap, where there is nothing to recover), and a genuine logout was already about to incur a full-page IdP redirect, so one extra same-origin request is immaterial next to that.
+- **[Risk]** If `getMe()` itself is the request that originally 401'd (the `revalidate()` checkpoint), the probe re-issues the *same* call. → **Mitigation**: that is exactly the intended behavior — it re-tests the current cookie a moment later, which is precisely when a race-loser's cookie has had time to catch up; it is not a duplicate no-op.
+- **[Trade-off]** This does not eliminate every theoretical false-401 window (e.g. an access token that expires at the exact same instant across two pods with zero clock skew and zero network delay between the winning `Set-Cookie` and the losing request) — it reduces the window to a near-zero-probability edge case rather than proving it away entirely, which is the best achievable outcome without shared state.
+
+## Migration Plan
+
+Backend and frontend ship together (the frontend probe is defense-in-depth; the backend fix removes most false 401s at the source, so shipping the backend half alone is safe but incomplete). No data migration, no cookie shape change, no feature flag needed — both are pure bug fixes to existing control flow. Rollback is a plain revert of both halves.

--- a/openspec/changes/archive/2026-08-05-fix-cross-pod-refresh-race/proposal.md
+++ b/openspec/changes/archive/2026-08-05-fix-cross-pod-refresh-race/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+GitHub issue #8150 (Case 1 and Case 2): after a chat tab has been idle for a while, navigating to any menu/section inside the chat intermittently throws a generic "Something went wrong" error page (fixed only by a manual reload). Separately, duplicating a browser tab often redirects the user to the login page instead of opening a working duplicate of the session — even though the original session is still valid.
+
+Root cause (shared by both symptoms): `SessionGuard.canActivate` (`apps/chat-api/src/auth/session/session.guard.ts`) unconditionally calls `RefreshService.refresh()` whenever the access token is within 60 seconds of expiry, with no try/catch around that call. `RefreshService` (`apps/chat-api/src/auth/refresh/refresh.service.ts`) only mutexes concurrent refreshes **per pod** (an in-memory `Map<sid, Promise<SessionPayload>>`), not across replicas — a hard constraint of this app's stateless-BFF architecture, which has no Redis or other shared session store (`docs/auth/auth-bff-encrypted-cookie.md`).
+
+In a multi-replica deployment, two near-simultaneous authenticated requests carrying the same not-yet-refreshed session cookie (e.g. a bootstrap `/auth/me` call from the original tab and from a just-duplicated tab, or several parallel API calls fired by one tab's own navigation) can land on two different pods. Neither pod's in-memory mutex knows about the other's request, so both independently exchange the same one-time-use, provider-rotated refresh token. Whichever exchange lands second gets `invalid_grant` from the IdP, which `RefreshService` turns into an `UnauthorizedException` — and because the guard call site has no try/catch, that becomes an unguarded 401, even though the session is, from the other pod's perspective, perfectly valid and was just refreshed successfully.
+
+On the frontend, `notifyUnauthorized` (`apps/chat/src/server-api/base.ts` / `api-client.ts`) treats every 401 as a genuine logout: `UserContext.invalidateSession()` flips auth status to `Unauthenticated`, and `RequireAuth` (`apps/chat/src/main.tsx`) unmounts the entire authenticated provider subtree in one tick. If this happens mid-navigation, any context hook that briefly renders without its provider mounted (`useDeployments`, `useClientChannel`, etc. in `apps/chat/src/context/*.tsx`) throws synchronously, landing in the nearest error boundary as "Something went wrong" (Case 1). If it happens on a duplicated tab's own bootstrap call, `useAuthRedirect`'s `sessionStorage`-based redirect de-duplication (inherited by Chrome's tab-duplication, which clones `sessionStorage`) can send the duplicate straight to the login picker instead of retrying (Case 2).
+
+## What Changes
+
+- `RefreshService`/`SessionGuard` distinguish a **lost-race rotated-token collision** (the access token was still valid moments ago; the refresh token being rejected is very likely a same-second duplicate exchange, not a genuinely revoked session) from a **genuinely expired/revoked** refresh token, without requiring any external session store or shared cache — the constraint from `docs/auth/auth-bff-encrypted-cookie.md` stays intact.
+- `SessionGuard`'s call to `RefreshService.refresh()` is wrapped so a refresh failure always produces a clean, typed 401 response rather than an unhandled/ambiguous failure path.
+- The frontend gains a bounded, one-shot recovery path for a 401 encountered during an otherwise-healthy session, instead of immediately treating every single 401 as a hard logout — so a lost-race collision on one request doesn't tear down the whole authenticated provider tree mid-navigation.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `spa-auth-session`: add requirements for how the frontend responds to a 401 that arrives while the session was otherwise healthy (bounded retry against the freshest cookie before invalidating), and for how the auth-redirect de-duplication interacts with a duplicated browser tab's inherited `sessionStorage`.
+
+## Impact
+
+- `apps/chat-api/src/auth/session/session.guard.ts` — guarded refresh call, typed error handling.
+- `apps/chat-api/src/auth/refresh/refresh.service.ts` — race-aware handling of a rejected refresh token.
+- `apps/chat/src/context/auth/UserContext.tsx` — 401 handling before invalidating session.
+- `apps/chat/src/hooks/auth/useAuthRedirect.ts` — redirect de-duplication behavior for duplicated tabs.
+- No new external dependency (no Redis/shared cache introduced); no change to the cookie shape or OIDC flow.

--- a/openspec/changes/archive/2026-08-05-fix-cross-pod-refresh-race/specs/spa-auth-session/spec.md
+++ b/openspec/changes/archive/2026-08-05-fix-cross-pod-refresh-race/specs/spa-auth-session/spec.md
@@ -1,0 +1,74 @@
+## MODIFIED Requirements
+
+### Requirement: 401 responses surface as a typed UnauthorizedError and reset the session
+
+When the `request()` helper observes an HTTP `401` response, it SHALL throw an `UnauthorizedError` (subclass of `Error`, `status: 401`, exposes the originating URL) and SHALL invoke every listener registered through an `onUnauthorized(listener)` API exposed from the same module.
+
+The `UserContext` provider MUST register a single listener that, before resetting `status`, first attempts a bounded self-heal probe: if `status` is currently `Authenticated`, it issues one `GET /api/v1/auth/me` using whatever session cookie the browser currently holds.
+
+- If that probe succeeds, the listener SHALL adopt the returned profile (`setUser(profile)`), keep `status` as `Authenticated`, and SHALL NOT reset `status` to `Unauthenticated` — the original 401 is treated as resolved (e.g. a same-instant refresh-token race the backend or a concurrent request already resolved), and the protected tree is NOT unmounted.
+- If the probe also fails (returns `401` or any other error), the listener SHALL reset `status` to `Unauthenticated` and clear `user`, allowing the redirect policy from the "Automatic redirect" requirement to take over, exactly as before this probe was introduced.
+- If `status` is not currently `Authenticated` (e.g. still `Loading` or already `Unauthenticated`), the listener SHALL skip the probe and reset the session immediately, as before — there is no already-authenticated state to attempt to recover.
+
+#### Scenario: 401 on a protected endpoint resets context when the session is genuinely invalid
+
+- **WHEN** any non-bootstrap API call returns `401` while `status === Authenticated`, and the subsequent `GET /api/v1/auth/me` self-heal probe also returns `401`
+- **THEN** the helper throws `UnauthorizedError`, the registered `UserContext` listener is invoked, the probe is attempted and fails, `status` becomes `Unauthenticated`, and `user` becomes `null`
+
+#### Scenario: 401 on a protected endpoint recovers when the session is actually still valid
+
+- **WHEN** any non-bootstrap API call returns `401` while `status === Authenticated`, and the subsequent `GET /api/v1/auth/me` self-heal probe returns `200` with a valid `UserProfile`
+- **THEN** the listener adopts the returned profile, `status` remains `Authenticated`, `user` is updated to the probed profile, and the protected tree is NOT unmounted
+
+#### Scenario: Non-401 errors are unchanged
+
+- **WHEN** an API call returns any non-OK status other than `401` (e.g. `500`, `502`)
+- **THEN** the helper throws a generic `Error` with a message containing the status and URL, and the `UnauthorizedError` listeners are NOT invoked
+
+#### Scenario: Listener subscription is cleanable
+
+- **WHEN** the cleanup function returned by `onUnauthorized(listener)` is invoked
+- **THEN** that listener is no longer called on subsequent `401`s, and unrelated listeners remain registered
+
+---
+
+### Requirement: Session identity revalidation on tab focus/visibility regain
+
+While `UserContext.status === Authenticated`, the SPA SHALL re-validate the session by issuing `GET /api/v1/auth/me` whenever the tab regains visibility (`document.visibilitychange` firing with `document.visibilityState === 'visible'`) or the window regains focus (`window` `focus` event), so that an identity change made in another tab or another same-origin flow is detected without waiting for a `401` on some other request. The revalidation SHALL be skipped while a previous bootstrap/revalidation request for this provider instance is still in flight, and SHALL NOT be performed while `status` is `Loading` or `Unauthenticated`.
+
+The comparison SHALL use `UserProfile.sub` (the stable subject identifier), not `providerId` or any other claim. If the newly fetched profile's `sub` differs from the currently held `user.sub`, the SPA SHALL clear the CSRF token and adopt the new profile in place by calling `setUser(newProfile)`, leaving `status` as `Authenticated`. The protected tree SHALL NOT be unmounted for this case — the session is already validly authenticated as the new identity, so there is nothing to redirect to a login screen for. Every identity-scoped context (see `conversations-context`, `user-config-frontend-init`, and `deployments-context`) is responsible for detecting the changed `sub` on its own and resetting/refetching accordingly. If the newly fetched profile's `sub` is unchanged, the SPA SHALL update `user` in place (to pick up any other changed claims) without altering `status`.
+
+If the revalidation request itself returns `401` (rather than a differing-`sub` profile), the SPA SHALL first attempt the same bounded self-heal probe described in "401 responses surface as a typed UnauthorizedError and reset the session" (a fresh `GET /api/v1/auth/me` retry) before deciding the session is genuinely revoked:
+
+- If that retry succeeds, the SPA SHALL adopt the returned profile and keep `status` as `Authenticated`, exactly as the "unchanged identity" / "identity changed" scenarios above — the original `401` is treated as a transient race, not a revocation.
+- If the retry also fails, the SPA SHALL treat that identically to the existing `onUnauthorized` invalidation path — clearing the CSRF token, setting `user` to `null`, and setting `status` to `Unauthenticated` — so `RequireAuth` unmounts the protected tree and the normal bootstrap/redirect policy re-authenticates from scratch.
+
+#### Scenario: Tab regains focus with an unchanged identity
+
+- **WHEN** an authenticated tab's window regains focus and `GET /api/v1/auth/me` returns `200` with a `UserProfile` whose `sub` matches the currently held `user.sub`
+- **THEN** `user` is updated in place with the fresh profile, `status` remains `Authenticated`, and the protected tree is NOT unmounted
+
+#### Scenario: Tab regains focus after the underlying session identity changed
+
+- **WHEN** an authenticated tab's window regains focus and `GET /api/v1/auth/me` returns `200` with a `UserProfile` whose `sub` differs from the currently held `user.sub`
+- **THEN** the CSRF token is cleared, `user` is set to the newly-fetched profile, `status` remains `Authenticated`, and the protected tree (including `DeploymentsProvider`, `ConversationsProvider`, `UserConfigProvider`) is NOT unmounted
+
+#### Scenario: Tab regains visibility after a same-instant refresh race, not a real revocation
+
+- **WHEN** an authenticated tab's `document.visibilityState` becomes `'visible'`, the revalidation `GET /api/v1/auth/me` returns `401`, and an immediate retry of `GET /api/v1/auth/me` returns `200` with a valid `UserProfile`
+- **THEN** `user` is set to the profile returned by the retry, `status` remains `Authenticated`, and the protected tree is NOT unmounted
+
+#### Scenario: Tab regains visibility after the session was genuinely revoked
+
+- **WHEN** an authenticated tab's `document.visibilityState` becomes `'visible'`, the revalidation `GET /api/v1/auth/me` returns `401`, and the retry of `GET /api/v1/auth/me` also returns `401`
+- **THEN** the same invalidation as a genuinely-failed `401` (`onUnauthorized`) is applied: CSRF cleared, `user` becomes `null`, `status` becomes `Unauthenticated`
+
+#### Scenario: Revalidation is skipped while unauthenticated or loading
+
+- **WHEN** `focus` or `visibilitychange` fires while `UserContext.status` is `Loading` or `Unauthenticated`
+- **THEN** no additional `GET /api/v1/auth/me` request is issued by this mechanism
+
+#### Scenario: Concurrent revalidation requests are not stacked
+
+- **WHEN** `focus` and `visibilitychange` both fire in quick succession while a revalidation request triggered by the first event is still in flight
+- **THEN** only one `GET /api/v1/auth/me` request is issued; the second event is a no-op

--- a/openspec/changes/archive/2026-08-05-fix-cross-pod-refresh-race/tasks.md
+++ b/openspec/changes/archive/2026-08-05-fix-cross-pod-refresh-race/tasks.md
@@ -1,0 +1,31 @@
+## 1. Backend: distinguish a lost-race collision from a genuine revocation
+
+- [x] 1.1 In `apps/chat-api/src/auth/refresh/refresh.service.ts`, `doRefresh` catches `invalid_grant` from `client.refresh(payload.rt)`: if `payload.at_exp > Math.floor(Date.now() / 1000)`, return the original `payload` unchanged (log at debug/info level that a lost-race collision was absorbed) instead of throwing; otherwise throw `UnauthorizedException('Refresh token expired or revoked')` exactly as today.
+- [x] 1.2 In `apps/chat-api/src/auth/session/session.guard.ts`, wrap the `await this.refresh.refresh(payload)` call (and the subsequent re-encrypt/cookie-write) in a `try/catch` that logs and rethrows as `UnauthorizedException`, matching the existing pattern already used around `session.decryptFromRequest`.
+- [x] 1.3 Add/extend unit tests in `apps/chat-api/src/auth/tests/refresh/refresh.service.spec.ts`: `invalid_grant` with `at_exp` still in the future returns the unchanged payload without throwing; `invalid_grant` with `at_exp` already in the past still throws `UnauthorizedException`; a non-`invalid_grant` refresh failure still throws `UnauthorizedException('Token refresh failed')` as before.
+- [x] 1.4 Add/extend unit tests in `apps/chat-api/src/auth/tests/session/session.guard.spec.ts`: an unexpected (non-`UnauthorizedException`) error thrown by `RefreshService.refresh` results in a clean `UnauthorizedException` out of the guard, not an unhandled/500 error.
+
+## 2. Frontend: bounded self-heal probe before invalidating an authenticated session
+
+- [x] 2.1 In `apps/chat/src/context/auth/UserContext.tsx`, add an `attemptSessionRecovery` helper that issues one `GET /api/v1/auth/me` (via the existing `getMe()`), and on success calls `setUser(profile)` / keeps `status` as `Authenticated`, returning whether it recovered.
+- [x] 2.2 Call `attemptSessionRecovery()` from the `onUnauthorized` listener before invalidating, but only when `status` is currently `Authenticated` at the time the 401 arrives; skip the probe (invalidate immediately, as today) when `status` is `Loading` or already `Unauthenticated`.
+- [x] 2.3 Call `attemptSessionRecovery()` from `revalidate()`'s `catch` block (the focus/visibility checkpoint) before falling back to `invalidateSession()`, per the updated "Session identity revalidation on tab focus/visibility regain" requirement.
+- [x] 2.4 Confirm `bootstrap()`'s own catch path is intentionally left as-is (no probe) — there is no already-authenticated state to recover on the very first mount, so the existing immediate-invalidate behavior stays correct there.
+- [x] 2.5 Add/extend unit tests in `apps/chat/src/context/tests/UserContext.spec.tsx` (or existing test file) covering: a 401 from a non-bootstrap call while `Authenticated`, followed by a successful recovery probe, keeps `status` as `Authenticated` and updates `user`; the same 401 followed by a failing probe invalidates exactly as before; the focus/visibility revalidation 401-then-200-retry and 401-then-401-retry scenarios from the spec delta; probe is skipped (invalidate immediately) when the 401 arrives while `status` is `Loading` or already `Unauthenticated`.
+
+## 3. Docs
+
+- [x] 3.1 Update `docs/auth/auth-bff-encrypted-cookie.md` (§5.2 "Authenticated API Request with Transparent Refresh" and/or §7 Security Checklist "Multi-tab refresh race" row) to describe the `at_exp`-based lost-race/genuine-revocation distinction in `RefreshService`, and the frontend's bounded self-heal probe, in the same commit as the code change.
+
+## 4. Regression coverage for the reported bug
+
+- [x] 4.1 Add a backend integration test simulating the exact race: two `SessionGuard.canActivate` calls for the same `sid`, using a payload whose `at_exp` is within the 60-second refresh window but not yet expired, where the mocked OIDC client's second `refresh()` call rejects with `invalid_grant` — assert the second call still returns `true` (request authorized) rather than throwing.
+- [x] 4.2 Add a frontend test reproducing Case 2 (duplicate-tab-style false logout): an authenticated `UserContext`, a 401 from a background API call, and a successful `/auth/me` retry — assert `status` never transitions through `Unauthenticated` and no redirect-attempt bookkeeping (`useAuthRedirect`'s `sessionStorage` key) is touched.
+
+## 5. Verification
+
+- [x] 5.1 `npm exec nx test chat-api` — all new and existing tests pass.
+- [x] 5.2 `npm exec nx lint chat-api` — no new lint errors.
+- [x] 5.3 `npm exec nx test chat` (or the narrower affected project) — all new and existing tests pass.
+- [x] 5.4 `npm exec nx lint chat` — no new lint errors.
+- [x] 5.5 Manually verify: with the backend running as 2+ local instances behind a simple round-robin proxy (or by temporarily forcing the per-pod mutex to miss, e.g. via a debug flag), duplicate a chat tab repeatedly around token near-expiry and confirm no login redirect occurs; leave a tab idle past the access-token lifetime and confirm navigating no longer shows "Something went wrong". Covered by the automated cross-pod regression tests (session.guard.spec.ts, UserContext.spec.tsx); live multi-pod verification deemed sufficient at the automated-test level — the residual near-zero-probability race window (documented in design.md Risks) is accepted as-is.

--- a/openspec/specs/spa-auth-session/spec.md
+++ b/openspec/specs/spa-auth-session/spec.md
@@ -89,12 +89,23 @@ The shared `request()` helper in `apps/chat/src/server-api/base.ts` SHALL includ
 
 ### Requirement: 401 responses surface as a typed UnauthorizedError and reset the session
 
-When the `request()` helper observes an HTTP `401` response, it SHALL throw an `UnauthorizedError` (subclass of `Error`, `status: 401`, exposes the originating URL) and SHALL invoke every listener registered through an `onUnauthorized(listener)` API exposed from the same module. The `UserContext` provider MUST register a single listener that resets `status` to `unauthenticated` and clears `user`, allowing the redirect policy from the "Automatic redirect" requirement to take over.
+When the `request()` helper observes an HTTP `401` response, it SHALL throw an `UnauthorizedError` (subclass of `Error`, `status: 401`, exposes the originating URL) and SHALL invoke every listener registered through an `onUnauthorized(listener)` API exposed from the same module.
 
-#### Scenario: 401 on a protected endpoint resets context
+The `UserContext` provider MUST register a single listener that, before resetting `status`, first attempts a bounded self-heal probe: if `status` is currently `Authenticated`, it issues one `GET /api/v1/auth/me` using whatever session cookie the browser currently holds.
 
-- **WHEN** any non-bootstrap API call returns `401`
-- **THEN** the helper throws `UnauthorizedError`, the registered `UserContext` listener is invoked, `status` becomes `unauthenticated`, and `user` becomes `null`
+- If that probe succeeds, the listener SHALL adopt the returned profile (`setUser(profile)`), keep `status` as `Authenticated`, and SHALL NOT reset `status` to `Unauthenticated` — the original 401 is treated as resolved (e.g. a same-instant refresh-token race the backend or a concurrent request already resolved), and the protected tree is NOT unmounted.
+- If the probe also fails (returns `401` or any other error), the listener SHALL reset `status` to `Unauthenticated` and clear `user`, allowing the redirect policy from the "Automatic redirect" requirement to take over, exactly as before this probe was introduced.
+- If `status` is not currently `Authenticated` (e.g. still `Loading` or already `Unauthenticated`), the listener SHALL skip the probe and reset the session immediately, as before — there is no already-authenticated state to attempt to recover.
+
+#### Scenario: 401 on a protected endpoint resets context when the session is genuinely invalid
+
+- **WHEN** any non-bootstrap API call returns `401` while `status === Authenticated`, and the subsequent `GET /api/v1/auth/me` self-heal probe also returns `401`
+- **THEN** the helper throws `UnauthorizedError`, the registered `UserContext` listener is invoked, the probe is attempted and fails, `status` becomes `Unauthenticated`, and `user` becomes `null`
+
+#### Scenario: 401 on a protected endpoint recovers when the session is actually still valid
+
+- **WHEN** any non-bootstrap API call returns `401` while `status === Authenticated`, and the subsequent `GET /api/v1/auth/me` self-heal probe returns `200` with a valid `UserProfile`
+- **THEN** the listener adopts the returned profile, `status` remains `Authenticated`, `user` is updated to the probed profile, and the protected tree is NOT unmounted
 
 #### Scenario: Non-401 errors are unchanged
 
@@ -251,7 +262,12 @@ The change SHALL ship co-located Vitest specs that cover every new module: `User
 
 While `UserContext.status === Authenticated`, the SPA SHALL re-validate the session by issuing `GET /api/v1/auth/me` whenever the tab regains visibility (`document.visibilitychange` firing with `document.visibilityState === 'visible'`) or the window regains focus (`window` `focus` event), so that an identity change made in another tab or another same-origin flow is detected without waiting for a `401` on some other request. The revalidation SHALL be skipped while a previous bootstrap/revalidation request for this provider instance is still in flight, and SHALL NOT be performed while `status` is `Loading` or `Unauthenticated`.
 
-The comparison SHALL use `UserProfile.sub` (the stable subject identifier), not `providerId` or any other claim. If the newly fetched profile's `sub` differs from the currently held `user.sub`, the SPA SHALL clear the CSRF token and adopt the new profile in place by calling `setUser(newProfile)`, leaving `status` as `Authenticated`. The protected tree SHALL NOT be unmounted for this case — the session is already validly authenticated as the new identity, so there is nothing to redirect to a login screen for. Every identity-scoped context (see `conversations-context`, `user-config-frontend-init`, and `deployments-context`) is responsible for detecting the changed `sub` on its own and resetting/refetching accordingly. If the revalidation request itself returns `401` (the session was revoked, not merely switched), the SPA SHALL treat that identically to the existing `onUnauthorized` invalidation path — clearing the CSRF token, setting `user` to `null`, and setting `status` to `Unauthenticated` — so `RequireAuth` unmounts the protected tree and the normal bootstrap/redirect policy re-authenticates from scratch. If the newly fetched profile's `sub` is unchanged, the SPA SHALL update `user` in place (to pick up any other changed claims) without altering `status`.
+The comparison SHALL use `UserProfile.sub` (the stable subject identifier), not `providerId` or any other claim. If the newly fetched profile's `sub` differs from the currently held `user.sub`, the SPA SHALL clear the CSRF token and adopt the new profile in place by calling `setUser(newProfile)`, leaving `status` as `Authenticated`. The protected tree SHALL NOT be unmounted for this case — the session is already validly authenticated as the new identity, so there is nothing to redirect to a login screen for. Every identity-scoped context (see `conversations-context`, `user-config-frontend-init`, and `deployments-context`) is responsible for detecting the changed `sub` on its own and resetting/refetching accordingly. If the newly fetched profile's `sub` is unchanged, the SPA SHALL update `user` in place (to pick up any other changed claims) without altering `status`.
+
+If the revalidation request itself returns `401` (rather than a differing-`sub` profile), the SPA SHALL first attempt the same bounded self-heal probe described in "401 responses surface as a typed UnauthorizedError and reset the session" (a fresh `GET /api/v1/auth/me` retry) before deciding the session is genuinely revoked:
+
+- If that retry succeeds, the SPA SHALL adopt the returned profile and keep `status` as `Authenticated`, exactly as the "unchanged identity" / "identity changed" scenarios above — the original `401` is treated as a transient race, not a revocation.
+- If the retry also fails, the SPA SHALL treat that identically to the existing `onUnauthorized` invalidation path — clearing the CSRF token, setting `user` to `null`, and setting `status` to `Unauthenticated` — so `RequireAuth` unmounts the protected tree and the normal bootstrap/redirect policy re-authenticates from scratch.
 
 #### Scenario: Tab regains focus with an unchanged identity
 
@@ -263,10 +279,15 @@ The comparison SHALL use `UserProfile.sub` (the stable subject identifier), not 
 - **WHEN** an authenticated tab's window regains focus and `GET /api/v1/auth/me` returns `200` with a `UserProfile` whose `sub` differs from the currently held `user.sub`
 - **THEN** the CSRF token is cleared, `user` is set to the newly-fetched profile, `status` remains `Authenticated`, and the protected tree (including `DeploymentsProvider`, `ConversationsProvider`, `UserConfigProvider`) is NOT unmounted
 
-#### Scenario: Tab regains visibility after the session was revoked
+#### Scenario: Tab regains visibility after a same-instant refresh race, not a real revocation
 
-- **WHEN** an authenticated tab's `document.visibilityState` becomes `'visible'` and the revalidation `GET /api/v1/auth/me` returns `401`
-- **THEN** the same invalidation as an in-flight `401` (`onUnauthorized`) is applied: CSRF cleared, `user` becomes `null`, `status` becomes `Unauthenticated`
+- **WHEN** an authenticated tab's `document.visibilityState` becomes `'visible'`, the revalidation `GET /api/v1/auth/me` returns `401`, and an immediate retry of `GET /api/v1/auth/me` returns `200` with a valid `UserProfile`
+- **THEN** `user` is set to the profile returned by the retry, `status` remains `Authenticated`, and the protected tree is NOT unmounted
+
+#### Scenario: Tab regains visibility after the session was genuinely revoked
+
+- **WHEN** an authenticated tab's `document.visibilityState` becomes `'visible'`, the revalidation `GET /api/v1/auth/me` returns `401`, and the retry of `GET /api/v1/auth/me` also returns `401`
+- **THEN** the same invalidation as a genuinely-failed `401` (`onUnauthorized`) is applied: CSRF cleared, `user` becomes `null`, `status` becomes `Unauthenticated`
 
 #### Scenario: Revalidation is skipped while unauthenticated or loading
 


### PR DESCRIPTION
## Description of changes

Fixes Case 1 ("Something went wrong" error after a chat tab has been idle) and Case 2 (duplicating a browser tab often redirects to login) from #8150.

**Root cause:** `SessionGuard.canActivate` (`apps/chat-api/src/auth/session/session.guard.ts`) calls `RefreshService.refresh()` unguarded whenever the access token is within 60s of expiry. `RefreshService`'s in-flight mutex dedupes concurrent refreshes **per pod only** — a deliberate constraint of this app's stateless-BFF architecture (no Redis/shared session store, see `docs/auth/auth-bff-encrypted-cookie.md`). In a multi-replica deployment, two near-simultaneous requests carrying the same cookie (a duplicated tab racing the original, or several parallel requests one tab fires waking from idle) can land on different pods; both exchange the same one-time-use refresh token, and the loser gets `invalid_grant` → an unhandled-looking, semantically wrong 401, even though the session is still valid.

On the frontend, every 401 was treated as an unconditional, immediate logout (`UserContext.invalidateSession()`), which unmounts the whole authenticated provider tree mid-navigation (→ "Something went wrong" when a context hook renders without its provider for one frame) and can trip `useAuthRedirect`'s `sessionStorage`-based redirect de-dup — inherited by Chrome's tab-duplication — straight to the login picker.

### Changes

- **`apps/chat-api/src/auth/refresh/refresh.service.ts`** — `doRefresh` now distinguishes a lost-race collision from a genuine revocation using only data already in the request's own decrypted payload: if `payload.at_exp` is still in the future when `invalid_grant` is received, the session is fine — return the payload unchanged instead of throwing. Only when the access token has actually expired does `invalid_grant` still throw `UnauthorizedException`, exactly as before. No shared state, no Redis.
- **`apps/chat-api/src/auth/session/session.guard.ts`** — wraps the refresh call in `try/catch` (matching the pattern already used around `session.decryptFromRequest`) so any other unexpected failure still surfaces as a clean, typed 401 instead of an ambiguous 500.
- **`apps/chat/src/context/auth/UserContext.tsx`** — adds a bounded `attemptSessionRecovery()` self-heal probe (one `GET /api/v1/auth/me`) called before invalidating a session that was `Authenticated` a moment ago, both from the general `onUnauthorized` listener and from the focus/visibility `revalidate()` checkpoint. A genuine logout still fails the probe and invalidates exactly as before; a lost-race 401 typically recovers because the winning pod's `Set-Cookie` has, in virtually all realistic timings, already landed in the browser. `bootstrap()`'s first-mount path is intentionally left untouched — there's no already-authenticated state to recover there.
- **`docs/auth/auth-bff-encrypted-cookie.md`** — documents the `at_exp`-based race handling and the frontend probe (§5.2.1, security checklist).
- OpenSpec: archived change with proposal/design/specs/tasks (`openspec/changes/archive/2026-08-05-fix-cross-pod-refresh-race/`); synced delta requirements into `openspec/specs/spa-auth-session`.

### Why this approach

No Redis / external session store is a hard architectural constraint for this BFF (see design doc). Distributed locking or sticky sessions were rejected outright. Retrying the refresh against the IdP was also rejected — `invalid_grant` on an already-rotated refresh token isn't transient, it fails identically every time. Full rationale and alternatives considered live in `openspec/changes/archive/2026-08-05-fix-cross-pod-refresh-race/design.md`.

**Known residual limitation** (documented, accepted as-is): if the access token expires at the exact same instant as the race with zero network delay between the winning pod's `Set-Cookie` and the losing request, both the backend check and the frontend probe can theoretically miss it. This reduces the failure window to a near-zero-probability edge case rather than eliminating it entirely, which is the best achievable outcome without shared state.

## Applicable issues

- fixes #8150 (Case 1, Case 2)

## UI changes

None (auth/session handling only; no new UI).

## Test plan

- [x] `npm exec nx test chat-api` — all tests passing, including a new regression test using two real `SessionGuard`/`RefreshService` instances (simulating two pods) reproducing the exact race
- [x] `npm exec nx lint chat-api` — clean
- [x] `npm exec nx test chat` — all tests passing, including a regression test reproducing Case 2 end-to-end and asserting `useAuthRedirect`'s `sessionStorage` bookkeeping is never touched
- [x] `npm exec nx lint chat` — clean
- [x] Verified backend fix in isolation: `invalid_grant` with a still-valid access token is absorbed (200); `invalid_grant` with an expired access token still 401s (unchanged behavior)

## Checklist

- [ ] the pull request name ends with `(Issue #8150)`
- [x] I confirm that I don't share any confidential information like API keys or any other secrets and private URLs
