### PR TITLE
fix(chat): remove backticks from blinking cursor in plain text response format (Issue #8196)

### DIFF
--- a/apps/chat/src/components/Markdown/ChatMDComponent.tsx
+++ b/apps/chat/src/components/Markdown/ChatMDComponent.tsx
@@ -295,7 +295,7 @@ export const ChatMDComponent = memo(
     if (plainTextMode) {
       return (
         <div className={mdClassNames}>
-          {`${processedContent}${isShowResponseLoader ? modelCursorSignWithBackquote : ''}`}
+          {`${processedContent}${isShowResponseLoader ? modelCursorSign : ''}`}
         </div>
       );
     }


### PR DESCRIPTION
…

When Response format is set to Plain text, the blinking cursor should display without backticks during response generation. Changed from modelCursorSignWithBackquote to modelCursorSign for plain text mode rendering.

## Description of changes

<!-- Please explain the changes you made right below this line. -->

## Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #8196

## UI changes

<Please, provide Screenshots or Figma links>

## Checklist

- [ ] the pull request name ends with `(Issue #<ISSUE_ID>)` (comma-separated list of issues)
- [ ] I confirm that I don't share any confidential information like API keys or any other secrets and private URLs

<details>
  <summary>PR title cheatsheet</summary>

`<type>[optional scope]: <description>`

1. type (required)
    - `feat` - A new feature
    - `fix` - A bug fix
    - `docs` - Documentation only changes
    - `test` - Adding missing tests or correcting existing tests
    - `ci` - Changes to our CI configuration files and scripts
    - `chore` - Other changes that are minor and/or not user-facing
2. scope (optional, current repo suggestions below)
    - `chat`
    - `overlay`
    - `shared`
    - `sandbox-overlay`
    - `visualizer-connector`

</details>
