### PR TITLE
fix: prevent deployment bucket id leak and add shared folder label for toolsets (Issue #7962)

### DIFF
--- a/apps/chat/src/components/DeploymentSelector/useDeploymentSelectorOverlay.tsx
+++ b/apps/chat/src/components/DeploymentSelector/useDeploymentSelectorOverlay.tsx
@@ -6,6 +6,7 @@ import {
   useState,
   type ReactNode,
 } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useDeployments } from '../../context/DeploymentsContext';
 import { useFavoriteApplications } from '../../context/FavoriteApplicationsContext';
 import { mapDeploymentToCatalogItem } from '../../utils/map-deployment-to-catalog-item';
@@ -29,6 +30,7 @@ interface UseDeploymentSelectorOverlayResult {
 export function useDeploymentSelectorOverlay(): UseDeploymentSelectorOverlayResult {
   const [isCatalogOpen, setIsCatalogOpen] = useState(false);
 
+  const { t } = useTranslation();
   const { items, selectedItemId, setSelectedItemId } = useDeployments();
   const { favoriteIds, toggleFavorite } = useFavoriteApplications();
 
@@ -36,8 +38,8 @@ export function useDeploymentSelectorOverlay(): UseDeploymentSelectorOverlayResu
     () =>
       items
         .filter((d) => favoriteIds.has(d.id))
-        .map((d) => mapDeploymentToCatalogItem(d, favoriteIds)),
-    [items, favoriteIds],
+        .map((d) => mapDeploymentToCatalogItem(d, favoriteIds, undefined, t)),
+    [items, favoriteIds, t],
   );
 
   const selectedDeployment = useMemo(
@@ -48,9 +50,14 @@ export function useDeploymentSelectorOverlay(): UseDeploymentSelectorOverlayResu
   const selectedCatalogItem = useMemo(
     () =>
       selectedDeployment
-        ? mapDeploymentToCatalogItem(selectedDeployment, favoriteIds)
+        ? mapDeploymentToCatalogItem(
+            selectedDeployment,
+            favoriteIds,
+            undefined,
+            t,
+          )
         : undefined,
-    [selectedDeployment, favoriteIds],
+    [selectedDeployment, favoriteIds, t],
   );
 
   const renderOverlay = useCallback(

--- a/apps/chat/src/utils/map-deployment-to-catalog-item.ts
+++ b/apps/chat/src/utils/map-deployment-to-catalog-item.ts
@@ -139,6 +139,10 @@ const resolveToolsetFolder = (
 
   const segments = stripPrefixSegments(raw, TOOLSETS_PREFIX).slice(0, -1);
 
+  if (toolset.sharedWithMe && t != null) {
+    return [t(CatalogI18nKeys.FolderShared), ...segments.slice(1)];
+  }
+
   if (segments[0]?.toLowerCase() === PUBLIC_SEGMENT && t != null) {
     return [t(CatalogI18nKeys.FolderPublic), ...segments.slice(1)];
   }
@@ -149,8 +153,8 @@ const resolveToolsetFolder = (
 export const mapDeploymentToCatalogItem = (
   deployment: DeploymentItemDto,
   favoriteIds: ReadonlySet<string> = new Set(),
-  entityDetails?: EntitySpecificDetails,
-  t?: TFunction,
+  entityDetails: EntitySpecificDetails | undefined,
+  t: TFunction,
   editableSchemaIds: string[] = [],
   isCustomAppsEditable = false,
 ): CatalogItem => {
@@ -181,10 +185,7 @@ export const mapDeploymentToCatalogItem = (
         (isCustomAppsEditable &&
           !deployment.applicationTypeSchemaId &&
           normalizedType === 'application')),
-    folder:
-      t != null
-        ? resolveDeploymentFolder(deployment, t)
-        : (deployment.applicationFolder?.split('/') ?? []),
+    folder: resolveDeploymentFolder(deployment, t),
     summary: undefined,
     details:
       entityDetails != null

--- a/apps/chat/src/utils/tests/map-deployment-to-catalog-item.spec.ts
+++ b/apps/chat/src/utils/tests/map-deployment-to-catalog-item.spec.ts
@@ -14,6 +14,8 @@ import {
 } from '../map-deployment-to-catalog-item';
 
 describe('mapDeploymentToCatalogItem', () => {
+  const t = ((key: string) => key) as TFunction;
+
   const baseDeployment: DeploymentItemDto = {
     id: 'applications/bucket/My App__1.0',
     displayName: 'My App',
@@ -27,7 +29,7 @@ describe('mapDeploymentToCatalogItem', () => {
       baseDeployment,
       undefined,
       undefined,
-      undefined,
+      t,
       ['schemas/quickapps2'],
     );
 
@@ -39,7 +41,7 @@ describe('mapDeploymentToCatalogItem', () => {
       baseDeployment,
       undefined,
       undefined,
-      undefined,
+      t,
       ['schemas/other'],
     );
 
@@ -51,7 +53,7 @@ describe('mapDeploymentToCatalogItem', () => {
       { ...baseDeployment, isMy: false },
       undefined,
       undefined,
-      undefined,
+      t,
       ['schemas/quickapps2'],
     );
 
@@ -59,7 +61,12 @@ describe('mapDeploymentToCatalogItem', () => {
   });
 
   it('is not editable when no editable schema id is supplied', () => {
-    const result = mapDeploymentToCatalogItem(baseDeployment);
+    const result = mapDeploymentToCatalogItem(
+      baseDeployment,
+      undefined,
+      undefined,
+      t,
+    );
 
     expect(result.isEditable).toBe(false);
   });
@@ -69,7 +76,7 @@ describe('mapDeploymentToCatalogItem', () => {
       { ...baseDeployment, isMy: false, canEdit: true },
       undefined,
       undefined,
-      undefined,
+      t,
       ['schemas/quickapps2'],
     );
 
@@ -81,7 +88,7 @@ describe('mapDeploymentToCatalogItem', () => {
       { ...baseDeployment, isMy: false, canEdit: false },
       undefined,
       undefined,
-      undefined,
+      t,
       ['schemas/quickapps2'],
     );
 
@@ -98,7 +105,7 @@ describe('mapDeploymentToCatalogItem', () => {
       },
       undefined,
       undefined,
-      undefined,
+      t,
       [],
       true,
     );
@@ -116,7 +123,7 @@ describe('mapDeploymentToCatalogItem', () => {
       },
       undefined,
       undefined,
-      undefined,
+      t,
       [],
       false,
     );
@@ -134,7 +141,7 @@ describe('mapDeploymentToCatalogItem', () => {
       },
       undefined,
       undefined,
-      undefined,
+      t,
       [],
       true,
     );
@@ -143,24 +150,32 @@ describe('mapDeploymentToCatalogItem', () => {
   });
 
   it('carries sharedWithMe through from the deployment DTO', () => {
-    const result = mapDeploymentToCatalogItem({
-      ...baseDeployment,
-      isMy: false,
-      sharedWithMe: true,
-    });
+    const result = mapDeploymentToCatalogItem(
+      {
+        ...baseDeployment,
+        isMy: false,
+        sharedWithMe: true,
+      },
+      undefined,
+      undefined,
+      t,
+    );
 
     expect(result.sharedWithMe).toBe(true);
   });
 
   it('defaults sharedWithMe to false when the field is absent from the DTO', () => {
-    const result = mapDeploymentToCatalogItem(baseDeployment);
+    const result = mapDeploymentToCatalogItem(
+      baseDeployment,
+      undefined,
+      undefined,
+      t,
+    );
 
     expect(result.sharedWithMe).toBe(false);
   });
 
   it('replaces the owner bucket with the translated shared folder for a shared application', () => {
-    const t = ((key: string) => key) as TFunction;
-
     const result = mapDeploymentToCatalogItem(
       {
         ...baseDeployment,
@@ -178,8 +193,6 @@ describe('mapDeploymentToCatalogItem', () => {
   });
 
   it('uses only the translated shared folder when a shared application has no folder metadata', () => {
-    const t = ((key: string) => key) as TFunction;
-
     const result = mapDeploymentToCatalogItem(
       {
         ...baseDeployment,
@@ -196,8 +209,6 @@ describe('mapDeploymentToCatalogItem', () => {
   });
 
   it('keeps the translated personal folder for an owned application', () => {
-    const t = ((key: string) => key) as TFunction;
-
     const result = mapDeploymentToCatalogItem(
       {
         ...baseDeployment,
@@ -212,8 +223,6 @@ describe('mapDeploymentToCatalogItem', () => {
   });
 
   it('keeps readable nested folders for a public application', () => {
-    const t = ((key: string) => key) as TFunction;
-
     const result = mapDeploymentToCatalogItem(
       {
         ...baseDeployment,
@@ -228,17 +237,51 @@ describe('mapDeploymentToCatalogItem', () => {
     expect(result.folder).toEqual([CatalogI18nKeys.FolderPublic, 'team']);
   });
 
+  it('never exposes the raw bucket ID for a shared application with a nested storage path', () => {
+    const result = mapDeploymentToCatalogItem(
+      {
+        ...baseDeployment,
+        isMy: false,
+        sharedWithMe: true,
+        applicationFolder:
+          'applications/8icWyDTafGxYQfmL4ZdHYbxsDCxTMXjgjFCSW/appdata/quick-apps',
+      },
+      undefined,
+      undefined,
+      t,
+    );
+
+    expect(result.folder).toEqual([
+      CatalogI18nKeys.FolderShared,
+      'appdata',
+      'quick-apps',
+    ]);
+    expect(result.folder).not.toContain(
+      '8icWyDTafGxYQfmL4ZdHYbxsDCxTMXjgjFCSW',
+    );
+  });
+
   it('sets supportsMcp to true when the deployment reports features.mcp true', () => {
-    const result = mapDeploymentToCatalogItem({
-      ...baseDeployment,
-      features: { systemPrompt: false, temperature: false, mcp: true },
-    });
+    const result = mapDeploymentToCatalogItem(
+      {
+        ...baseDeployment,
+        features: { systemPrompt: false, temperature: false, mcp: true },
+      },
+      undefined,
+      undefined,
+      t,
+    );
 
     expect(result.supportsMcp).toBe(true);
   });
 
   it('sets supportsMcp to false when features.mcp is absent', () => {
-    const result = mapDeploymentToCatalogItem(baseDeployment);
+    const result = mapDeploymentToCatalogItem(
+      baseDeployment,
+      undefined,
+      undefined,
+      t,
+    );
 
     expect(result.supportsMcp).toBe(false);
   });
@@ -352,6 +395,47 @@ describe('mapToolsetToCatalogItem', () => {
     );
 
     expect(result.folder).toEqual([CatalogI18nKeys.FolderPersonal]);
+  });
+
+  it('shows the translated Shared folder for a shared toolset with no nested folder', () => {
+    const t = ((key: string) => key) as TFunction;
+
+    const result = mapToolsetToCatalogItem(
+      {
+        id: 'toolsets/8icWyDTafGxYQfmL4ZdHYbxsDCxTMXjgjFCSW/my-toolset__0.0.1',
+        toolset:
+          'toolsets/8icWyDTafGxYQfmL4ZdHYbxsDCxTMXjgjFCSW/my-toolset__0.0.1',
+        isMy: false,
+        sharedWithMe: true,
+      },
+      undefined,
+      false,
+      t,
+    );
+
+    expect(result.folder).toEqual([CatalogI18nKeys.FolderShared]);
+  });
+
+  it('shows the translated Shared folder plus the nested path for a shared toolset', () => {
+    const t = ((key: string) => key) as TFunction;
+
+    const result = mapToolsetToCatalogItem(
+      {
+        id: 'toolsets/8icWyDTafGxYQfmL4ZdHYbxsDCxTMXjgjFCSW/team/my-toolset__0.0.1',
+        toolset:
+          'toolsets/8icWyDTafGxYQfmL4ZdHYbxsDCxTMXjgjFCSW/team/my-toolset__0.0.1',
+        isMy: false,
+        sharedWithMe: true,
+      },
+      undefined,
+      false,
+      t,
+    );
+
+    expect(result.folder).toEqual([CatalogI18nKeys.FolderShared, 'team']);
+    expect(result.folder).not.toContain(
+      '8icWyDTafGxYQfmL4ZdHYbxsDCxTMXjgjFCSW',
+    );
   });
 
   it('marks a public toolset as isPublic and manageable by an admin', () => {

--- a/openspec/changes/archive/2026-08-06-add-toolset-shared-folder-label/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-06-add-toolset-shared-folder-label/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-06

--- a/openspec/changes/archive/2026-08-06-add-toolset-shared-folder-label/design.md
+++ b/openspec/changes/archive/2026-08-06-add-toolset-shared-folder-label/design.md
@@ -1,0 +1,22 @@
+## Context
+
+`resolveToolsetFolder` and `resolveDeploymentFolder` (`apps/chat/src/utils/map-deployment-to-catalog-item.ts`) both derive a `CatalogItem.folder: string[]` used to render a folder/path label in the Catalog details panel header. `resolveDeploymentFolder` has three branches — Personal (`isMy`), Shared (`sharedWithMe`), Public — each substituting a localized label for the raw bucket/root segment. `resolveToolsetFolder` only has Personal and Public branches; a shared, non-public toolset falls through to a bare `segments.slice(1)`, which drops the bucket segment without substituting any label, so the details panel shows no folder text at all for shared toolsets whose remaining path is empty.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Shared toolsets show a translated "Shared" folder label, matching shared applications' behavior.
+
+**Non-Goals:**
+- Any change to `resolveDeploymentFolder` or the application folder-resolution path (already correct).
+- Any change to how `sharedWithMe` is computed or transmitted from the backend.
+
+## Decisions
+
+Add a `toolset.sharedWithMe` branch to `resolveToolsetFolder`, placed after the `isMy` check and before the raw-segment computation needs to happen (mirroring `resolveDeploymentFolder`'s branch ordering: Personal → Shared → Public → raw). Since `segments` (the parsed/stripped path) is needed for both the Shared and Public branches, the branch checks `toolset.sharedWithMe` after `segments` is computed, then returns `[t(CatalogI18nKeys.FolderShared), ...segments.slice(1)]` before the existing Public check, matching the deployment-side precedence (checked before Public, since a bucket segment is never literally `"public"` for a truly shared item in practice, but following the same order keeps the two functions structurally parallel and easy to compare).
+
+Alternative considered: guard the Shared branch on `t != null` the way the existing Personal/Public branches do (since `t` is optional on this function). Rejected for the same reason as the sibling change `fix-deployment-folder-bucket-id-leak` — but this function's `t` param stays optional here (unlike `mapDeploymentToCatalogItem`'s `t`) because `mapToolsetToCatalogItem`'s only call site (`CatalogView.tsx`) always supplies `t`, and no un-decoded/un-prefixed raw segment can leak from this function regardless of `t` (verified in the prior change) — so keeping the guard on the new branch, consistent with the two existing branches, does not reintroduce that risk.
+
+## Risks / Trade-offs
+
+[Existing tests hard-coding `resolveToolsetFolder` behavior for a shared, non-public toolset] → none found currently exercise this exact case; new test added to cover it.

--- a/openspec/changes/archive/2026-08-06-add-toolset-shared-folder-label/proposal.md
+++ b/openspec/changes/archive/2026-08-06-add-toolset-shared-folder-label/proposal.md
@@ -1,0 +1,20 @@
+## Why
+
+A shared Toolset shows no folder/path label at all in the Catalog details panel ("About" header, below the name), while a shared Application correctly shows a translated "Shared" label there. Root cause: `resolveToolsetFolder` (`apps/chat/src/utils/map-deployment-to-catalog-item.ts`) has no branch for `toolset.sharedWithMe`, unlike `resolveDeploymentFolder`, which explicitly returns `[t(CatalogI18nKeys.FolderShared), ...segments.slice(1)]` when `deployment.sharedWithMe` is true. For a shared toolset that isn't public and isn't owned by the current user, `resolveToolsetFolder` falls through to `segments.slice(1)`, silently dropping the bucket segment with no replacement label — if the toolset has no additional nested folder beyond its owner bucket, the result is an empty array and the details panel shows nothing where "Shared" should appear.
+
+## What Changes
+
+- Add a `sharedWithMe` branch to `resolveToolsetFolder`, mirroring `resolveDeploymentFolder`: when `toolset.sharedWithMe` is true, return `[t(CatalogI18nKeys.FolderShared), ...segments.slice(1)]` instead of falling through to the generic `segments.slice(1)` return.
+- No change to the `isMy`/Personal branch, the `public` branch, or `mapDeploymentToCatalogItem`/`resolveDeploymentFolder` (already correct).
+
+## Capabilities
+
+### Modified Capabilities
+
+- `deployment-catalog-item-mapping`: extends the existing `resolveToolsetFolder`-related mapping behavior (introduced alongside `resolveDeploymentFolder` in the prior `fix-deployment-folder-bucket-id-leak` change) to also localize the shared-toolset folder segment instead of silently dropping it.
+
+## Impact
+
+- `apps/chat/src/utils/map-deployment-to-catalog-item.ts` — `resolveToolsetFolder` gains a `sharedWithMe` branch.
+- `apps/chat/src/utils/tests/map-deployment-to-catalog-item.spec.ts` — add test coverage for a shared toolset's folder label.
+- No backend, API, or DTO changes — `DialToolsetDto.sharedWithMe` already exists and is already passed through by `mapToolsetToCatalogItem`.

--- a/openspec/changes/archive/2026-08-06-add-toolset-shared-folder-label/specs/deployment-catalog-item-mapping/spec.md
+++ b/openspec/changes/archive/2026-08-06-add-toolset-shared-folder-label/specs/deployment-catalog-item-mapping/spec.md
@@ -1,0 +1,17 @@
+## ADDED Requirements
+
+### Requirement: Shared toolset folder is localized, not silently dropped
+
+`resolveToolsetFolder` (`apps/chat/src/utils/map-deployment-to-catalog-item.ts`) SHALL return `[t(CatalogI18nKeys.FolderShared), ...segments.slice(1)]` when `toolset.sharedWithMe` is true and the toolset is neither owned by the current user (`isMy`) nor rooted under the `public` segment, where `segments` is the toolset's path parsed via `stripPrefixSegments(raw, TOOLSETS_PREFIX).slice(0, -1)`.
+
+This SHALL mirror `resolveDeploymentFolder`'s existing `sharedWithMe` branch for applications, so a shared toolset never renders an empty folder label when its remaining path segments (after dropping the owner bucket) are empty.
+
+#### Scenario: Shared toolset with no nested folder shows the translated Shared label
+
+- **WHEN** `mapToolsetToCatalogItem` maps a toolset with `sharedWithMe: true`, `isMy: false`, and `toolset: "toolsets/8icWyDTafGxYQfmL4ZdHYbxsDCxTMXjgjFCSW/my-toolset__0.0.1"`
+- **THEN** the resulting `CatalogItem.folder` is `[t(CatalogI18nKeys.FolderShared)]`, not `[]`
+
+#### Scenario: Shared toolset with a nested folder shows the translated Shared label plus the nested path
+
+- **WHEN** `mapToolsetToCatalogItem` maps a toolset with `sharedWithMe: true`, `isMy: false`, and `toolset: "toolsets/8icWyDTafGxYQfmL4ZdHYbxsDCxTMXjgjFCSW/team/my-toolset__0.0.1"`
+- **THEN** the resulting `CatalogItem.folder` is `[t(CatalogI18nKeys.FolderShared), "team"]`, and does not contain the raw bucket ID `"8icWyDTafGxYQfmL4ZdHYbxsDCxTMXjgjFCSW"`

--- a/openspec/changes/archive/2026-08-06-add-toolset-shared-folder-label/tasks.md
+++ b/openspec/changes/archive/2026-08-06-add-toolset-shared-folder-label/tasks.md
@@ -1,0 +1,12 @@
+## 1. Fix resolveToolsetFolder
+
+- [x] 1.1 In `apps/chat/src/utils/map-deployment-to-catalog-item.ts`, add a `toolset.sharedWithMe` branch to `resolveToolsetFolder` that returns `[t(CatalogI18nKeys.FolderShared), ...segments.slice(1)]`, placed after computing `segments` and before the existing `public` check.
+
+## 2. Add test coverage
+
+- [x] 2.1 In `apps/chat/src/utils/tests/map-deployment-to-catalog-item.spec.ts`, add tests for a shared, non-public toolset: one with no nested folder (expect `[FolderShared]`, not `[]`) and one with a nested folder (expect `[FolderShared, "team"]`, and assert the raw bucket ID is absent).
+
+## 3. Verify
+
+- [x] 3.1 Run `npm exec nx test chat` to confirm all mapping tests pass.
+- [x] 3.2 Run `npm exec nx lint chat` and `npm exec nx build chat` to confirm no regressions.

--- a/openspec/changes/archive/2026-08-06-fix-deployment-folder-bucket-id-leak/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-06-fix-deployment-folder-bucket-id-leak/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-06

--- a/openspec/changes/archive/2026-08-06-fix-deployment-folder-bucket-id-leak/design.md
+++ b/openspec/changes/archive/2026-08-06-fix-deployment-folder-bucket-id-leak/design.md
@@ -1,0 +1,43 @@
+## Context
+
+`mapDeploymentToCatalogItem` (`apps/chat/src/utils/map-deployment-to-catalog-item.ts`) is the single mapping function from the backend `DeploymentItemDto` to the frontend `CatalogItem` shape consumed by both the full Catalog view and the compact deployment-selector overlay. It has two `folder`-resolution code paths gated on whether an i18next `TFunction` is passed:
+
+- `t` provided → `resolveDeploymentFolder(deployment, t)`: strips the `applications/` prefix, decodes percent-encoded segments, and replaces the bucket/root segment with a localized `Personal`/`Shared`/`Public` label.
+- `t` omitted → `deployment.applicationFolder?.split('/') ?? []`: a raw split with none of the above, so for a shared app whose `applicationFolder` looks like `applications/<bucket-id>/appdata/quick-apps/...`, the literal bucket ID surfaces as a folder segment.
+
+`useDeploymentSelectorOverlay.tsx` is the only caller that omits `t` (both of its two call sites), which is the exact path GitHub issue #7962 reproduces through.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Guarantee a raw, un-decoded `applicationFolder` value can never reach `CatalogItem.folder` from any call site, present or future.
+- Preserve existing behavior for callers that already pass `t` (`CatalogView.tsx`) — no visible change there.
+
+**Non-Goals:**
+- Reworking `resolveDeploymentFolder`'s localization/decoding logic itself (already correct).
+- Touching `mapToolsetToCatalogItem` / `resolveToolsetFolder` — verified safe already, since that function unconditionally drops the raw bucket/public segment via `.slice(1)` regardless of `t`.
+- Any backend/DTO change — `applicationFolder`'s shape and derivation (`deployments-application-folder` spec) is unchanged.
+
+## Decisions
+
+**Make `t: TFunction` a required parameter of `mapDeploymentToCatalogItem`, deleting the raw-split fallback branch entirely**, rather than teaching the fallback branch to also strip/decode segments.
+
+Rationale: a second, parallel "safe-ish" fallback implementation is exactly how this bug was introduced — two code paths computing the same derived value invite drift. `t` is always available synchronously via `useTranslation()` in every actual call site (both are React hooks/components), so there is no real caller for whom `t` is unavailable. Removing the optional path is a compile-time guarantee (TypeScript will error at any call site that forgets to pass `t`) rather than a runtime convention that can regress silently.
+
+Alternative considered: keep `t` optional but make the fallback call `resolveDeploymentFolder` with a no-op identity `TFunction`-shaped stub (i.e., `(key) => key`) instead of raw-splitting. Rejected — it still permits an un-decoded/un-prefixed bucket path to leak whenever a translated label isn't substituted for the root segment (the actual field being leaked isn't the label, it's `segments` itself, which the raw path never strips the first element from). Requiring `t` and reusing the one correct implementation is simpler and removes the bug class instead of patching one instance of it.
+
+## Risks / Trade-offs
+
+[Existing unit tests for `mapDeploymentToCatalogItem` that call it without `t`] → will fail to typecheck once `t` is required; update them to pass a test `TFunction` (e.g. from `i18next` test setup or a simple `(key: string) => key` cast) as part of this change.
+
+[Any other future/undiscovered caller of `mapDeploymentToCatalogItem` omitting `t`] → becomes a TypeScript compile error immediately, not a runtime leak — this is the point of the decision, not a residual risk.
+
+## Migration Plan
+
+1. Update `mapDeploymentToCatalogItem` signature: require `t: TFunction`, remove the `t != null ? ... : ...` ternary for `folder`, call `resolveDeploymentFolder(deployment, t)` directly.
+2. Update both call sites in `useDeploymentSelectorOverlay.tsx` to obtain `t` via `useTranslation()` and pass it to `mapDeploymentToCatalogItem`.
+3. Update `CatalogView.tsx`'s existing call (already passes `t`) — no change needed, verify it still typechecks.
+4. Fix/update any unit tests exercising the old optional-`t` fallback.
+5. Run `nx affected` build/lint/test for `apps/chat` to confirm no other call sites broke.
+
+No backend deploy, feature flag, or data migration involved — this is a pure frontend, non-persisted display-mapping fix.

--- a/openspec/changes/archive/2026-08-06-fix-deployment-folder-bucket-id-leak/proposal.md
+++ b/openspec/changes/archive/2026-08-06-fix-deployment-folder-bucket-id-leak/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+GitHub issue [#7962](https://github.com/epam/ai-dial-chat/issues/7962): in the deployment-selector overlay (the compact "Application details" popover reached from the conversation input, not the full Catalog view), a shared Quick App shows the raw internal DIAL bucket ID (e.g. `8icWyDTafGxYQfmL4ZdHYbxsDCxTMXjgjFCSW...`) as its folder/path label instead of a readable, localized value. This leaks an internal storage identifier to end users.
+
+Root cause: `mapDeploymentToCatalogItem` (`apps/chat/src/utils/map-deployment-to-catalog-item.ts`) resolves the `folder` field via `resolveDeploymentFolder(deployment, t)` — which correctly strips the `applications/` prefix, decodes segments, and substitutes localized labels for Personal/Shared/Public roots — only when an i18next `TFunction` is supplied. When `t` is omitted, it falls back to `deployment.applicationFolder?.split('/') ?? []`, a raw, undecoded split with no prefix-stripping or bucket-segment removal. `useDeploymentSelectorOverlay.tsx` calls `mapDeploymentToCatalogItem` at two call sites without passing `t`, hitting this unsafe fallback.
+
+## What Changes
+
+- Make the `t: TFunction` parameter of `mapDeploymentToCatalogItem` required (remove the optional raw-split fallback branch) so a raw, un-decoded bucket path can never reach the UI. **BREAKING** (internal utility signature only — no external API/contract change).
+- Update both call sites in `apps/chat/src/components/DeploymentSelector/useDeploymentSelectorOverlay.tsx` to obtain `t` via `useTranslation()` and pass it through, so the existing correct `resolveDeploymentFolder` logic (prefix-stripping, decoding, localized Personal/Shared/Public root labels) always runs.
+- No changes to `mapToolsetToCatalogItem` / `resolveToolsetFolder` — confirmed already safe: `resolveToolsetFolder` unconditionally drops the raw bucket/public segment via `.slice(1)` on every return path regardless of whether `t` is passed, so toolsets have no equivalent leak.
+
+## Capabilities
+
+### New Capabilities
+
+- `deployment-catalog-item-mapping`: the frontend mapping from a `DeploymentItemDto` to a catalog-display `CatalogItem`, including the requirement that the derived `folder` path is always resolved through localized, decoded, bucket-free segments — never a raw un-decoded split of `applicationFolder`.
+
+### Modified Capabilities
+
+_None — no existing spec in `openspec/specs/` documents this frontend mapping contract; `deployments-application-folder` covers the backend-computed source field, not this frontend consumption logic._
+
+## Impact
+
+- `apps/chat/src/utils/map-deployment-to-catalog-item.ts` — `mapDeploymentToCatalogItem` signature change (drop optional fallback, require `t`).
+- `apps/chat/src/components/DeploymentSelector/useDeploymentSelectorOverlay.tsx` — both call sites updated to pass `t`.
+- Any existing unit tests for `mapDeploymentToCatalogItem` that call it without `t` need updating.
+- No backend, API, or DTO changes.

--- a/openspec/changes/archive/2026-08-06-fix-deployment-folder-bucket-id-leak/specs/deployment-catalog-item-mapping/spec.md
+++ b/openspec/changes/archive/2026-08-06-fix-deployment-folder-bucket-id-leak/specs/deployment-catalog-item-mapping/spec.md
@@ -1,0 +1,33 @@
+## ADDED Requirements
+
+### Requirement: Deployment folder is always resolved through localized, decoded segments
+
+`mapDeploymentToCatalogItem` (`apps/chat/src/utils/map-deployment-to-catalog-item.ts`) SHALL accept a required `t: TFunction` parameter and SHALL derive the returned `CatalogItem.folder` value exclusively via `resolveDeploymentFolder(deployment, t)`. There SHALL be no code path in which `CatalogItem.folder` is derived from an un-decoded, un-prefix-stripped split of `deployment.applicationFolder`.
+
+`resolveDeploymentFolder` SHALL continue to:
+- Return `[t(CatalogI18nKeys.FolderPersonal)]` when `deployment.isMy` is true.
+- Strip the `applications/` prefix from `deployment.applicationFolder` and percent-decode each path segment before use.
+- Replace the first remaining segment with `t(CatalogI18nKeys.FolderShared)` when `deployment.sharedWithMe` is true, dropping that segment (the bucket ID) from the returned path.
+- Replace the first remaining segment with `t(CatalogI18nKeys.FolderPublic)` when it case-insensitively equals `"public"`, dropping that segment from the returned path.
+
+Every call site of `mapDeploymentToCatalogItem` SHALL supply `t` obtained from `useTranslation()` (or an equivalent `TFunction`), including both call sites in `apps/chat/src/components/DeploymentSelector/useDeploymentSelectorOverlay.tsx`.
+
+#### Scenario: Shared Quick App folder never exposes the raw bucket ID
+
+- **WHEN** `useDeploymentSelectorOverlay` maps a deployment with `sharedWithMe: true` and `applicationFolder: "applications/8icWyDTafGxYQfmL4ZdHYbxsDCxTMXjgjFCSW/appdata/quick-apps"` into a `CatalogItem` for the details panel
+- **THEN** the resulting `CatalogItem.folder` is `[t(CatalogI18nKeys.FolderShared), "appdata", "quick-apps"]` and contains no segment equal to the raw bucket ID `"8icWyDTafGxYQfmL4ZdHYbxsDCxTMXjgjFCSW"`
+
+#### Scenario: Public app folder is localized, not raw
+
+- **WHEN** a deployment with `sharedWithMe: false`, `isMy: false`, and `applicationFolder: "applications/public/my-folder"` is mapped
+- **THEN** the resulting `CatalogItem.folder` is `[t(CatalogI18nKeys.FolderPublic), "my-folder"]`
+
+#### Scenario: Personal app folder is localized
+
+- **WHEN** a deployment with `isMy: true` is mapped, regardless of its `applicationFolder` value
+- **THEN** the resulting `CatalogItem.folder` is `[t(CatalogI18nKeys.FolderPersonal)]`
+
+#### Scenario: Compile-time enforcement that `t` is always supplied
+
+- **WHEN** any code in `apps/chat/src` calls `mapDeploymentToCatalogItem` without passing a `t` argument
+- **THEN** the TypeScript build fails, since `t` is a required (non-optional) parameter

--- a/openspec/changes/archive/2026-08-06-fix-deployment-folder-bucket-id-leak/tasks.md
+++ b/openspec/changes/archive/2026-08-06-fix-deployment-folder-bucket-id-leak/tasks.md
@@ -1,0 +1,21 @@
+## 1. Fix the mapping utility
+
+- [x] 1.1 In `apps/chat/src/utils/map-deployment-to-catalog-item.ts`, change `mapDeploymentToCatalogItem`'s `t` parameter from optional (`t?: TFunction`) to required (`t: TFunction`), and replace the `folder: t != null ? resolveDeploymentFolder(deployment, t) : (deployment.applicationFolder?.split('/') ?? [])` ternary with a direct `folder: resolveDeploymentFolder(deployment, t)` call.
+- [x] 1.2 Confirm `mapToolsetToCatalogItem` / `resolveToolsetFolder` are left unchanged (already safe — no raw bucket segment can leak regardless of `t`).
+
+## 2. Update call sites
+
+- [x] 2.1 In `apps/chat/src/components/DeploymentSelector/useDeploymentSelectorOverlay.tsx`, import and call `useTranslation()` to obtain `t`, then pass it as the third argument to both `mapDeploymentToCatalogItem` calls (the `favoriteCatalogItems` mapper and the `selectedCatalogItem` mapper), adding `t` to the relevant `useMemo` dependency arrays.
+- [x] 2.2 Verify `apps/chat/src/components/CatalogView/CatalogView.tsx`'s existing call (already passes `t`) still typechecks with the new required signature.
+- [x] 2.3 Search `apps/chat/src` for any other call sites of `mapDeploymentToCatalogItem` and update them to pass `t` if found. (No other call sites found besides the two above.)
+
+## 3. Update tests
+
+- [x] 3.1 In `apps/chat/src/utils/tests/map-deployment-to-catalog-item.spec.ts`, update any test invoking `mapDeploymentToCatalogItem` without a `t` argument to pass one, and add/adjust a test case asserting that a shared deployment's raw bucket-ID `applicationFolder` segment never appears in the resulting `CatalogItem.folder` (per the `deployment-catalog-item-mapping` spec scenario).
+- [x] 3.2 Check `useDeploymentSelectorOverlay`'s test coverage (if any exists under a `tests/` subfolder) and update/add tests to assert `t` is passed through to the mapper. (No existing test file for this hook; none needed adding per scope of this fix.)
+
+## 4. Verify
+
+- [x] 4.1 Run `npm exec nx test chat` (or the affected project) to confirm all mapping and hook tests pass.
+- [x] 4.2 Run `npm exec nx lint chat` and `npm exec nx build chat` to confirm no typecheck/lint regressions from the signature change.
+- [x] 4.3 Manually verify in the running app: open a shared Quick App's details panel via the deployment selector and confirm the folder path shows a localized "Shared" label with no raw bucket ID, not just via the full Catalog view.

--- a/openspec/specs/deployment-catalog-item-mapping/spec.md
+++ b/openspec/specs/deployment-catalog-item-mapping/spec.md
@@ -1,0 +1,53 @@
+# deployment-catalog-item-mapping Specification
+
+## Purpose
+TBD - created by archiving change fix-deployment-folder-bucket-id-leak. Update Purpose after archive.
+## Requirements
+### Requirement: Deployment folder is always resolved through localized, decoded segments
+
+`mapDeploymentToCatalogItem` (`apps/chat/src/utils/map-deployment-to-catalog-item.ts`) SHALL accept a required `t: TFunction` parameter and SHALL derive the returned `CatalogItem.folder` value exclusively via `resolveDeploymentFolder(deployment, t)`. There SHALL be no code path in which `CatalogItem.folder` is derived from an un-decoded, un-prefix-stripped split of `deployment.applicationFolder`.
+
+`resolveDeploymentFolder` SHALL continue to:
+- Return `[t(CatalogI18nKeys.FolderPersonal)]` when `deployment.isMy` is true.
+- Strip the `applications/` prefix from `deployment.applicationFolder` and percent-decode each path segment before use.
+- Replace the first remaining segment with `t(CatalogI18nKeys.FolderShared)` when `deployment.sharedWithMe` is true, dropping that segment (the bucket ID) from the returned path.
+- Replace the first remaining segment with `t(CatalogI18nKeys.FolderPublic)` when it case-insensitively equals `"public"`, dropping that segment from the returned path.
+
+Every call site of `mapDeploymentToCatalogItem` SHALL supply `t` obtained from `useTranslation()` (or an equivalent `TFunction`), including both call sites in `apps/chat/src/components/DeploymentSelector/useDeploymentSelectorOverlay.tsx`.
+
+#### Scenario: Shared Quick App folder never exposes the raw bucket ID
+
+- **WHEN** `useDeploymentSelectorOverlay` maps a deployment with `sharedWithMe: true` and `applicationFolder: "applications/8icWyDTafGxYQfmL4ZdHYbxsDCxTMXjgjFCSW/appdata/quick-apps"` into a `CatalogItem` for the details panel
+- **THEN** the resulting `CatalogItem.folder` is `[t(CatalogI18nKeys.FolderShared), "appdata", "quick-apps"]` and contains no segment equal to the raw bucket ID `"8icWyDTafGxYQfmL4ZdHYbxsDCxTMXjgjFCSW"`
+
+#### Scenario: Public app folder is localized, not raw
+
+- **WHEN** a deployment with `sharedWithMe: false`, `isMy: false`, and `applicationFolder: "applications/public/my-folder"` is mapped
+- **THEN** the resulting `CatalogItem.folder` is `[t(CatalogI18nKeys.FolderPublic), "my-folder"]`
+
+#### Scenario: Personal app folder is localized
+
+- **WHEN** a deployment with `isMy: true` is mapped, regardless of its `applicationFolder` value
+- **THEN** the resulting `CatalogItem.folder` is `[t(CatalogI18nKeys.FolderPersonal)]`
+
+#### Scenario: Compile-time enforcement that `t` is always supplied
+
+- **WHEN** any code in `apps/chat/src` calls `mapDeploymentToCatalogItem` without passing a `t` argument
+- **THEN** the TypeScript build fails, since `t` is a required (non-optional) parameter
+
+### Requirement: Shared toolset folder is localized, not silently dropped
+
+`resolveToolsetFolder` (`apps/chat/src/utils/map-deployment-to-catalog-item.ts`) SHALL return `[t(CatalogI18nKeys.FolderShared), ...segments.slice(1)]` when `toolset.sharedWithMe` is true and the toolset is neither owned by the current user (`isMy`) nor rooted under the `public` segment, where `segments` is the toolset's path parsed via `stripPrefixSegments(raw, TOOLSETS_PREFIX).slice(0, -1)`.
+
+This SHALL mirror `resolveDeploymentFolder`'s existing `sharedWithMe` branch for applications, so a shared toolset never renders an empty folder label when its remaining path segments (after dropping the owner bucket) are empty.
+
+#### Scenario: Shared toolset with no nested folder shows the translated Shared label
+
+- **WHEN** `mapToolsetToCatalogItem` maps a toolset with `sharedWithMe: true`, `isMy: false`, and `toolset: "toolsets/8icWyDTafGxYQfmL4ZdHYbxsDCxTMXjgjFCSW/my-toolset__0.0.1"`
+- **THEN** the resulting `CatalogItem.folder` is `[t(CatalogI18nKeys.FolderShared)]`, not `[]`
+
+#### Scenario: Shared toolset with a nested folder shows the translated Shared label plus the nested path
+
+- **WHEN** `mapToolsetToCatalogItem` maps a toolset with `sharedWithMe: true`, `isMy: false`, and `toolset: "toolsets/8icWyDTafGxYQfmL4ZdHYbxsDCxTMXjgjFCSW/team/my-toolset__0.0.1"`
+- **THEN** the resulting `CatalogItem.folder` is `[t(CatalogI18nKeys.FolderShared), "team"]`, and does not contain the raw bucket ID `"8icWyDTafGxYQfmL4ZdHYbxsDCxTMXjgjFCSW"`
+


### PR DESCRIPTION
**Description:**

Fixed a bug where shared Quick App catalog items and toolsets were leaking raw bucket IDs instead of showing user-friendly folder labels. Made the translation function a required parameter in the deployment-to-catalog-item mapping to ensure proper i18n handling of folder labels. Added missing "Shared" folder label for shared toolsets to match the behavior for shared Quick Apps.

<img width="1916" height="1108" alt="image" src="https://github.com/user-attachments/assets/653a796b-8bcb-460f-9982-501b600a37f4" />


Issues:

- Issue #7962

**UI changes**

No UI changes — bug fix that corrects folder label display in shared catalog items.

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(chat):`
- [x] the pull request name ends with `(Issue #7962)`
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs