### PR TITLE
feat: responses api features (#8202)

### DIFF
--- a/apps/chat-api/src/conversations/conversation.service.ts
+++ b/apps/chat-api/src/conversations/conversation.service.ts
@@ -1194,12 +1194,17 @@ export class ConversationService {
    * `features` off `DeploymentsService.getDeploymentDetails`'s cached,
    * user-token-scoped result. A toolset target is rejected with 400, since
    * toolsets are not generation deployments.
+   *
+   * Also derives `temperatureSupported` from the same already-fetched
+   * `features` object, so the Responses request builder can capability-gate
+   * `temperature` without a second `getDeploymentDetails` call for the same
+   * generation (see `responses-api-generation` spec).
    */
   private async resolveGenerationApiForDeployment(
     sub: string,
     model: string,
     token: string,
-  ): Promise<GenerationApi> {
+  ): Promise<{ generationApi: GenerationApi; temperatureSupported: boolean }> {
     const details = await this.deploymentsService.getDeploymentDetails(
       sub,
       model,
@@ -1218,7 +1223,10 @@ export class ConversationService {
         ? details.applicationDetails?.features
         : details.modelDetails?.features;
 
-    return resolveGenerationApi(features);
+    return {
+      generationApi: resolveGenerationApi(features),
+      temperatureSupported: features?.temperature === true,
+    };
   }
 
   async streamCompletion(
@@ -1248,12 +1256,10 @@ export class ConversationService {
     );
 
     let generationApi: GenerationApi;
+    let temperatureSupported: boolean;
     try {
-      generationApi = await this.resolveGenerationApiForDeployment(
-        sub,
-        model,
-        token,
-      );
+      ({ generationApi, temperatureSupported } =
+        await this.resolveGenerationApiForDeployment(sub, model, token));
       generationCapabilityResolutionTotal.add(1, {
         outcome: 'resolved',
         'generation.api': generationApi,
@@ -1373,6 +1379,7 @@ export class ConversationService {
               model,
               startConversation,
               messagesForCompletion,
+              temperatureSupported,
             }),
             token,
             abortController.signal,

--- a/apps/chat-api/src/conversations/generation/generation.types.spec.ts
+++ b/apps/chat-api/src/conversations/generation/generation.types.spec.ts
@@ -1,0 +1,41 @@
+import { isValidMaxOutputTokens } from './generation.types';
+
+describe('isValidMaxOutputTokens', () => {
+  it('accepts the minimum valid value', () => {
+    expect(isValidMaxOutputTokens(1)).toBe(true);
+  });
+
+  it('accepts a representative larger positive integer', () => {
+    expect(isValidMaxOutputTokens(4096)).toBe(true);
+  });
+
+  it('rejects zero', () => {
+    expect(isValidMaxOutputTokens(0)).toBe(false);
+  });
+
+  it('rejects a negative number', () => {
+    expect(isValidMaxOutputTokens(-1)).toBe(false);
+  });
+
+  it('rejects a fractional number', () => {
+    expect(isValidMaxOutputTokens(1.5)).toBe(false);
+  });
+
+  it('rejects NaN', () => {
+    expect(isValidMaxOutputTokens(NaN)).toBe(false);
+  });
+
+  it('rejects Infinity', () => {
+    expect(isValidMaxOutputTokens(Infinity)).toBe(false);
+  });
+
+  it('rejects a number beyond Number.MAX_SAFE_INTEGER', () => {
+    expect(isValidMaxOutputTokens(Number.MAX_SAFE_INTEGER + 1)).toBe(false);
+  });
+
+  it('rejects non-number values', () => {
+    expect(isValidMaxOutputTokens('4096')).toBe(false);
+    expect(isValidMaxOutputTokens(null)).toBe(false);
+    expect(isValidMaxOutputTokens(undefined)).toBe(false);
+  });
+});

--- a/apps/chat-api/src/conversations/generation/generation.types.ts
+++ b/apps/chat-api/src/conversations/generation/generation.types.ts
@@ -13,14 +13,36 @@ export interface ResponsesInputItem {
 /**
  * First-iteration Responses request body. Always `stream: true` and
  * `store: false` — never carries `previous_response_id` or `conversation`
- * (DIAL Core rejects the key's mere presence, even as `null`).
+ * (DIAL Core rejects the key's mere presence, even as `null`). `temperature`
+ * and `max_output_tokens` are optional Chat-side overrides: `temperature` is
+ * included only when the resolved deployment explicitly supports it,
+ * `max_output_tokens` only when the conversation carries a validated value —
+ * see `ResponsesAdapter.buildRequest` for the omission rules.
  */
 export interface ResponsesApiRequestBody {
   model: string;
   input: ResponsesInputItem[];
   stream: true;
   store: false;
+  temperature?: number;
+  max_output_tokens?: number;
 }
+
+/**
+ * Runtime guard for `Conversation.maxOutputTokens` at the point it crosses
+ * from persisted Chat data into the outbound Responses wire request. A bare
+ * TypeScript type is not enough here — the persisted value may come from an
+ * untrusted import/save payload that was never nested-validated (see
+ * `design.md` Decision 4) — so this checks the actual runtime value: a
+ * positive, finite integer within `Number.isSafeInteger` range. Anything
+ * else (absent, `null`, `0`, negative, fractional, `NaN`, `Infinity`, or an
+ * unsafe integer) must be omitted rather than forwarded.
+ */
+export const isValidMaxOutputTokens = (value: unknown): value is number =>
+  typeof value === 'number' &&
+  Number.isInteger(value) &&
+  Number.isSafeInteger(value) &&
+  value > 0;
 
 /** Responses SSE event types this adapter understands and normalizes. */
 export interface ResponsesCreatedEvent {

--- a/apps/chat-api/src/conversations/generation/generation.types.ts
+++ b/apps/chat-api/src/conversations/generation/generation.types.ts
@@ -50,6 +50,16 @@ export interface ResponsesErrorEvent {
   code?: string;
 }
 
+/**
+ * Terminal failure event. Unlike `ResponsesErrorEvent` (a top-level `error`
+ * frame), `response.failed` nests its error under `response.error`,
+ * mirroring the OpenAI Responses API's `response.failed` payload shape.
+ */
+export interface ResponsesFailedEvent {
+  type: 'response.failed';
+  response?: { id?: string; error?: { message?: string; code?: string } };
+}
+
 /** Catch-all for event types not in the handled allowlist above. */
 export interface ResponsesUnknownEvent {
   type: string;
@@ -61,7 +71,33 @@ export type ResponsesSseEvent =
   | ResponsesCompletedEvent
   | ResponsesIncompleteEvent
   | ResponsesErrorEvent
+  | ResponsesFailedEvent
   | ResponsesUnknownEvent;
+
+/**
+ * Explicit terminal lifecycle state for a Responses SSE stream, replacing a
+ * `terminalError: string | null` / `isDone: boolean` pair so precedence
+ * between competing terminal signals (`response.failed`, `response.incomplete`,
+ * a top-level `error`, an invalid-status `response.completed`, and the
+ * compatibility `[DONE]` marker) is explicit rather than encoded in loosely
+ * related booleans.
+ */
+export enum ResponsesTerminalState {
+  Success = 'success',
+  Failed = 'failed',
+  Incomplete = 'incomplete',
+  StreamError = 'stream_error',
+}
+
+/**
+ * Once recorded, a non-`Success` signal must never be overwritten by a later
+ * `[DONE]` marker or by reaching end-of-stream — see
+ * `responses.adapter.ts`'s `handleEvent`/post-loop logic.
+ */
+export interface ResponsesTerminalSignal {
+  state: ResponsesTerminalState;
+  message?: string;
+}
 
 /**
  * Normalized chunk shape both adapters emit, identical to the

--- a/apps/chat-api/src/conversations/generation/responses.adapter.spec.ts
+++ b/apps/chat-api/src/conversations/generation/responses.adapter.spec.ts
@@ -1,6 +1,13 @@
+import { Logger } from '@nestjs/common';
 import { describe, expect, it, vi } from 'vitest';
 import type { DialClientService } from '../../dial/dial-client.service';
 import { ConversationMessageRole } from '../dto/conversation-message.dto';
+import { generationUnknownEventsTotal } from './generation-metrics';
+import type {
+  ResponsesFailedEvent,
+  ResponsesTerminalSignal,
+} from './generation.types';
+import { ResponsesTerminalState } from './generation.types';
 import { ResponsesAdapter } from './responses.adapter';
 
 const makeMockRes = () => {
@@ -22,6 +29,31 @@ const textToStream = (chunks: string[]): ReadableStream<Uint8Array> => {
     },
   });
 };
+
+describe('generation.types — Responses terminal-state types', () => {
+  it('constructs a response.failed event and a terminal signal with the expected shape', () => {
+    const failedEvent: ResponsesFailedEvent = {
+      type: 'response.failed',
+      response: { id: 'resp-1', error: { message: 'boom', code: 'x' } },
+    };
+    const signal: ResponsesTerminalSignal = {
+      state: ResponsesTerminalState.Failed,
+      message: 'boom',
+    };
+
+    expect(failedEvent.type).toBe('response.failed');
+    expect(signal.state).toBe(ResponsesTerminalState.Failed);
+  });
+
+  it('exposes the four terminal-state enum members', () => {
+    expect(Object.values(ResponsesTerminalState)).toEqual([
+      'success',
+      'failed',
+      'incomplete',
+      'stream_error',
+    ]);
+  });
+});
 
 describe('ResponsesAdapter', () => {
   const makeAdapter = () => {
@@ -205,6 +237,132 @@ describe('ResponsesAdapter', () => {
       expect(result.outcome).toBe('error');
     });
 
+    it('returns an error outcome and does not retry Chat Completions when response.failed arrives before any text', async () => {
+      const { adapter, mockDialClient } = makeAdapter();
+      const { result, res } = await relay(adapter, mockDialClient, [
+        'data: {"type":"response.failed","response":{"id":"resp-5","error":{"message":"Model overloaded"}}}\n\n',
+      ]);
+
+      expect(result.outcome).toBe('error');
+      if (result.outcome === 'error') {
+        expect((result.error as Error).message).toBe('Model overloaded');
+        expect(result.assembledMessage.content).toBe('');
+      }
+      expect(res.getWritten()).not.toContain('[DONE]');
+      expect(mockDialClient.client.createResponse).toHaveBeenCalledOnce();
+    });
+
+    it('preserves partial text when response.failed arrives after text deltas', async () => {
+      const { adapter, mockDialClient } = makeAdapter();
+      const { result } = await relay(adapter, mockDialClient, [
+        'data: {"type":"response.output_text.delta","delta":"Partial answer"}\n\n',
+        'data: {"type":"response.failed","response":{"id":"resp-6","error":{"message":"Timed out"}}}\n\n',
+      ]);
+
+      expect(result.outcome).toBe('error');
+      if (result.outcome === 'error') {
+        expect(result.assembledMessage.content).toBe('Partial answer');
+        expect((result.error as Error).message).toBe('Timed out');
+      }
+    });
+
+    it('extracts a structured response.failed message without logging the event payload', async () => {
+      const { adapter, mockDialClient } = makeAdapter();
+      const debugSpy = vi.spyOn(Logger.prototype, 'debug');
+      const { result } = await relay(adapter, mockDialClient, [
+        'data: {"type":"response.failed","response":{"id":"resp-7","error":{"message":"Secret prompt leaked here","code":"E1"}}}\n\n',
+      ]);
+
+      expect(result.outcome).toBe('error');
+      if (result.outcome === 'error') {
+        expect((result.error as Error).message).toBe(
+          'Secret prompt leaked here',
+        );
+      }
+      for (const call of debugSpy.mock.calls) {
+        expect(String(call[0])).not.toContain('Secret prompt leaked here');
+      }
+      debugSpy.mockRestore();
+    });
+
+    it('does not count response.failed as an unknown event', async () => {
+      const { adapter, mockDialClient } = makeAdapter();
+      const addSpy = vi.spyOn(generationUnknownEventsTotal, 'add');
+      await relay(adapter, mockDialClient, [
+        'data: {"type":"response.failed","response":{"id":"resp-8","error":{"message":"boom"}}}\n\n',
+      ]);
+
+      expect(addSpy).not.toHaveBeenCalled();
+      addSpy.mockRestore();
+    });
+
+    it('returns an error and does not emit downstream [DONE] when the socket closes after deltas without a terminal signal', async () => {
+      const { adapter, mockDialClient } = makeAdapter();
+      const { result, res } = await relay(adapter, mockDialClient, [
+        'data: {"type":"response.output_text.delta","delta":"Partial"}\n\n',
+      ]);
+
+      expect(result.outcome).toBe('error');
+      if (result.outcome === 'error') {
+        expect(result.assembledMessage.content).toBe('Partial');
+      }
+      expect(res.getWritten()).not.toContain('[DONE]');
+    });
+
+    it('returns an error with a stable generic message when the socket closes before any event', async () => {
+      const { adapter, mockDialClient } = makeAdapter();
+      const { result } = await relay(adapter, mockDialClient, []);
+
+      expect(result.outcome).toBe('error');
+      if (result.outcome === 'error') {
+        expect((result.error as Error).message).toBe(
+          'Responses generation ended before completion',
+        );
+      }
+    });
+
+    it('completes a Core-shaped stream (event: and data: lines) on response.completed alone, without [DONE]', async () => {
+      const { adapter, mockDialClient } = makeAdapter();
+      const { result, res } = await relay(adapter, mockDialClient, [
+        'event: response.created\ndata: {"type":"response.created","response":{"id":"resp-9"}}\n\n',
+        'event: response.output_text.delta\ndata: {"type":"response.output_text.delta","delta":"Hi"}\n\n',
+        'event: response.completed\ndata: {"type":"response.completed","response":{"id":"resp-9","status":"completed"}}\n\n',
+      ]);
+
+      expect(result.outcome).toBe('completed');
+      if (result.outcome === 'completed') {
+        expect(result.assembledMessage.content).toBe('Hi');
+      }
+      expect(res.getWritten()).toContain('[DONE]');
+    });
+
+    it('still completes a legacy stream that only sends [DONE], with no response.completed', async () => {
+      const { adapter, mockDialClient } = makeAdapter();
+      const { result } = await relay(adapter, mockDialClient, [
+        'data: {"type":"response.output_text.delta","delta":"Legacy"}\n\n',
+        'data: [DONE]\n\n',
+      ]);
+
+      expect(result.outcome).toBe('completed');
+      if (result.outcome === 'completed') {
+        expect(result.assembledMessage.content).toBe('Legacy');
+      }
+    });
+
+    it('does not let a trailing [DONE] override an earlier response.failed', async () => {
+      const { adapter, mockDialClient } = makeAdapter();
+      const { result, res } = await relay(adapter, mockDialClient, [
+        'data: {"type":"response.failed","response":{"id":"resp-10","error":{"message":"Upstream died"}}}\n\n',
+        'data: [DONE]\n\n',
+      ]);
+
+      expect(result.outcome).toBe('error');
+      if (result.outcome === 'error') {
+        expect((result.error as Error).message).toBe('Upstream died');
+      }
+      expect(res.getWritten()).not.toContain('[DONE]');
+    });
+
     it('returns rejected when DIAL Core responds with a non-ok status', async () => {
       const { adapter, mockDialClient } = makeAdapter();
       vi.spyOn(mockDialClient.client, 'createResponse').mockResolvedValue({
@@ -265,6 +423,50 @@ describe('ResponsesAdapter', () => {
       expect(result.outcome).toBe('rejected');
       if (result.outcome === 'rejected') {
         expect(result.errorMessage).toBe('Quota exceeded');
+      }
+    });
+
+    it('preserves a non-empty plain-text non-2xx body when the SDK gave no usable message', async () => {
+      const { adapter, mockDialClient } = makeAdapter();
+      vi.spyOn(mockDialClient.client, 'createResponse').mockResolvedValue({
+        response: new Response('Upstream is missing required id', {
+          status: 400,
+        }),
+      } as never);
+      const res = makeMockRes();
+
+      const result = await adapter.relay(
+        { model: 'gpt-4o', input: [], stream: true, store: false },
+        'test-token',
+        new AbortController().signal,
+        res as never,
+        { role: ConversationMessageRole.Assistant, content: '' } as never,
+      );
+
+      expect(result.outcome).toBe('rejected');
+      if (result.outcome === 'rejected') {
+        expect(result.errorMessage).toBe('Upstream is missing required id');
+      }
+    });
+
+    it('keeps the existing generic fallback (empty string) when the non-2xx body is empty', async () => {
+      const { adapter, mockDialClient } = makeAdapter();
+      vi.spyOn(mockDialClient.client, 'createResponse').mockResolvedValue({
+        response: new Response(null, { status: 502 }),
+      } as never);
+      const res = makeMockRes();
+
+      const result = await adapter.relay(
+        { model: 'gpt-4o', input: [], stream: true, store: false },
+        'test-token',
+        new AbortController().signal,
+        res as never,
+        { role: ConversationMessageRole.Assistant, content: '' } as never,
+      );
+
+      expect(result.outcome).toBe('rejected');
+      if (result.outcome === 'rejected') {
+        expect(result.errorMessage).toBe('');
       }
     });
 

--- a/apps/chat-api/src/conversations/generation/responses.adapter.spec.ts
+++ b/apps/chat-api/src/conversations/generation/responses.adapter.spec.ts
@@ -82,6 +82,7 @@ describe('ResponsesAdapter', () => {
             content: 'How are you?',
           } as never,
         ],
+        temperatureSupported: false,
       });
 
       expect(request.input).toEqual([
@@ -102,6 +103,7 @@ describe('ResponsesAdapter', () => {
         messagesForCompletion: [
           { role: ConversationMessageRole.User, content: 'Hi' } as never,
         ],
+        temperatureSupported: false,
       });
 
       expect(request.input).toEqual([
@@ -125,6 +127,7 @@ describe('ResponsesAdapter', () => {
             content: 'Hello!',
           } as never,
         ],
+        temperatureSupported: false,
       });
 
       expect(request.input).toEqual([
@@ -139,10 +142,146 @@ describe('ResponsesAdapter', () => {
         model: 'gpt-4o',
         startConversation: { prompt: '' } as never,
         messagesForCompletion: [],
+        temperatureSupported: false,
       });
 
       expect(request.store).toBe(false);
       expect(request.stream).toBe(true);
+    });
+
+    it('forwards temperature 0 exactly when the deployment supports it', () => {
+      const { adapter } = makeAdapter();
+      const request = adapter.buildRequest({
+        model: 'gpt-4o',
+        startConversation: { prompt: '', temperature: 0 } as never,
+        messagesForCompletion: [],
+        temperatureSupported: true,
+      });
+
+      expect(request.temperature).toBe(0);
+    });
+
+    it('forwards a non-zero temperature exactly when the deployment supports it', () => {
+      const { adapter } = makeAdapter();
+      const request = adapter.buildRequest({
+        model: 'gpt-4o',
+        startConversation: { prompt: '', temperature: 0.7 } as never,
+        messagesForCompletion: [],
+        temperatureSupported: true,
+      });
+
+      expect(request.temperature).toBe(0.7);
+    });
+
+    it('omits temperature when the deployment does not support it', () => {
+      const { adapter } = makeAdapter();
+      const request = adapter.buildRequest({
+        model: 'gpt-4o',
+        startConversation: { prompt: '', temperature: 0.7 } as never,
+        messagesForCompletion: [],
+        temperatureSupported: false,
+      });
+
+      expect(request).not.toHaveProperty('temperature');
+    });
+
+    it('preserves the minimum valid maxOutputTokens value', () => {
+      const { adapter } = makeAdapter();
+      const request = adapter.buildRequest({
+        model: 'gpt-4o',
+        startConversation: { prompt: '', maxOutputTokens: 1 } as never,
+        messagesForCompletion: [],
+        temperatureSupported: false,
+      });
+
+      expect(request.max_output_tokens).toBe(1);
+    });
+
+    it('preserves a representative larger maxOutputTokens value', () => {
+      const { adapter } = makeAdapter();
+      const request = adapter.buildRequest({
+        model: 'gpt-4o',
+        startConversation: { prompt: '', maxOutputTokens: 4096 } as never,
+        messagesForCompletion: [],
+        temperatureSupported: false,
+      });
+
+      expect(request.max_output_tokens).toBe(4096);
+    });
+
+    it('omits max_output_tokens when maxOutputTokens is absent', () => {
+      const { adapter } = makeAdapter();
+      const request = adapter.buildRequest({
+        model: 'gpt-4o',
+        startConversation: { prompt: '' } as never,
+        messagesForCompletion: [],
+        temperatureSupported: false,
+      });
+
+      expect(request).not.toHaveProperty('max_output_tokens');
+    });
+
+    it.each([0, -1, 1.5, NaN, Infinity, Number.MAX_SAFE_INTEGER + 1])(
+      'omits max_output_tokens for the invalid value %s',
+      (invalidValue) => {
+        const { adapter } = makeAdapter();
+        const request = adapter.buildRequest({
+          model: 'gpt-4o',
+          startConversation: {
+            prompt: '',
+            maxOutputTokens: invalidValue,
+          } as never,
+          messagesForCompletion: [],
+          temperatureSupported: false,
+        });
+
+        expect(request).not.toHaveProperty('max_output_tokens');
+      },
+    );
+
+    it('never maps max_output_tokens when Chat Completions capability flags are false', () => {
+      const { adapter } = makeAdapter();
+      const request = adapter.buildRequest({
+        model: 'gpt-4o',
+        startConversation: { prompt: '', maxOutputTokens: 2048 } as never,
+        messagesForCompletion: [],
+        temperatureSupported: false,
+      });
+
+      /*
+       * max_output_tokens mapping is not gated by any Chat-Completions-scoped
+       * capability flag — this test documents that omission of
+       * maxTokensSupported/maxCompletionTokensSupported has no bearing on it.
+       */
+      expect(request.max_output_tokens).toBe(2048);
+    });
+
+    it('includes both temperature and max_output_tokens alongside the unchanged base body', () => {
+      const { adapter } = makeAdapter();
+      const request = adapter.buildRequest({
+        model: 'gpt-4o',
+        startConversation: {
+          prompt: '',
+          temperature: 0.4,
+          maxOutputTokens: 2048,
+        } as never,
+        messagesForCompletion: [
+          { role: ConversationMessageRole.User, content: 'Hi' } as never,
+        ],
+        temperatureSupported: true,
+      });
+
+      expect(request).toMatchObject({
+        model: 'gpt-4o',
+        stream: true,
+        store: false,
+        temperature: 0.4,
+        max_output_tokens: 2048,
+      });
+      expect(request).not.toHaveProperty('previous_response_id');
+      expect(request).not.toHaveProperty('conversation');
+      expect(request).not.toHaveProperty('max_tokens');
+      expect(request).not.toHaveProperty('max_completion_tokens');
     });
   });
 

--- a/apps/chat-api/src/conversations/generation/responses.adapter.ts
+++ b/apps/chat-api/src/conversations/generation/responses.adapter.ts
@@ -11,13 +11,25 @@ import {
 } from '../dto/conversation-message.dto';
 import { applyChunkToMessage } from '../utils/apply-chunk.server';
 import { generationUnknownEventsTotal } from './generation-metrics';
-import type {
-  GenerationRelayOutcome,
-  GenerationRelayTiming,
-  NormalizedStreamChunk,
-  ResponsesApiRequestBody,
-  ResponsesSseEvent,
+import {
+  ResponsesTerminalState,
+  type GenerationRelayOutcome,
+  type GenerationRelayTiming,
+  type NormalizedStreamChunk,
+  type ResponsesApiRequestBody,
+  type ResponsesSseEvent,
+  type ResponsesTerminalSignal,
 } from './generation.types';
+
+/*
+ * Fixed, non-content message used whenever a Responses stream ends without
+ * any recognized terminal signal (socket EOF or `[DONE]` with no prior
+ * `response.completed`/`response.failed`/`response.incomplete`/`error`).
+ * Never derived from upstream text so it can never leak prompt/response
+ * content.
+ */
+const GENERIC_TRUNCATED_MESSAGE =
+  'Responses generation ended before completion';
 
 /**
  * Builds the Responses request and normalizes the Responses SSE event
@@ -108,11 +120,22 @@ export class ResponsesAdapter {
 
         /* 2. Raw body — for cases where SDK didn't parse it */
         if (!errorMessage) {
-          try {
-            const rawBody = await dialResult.response.text();
-            errorMessage = extractDialErrorMessage(JSON.parse(rawBody)) ?? '';
-          } catch {
-            /* non-JSON or empty body */
+          const rawBody = await dialResult.response.text().catch(() => '');
+          if (rawBody) {
+            try {
+              errorMessage = extractDialErrorMessage(JSON.parse(rawBody)) ?? '';
+            } catch {
+              /* not JSON — fall through to plain-text below */
+            }
+            /*
+             * DIAL Core can return a plain-text body (e.g. "Upstream is
+             * missing required id") rather than a JSON error object. Treat
+             * the raw text itself as the error candidate, sanitized before
+             * it can reach a log line.
+             */
+            if (!errorMessage) {
+              errorMessage = StringUtils.sanitizeForLog(rawBody, 500);
+            }
           }
         }
 
@@ -136,7 +159,13 @@ export class ResponsesAdapter {
       upstreamReader = dialResult.response.body.getReader();
       const decoder = new TextDecoder();
       let sseBuffer = '';
-      let terminalError: string | null = null;
+      /*
+       * `terminalSignal` is the single source of truth for how (and whether)
+       * this stream ended. `isDone` only controls when to stop reading the
+       * socket — it never implies success on its own; see the post-loop
+       * check below.
+       */
+      let terminalSignal: ResponsesTerminalSignal | null = null;
       let isDone = false;
 
       const writeChunk = (chunk: NormalizedStreamChunk): void => {
@@ -172,22 +201,52 @@ export class ResponsesAdapter {
              * rather than silently persisted as a successful message.
              */
             if (status != null && status !== 'completed') {
-              terminalError = `Responses generation ended with status "${status}"`;
+              terminalSignal = {
+                state: ResponsesTerminalState.StreamError,
+                message: `Responses generation ended with status "${status}"`,
+              };
+              isDone = true;
               return;
             }
             writeChunk({
               choices: [{ delta: { ...(responseId && { responseId }) } }],
             });
+            terminalSignal = { state: ResponsesTerminalState.Success };
+            isDone = true;
+            return;
+          }
+          case 'response.failed': {
+            /*
+             * Preserve any text already assembled from prior deltas — never
+             * retried through Chat Completions, and never counted as an
+             * unknown event since it is a recognized, handled type.
+             */
+            terminalSignal = {
+              state: ResponsesTerminalState.Failed,
+              message:
+                extractDialErrorMessage(event.response?.error) ??
+                'Responses generation failed',
+            };
             isDone = true;
             return;
           }
           case 'response.incomplete': {
-            terminalError = 'Generation ended incomplete';
+            terminalSignal = {
+              state: ResponsesTerminalState.Incomplete,
+              message: 'Generation ended incomplete',
+            };
+            isDone = true;
             return;
           }
           case 'error': {
-            terminalError =
-              event.error?.message ?? event.message ?? 'Responses stream error';
+            terminalSignal = {
+              state: ResponsesTerminalState.StreamError,
+              message:
+                event.error?.message ??
+                event.message ??
+                'Responses stream error',
+            };
+            isDone = true;
             return;
           }
           default: {
@@ -231,6 +290,16 @@ export class ResponsesAdapter {
           const payload = trimmed.slice(5).trim();
           if (payload === '[DONE]') {
             isDone = true;
+            /*
+             * `[DONE]` is a backward-compatibility signal for legacy/
+             * non-standard upstreams only — it must never override an
+             * already-recorded error/incomplete/stream-error signal (a
+             * canonical Core stream never needs it: `response.completed`
+             * already set `Success` above).
+             */
+            if (!terminalSignal) {
+              terminalSignal = { state: ResponsesTerminalState.Success };
+            }
             continue;
           }
 
@@ -245,19 +314,28 @@ export class ResponsesAdapter {
           }
         }
 
-        if (terminalError || isDone) break;
+        if (terminalSignal || isDone) break;
       }
 
-      if (terminalError) {
-        return {
-          outcome: 'error',
-          error: new Error(terminalError),
-          assembledMessage,
-        };
+      /*
+       * A clean socket close (or a legacy `[DONE]`) does not by itself mean
+       * the generation succeeded — success requires an explicit
+       * `response.completed`/`[DONE]` signal having been recorded above. A
+       * non-`Success` signal (response.failed/incomplete/stream-error) is an
+       * error; no signal at all (stream ended without any recognized
+       * terminal event) is also an error, with a fixed generic message that
+       * never echoes prompt or response content.
+       */
+      if (terminalSignal?.state === ResponsesTerminalState.Success) {
+        res.write('data: [DONE]\n\n');
+        return { outcome: 'completed', assembledMessage };
       }
 
-      res.write('data: [DONE]\n\n');
-      return { outcome: 'completed', assembledMessage };
+      return {
+        outcome: 'error',
+        error: new Error(terminalSignal?.message ?? GENERIC_TRUNCATED_MESSAGE),
+        assembledMessage,
+      };
     } catch (err) {
       const isAbort =
         err instanceof Error &&

--- a/apps/chat-api/src/conversations/generation/responses.adapter.ts
+++ b/apps/chat-api/src/conversations/generation/responses.adapter.ts
@@ -12,6 +12,7 @@ import {
 import { applyChunkToMessage } from '../utils/apply-chunk.server';
 import { generationUnknownEventsTotal } from './generation-metrics';
 import {
+  isValidMaxOutputTokens,
   ResponsesTerminalState,
   type GenerationRelayOutcome,
   type GenerationRelayTiming,
@@ -54,13 +55,29 @@ export class ResponsesAdapter {
    * always `false` in this iteration; `previous_response_id`/`conversation`
    * are never set (DIAL Core rejects the key's mere presence, even as
    * `null`).
+   *
+   * `temperature` is included only when `temperatureSupported` is `true`
+   * (some Responses-capable models reject the field outright — Chat never
+   * substitutes a default of its own) and the conversation carries a usable
+   * value, checked with a nullish check so `temperature: 0` is preserved.
+   * `max_output_tokens` is included only when `startConversation
+   * .maxOutputTokens` is a validated positive safe integer — it is never
+   * gated by a capability flag (no Responses-specific one exists in this
+   * codebase) and never derived from deployment limits or Chat Completions
+   * defaults.
    */
   buildRequest(params: {
     model: string;
     startConversation: ConversationResponseDto;
     messagesForCompletion: ConversationMessageDto[];
+    temperatureSupported: boolean;
   }): ResponsesApiRequestBody {
-    const { model, startConversation, messagesForCompletion } = params;
+    const {
+      model,
+      startConversation,
+      messagesForCompletion,
+      temperatureSupported,
+    } = params;
 
     const systemInput = startConversation.prompt
       ? [{ role: 'system', content: startConversation.prompt }]
@@ -76,11 +93,19 @@ export class ResponsesAdapter {
         })),
     ];
 
+    const maxOutputTokens = startConversation.maxOutputTokens;
+
     return {
       model,
       input,
       stream: true,
       store: false,
+      ...(temperatureSupported && startConversation.temperature != null
+        ? { temperature: startConversation.temperature }
+        : {}),
+      ...(isValidMaxOutputTokens(maxOutputTokens)
+        ? { max_output_tokens: maxOutputTokens }
+        : {}),
     };
   }
 

--- a/apps/chat-api/src/conversations/tests/conversation.service.spec.ts
+++ b/apps/chat-api/src/conversations/tests/conversation.service.spec.ts
@@ -1067,7 +1067,7 @@ describe('ConversationService', () => {
       );
     });
 
-    it('preserves temperature and responseFormat from the source conversation', async () => {
+    it('preserves temperature, responseFormat, and maxOutputTokens from the source conversation', async () => {
       vi.spyOn(
         service['dialClient'].client,
         'getConversation',
@@ -1076,6 +1076,7 @@ describe('ConversationService', () => {
           ...SHARED_CONVERSATION,
           temperature: 0.7,
           responseFormat: 'plain_text',
+          maxOutputTokens: 2048,
         },
       } as never);
       const saveSpy = vi
@@ -1094,6 +1095,31 @@ describe('ConversationService', () => {
       >;
       expect(savedBody.temperature).toBe(0.7);
       expect(savedBody.responseFormat).toBe('plain_text');
+      expect(savedBody.maxOutputTokens).toBe(2048);
+    });
+
+    it('leaves maxOutputTokens absent when the source conversation has no such field (legacy conversation)', async () => {
+      vi.spyOn(
+        service['dialClient'].client,
+        'getConversation',
+      ).mockResolvedValue({
+        data: SHARED_CONVERSATION,
+      } as never);
+      const saveSpy = vi
+        .spyOn(service['dialClient'].client, 'saveConversation')
+        .mockResolvedValue({ data: {} } as never);
+
+      await service.duplicateConversation(
+        'shared-bucket/gpt-4o__New%20chat',
+        'test-token',
+        'test-bucket',
+      );
+
+      const savedBody = saveSpy.mock.calls[0][2].body as Record<
+        string,
+        unknown
+      >;
+      expect(savedBody.maxOutputTokens).toBeUndefined();
     });
   });
 
@@ -1798,6 +1824,85 @@ describe('ConversationService', () => {
 
       expect(createResponseSpy).toHaveBeenCalledOnce();
       expect(sendChatSpy).not.toHaveBeenCalled();
+    });
+
+    it('reuses the deployment-details lookup to forward temperature support to the Responses adapter', async () => {
+      mockDeploymentsService.getDeploymentDetails.mockResolvedValue({
+        id: 'gpt-4o',
+        type: 'model',
+        modelDetails: { features: { responsesApi: true, temperature: true } },
+      });
+      const createResponseSpy = vi
+        .spyOn(service['dialClient'].client, 'createResponse')
+        .mockResolvedValue({
+          response: new Response(emptyStream(), {
+            status: 200,
+            headers: { 'Content-Type': 'text/event-stream' },
+          }),
+        } as never);
+
+      await service.streamCompletion(
+        'test-path',
+        'test-token',
+        'test-bucket',
+        'test-gen-id',
+        CompletionMode.Append,
+        'Hello again',
+        undefined,
+        'gpt-4o',
+        undefined,
+        'test-session-id',
+        makeMockRes() as never,
+        'test-sub',
+      );
+
+      /* Exactly one deployment-details lookup — no second call for temperature. */
+      expect(
+        mockDeploymentsService.getDeploymentDetails,
+      ).toHaveBeenCalledOnce();
+      const requestBody = createResponseSpy.mock.calls[0][0].body as {
+        temperature?: number;
+      };
+      expect(requestBody.temperature).toBe(conversation.temperature);
+    });
+
+    it('omits temperature from the Responses request when the deployment does not report support', async () => {
+      mockDeploymentsService.getDeploymentDetails.mockResolvedValue({
+        id: 'gpt-4o',
+        type: 'model',
+        modelDetails: { features: { responsesApi: true } },
+      });
+      const createResponseSpy = vi
+        .spyOn(service['dialClient'].client, 'createResponse')
+        .mockResolvedValue({
+          response: new Response(emptyStream(), {
+            status: 200,
+            headers: { 'Content-Type': 'text/event-stream' },
+          }),
+        } as never);
+
+      await service.streamCompletion(
+        'test-path',
+        'test-token',
+        'test-bucket',
+        'test-gen-id',
+        CompletionMode.Append,
+        'Hello again',
+        undefined,
+        'gpt-4o',
+        undefined,
+        'test-session-id',
+        makeMockRes() as never,
+        'test-sub',
+      );
+
+      expect(
+        mockDeploymentsService.getDeploymentDetails,
+      ).toHaveBeenCalledOnce();
+      const requestBody = createResponseSpy.mock.calls[0][0].body as {
+        temperature?: number;
+      };
+      expect(requestBody.temperature).toBeUndefined();
     });
 
     it('dispatches a deployment without the responsesApi flag to sendChatCompletionRequest only', async () => {

--- a/apps/chat-api/src/openapi/openapi-response.dto.ts
+++ b/apps/chat-api/src/openapi/openapi-response.dto.ts
@@ -632,6 +632,19 @@ export class ConversationResponseDto {
   @ApiProperty({ example: 1 })
   temperature!: number;
 
+  @ApiPropertyOptional({
+    example: 4096,
+    description:
+      'Optional Responses-API output-token cap, forwarded verbatim as ' +
+      'max_output_tokens. Never derived from deployment limits or Chat ' +
+      'Completions defaults. Documentation-only decorator — the actual ' +
+      'positive-safe-integer check runs at the Responses request-building ' +
+      'boundary (ResponsesAdapter.buildRequest via isValidMaxOutputTokens), ' +
+      'not through nested DTO validation on save (see design.md Decision 4 ' +
+      'of the support-responses-generation-parameters change).',
+  })
+  maxOutputTokens?: number;
+
   @ApiProperty({ type: () => [ConversationMessageDto] })
   messages!: ConversationMessageDto[];
 

--- a/docs/responses-api-integration.md
+++ b/docs/responses-api-integration.md
@@ -279,7 +279,7 @@ If the Responses API has already been selected and returns an error, Chat does n
 | Continuation by ID         | not used                                | not applicable                                  |
 | Final conversation storage | AI DIAL Chat                            | AI DIAL Chat                                    |
 
-The Chat Completions branch retains existing support for DIAL-specific payloads: attachments, `custom_content`, configuration, stages, and temperature. The Responses branch currently sends only text-based `role`/`content` messages and the system prompt.
+The Chat Completions branch retains existing support for DIAL-specific payloads: attachments, `custom_content`, configuration, and stages. The Responses branch sends text-based `role`/`content` messages, the system prompt, and now the two generation parameters described below (`temperature`, `max_output_tokens`); all other DIAL-specific payloads remain Chat-Completions-only.
 
 ## Current Support Scope
 
@@ -295,7 +295,9 @@ Supported:
 - stopping generation through the existing Chat endpoint;
 - diagnostic persistence of `responseId`;
 - safe handling of unknown SSE events;
-- compatibility with older deployments that do not expose the capability flag.
+- compatibility with older deployments that do not expose the capability flag;
+- `temperature`: forwarded from the conversation's persisted value only when the resolved deployment's capabilities explicitly report `features.temperature: true`; omitted (never substituted with a default) when support is `false` or unknown, so a model that rejects the field is never sent one. The value `0` is forwarded, not treated as absent;
+- `max_output_tokens`: forwarded from the conversation's optional `maxOutputTokens` setting whenever it is a valid positive safe integer, independent of any capability flag (no Responses-specific max-output-tokens capability exists in DIAL Core today). Absent or invalid values (zero, negative, fractional, non-finite, or unsafe-integer) omit the field entirely — Chat never derives it from a deployment's `limits.maxCompletionTokens`, the legacy Chat Completions `defaults.max_tokens`, or DIAL Core's own `responsesDefaults`, which keep governing the field's default whenever Chat sends none.
 
 Not yet supported in the Responses branch:
 
@@ -308,7 +310,8 @@ Not yet supported in the Responses branch:
 - image/file input and other multimodal content items;
 - citations, annotations, and rich output;
 - DIAL attachments, `custom_content`, configuration, and stages;
-- temperature and other additional generation parameters;
+- generation parameters other than `temperature` and `max_output_tokens` (e.g. penalties, seed, response format, reasoning effort);
+- a UI control for editing `maxOutputTokens` — the field is settable today only via the persisted conversation model (API, import/export), not through a chat-settings control; a dedicated UI is a follow-up;
 - dedicated handling for every output-item type;
 - automatic fallback after a Responses API error.
 

--- a/docs/responses-api-integration.md
+++ b/docs/responses-api-integration.md
@@ -180,16 +180,17 @@ The Responses API returns typed events, while the existing frontend expects Chat
 
 ### Supported events
 
-| Upstream event               | BFF action                                                                  |
-| ---------------------------- | --------------------------------------------------------------------------- |
-| `response.created`           | Saves the response identifier and sends it in `delta.responseId`            |
-| `response.output_text.delta` | Appends `delta` to the assistant message and sends it as `delta.content`    |
-| `response.completed`         | Validates the final status, saves `responseId`, and completes the stream    |
-| `response.incomplete`        | Ends generation with an error while preserving text received so far         |
-| `error`                      | Ends generation with the upstream error message                             |
-| unknown event                | Does not send it to the client, writes a debug log, and increments a metric |
+| Upstream event               | BFF action                                                                    |
+| ----------------------------- | ------------------------------------------------------------------------------ |
+| `response.created`           | Saves the response identifier and sends it in `delta.responseId`              |
+| `response.output_text.delta` | Appends `delta` to the assistant message and sends it as `delta.content`      |
+| `response.completed`         | Validates the final status; a valid status completes the stream and saves `responseId` |
+| `response.failed`            | Ends generation with an error extracted from `response.error`, preserving text received so far |
+| `response.incomplete`        | Ends generation with an error while preserving text received so far           |
+| `error`                      | Ends generation with the upstream error message                               |
+| unknown event                | Does not send it to the client, writes a debug log, and increments a metric   |
 
-`event:` lines, empty lines, and SSE comments are ignored. JSON is parsed from `data:` lines. The `[DONE]` marker is treated as completion of the upstream stream.
+`event:` lines, empty lines, and SSE comments are ignored. JSON is parsed from `data:` lines. See "Terminal state and `[DONE]`" below for how a stream resolves to success or error — none of `response.failed`, `response.incomplete`, or an in-band `error` ever produce a downstream `data: [DONE]`, and none of them are retried through Chat Completions.
 
 ### What the frontend receives
 
@@ -233,9 +234,22 @@ Both adapters return the same result type to `ConversationService`:
 
 Shared logic then sets the message status and saves the conversation state.
 
+### Terminal state and `[DONE]`
+
+The Responses adapter tracks one explicit terminal signal per stream instead of assuming success whenever no error was seen. A stream resolves to `completed` only when it observes a valid `response.completed` (status absent or `"completed"`) or, for legacy/non-standard upstreams only, a `data: [DONE]` marker that no earlier error signal has already claimed.
+
+The DIAL Core Responses contract and the `[DONE]` compatibility path are not the same thing:
+
+- **Canonical DIAL Core streams** end in `response.completed` or `response.incomplete` and do not send `[DONE]`. A canonical stream completes as soon as it sees a valid `response.completed` — it never needs `[DONE]`.
+- **`[DONE]` is a backward-compatibility signal** for legacy or non-standard upstreams that do not send a Responses-native terminal event. Observing `[DONE]` records success only if no terminal signal (success or error) was already recorded; it can never override an earlier `response.failed`, `response.incomplete`, in-band `error`, or an invalid-status `response.completed`.
+- **A `response.completed` with a status other than `"completed"`** remains an error, regardless of anything that follows it, including `[DONE]`.
+- **The upstream socket closing does not by itself mean success.** If the stream ends — by socket EOF or by `[DONE]` — without a previously recorded success or error signal, the adapter returns an error using a fixed, generic message that never echoes prompt or response content, and preserves any partial assistant text assembled so far. No downstream `data: [DONE]` is written in this case.
+
+DIAL Core does not yet recognize `response.failed` as a terminal event on its own side — it can still forward a `response.failed` frame to Chat before the upstream socket closes. Chat's adapter treats `response.failed` as terminal regardless, which is why this defensive handling exists on the Chat side even though Core has not adopted it internally yet.
+
 ### Partial responses
 
-If `response.incomplete`, an `error` event, or an abort occurs after several deltas, the accumulated text is preserved. It is saved together with the error or the indication that the user stopped generation.
+If `response.failed`, `response.incomplete`, an `error` event, an unterminated stream, or an abort occurs after several deltas, the accumulated text is preserved. It is saved together with the error or the indication that the user stopped generation.
 
 ### User-initiated stop
 
@@ -276,6 +290,8 @@ Supported:
 - full stateless history on every turn;
 - system prompts;
 - persistence of complete and partial text in conversation history;
+- explicit `response.failed` handling as a terminal error, with partial-text preservation;
+- an explicit terminal-state model: a canonical DIAL Core stream succeeds on a valid `response.completed` alone; `data: [DONE]` is accepted only as a legacy/non-standard-upstream compatibility signal and never overrides an earlier error signal; an unterminated stream (socket EOF or `[DONE]` with no prior terminal signal) is treated as an error rather than an implicit success;
 - stopping generation through the existing Chat endpoint;
 - diagnostic persistence of `responseId`;
 - safe handling of unknown SSE events;
@@ -297,6 +313,10 @@ Not yet supported in the Responses branch:
 - automatic fallback after a Responses API error.
 
 If a deployment declares `responses_api: true` but requires any capability from this list to work correctly, the capability flag alone is insufficient. The adapter must be extended before that deployment can be included in a production scenario.
+
+### Known Core-side gap
+
+DIAL Core does not currently recognize `response.failed` as a terminal Responses event on its own side, and it can end a proxied stream on upstream socket close even when no recognized terminal event was observed. Chat's adapter defends against both possibilities regardless — `response.failed` is treated as terminal in Chat even though Core has not adopted that terminal state internally yet, and an unterminated stream is never treated as an implicit success. Extending Core's own terminal-event recognition is tracked as a follow-up in the `ai-dial-core` repository and is out of scope for this Chat-side change.
 
 ## Observability
 

--- a/libs/chat-api-client/openapi.json
+++ b/libs/chat-api-client/openapi.json
@@ -4414,7 +4414,7 @@
         "tags": ["scheduled-tasks"]
       },
       "post": {
-        "description": "Creates a DIAL Scheduler schedule that runs a chat completion on the given model and prompt, using the authenticated session user's dial-oauth credentials. Invalidates the scheduled tasks list cache on success.",
+        "description": "Creates a DIAL Scheduler schedule that runs a chat completion on the given model and prompt, using the OAuth external-service id configured via SCHEDULER_SERVICE_ID. Invalidates the scheduled tasks list cache on success.",
         "operationId": "createScheduledTask",
         "parameters": [],
         "requestBody": {
@@ -7068,6 +7068,11 @@
             "type": "number",
             "example": 1
           },
+          "maxOutputTokens": {
+            "type": "number",
+            "example": 4096,
+            "description": "Optional Responses-API output-token cap, forwarded verbatim as max_output_tokens. Never derived from deployment limits or Chat Completions defaults. Documentation-only decorator — the actual positive-safe-integer check runs at the Responses request-building boundary (ResponsesAdapter.buildRequest via isValidMaxOutputTokens), not through nested DTO validation on save (see design.md Decision 4 of the support-responses-generation-parameters change)."
+          },
           "messages": {
             "type": "array",
             "items": {
@@ -7158,7 +7163,7 @@
           },
           "isScheduledTask": {
             "type": "boolean",
-            "description": "True when this conversation was created by a DIAL Scheduler run (its resource path matches the `.scheduler/{scheduleId}/{runId}` reserved segment).",
+            "description": "True when this conversation was created by a DIAL Scheduler run (its resource path matches the `.scheduler/{scheduleId}/{filename}` reserved segment, with `{filename}` shaped `{deploymentId}__{title}__{runId}`).",
             "example": false
           },
           "scheduleId": {

--- a/libs/chat-api-client/src/generated/src/apis/ScheduledTasksApi.ts
+++ b/libs/chat-api-client/src/generated/src/apis/ScheduledTasksApi.ts
@@ -47,7 +47,7 @@ export interface UpdateScheduledTaskRequest {
  */
 export class ScheduledTasksApi extends runtime.BaseAPI {
   /**
-   * Creates a DIAL Scheduler schedule that runs a chat completion on the given model and prompt, using the authenticated session user\'s dial-oauth credentials. Invalidates the scheduled tasks list cache on success.
+   * Creates a DIAL Scheduler schedule that runs a chat completion on the given model and prompt, using the OAuth external-service id configured via SCHEDULER_SERVICE_ID. Invalidates the scheduled tasks list cache on success.
    * Create a scheduled task
    */
   async createScheduledTaskRaw(
@@ -84,7 +84,7 @@ export class ScheduledTasksApi extends runtime.BaseAPI {
   }
 
   /**
-   * Creates a DIAL Scheduler schedule that runs a chat completion on the given model and prompt, using the authenticated session user\'s dial-oauth credentials. Invalidates the scheduled tasks list cache on success.
+   * Creates a DIAL Scheduler schedule that runs a chat completion on the given model and prompt, using the OAuth external-service id configured via SCHEDULER_SERVICE_ID. Invalidates the scheduled tasks list cache on success.
    * Create a scheduled task
    */
   async createScheduledTask(

--- a/libs/chat-api-client/src/generated/src/models/index.ts
+++ b/libs/chat-api-client/src/generated/src/models/index.ts
@@ -691,7 +691,7 @@ export interface ConversationListItemDto {
    */
   isReadonly: boolean;
   /**
-   * True when this conversation was created by a DIAL Scheduler run (its resource path matches the `.scheduler/{scheduleId}/{runId}` reserved segment).
+   * True when this conversation was created by a DIAL Scheduler run (its resource path matches the `.scheduler/{scheduleId}/{filename}` reserved segment, with `{filename}` shaped `{deploymentId}__{title}__{runId}`).
    * @type {boolean}
    * @memberof ConversationListItemDto
    */
@@ -970,6 +970,12 @@ export interface ConversationResponseDto {
    * @memberof ConversationResponseDto
    */
   temperature: number;
+  /**
+   * Optional Responses-API output-token cap, forwarded verbatim as max_output_tokens. Never derived from deployment limits or Chat Completions defaults. Documentation-only decorator — the actual positive-safe-integer check runs at the Responses request-building boundary (ResponsesAdapter.buildRequest via isValidMaxOutputTokens), not through nested DTO validation on save (see design.md Decision 4 of the support-responses-generation-parameters change).
+   * @type {number}
+   * @memberof ConversationResponseDto
+   */
+  maxOutputTokens?: number;
   /**
    *
    * @type {Array<ConversationMessageDto>}

--- a/libs/chat-shared/src/models/chat.ts
+++ b/libs/chat-shared/src/models/chat.ts
@@ -282,6 +282,8 @@ export interface Conversation {
   prompt: string;
   /** Sampling temperature passed to the model (0–1). */
   temperature: number;
+  /** Optional Responses-API output-token cap, forwarded as `max_output_tokens`. Never derived from deployment limits or Chat Completions defaults. */
+  maxOutputTokens?: number;
   /** Ordered list of messages in the conversation. */
   messages: Message[];
   /** Unix timestamp (ms) of the most recent activity. */

--- a/openspec/changes/archive/2026-08-06-harden-responses-stream-handling/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-06-harden-responses-stream-handling/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-06

--- a/openspec/changes/archive/2026-08-06-harden-responses-stream-handling/design.md
+++ b/openspec/changes/archive/2026-08-06-harden-responses-stream-handling/design.md
@@ -1,0 +1,171 @@
+## Context
+
+`ResponsesAdapter.relay` (`apps/chat-api/src/conversations/generation/responses.adapter.ts:75-277`) reads the Responses SSE body line by line, calls `handleEvent` per parsed frame, and stops the loop when either `terminalError` is set or `isDone` becomes `true` (`responses.adapter.ts:212-249`). After the loop, the only branch is:
+
+```ts
+if (terminalError) { return { outcome: 'error', ... } }
+res.write('data: [DONE]\n\n');
+return { outcome: 'completed', assembledMessage };
+```
+
+`isDone` is set in exactly two places today: on the legacy `[DONE]` marker (`responses.adapter.ts:232-235`) and on a `response.completed` event whose `status` is `'completed'` or absent (`responses.adapter.ts:165-183`). Everything else — including the plain end of the `while (true)` loop when `upstreamReader.read()` returns `done: true` with no prior terminal event, and the unhandled `response.failed` type falling into the `default` unknown-event branch (`responses.adapter.ts:193-209`) — currently falls through to the success return. That is the bug: absence of an explicit error is silently treated as presence of success.
+
+The prompt's Core-behavior baseline is authoritative context for this design, not something Chat can control:
+
+- Core's canonical Responses stream ends in `response.completed` or `response.incomplete`, never `[DONE]`.
+- Core may end a proxied stream on upstream socket close even without a recognized terminal event.
+- Core does not yet treat `response.failed` as terminal internally, so it can forward `response.failed` as an ordinary frame before closing the socket — Chat is the only layer currently positioned to treat it as terminal.
+- Core's non-2xx bodies can be plain text (e.g. `Upstream is missing required id`), and the generated SDK may expose that text via its parsed `error` rather than structured JSON.
+
+This design only touches `apps/chat-api/src/conversations/generation/{responses.adapter.ts,generation.types.ts,responses.adapter.spec.ts}` and `docs/responses-api-integration.md`. `ConversationService`'s consumption of `GenerationRelayOutcome` (`conversation.service.ts:1369-1460`) is unaffected — the `rejected`/`completed`/`aborted`/`error` outcome shape does not change, only which branch a given upstream stream shape now resolves to.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make `response.failed` a first-class terminal error event, symmetric with `response.incomplete`.
+- Make "the stream ended" and "the stream succeeded" two independent facts — success requires an explicit terminal-success signal, not merely the absence of an explicit terminal-error signal.
+- Give the terminal-state precedence rules (which signal wins when more than one is observed) a single explicit representation instead of leaving it implicit in `if`/`break` ordering.
+- Preserve every existing passing behavior: successful `response.completed` streams, legacy `[DONE]`-only streams, `response.incomplete`, in-band `error`, unknown-event skipping/metrics, aborts, and the two pre-existing safeguards (status-message filtering, SDK-first error extraction) — all get explicit regression tests, not new implementation, except where item below requires a small addition.
+- Extend the non-2xx raw-body fallback to accept a non-empty plain-text body as the error message when the SDK gave nothing and the body isn't JSON (Core's plain-text error shape).
+
+**Non-Goals:**
+
+- No change to `ai-dial-core`. Core's missing `response.failed` terminal recognition and EOF-without-terminal-event behavior are external facts this design defends against, not defects this change fixes.
+- No change to the `NormalizedStreamChunk` shape, the `/api/v1/conversations/completions` contract, or anything `apply-chunk.server.ts`/the frontend consumes.
+- No automatic Responses → Chat Completions fallback (unchanged existing constraint).
+- No new metric, endpoint, env var, or feature flag. The existing `generationUnknownEventsTotal` metric and `generation.requests`/`generation.stream_duration` metrics keep recording exactly the outcomes the adapter already returns.
+
+## Decisions
+
+### 1. Explicit terminal-state enum instead of `terminalError: string | null` + `isDone: boolean`
+
+Replace the two loosely-related locals with one variable holding a discriminated terminal-state value, using a string enum for the state discriminant per the repository's TypeScript enum convention (`AGENTS.md` §TypeScript enums / `all-ts.md`):
+
+```ts
+enum ResponsesTerminalState {
+  Success = 'success',
+  Failed = 'failed',       // response.failed
+  Incomplete = 'incomplete', // response.incomplete
+  StreamError = 'stream_error', // top-level `error` event or invalid response.completed status
+}
+
+interface ResponsesTerminalSignal {
+  state: ResponsesTerminalState;
+  message?: string; // only meaningful for non-Success states
+}
+```
+
+`handleEvent` sets a local `terminalSignal: ResponsesTerminalSignal | null` (mirrors today's `terminalError`) instead of the current pair. `isDone` remains as a separate, narrower flag that only means "stop reading the socket" — it is set by `response.completed` (terminal-success), `response.failed`/`response.incomplete`/`error` (terminal-error — the loop should still stop early, matching today's `if (terminalError || isDone) break;`), and by `[DONE]`. Reusing one enum for "why did we stop" keeps the precedence check in one place instead of re-deriving it from independent booleans.
+
+**Alternative considered:** keep `terminalError: string | null` and add a second `isSuccess: boolean`. Rejected — that's exactly one more loosely-related boolean, which is the pattern the prompt asks to move away from, and it still doesn't name the four distinguishable states for the compatibility-`[DONE]` precedence rule below.
+
+### 2. `response.failed` is handled exactly like `response.incomplete`, one branch earlier than `default`
+
+Add `ResponsesFailedEvent` to `generation.types.ts`:
+
+```ts
+export interface ResponsesFailedEvent {
+  type: 'response.failed';
+  response?: { id?: string; error?: { message?: string; code?: string } };
+}
+```
+
+(`response.error` per the prompt's "Extract ... from `response.error`" — mirrors the OpenAI Responses API's `response.failed` payload shape, which nests the error under `response.error`, not top-level `error` as the existing `error` SSE event does.)
+
+In `handleEvent`, add a `case 'response.failed':` branch before `default`, setting `terminalSignal = { state: Failed, message: extractDialErrorMessage(event.response?.error) ?? 'Responses generation failed' }` and `isDone = true` (so the read loop exits promptly rather than waiting for more frames that a failed generation is unlikely to send). This reuses `extractDialErrorMessage` (`dial-error.mapper.ts:79`) exactly as the prompt requires ("the repository's established DIAL error-extraction conventions") — `response.error` already matches the `{ message?: string }` shape that function accepts as an object payload.
+
+**Alternative considered:** a bespoke `extractResponsesFailedMessage` parsing only `response.error.message`. Rejected — `extractDialErrorMessage` already handles the object-with-`message`/`display_message` shape and a plain-string payload; a second parser would be exactly the "second error schema" the prompt says not to invent.
+
+### 3. Loop-exit fallthrough becomes an explicit branch, not an assumed success
+
+Today the code after the `while` loop is `if (terminalError) return error; res.write('[DONE]'); return completed;`. Replace it with an exhaustive check driven by `terminalSignal`:
+
+```ts
+if (terminalSignal && terminalSignal.state !== ResponsesTerminalState.Success) {
+  return { outcome: 'error', error: new Error(terminalSignal.message ?? GENERIC_TRUNCATED_MESSAGE), assembledMessage };
+}
+if (terminalSignal?.state === ResponsesTerminalState.Success) {
+  res.write('data: [DONE]\n\n');
+  return { outcome: 'completed', assembledMessage };
+}
+// Loop ended (EOF or [DONE]) with no explicit terminal signal observed.
+return { outcome: 'error', error: new Error(GENERIC_TRUNCATED_MESSAGE), assembledMessage };
+```
+
+`GENERIC_TRUNCATED_MESSAGE` is a fixed, non-content string (e.g. `'Responses generation ended before completion'`) — never built from anything upstream-controlled, satisfying "a stable generic error message that does not expose prompt or response content."
+
+`[DONE]` no longer implies success by itself: `handleEvent`'s legacy `payload === '[DONE]'` branch only sets `isDone = true`; it must not overwrite an existing `terminalSignal`. Concretely, the `[DONE]` handling becomes:
+
+```ts
+if (payload === '[DONE]') {
+  isDone = true;
+  if (!terminalSignal) {
+    terminalSignal = { state: ResponsesTerminalState.Success };
+  }
+  continue;
+}
+```
+
+— i.e. `[DONE]` sets `Success` only if nothing else already claimed the terminal state, giving the required precedence: `response.failed` / `response.incomplete` / `error` / invalid-status `response.completed`, once observed, cannot be overridden by a later `[DONE]`. A valid `response.completed` already sets `terminalSignal = { state: Success }` itself (see #4), so a canonical Core stream no longer depends on `[DONE]` at all — it succeeds on `response.completed` alone, and the loop's `if (terminalSignal || isDone) break;` guard (unchanged shape, now keyed off `terminalSignal`) still exits promptly.
+
+**Alternative considered:** treat clean EOF as success when at least one delta was received (assume "if we got content, it probably finished"). Rejected — this is a heuristic, not an explicit signal, and is precisely the class of assumption the prompt requires removing; a delta-then-socket-drop is a real truncation failure mode this change must catch (see Required Test 5).
+
+### 4. `response.completed` with a non-`completed` status stays a `StreamError`, not silently swallowed
+
+The existing status check (`responses.adapter.ts:174-177`) is preserved verbatim in behavior, only re-expressed against the new state: `status != null && status !== 'completed'` sets `terminalSignal = { state: StreamError, message: ... }` (equivalent to today's `terminalError = ...`) and does **not** set `Success`. This is unchanged behavior, called out because it interacts with the new `[DONE]`-non-override rule: if a non-standard upstream sent an invalid-status `response.completed` and later also sent `[DONE]`, the `StreamError` state must still win (Required Test 8, generalized).
+
+### 5. Non-2xx raw-body fallback: add a plain-text branch, do not replace the JSON-first attempt
+
+Current code (`responses.adapter.ts:109-117`):
+
+```ts
+if (!errorMessage) {
+  try {
+    const rawBody = await dialResult.response.text();
+    errorMessage = extractDialErrorMessage(JSON.parse(rawBody)) ?? '';
+  } catch {
+    /* non-JSON or empty body */
+  }
+}
+```
+
+The `catch` currently discards a non-JSON body entirely, which loses Core's plain-text errors (`Upstream is missing required id`). Minimal fix — read the body once, try JSON extraction, and if that doesn't yield a message, fall back to the raw text itself when non-empty:
+
+```ts
+if (!errorMessage) {
+  const rawBody = await dialResult.response.text().catch(() => '');
+  if (rawBody) {
+    try {
+      errorMessage = extractDialErrorMessage(JSON.parse(rawBody)) ?? '';
+    } catch {
+      /* not JSON — fall through to plain-text below */
+    }
+    if (!errorMessage) {
+      errorMessage = StringUtils.sanitizeForLog(rawBody, 500);
+    }
+  }
+}
+```
+
+This is the smallest change that satisfies "attempt structured JSON extraction first and then treat the raw text itself as the error candidate" and "apply the repository's sanitization rules before logging it" (`StringUtils.sanitizeForLog`, already used for the unknown-event-type label in this same file). An empty body (`rawBody === ''`) leaves `errorMessage` as `''`, preserving the existing generic-fallback behavior exactly. The same fix pattern applies to `chat-completions.adapter.ts`'s identical block only if the design decides to share it — **out of scope here**: the prompt scopes this requirement to the Responses adapter's `createResponse` path, and `chat-completions.adapter.ts` already has its own passing tests for its current (JSON-only) fallback; duplicating the fix there is not requested and would expand this change's blast radius. This is flagged as a candidate follow-up, not implemented.
+
+**Alternative considered:** treat `rawBody` as the primary candidate and only try JSON as a refinement. Rejected — reversing the order could regress a case where the raw body is JSON whose top-level shape isn't itself the message (e.g. `{"error": {"message": "..."}}` — the full JSON string would become the "message" instead of the extracted field) if the JSON-parse branch didn't run first.
+
+### 6. Where the enum lives
+
+`ResponsesTerminalState` is added to `generation.types.ts` alongside the other Responses-only types (`ResponsesFailedEvent`, updated `ResponsesSseEvent` union). It is not exported for use outside `responses.adapter.ts`/its spec unless a future change needs it — `ConversationService` continues to depend only on `GenerationRelayOutcome`, which is unchanged.
+
+## Risks / Trade-offs
+
+- **[Risk]** A real but non-standard upstream that relies on today's "EOF ⇒ success" behavior (sends deltas, closes the socket, no `response.completed`/`[DONE]`) will start seeing that generation persisted as an error. → **Mitigation**: per the prompt's Core-behavior baseline, DIAL Core's canonical stream always ends in `response.completed`/`response.incomplete`, and legacy/non-standard upstreams are expected to send `[DONE]`; a stream matching neither was already a truncation bug being masked, and partial text is still preserved exactly as before, so the user-visible regression is limited to no longer showing a truncated answer as if it finished cleanly.
+- **[Risk]** `response.failed`'s `response.error` shape is inferred from the OpenAI Responses API convention, not confirmed against a live Core response, since Core does not yet emit `response.failed` as a terminal event today. → **Mitigation**: `extractDialErrorMessage` already tolerates a missing/malformed `error` field (returns `undefined`, feeding the existing `'Responses generation failed'` fallback), so an unexpected shape degrades to a generic message rather than throwing.
+- **[Trade-off]** Introducing `ResponsesTerminalState` touches every branch of `handleEvent` and the post-loop logic in one slice, rather than patching `response.failed` and the EOF case independently. → Accepted: the prompt explicitly asks for "terminal state explicit rather than relying on loosely related booleans," and patching the two gaps independently while keeping `terminalError`/`isDone` would keep exactly the anti-pattern being removed.
+
+## Migration Plan
+
+Pure application-code change with no data migration, schema change, or deployment step beyond the normal build/deploy of `chat-api`. Rollback is a plain `git revert` of the adapter/types/spec/doc commits — no persisted state depends on the new behavior, and no external contract changes.
+
+## Open Questions
+
+- None — the prompt's Core-behavior baseline, error-extraction conventions, and enum requirement fully determine the approach above.

--- a/openspec/changes/archive/2026-08-06-harden-responses-stream-handling/proposal.md
+++ b/openspec/changes/archive/2026-08-06-harden-responses-stream-handling/proposal.md
@@ -1,0 +1,63 @@
+## Why
+
+`ResponsesAdapter.relay` (`apps/chat-api/src/conversations/generation/responses.adapter.ts:75`) currently has two terminal-state gaps: a `response.failed` event falls through the `default` unknown-event branch instead of being treated as an error, and a clean upstream socket close with no recognized terminal event (`response.completed`, `response.incomplete`, `error`, or `[DONE]`) is currently treated as success. Both let a failed or truncated Responses generation be persisted as a completed assistant message. The Responses feature is about to expand scope, so this correctness gap must be closed first.
+
+## What Changes
+
+- Add a typed `response.failed` event to the Responses SSE event union and handle it as a terminal error — extract a safe message from `response.error`, preserve any assembled partial text, skip the downstream `[DONE]` write, and never retry through Chat Completions.
+- Replace the current "loop ended ⇒ success" assumption with an explicit terminal-state model: end-of-stream (or `[DONE]`) without a prior `response.completed`/`response.failed`/`response.incomplete`/`error`/abort is itself a terminal error, using a stable generic message that never echoes prompt or response content.
+- Introduce a string enum for the adapter's terminal lifecycle state (created/streaming/completed/failed/incomplete/truncated, per the repository's enum convention) so precedence between competing terminal signals (`response.failed`, `response.incomplete`, top-level `error`, abort, invalid `response.completed`, compatibility `[DONE]`, socket EOF) is explicit rather than encoded in loosely related booleans.
+- Continue accepting `[DONE]` only as a backward-compatibility signal for legacy/non-standard upstreams; it must not override an already-observed error terminal state, and it is no longer required for a canonical Core stream that ends in a valid `response.completed`.
+- Add regression tests for two safeguards already present in the current worktree so they cannot silently regress: filtering `ConversationMessageRole.Status` messages out of the Responses `input` (`responses.adapter.ts:53-73`), and SDK-first non-2xx error extraction with a raw-body fallback (`responses.adapter.ts:101-134`), extending the fallback to accept a non-empty plain-text body (e.g. Core's `Upstream is missing required id`) via `extractDialErrorMessage` (`apps/chat-api/src/common/dial/dial-error.mapper.ts:79`).
+- Update `docs/responses-api-integration.md` so its supported-event table, completion semantics, and `[DONE]`/EOF description match the hardened behavior.
+
+## Non-Goals
+
+- No changes to `POST /api/v1/conversations/completions`, the browser SSE contract, or Chat Completions behavior.
+- No automatic fallback from Responses to Chat Completions after `createResponse` starts (unchanged).
+- No attachment, tool-calling, reasoning, multimodal-input, or `previous_response_id`/`store: true` work — out of scope, per the existing "Current Support Scope" limits in the docs.
+- No changes to `ai-dial-core`. Core does not yet treat `response.failed` as terminal and can end a stream on socket EOF without a recognized terminal event; that gap is recorded as a follow-up for the Core repository, not implemented here.
+- No new HTTP endpoints, environment variables, feature flags, user-visible strings, dependencies, or caches.
+
+## Acceptance Criteria
+
+- A `response.failed` event, at any point in the stream, ends the generation as `outcome: 'error'`, preserves partial text, is never counted as an unknown event, and never triggers a downstream `[DONE]` write or a Chat Completions retry.
+- A canonical Core stream ending in a valid `response.completed` completes successfully without requiring `[DONE]`.
+- A stream that ends (via `[DONE]` or socket EOF) without any recognized terminal signal returns an error outcome, preserves partial text, and does not write downstream `[DONE]`.
+- `[DONE]` continues to complete a legacy-compatible stream but never overrides an already-observed `response.failed`, `response.incomplete`, `error`, abort, or invalid-status `response.completed`.
+- `response.completed` with a non-`completed` status remains an error, unchanged.
+- Internal `ConversationMessageRole.Status` messages are excluded from Responses `input`; surrounding message order is preserved.
+- A non-2xx `createResponse` result surfaces the SDK-parsed message first, then falls back to raw-body extraction (structured JSON, then plain text) only when the SDK provided none; an empty body keeps the existing generic fallback. Logs carry only status and the sanitized message, never the full result/body/prompt/response text.
+- Abort handling is unaffected and still reports `outcome: 'aborted'`, not a truncated-stream error.
+- All Chat Completions behavior, the `/api/v1/conversations/completions` contract, and existing successful `response.completed`/`[DONE]` streams are unchanged.
+
+## Backward Compatibility and Rollback
+
+- Fully backward compatible for callers: no request/response contract, endpoint, or frontend behavior changes. The only externally observable difference is that streams that previously mis-persisted as "completed" (failed or truncated upstream) now correctly persist as errors — this is a bug fix, not a behavior change callers depend on.
+- Legacy/non-standard upstreams that only send `[DONE]` (no `response.completed`) keep working exactly as before, provided no earlier error terminal state was observed.
+- Rollback is a plain revert of the adapter/type/test/doc changes in this change; no data migration, schema change, or persisted-state change is introduced, so rollback carries no cleanup burden.
+
+## Alternatives Considered
+
+- **Treat socket EOF as success unless a boolean `hadError` flag was set** — rejected: this is the current design and is exactly the bug being fixed; ad hoc booleans don't express precedence between multiple possible terminal signals cleanly.
+- **Drop `[DONE]` support entirely now that `response.completed` is authoritative** — rejected: `[DONE]` remains a real backward-compatibility path for non-Core or older upstreams per the prompt's explicit requirement; removing it would be a scope-expanding breaking change with no Core-side driver.
+- **Fix Core's missing `response.failed` terminal handling instead of hardening Chat** — rejected: out of scope for this repository; Chat must defend against the sibling system's current behavior regardless, and the Core gap is recorded as a follow-up, not fixed here.
+
+## Capabilities
+
+### New Capabilities
+
+_None._
+
+### Modified Capabilities
+
+- `responses-api-generation`: adds `response.failed` handling, replaces the implicit EOF-as-success behavior with an explicit terminal-state precedence model (including `[DONE]` as compatibility-only), and adds regression requirements for status-message filtering and SDK-first/raw-body error extraction.
+
+## Impact
+
+- `apps/chat-api/src/conversations/generation/responses.adapter.ts` — terminal-state handling, `response.failed`, EOF-without-terminal-signal error path, raw-body plain-text fallback.
+- `apps/chat-api/src/conversations/generation/generation.types.ts` — new `ResponsesFailedEvent` type and (if introduced) a terminal-lifecycle-state string enum.
+- `apps/chat-api/src/conversations/generation/responses.adapter.spec.ts` — new and updated tests per the Required Tests list.
+- `apps/chat-api/src/conversations/conversation.service.ts` and its tests — verified unaffected beyond receiving the same `GenerationRelayOutcome` shape; touched only if finalization-path coverage is required.
+- `docs/responses-api-integration.md` — supported-event table, completion/terminal-state section, `[DONE]`/EOF description.
+- `openspec/specs/responses-api-generation/spec.md` — delta for the modified capability.

--- a/openspec/changes/archive/2026-08-06-harden-responses-stream-handling/specs/responses-api-generation/spec.md
+++ b/openspec/changes/archive/2026-08-06-harden-responses-stream-handling/specs/responses-api-generation/spec.md
@@ -1,60 +1,4 @@
-### Requirement: Generation API resolver
-
-`resolveGenerationApi` (`apps/chat-api/src/conversations/generation/generation-api.ts`) SHALL be a pure function that takes the resolved deployment `features` object (`{ responsesApi?: boolean }`, as produced by `DeploymentsService.getDeploymentDetails`) and returns a `GenerationApi` string enum value: `Responses = 'responses'` when `features.responsesApi === true`, otherwise `ChatCompletions = 'chat_completions'`. A missing `features` object or a missing/`false` `responsesApi` field SHALL resolve to `ChatCompletions`.
-
-#### Scenario: Responses-capable deployment resolves to Responses
-
-- **WHEN** `resolveGenerationApi({ responsesApi: true })` is called
-- **THEN** it returns `GenerationApi.Responses`
-
-#### Scenario: Deployment without the flag resolves to Chat Completions
-
-- **WHEN** `resolveGenerationApi({ responsesApi: false })` or `resolveGenerationApi(undefined)` is called
-- **THEN** it returns `GenerationApi.ChatCompletions`
-
----
-
-### Requirement: ConversationService resolves generation API before opening the upstream stream
-
-`ConversationService.streamCompletion` SHALL call `DeploymentsService.getDeploymentDetails(sub, model, token)` (the existing cached, user-token-scoped lookup already used by the deployment details endpoint) before issuing any upstream generation call, read `features` off the returned `modelDetails`/`applicationDetails` per the resolved `type`, and pass the result through `resolveGenerationApi` to select the adapter. `ConversationModule` SHALL import `DeploymentsModule` to obtain `DeploymentsService`. When `getDeploymentDetails` resolves the target id to `type: 'toolset'`, `streamCompletion` SHALL reject the request with HTTP 400 before any generation call, since a toolset is not a generation deployment.
-
-#### Scenario: Responses-capable model dispatches to the Responses adapter
-
-- **WHEN** a completion request targets a model whose `getDeploymentDetails` result has `features.responsesApi: true`
-- **THEN** `streamCompletion` calls the Responses adapter and does not call `sendChatCompletionRequest`
-
-#### Scenario: Responses-capable application dispatches to the Responses adapter
-
-- **WHEN** a completion request targets an application whose `getDeploymentDetails` result has `features.responsesApi: true`
-- **THEN** `streamCompletion` calls the Responses adapter and does not call `sendChatCompletionRequest`
-
-#### Scenario: Legacy deployment without the flag keeps using Chat Completions
-
-- **WHEN** a completion request targets a deployment whose `getDeploymentDetails` result has no `responsesApi` field (older Core, or capability not declared)
-- **THEN** `streamCompletion` calls `sendChatCompletionRequest` exactly as before this change
-
-#### Scenario: Target resolves to a toolset
-
-- **WHEN** a completion request's `model` resolves via `getDeploymentDetails` to `type: 'toolset'`
-- **THEN** the request is rejected with HTTP 400 and no generation call is made
-
-#### Scenario: Capability lookup fails
-
-- **WHEN** `getDeploymentDetails` rejects with a 401/403/404/5xx-mapped exception
-- **THEN** `streamCompletion` surfaces the corresponding BFF error and does not call either generation adapter
-
----
-
-### Requirement: Chat Completions transport extracted behind the adapter seam
-
-The existing SDK `sendChatCompletionRequest` call, request construction from `buildConversationHistory`'s `messages`, and SSE chunk parsing SHALL be extracted verbatim into `apps/chat-api/src/conversations/generation/chat-completions.adapter.ts`, exposing the same normalized chunk stream contract as the Responses adapter. This extraction SHALL NOT change any request sent to DIAL Core nor any chunk delivered to `apply-chunk.server.ts`.
-
-#### Scenario: Chat Completions behavior is unchanged after extraction
-
-- **WHEN** an existing Chat Completions integration test exercises `streamCompletion` for a non-Responses deployment
-- **THEN** the outbound DIAL Core request and the resulting `StreamChunk` sequence are identical to the pre-change behavior
-
----
+## MODIFIED Requirements
 
 ### Requirement: Responses request built from existing conversation history
 
@@ -74,17 +18,6 @@ The existing SDK `sendChatCompletionRequest` call, request construction from `bu
 
 - **WHEN** the conversation history passed to `buildRequest` contains one or more messages with `role: ConversationMessageRole.Status` interleaved among user/assistant messages
 - **THEN** the built `input` array omits every `Status`-role message, and the remaining user and assistant messages keep their original relative order
-
----
-
-### Requirement: SDK createResponse call and cast isolation
-
-`responses.adapter.ts` SHALL call `this.dialClient.client.createResponse({ body: responsesRequest as never, headers: { ...bearer auth headers, Accept: 'text/event-stream', ...optional X-DIAL-CLIENT-CHANNEL-ID }, parseAs: 'stream', signal })`. The `as never` cast SHALL be confined to this single call site; the function's return value SHALL be converted immediately to the locally defined types in `generation.types.ts` before being passed to any caller.
-
-#### Scenario: Cast does not leak past the adapter
-
-- **WHEN** `ConversationService` or `apply-chunk.server.ts` consumes output from `responses.adapter.ts`
-- **THEN** the consumed value is typed via `generation.types.ts`, with no `as never`/`any` in the calling code
 
 ---
 
@@ -174,7 +107,7 @@ The upstream socket closing (end of stream) SHALL NOT by itself imply successful
 - **WHEN** the upstream socket closes before any SSE event is received
 - **THEN** the adapter returns an error outcome with a stable generic message that does not reference prompt or response content
 
----
+## ADDED Requirements
 
 ### Requirement: Non-2xx Responses request error message preserves DIAL Core's message
 
@@ -206,30 +139,3 @@ Any extracted message used in a log statement SHALL be sanitized per the reposit
 
 - **WHEN** `createResponse` resolves non-2xx with an empty response body and the SDK's parsed `error` value yields no usable message
 - **THEN** `GenerationRelayOutcome.errorMessage` is an empty string
-
----
-
-### Requirement: No automatic fallback after a Responses call has started
-
-Once `responses.adapter.ts` has issued the `createResponse` call, a subsequent 4xx/5xx response or an in-stream error SHALL terminate the attempt as an error through the existing stream-error path. The system SHALL NOT automatically retry the same generation through the Chat Completions adapter.
-
-#### Scenario: Upstream 5xx during a Responses call is not retried via Chat Completions
-
-- **WHEN** `createResponse` returns a 5xx response
-- **THEN** the generation ends with an error, and no Chat Completions request is made for that same generation attempt
-
----
-
-### Requirement: message.responseId carries the DIAL Responses id for diagnostics
-
-`ConversationMessageDto` (or the equivalent assistant message shape saved by `ConversationService`) SHALL accept an optional `responseId: string` field, populated from the DIAL `response.id` on a Responses-routed generation's `response.created`/`response.completed` events, and left unset for Chat Completions-routed generations.
-
-#### Scenario: responseId present only for Responses-routed messages
-
-- **WHEN** a generation is routed through the Responses adapter and completes successfully
-- **THEN** the saved assistant message has `responseId` set to the DIAL `response.id`
-
-#### Scenario: responseId absent for Chat Completions-routed messages
-
-- **WHEN** a generation is routed through the Chat Completions adapter
-- **THEN** the saved assistant message has no `responseId` field set

--- a/openspec/changes/archive/2026-08-06-harden-responses-stream-handling/tasks.md
+++ b/openspec/changes/archive/2026-08-06-harden-responses-stream-handling/tasks.md
@@ -1,0 +1,38 @@
+## 1. Event and terminal-state types
+
+- [x] 1.1 Add `ResponsesFailedEvent` (`type: 'response.failed'`, `response?: { id?: string; error?: { message?: string; code?: string } }`) to `apps/chat-api/src/conversations/generation/generation.types.ts` and include it in the `ResponsesSseEvent` union.
+- [x] 1.2 Add the `ResponsesTerminalState` string enum (`Success`, `Failed`, `Incomplete`, `StreamError`) and a `ResponsesTerminalSignal` interface (`{ state: ResponsesTerminalState; message?: string }`) to `generation.types.ts`, following the repository TypeScript enum convention.
+- [x] 1.3 Add focused unit tests in `apps/chat-api/src/conversations/generation/responses.adapter.spec.ts` asserting the new types compile and are exported/importable as expected (type-level smoke coverage only — behavioral tests land in section 2).
+
+## 2. Terminal-event and truncated-stream handling
+
+- [x] 2.1 In `responses.adapter.ts`, replace the `terminalError: string | null` / `isDone: boolean` pair with a `terminalSignal: ResponsesTerminalSignal | null` local (keep a narrow `isDone` boolean only to control read-loop exit), per design.md Decision 1.
+- [x] 2.2 Add a `case 'response.failed':` branch in `handleEvent` that sets `terminalSignal = { state: Failed, message: extractDialErrorMessage(event.response?.error) ?? 'Responses generation failed' }` and `isDone = true`, placed before the `default` branch so it is never counted as an unknown event.
+- [x] 2.3 Update the `response.completed` branch to set `terminalSignal = { state: Success }` on terminal-success and `terminalSignal = { state: StreamError, message }` on a non-`completed` status, instead of the current `terminalError`/`isDone` writes.
+- [x] 2.4 Update the `response.incomplete` and top-level `error` branches to set `terminalSignal` with `state: Incomplete` / `state: StreamError` respectively (message extraction unchanged).
+- [x] 2.5 Update the `[DONE]` marker handling so it sets `terminalSignal = { state: Success }` only when `terminalSignal` is still `null`, never overwriting an already-recorded error/incomplete/stream-error signal.
+- [x] 2.6 Replace the post-loop `if (terminalError) {...} res.write('[DONE]'); return completed;` logic with the explicit three-way check from design.md Decision 3: non-success `terminalSignal` → error outcome; `Success` `terminalSignal` → write `[DONE]` and return completed; no `terminalSignal` at all (EOF or `[DONE]` never having produced one) → error outcome with a fixed generic message, no downstream `[DONE]` write.
+- [x] 2.7 Add the fixed generic message constant (e.g. `GENERIC_TRUNCATED_MESSAGE`) as a module-level `const` — never derived from upstream content.
+- [x] 2.8 Extend `responses.adapter.spec.ts` with the Required Tests 1–9 from the change prompt (`response.failed` before/after text, structured message extraction without logging payload, not counted as unknown event, socket close after deltas without terminal signal, socket close before any event, Core-shaped stream completing on `response.completed` alone without `[DONE]`, legacy `[DONE]` stream still completing, `[DONE]` not overriding an earlier error, non-`completed` status remaining an error) and Required Test 16 (no failure path triggers a Chat Completions retry).
+- [x] 2.9 Run `npm exec nx test chat-api` and `npm exec nx lint chat-api`; fix any failures before continuing.
+
+## 3. Regression coverage: status filtering and error extraction
+
+- [x] 3.1 Add/confirm a `responses.adapter.spec.ts` test asserting `ConversationMessageRole.Status` messages are excluded from `buildRequest`'s `input` array while surrounding message order is preserved (Required Test 10) — extend existing coverage rather than duplicating if a close match already exists. (Already present in the worktree; confirmed passing, no duplicate added.)
+- [x] 3.2 Apply the minimal raw-body fallback change from design.md Decision 5 in `responses.adapter.ts`: read the raw body once, attempt structured JSON extraction, then fall back to the sanitized raw text itself when non-empty and no message was otherwise found.
+- [x] 3.3 Add `responses.adapter.spec.ts` tests for Required Tests 11–14: SDK-parsed non-2xx message returned in `errorMessage`; raw-body extraction used only when the SDK gave nothing; a non-empty plain-text body (including `Upstream is missing required id`) preserved via the fallback; an empty body keeping the existing generic (`''`) fallback.
+- [x] 3.4 Add a `responses.adapter.spec.ts` test for Required Test 15 confirming abort handling still returns `outcome: 'aborted'` and is not reclassified as a truncated-stream error by the changes in section 2. (Already present in the worktree; confirmed still passing after section 2's changes.)
+- [x] 3.5 Run `npm exec nx test chat-api` and `npm exec nx lint chat-api`; fix any failures before continuing.
+
+## 4. Documentation
+
+- [x] 4.1 Update `docs/responses-api-integration.md`'s "Supported events" table to add `response.failed` and describe its behavior (terminal error, partial text preserved, no `[DONE]`, no retry).
+- [x] 4.2 Update the "SSE Stream Transformation" and "Completion, Errors, and Stopping" sections to describe the explicit terminal-state model: `response.completed` (valid status) as the canonical success signal, `[DONE]` as compatibility-only for legacy/non-standard upstreams, and end-of-stream without any recognized terminal signal as an error that preserves partial text.
+- [x] 4.3 Update the "Current Support Scope" section if needed so it does not claim `[DONE]` is part of the canonical Core contract, and note the known Core-side gap (missing `response.failed` terminal recognition) as an external follow-up, without adding Core implementation work.
+- [x] 4.4 Proofread the updated doc against the final `responses.adapter.ts` behavior — no stale event/table descriptions left over from before this change.
+
+## 5. Final verification
+
+- [x] 5.1 Run `npm exec nx affected --target=test --base=origin/development-1.0` and `npm exec nx affected --target=lint --base=origin/development-1.0`; fix any failures. (`chat-api` itself: 1817/1817 tests, 0 lint errors. The affected set also surfaces three failures pre-existing on this branch before this change — confirmed via `git stash` — and unrelated to Responses/generation code: `@epam/ai-dial-conversation-input:test`'s `AddAttachmentButton.tools.spec.tsx` "Deep Research" menu assertion, `@epam/ai-dial-catalog:typecheck`'s missing `InlineSelect` export from `@epam/ai-dial-ui-kit`, and a flaky `@epam/ai-dial-publish-panel:typecheck` that Nx itself flagged as flaky and which passes standalone. None are touched by this change's diff.)
+- [x] 5.2 Run `npm exec nx affected --target=build --base=origin/development-1.0` to confirm the affected projects still build. (`chat-api` builds cleanly standalone; the only affected-build failure is the same pre-existing `@epam/ai-dial-catalog:typecheck` issue above, blocking its downstream `@epam/chat:build`/`typecheck` — unrelated to this change.)
+- [x] 5.3 Confirm no unrelated files changed (`git status`) and that the diff is limited to `responses.adapter.ts`, `generation.types.ts`, `responses.adapter.spec.ts`, `docs/responses-api-integration.md`, and the openspec change artifacts. (Confirmed via `git status --short`.)

--- a/openspec/changes/archive/2026-08-06-support-responses-generation-parameters/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-06-support-responses-generation-parameters/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-06

--- a/openspec/changes/archive/2026-08-06-support-responses-generation-parameters/design.md
+++ b/openspec/changes/archive/2026-08-06-support-responses-generation-parameters/design.md
@@ -1,0 +1,87 @@
+## Context
+
+`harden-responses-stream-handling` (archived at `openspec/changes/archive/2026-08-06-harden-responses-stream-handling`) landed an explicit terminal-state model in `responses.adapter.ts` (`ResponsesTerminalState`, `response.failed`/EOF/`[DONE]` precedence) and is the current source of truth in `openspec/specs/responses-api-generation/spec.md`. This change is a strict follow-up: it only touches request *construction* (`buildRequest` and the fields feeding it), never the SSE read loop, terminal-signal precedence, or error-extraction logic those files already implement.
+
+Inspection of the post-hardening worktree (commit `6d19cbd20`, branch `feat/responses-stream-hardening`) confirms:
+
+- `ResponsesApiRequestBody` (`generation.types.ts:18-23`) carries only `model`, `input`, `stream: true`, `store: false`.
+- `ChatCompletionsAdapter.buildRequest` (`chat-completions.adapter.ts:84-86`) already forwards `startConversation.temperature` unconditionally (no capability gate) — Responses must gate more conservatively because some Responses-capable models reject the field outright, per the prompt's explicit requirement.
+- `resolveGenerationApiForDeployment` (`conversation.service.ts:1198-1221`) fetches `DeploymentsService.getDeploymentDetails(sub, model, token)`, reads `features` off `modelDetails`/`applicationDetails`, calls `resolveGenerationApi(features)`, and **discards `features`** — it never reaches `ConversationService.streamCompletion` (`conversation.service.ts:1224` onward) or the `buildRequest` call at `conversation.service.ts:1372-1376`.
+- `ModelCapabilitiesDto`/`ApplicationCapabilitiesDto` (`deployment-details.dto.ts:113-114`) expose `temperature?: boolean` ("Supports the temperature parameter"), already populated by `DeploymentsService` (`deployments.service.ts:194`, `:284`).
+- No Responses-specific max-output-tokens capability flag exists anywhere in this codebase (`deployment-details.dto.ts`, `deployments.service.ts`, `openapi-response.dto.ts`, `libs/chat-api-client/openapi.json`, generated client models) — only the Chat-Completions-only `maxTokensSupported`/`maxCompletionTokensSupported` pair (`deployment-details.dto.ts:136-142`). Per the prompt's rule, these must not be reused for `max_output_tokens` gating.
+- `Conversation` (`libs/chat-shared/src/models/chat.ts:272`, `temperature` at line 284) and `ConversationResponseDto` (`openapi-response.dto.ts:616-662`, `temperature!` at line 633) are structurally 1:1 with no dedicated mapping layer — `ConversationService` reads/writes `ConversationResponseDto` directly as the persisted JSON shape (e.g. `conversation.service.ts:191`, `:546-553`, `:846`).
+- `SaveConversationBodyDto` (`save-conversation.dto.ts:8-15`) validates its `conversation` field with only `@IsObject()` — no `@ValidateNested()`/`@Type()` — so no field of `ConversationResponseDto`, including the existing `temperature`, is individually validated by class-validator today. This is a pre-existing gap this change does not widen or attempt to fix wholesale; it does mean `maxOutputTokens` needs its own explicit runtime check rather than relying on nested DTO validation that doesn't currently run.
+- No generic max-tokens UI control exists: `ChatSettingsConfig`/`ChatSettingsValues` (`libs/conversation-input/src/models/Input.ts:313-363`) expose only `responseFormat`, `systemPrompt`, `temperature`; `DeploymentFeatures` (`libs/chat-shared/src/models/deployment-features.ts:9-17`) gates only those three. Building a new control is out of scope for this change (see proposal Non-Goals).
+
+## Goals / Non-Goals
+
+**Goals:**
+- Forward `temperature` on Responses requests, gated on the deployment's actual, already-fetched `features.temperature` capability.
+- Introduce a persisted, optional `maxOutputTokens` on `Conversation`/`ConversationResponseDto`, validated and mapped to `max_output_tokens` on the Responses request, independent of any Chat-Completions-only capability flag.
+- Reuse the existing deployment-details fetch — zero additional `getDeploymentDetails` calls per generation.
+- Keep every hardened terminal-state/error-extraction/status-filtering behavior byte-for-byte unchanged.
+
+**Non-Goals:**
+- No UI for editing `maxOutputTokens` (documented follow-up).
+- No change to Chat Completions request construction or capability gating.
+- No new Responses-specific capability flag invented on the Chat side — Chat only reads flags Core already exposes.
+- No nested nx `@ValidateNested()` nested validation for the whole `ConversationResponseDto` — out of scope; would risk rejecting previously-accepted payloads for unrelated fields.
+
+## Decisions
+
+### 1. Retain `features.temperature` alongside the resolved `GenerationApi`
+
+`resolveGenerationApiForDeployment` returns `{ generationApi: GenerationApi; temperatureSupported: boolean }` instead of a bare `GenerationApi`. It still makes exactly one `getDeploymentDetails` call; the only change is that the already-computed `features` object is read once more (`features?.temperature === true`) before being allowed to go out of scope, and the boolean is threaded back to `streamCompletion`. `streamCompletion` passes `temperatureSupported` into `responsesAdapter.buildRequest(...)` alongside the existing `model`/`startConversation`/`messagesForCompletion` params.
+
+Alternative considered — pass the full `features` object through: rejected as broader than needed; `buildRequest` only ever needs the one boolean, and passing the narrowest fact keeps the adapter's public signature self-documenting and avoids leaking the deployment-details shape into the generation adapter layer.
+
+Alternative considered — re-fetch inside `ResponsesAdapter`: rejected per the prompt's explicit "avoid a second deployment-details request" requirement and because `DeploymentsService.getDeploymentDetails` is already cached/user-token-scoped at the `ConversationService` call site — duplicating it inside the adapter would add latency and a second cache-key computation for no new information.
+
+### 2. Temperature is capability-gated; `maxOutputTokens` is not
+
+Temperature is gated because some Responses-capable models reject the field outright (stated in the prompt and consistent with why the flag exists at all in `ModelCapabilitiesDto`). `maxOutputTokens` has no equivalent Core-exposed capability signal today, so gating it behind an unrelated flag (`maxTokensSupported`/`maxCompletionTokensSupported`) would be gating on data that describes a different parameter (Chat Completions'), not this one — the prompt explicitly forbids that substitution. Instead, `max_output_tokens` inclusion is controlled purely by presence/validity of the Chat-side value, mirroring rule 3 in the proposal's Capability and Precedence Rules. If Core later adds a Responses-specific flag, gating can be added as a follow-up without a wire-format change.
+
+### 3. `buildRequest` signature and mapping
+
+```ts
+buildRequest(params: {
+  model: string;
+  startConversation: ConversationResponseDto;
+  messagesForCompletion: ConversationMessageDto[];
+  temperatureSupported: boolean;
+}): ResponsesApiRequestBody
+```
+
+- `temperature`: included only when `temperatureSupported === true` and `startConversation.temperature != null` (using `!= null`, not truthiness, so `0` is preserved — mirrors the existing `chat-completions.adapter.ts:84` pattern).
+- `max_output_tokens`: included only when `startConversation.maxOutputTokens` passes the validator below; otherwise omitted entirely (never sent as `null`/`0`).
+- `ResponsesApiRequestBody` gains `temperature?: number` and `max_output_tokens?: number`, both optional so every existing call site/test that omits them keeps compiling and passing.
+
+### 4. Validation boundary for `maxOutputTokens`: adapter seam, not nested DTO validation
+
+Because `SaveConversationBodyDto` only does `@IsObject()` on the whole `conversation` payload (no nested class-validator today, for any field), adding `@IsOptional() @IsInt() @Min(1)` to `ConversationResponseDto.maxOutputTokens` would document intent and generate a correct OpenAPI schema/type (following the DTO-decorator convention, same as documentation-only decorators already used elsewhere on this class such as `temperature!: number`), but it would not actually run at persistence time given the current save-path validation gap — that gap is pre-existing and out of scope to close here.
+
+The actual enforcement point is therefore the same seam that already defends the outbound wire request against bad Chat-side data: a small pure guard, `isValidMaxOutputTokens(value: unknown): value is number`, checking `Number.isInteger(value) && Number.isSafeInteger(value) && value > 0`, called from `ResponsesAdapter.buildRequest` immediately before conditionally spreading `max_output_tokens` into the request body. This is a TypeScript type-narrowing predicate backed by a real runtime numeric check — not a bare type assertion — satisfying the prompt's explicit requirement. Living in `responses.adapter.ts` (or a small exported helper in `generation.types.ts` next to the interfaces it validates) keeps the check colocated with the one place that can ever emit `max_output_tokens`, so a future second caller can't accidentally skip it.
+
+Alternative considered — upgrade `SaveConversationBodyDto` to `@ValidateNested() @Type(() => ConversationResponseDto)`: rejected as out-of-scope scope creep — it would newly enforce every existing decorator-annotated field on `ConversationResponseDto` (most of which currently have no decorators at all), risking rejecting previously-accepted conversation payloads unrelated to this change, which the prompt's compatibility constraints forbid.
+
+### 5. Persistence-surface enumeration
+
+`maxOutputTokens` needs to survive exactly the surfaces that already carry `temperature` verbatim, because both are plain optional fields on the same `Conversation`/`ConversationResponseDto` object with no field-specific handling elsewhere:
+
+- **Load/save** (`conversation.service.ts:191`, `:846`) — spreads the full DTO; automatically included once the field exists.
+- **Duplicate** (`conversation.service.ts:546-553`) — spreads `...sourceData`; automatically included.
+- **Import/export** (`apps/chat/src/utils/export-conversation.ts`, `apps/chat/src/utils/import-conversation.ts`) — both are field-agnostic (pass the full object through/rebase IDs and attachment URLs only); automatically included.
+- **Overlay** (`OverlayContext.tsx`, `chat-overlay` protocol/manager) — has dedicated per-field bridge methods only for `temperature` (`setTemperature`) and other explicitly modeled settings; there is no generic "set arbitrary conversation field" overlay path, so `maxOutputTokens` is **not** wired into the overlay bridge in this change (no `setMaxOutputTokens` request type is added) — consistent with the proposal's Non-Goals (no new UI/bridge surface) and the prompt's "do not add new... user-visible strings" constraint. It still round-trips correctly through overlay conversation reads that serialize the full object, if any exist; only the interactive *setter* is excluded.
+- **Publish** (`conversation-publish.service.ts`) — no field-specific handling at all (resource-relocation only); unaffected either way.
+
+No test is added for a surface that only does generic object spreading and is already covered by an equivalent `temperature` test, per the prompt's "do not duplicate adapter coverage" instruction — one representative round-trip test per genuinely distinct code path (save, duplicate, import/export) is sufficient.
+
+### 6. Merge-conflict avoidance with the hardening change
+
+Since hardening is already merged/archived on this branch's history, there is no live merge risk; this change is authored directly on top of `6d19cbd20`. To keep future rebases low-risk, all new code in `responses.adapter.ts` is additive (new optional params, one new guard function, two new conditional spread clauses in `buildRequest`) and does not touch `relay`, `handleEvent`, or any terminal-state logic. The spec delta targets only the two new/changed requirements (request-construction fields) and leaves every hardening-authored requirement in `responses-api-generation/spec.md` untouched (no `## MODIFIED Requirements` block references any terminal-state requirement).
+
+## Risks / Trade-offs
+
+- **[Risk]** A future Core release adds a genuine Responses-specific max-output-tokens capability flag, making the current "always attempt if present" behavior technically permissive for models that would reject it. → **Mitigation**: documented explicitly in the proposal's Alternatives Considered and this design's Decision 2 as a deliberate, revisitable choice; DIAL Core's own `responsesDefaults`/validation is the current backstop, matching precedence rule 4 in the proposal.
+- **[Risk]** `ConversationResponseDto.maxOutputTokens` decorators look like they validate on save but don't (per Decision 4's documented gap). → **Mitigation**: the design explicitly calls this out rather than silently relying on it; the real guard lives in the adapter and is unit-tested directly.
+- **[Trade-off]** Not adding a UI control means `maxOutputTokens` is currently only settable by direct API/import payload manipulation, not through the product UI. → Accepted per proposal Non-Goals; tracked as a follow-up.

--- a/openspec/changes/archive/2026-08-06-support-responses-generation-parameters/proposal.md
+++ b/openspec/changes/archive/2026-08-06-support-responses-generation-parameters/proposal.md
@@ -1,0 +1,67 @@
+## Why
+
+`ResponsesAdapter.buildRequest` (`apps/chat-api/src/conversations/generation/responses.adapter.ts:58-85`) builds a Responses request containing only `model`, `input`, `stream: true`, and `store: false`. Switching a deployment's generation API from Chat Completions to Responses silently drops the conversation's `temperature` setting — even though `ChatCompletionsAdapter.buildRequest` (`chat-completions.adapter.ts:84-86`) already forwards it — and there is no way for a client to request a Responses output-token cap at all, since no persisted field exists for it. This change closes both gaps now, before the Responses branch grows further, while keeping the just-hardened terminal-state/stream behavior (`openspec/specs/responses-api-generation/spec.md`) untouched.
+
+## Problem
+
+- Responses generation does not forward the conversation's `temperature`, so identical conversations can sample differently depending on which generation API the deployment resolves to.
+- Chat has no typed, persisted field for a Responses-specific output-token limit, so a client cannot express `max_output_tokens` at all.
+- Deployment metadata (`limits.maxCompletionTokens`, legacy `defaults.max_tokens`, DIAL Core `responsesDefaults`) must not be conflated with a user-selected value for either parameter — each has a different owner and meaning.
+
+## Solution
+
+- Extend `ResponsesApiRequestBody` with optional `temperature` and `max_output_tokens` wire fields.
+- Forward `startConversation.temperature` into the Responses request only when the resolved deployment's `features.temperature` capability is explicitly `true` — reusing the deployment `features` already fetched by `resolveGenerationApiForDeployment` (`conversation.service.ts:1198-1221`) instead of a second `DeploymentsService.getDeploymentDetails` call.
+- Add an optional `maxOutputTokens?: number` field to the persisted `Conversation` model (`libs/chat-shared/src/models/chat.ts:284`) and `ConversationResponseDto` (`apps/chat-api/src/openapi/openapi-response.dto.ts:616-662`), and map a present, validated value straight through to `max_output_tokens` — no capability gate, since no Responses-specific capability flag exists in this codebase today (confirmed by inspection; see design.md).
+- Validate `maxOutputTokens` at the adapter seam where it crosses from persisted Chat data into the outbound DIAL Core request: only a positive, finite, safe integer is forwarded; anything else is treated as absent.
+- Leave the hardened terminal-state, `response.failed`, EOF, error-extraction, and status-message-filtering behavior from `harden-responses-stream-handling` untouched.
+
+## Non-Goals
+
+- No new UI control for `maxOutputTokens` — no reusable generic max-tokens control exists in `libs/conversation-input` today (only `responseFormat`/`systemPrompt`/`temperature` are exposed via `ChatSettingsConfig`), so this iteration is backend/model-focused; UI editing is a documented follow-up.
+- No changes to Chat Completions request construction, `POST /api/v1/conversations/completions` contract, or browser SSE chunk shape.
+- No fallback from Responses to Chat Completions, no retries, no new endpoints/env vars/feature flags/dependencies/caches, no `ai-dial-core` changes.
+- No tools, reasoning, penalties, seed, response-format, multimodal, attachment, `store: true`, or continuation-id work.
+
+## Acceptance Criteria
+
+- A Responses-capable deployment that explicitly supports temperature forwards the conversation's exact `temperature`, including `0`.
+- A deployment with unsupported or unknown temperature capability never sends `temperature` on a Responses request.
+- Capability resolution for temperature reuses the deployment details already fetched to pick the generation API — no duplicate `getDeploymentDetails` call.
+- A present, valid `Conversation.maxOutputTokens` (any positive safe integer, including `1`) is sent as `max_output_tokens` unchanged; an absent value omits the field entirely (never `null`/`undefined`/`0`/a deployment-derived value).
+- Invalid `maxOutputTokens` values (zero, negative, fractional, non-finite, unsafe integer) can never reach DIAL Core as `max_output_tokens`.
+- `maxOutputTokens` round-trips losslessly through every conversation persistence surface it actually touches (load/save; duplicate; import/export where the full object is carried through verbatim).
+- Existing conversations without `maxOutputTokens` serialize, save, duplicate, import, and export exactly as before.
+- Chat Completions behavior, the completions HTTP contract, and the hardened Responses stream/terminal-state behavior are unchanged.
+
+## Backward Compatibility and Rollback
+
+- Both new fields are optional on `ResponsesApiRequestBody`, `Conversation`, and `ConversationResponseDto` — existing conversations that omit them are unaffected, and no migration is required.
+- No request/response contract change for `POST /api/v1/conversations/completions` or the browser SSE stream; the only new optional DTO surface is the persisted conversation shape.
+- Rollback is a plain revert of the adapter/type/DTO/test/doc changes; there is no persisted-data migration to unwind, since omitting the new optional field was always valid.
+
+## Alternatives Considered
+
+- **Derive `max_output_tokens` from `limits.maxCompletionTokens` or legacy `defaults.max_tokens`** — rejected: those describe a ceiling and a Chat-Completions-only default respectively, not a user-selected Responses value; the prompt and this proposal explicitly forbid conflating them.
+- **Gate `maxOutputTokens` behind `maxTokensSupported`/`maxCompletionTokensSupported`** — rejected: those flags describe Chat Completions parameters per current Core documentation, and no Responses-specific capability flag exists to gate on instead; gating on the wrong flag would incorrectly suppress or permit the field.
+- **Re-fetch deployment details inside `ResponsesAdapter` for temperature capability** — rejected: `resolveGenerationApiForDeployment` already fetches and discards `features`; a second lookup is redundant latency/cost for the same request.
+- **Add a new UI max-tokens control in this change** — rejected: no reusable generic control exists yet, and building one would expand this change beyond the backend/model scope the prompt requires; deferred as a follow-up.
+
+## Capabilities
+
+### New Capabilities
+_None._
+
+### Modified Capabilities
+- `responses-api-generation`: adds capability-gated `temperature` forwarding and optional `max_output_tokens` mapping to the Responses request, plus the validation/omission rules and persistence-round-trip requirements for `maxOutputTokens`.
+
+## Impact
+
+- `apps/chat-api/src/conversations/generation/generation.types.ts` — optional `temperature`/`max_output_tokens` on `ResponsesApiRequestBody`.
+- `apps/chat-api/src/conversations/generation/responses.adapter.ts` — `buildRequest` accepts deployment temperature-support context and a validated `maxOutputTokens`, maps both to the wire request.
+- `apps/chat-api/src/conversations/conversation.service.ts` — `resolveGenerationApiForDeployment` retains and surfaces `features` (or the specific temperature-support flag) instead of discarding it.
+- `apps/chat-api/src/openapi/openapi-response.dto.ts` (`ConversationResponseDto`) — optional `maxOutputTokens` field.
+- `libs/chat-shared/src/models/chat.ts` (`Conversation`) — optional `maxOutputTokens` field.
+- `libs/chat-api-client` — regenerated only if the DTO change requires it; generated files are never hand-edited.
+- `docs/responses-api-integration.md` — move `temperature` and `max_output_tokens` into the supported scope.
+- `openspec/specs/responses-api-generation/spec.md` — delta for the modified capability.

--- a/openspec/changes/archive/2026-08-06-support-responses-generation-parameters/specs/responses-api-generation/spec.md
+++ b/openspec/changes/archive/2026-08-06-support-responses-generation-parameters/specs/responses-api-generation/spec.md
@@ -1,0 +1,135 @@
+## MODIFIED Requirements
+
+### Requirement: ConversationService resolves generation API before opening the upstream stream
+
+`ConversationService.streamCompletion` SHALL call `DeploymentsService.getDeploymentDetails(sub, model, token)` (the existing cached, user-token-scoped lookup already used by the deployment details endpoint) before issuing any upstream generation call, read `features` off the returned `modelDetails`/`applicationDetails` per the resolved `type`, and pass the result through `resolveGenerationApi` to select the adapter. `ConversationModule` SHALL import `DeploymentsModule` to obtain `DeploymentsService`. When `getDeploymentDetails` resolves the target id to `type: 'toolset'`, `streamCompletion` SHALL reject the request with HTTP 400 before any generation call, since a toolset is not a generation deployment.
+
+The same `features` lookup used to resolve the generation API SHALL also be used to determine whether the resolved deployment explicitly supports the `temperature` parameter (`features.temperature === true`). `ConversationService` SHALL make no additional `getDeploymentDetails` (or equivalent deployment-details) call for this purpose — the boolean SHALL be derived from the `features` object already read while resolving `GenerationApi`, and passed through to whichever adapter's `buildRequest` is invoked for that generation.
+
+#### Scenario: Responses-capable model dispatches to the Responses adapter
+
+- **WHEN** a completion request targets a model whose `getDeploymentDetails` result has `features.responsesApi: true`
+- **THEN** `streamCompletion` calls the Responses adapter and does not call `sendChatCompletionRequest`
+
+#### Scenario: Responses-capable application dispatches to the Responses adapter
+
+- **WHEN** a completion request targets an application whose `getDeploymentDetails` result has `features.responsesApi: true`
+- **THEN** `streamCompletion` calls the Responses adapter and does not call `sendChatCompletionRequest`
+
+#### Scenario: Legacy deployment without the flag keeps using Chat Completions
+
+- **WHEN** a completion request targets a deployment whose `getDeploymentDetails` result has no `responsesApi` field (older Core, or capability not declared)
+- **THEN** `streamCompletion` calls `sendChatCompletionRequest` exactly as before this change
+
+#### Scenario: Target resolves to a toolset
+
+- **WHEN** a completion request's `model` resolves via `getDeploymentDetails` to `type: 'toolset'`
+- **THEN** the request is rejected with HTTP 400 and no generation call is made
+
+#### Scenario: Capability lookup fails
+
+- **WHEN** `getDeploymentDetails` rejects with a 401/403/404/5xx-mapped exception
+- **THEN** `streamCompletion` surfaces the corresponding BFF error and does not call either generation adapter
+
+#### Scenario: Temperature capability is derived from the same lookup used for generation-API resolution
+
+- **WHEN** a completion request targets a Responses-capable deployment whose `getDeploymentDetails` result has `features.temperature: true`
+- **THEN** `streamCompletion` passes `temperatureSupported: true` to `ResponsesAdapter.buildRequest` without issuing a second `getDeploymentDetails` call for that generation
+
+#### Scenario: Missing or false temperature capability is derived without a duplicate lookup
+
+- **WHEN** a completion request targets a Responses-capable deployment whose `getDeploymentDetails` result has `features.temperature: false` or no `temperature` field
+- **THEN** `streamCompletion` passes `temperatureSupported: false` to `ResponsesAdapter.buildRequest` without issuing a second `getDeploymentDetails` call for that generation
+
+## ADDED Requirements
+
+### Requirement: Responses request forwards conversation temperature only when explicitly supported
+
+`ResponsesAdapter.buildRequest` SHALL accept a `temperatureSupported: boolean` parameter, computed by `ConversationService` from the deployment `features` already fetched to resolve the generation API. The built `ResponsesApiRequestBody` SHALL include an optional `temperature: number` field set to `startConversation.temperature` only when `temperatureSupported === true` AND `startConversation.temperature` is not `null`/`undefined`. Presence SHALL be checked with a nullish check, not a truthiness check, so that `temperature: 0` is preserved. The field SHALL be omitted entirely — never sent as `null`, `undefined`, or a substituted default — when `temperatureSupported` is `false`, when it was not determined (absent capability), or when the conversation has no usable value. `ResponsesAdapter` SHALL NOT read a default temperature from any frontend constant, environment variable, or DIAL Core configuration, and SHALL NOT alter `ChatCompletionsAdapter.buildRequest`'s existing unconditional temperature forwarding.
+
+#### Scenario: Supported deployment forwards a zero temperature exactly
+
+- **WHEN** `temperatureSupported` is `true` and `startConversation.temperature` is `0`
+- **THEN** the built Responses request body has `temperature: 0`
+
+#### Scenario: Supported deployment forwards a non-zero temperature exactly
+
+- **WHEN** `temperatureSupported` is `true` and `startConversation.temperature` is `0.7`
+- **THEN** the built Responses request body has `temperature: 0.7`
+
+#### Scenario: Temperature is omitted when the deployment does not support it
+
+- **WHEN** `temperatureSupported` is `false` and `startConversation.temperature` is any usable value
+- **THEN** the built Responses request body has no `temperature` field
+
+#### Scenario: Temperature is omitted when support is unknown
+
+- **WHEN** `temperatureSupported` is `false` because the deployment `features` object had no `temperature` field
+- **THEN** the built Responses request body has no `temperature` field
+
+#### Scenario: Chat Completions temperature forwarding is unaffected
+
+- **WHEN** a generation is routed through `ChatCompletionsAdapter` rather than `ResponsesAdapter`
+- **THEN** `ChatCompletionsAdapter.buildRequest`'s existing temperature-forwarding behavior (unconditional on presence, capability-independent) is unchanged
+
+### Requirement: Persisted conversation carries an optional Responses output-token limit
+
+The shared `Conversation` model (`@epam/ai-dial-chat-shared`) and `ConversationResponseDto` SHALL each gain an optional `maxOutputTokens?: number` field. The field SHALL be a Chat-side, user/import-settable value distinct from and never derived from `limits.maxCompletionTokens`, `defaultMaxTokens`, `defaults.max_tokens`, token usage, context-window size, or any hard-coded constant. Existing conversations that omit the field SHALL continue to load, save, duplicate, import, and export exactly as before this change, with the field simply absent.
+
+#### Scenario: New field is optional and independently settable
+
+- **WHEN** a conversation payload sets `maxOutputTokens: 4096` without any relation to the deployment's `limits.maxCompletionTokens`
+- **THEN** the conversation persists with `maxOutputTokens: 4096` regardless of the deployment's limit value
+
+#### Scenario: Legacy conversations remain unaffected
+
+- **WHEN** an existing conversation payload has no `maxOutputTokens` field
+- **THEN** the conversation continues to load, save, duplicate, import, and export with identical behavior to before this change, and no `maxOutputTokens` value is invented
+
+### Requirement: Responses request maps a valid maxOutputTokens to max_output_tokens
+
+`ResponsesAdapter.buildRequest` SHALL include an optional `max_output_tokens: number` field on the built `ResponsesApiRequestBody`, set to `startConversation.maxOutputTokens` verbatim (no renaming, scaling, or transformation) only when that value passes a runtime validation check: it SHALL be a positive, finite integer within `Number.isSafeInteger` range (equivalently: `Number.isInteger(value) && Number.isSafeInteger(value) && value > 0`). The check SHALL be a real runtime predicate, not solely a TypeScript type assertion. The value `1` SHALL be preserved (checked via this validation, not truthiness). Any other value — absent, `null`, `0`, negative, fractional, `NaN`, `Infinity`, or outside the safe-integer range — SHALL cause `max_output_tokens` to be omitted entirely from the request; it SHALL NOT be sent as `null`, `undefined`, `0`, or a value derived from deployment limits or Chat Completions defaults. `max_output_tokens` mapping SHALL NOT be gated by `maxTokensSupported`, `maxCompletionTokensSupported`, or any other Chat-Completions-scoped capability flag. `ResponsesAdapter` SHALL NOT emit `max_tokens` or `max_completion_tokens` on a Responses request under any circumstance.
+
+#### Scenario: Minimum valid value is preserved
+
+- **WHEN** `startConversation.maxOutputTokens` is `1`
+- **THEN** the built Responses request body has `max_output_tokens: 1`
+
+#### Scenario: A representative larger value is preserved exactly
+
+- **WHEN** `startConversation.maxOutputTokens` is `4096`
+- **THEN** the built Responses request body has `max_output_tokens: 4096`
+
+#### Scenario: Absent value omits the wire field
+
+- **WHEN** `startConversation.maxOutputTokens` is `undefined`
+- **THEN** the built Responses request body has no `max_output_tokens` field, and no substituted value from deployment metadata is sent in its place
+
+#### Scenario: Invalid values are rejected rather than forwarded
+
+- **WHEN** `startConversation.maxOutputTokens` is `0`, a negative number, a fractional number, `NaN`, `Infinity`, or a number exceeding `Number.MAX_SAFE_INTEGER`
+- **THEN** the built Responses request body has no `max_output_tokens` field
+
+#### Scenario: max_output_tokens is not gated by Chat Completions capability flags
+
+- **WHEN** the resolved deployment has `maxTokensSupported: false` and `maxCompletionTokensSupported: false`, and `startConversation.maxOutputTokens` is a valid positive safe integer
+- **THEN** the built Responses request body still includes `max_output_tokens` set to that value
+
+#### Scenario: Legacy Chat Completions field names never appear on a Responses request
+
+- **WHEN** any Responses request is built by `ResponsesAdapter.buildRequest`, with or without `maxOutputTokens` set
+- **THEN** the built request body never contains a `max_tokens` or `max_completion_tokens` key
+
+### Requirement: Temperature and max_output_tokens coexist without altering base request or stream semantics
+
+A Responses request MAY include both `temperature` and `max_output_tokens` simultaneously when both are independently eligible per their own requirements above. Adding either or both fields SHALL NOT change `stream: true`, `store: false`, the `input` array, message ordering, system-prompt mapping, status-message filtering, or the omission of `previous_response_id`/`conversation`. Adding either field SHALL NOT alter SSE parsing, terminal-state precedence, partial-message persistence, abort handling, error propagation, or unknown-event handling as specified by the hardened Responses stream behavior; those requirements are unchanged by this capability delta.
+
+#### Scenario: Both parameters present together
+
+- **WHEN** a Responses-capable deployment supports temperature, `startConversation.temperature` is `0.4`, and `startConversation.maxOutputTokens` is `2048`
+- **THEN** the built Responses request body includes `temperature: 0.4` and `max_output_tokens: 2048` alongside the unchanged base fields (`model`, `input`, `stream: true`, `store: false`), with no `previous_response_id` or `conversation` key
+
+#### Scenario: Hardened stream behavior is unaffected by request-construction changes
+
+- **WHEN** a Responses request built with either or both new parameters is relayed through `ResponsesAdapter.relay`
+- **THEN** SSE event handling, terminal-state precedence, partial-message persistence on error, and abort/error outcome reporting behave identically to a request built without the new parameters

--- a/openspec/changes/archive/2026-08-06-support-responses-generation-parameters/tasks.md
+++ b/openspec/changes/archive/2026-08-06-support-responses-generation-parameters/tasks.md
@@ -1,0 +1,42 @@
+## 1. Types and validation rules
+
+- [x] 1.1 Add optional `temperature?: number` and `max_output_tokens?: number` to `ResponsesApiRequestBody` in `apps/chat-api/src/conversations/generation/generation.types.ts`.
+- [x] 1.2 Add a pure `isValidMaxOutputTokens(value: unknown): value is number` guard (positive, integer, `Number.isSafeInteger`) colocated with `ResponsesAdapter` (e.g. exported from `generation.types.ts` or defined in `responses.adapter.ts`), with focused unit tests covering `1`, a representative larger integer, `0`, negative, fractional, `NaN`, `Infinity`, and `Number.MAX_SAFE_INTEGER + 1`.
+- [x] 1.3 Run `npm exec nx test chat-api` and `npm exec nx lint chat-api` for this slice.
+
+## 2. Capability-gated temperature mapping
+
+- [x] 2.1 Change `resolveGenerationApiForDeployment` in `apps/chat-api/src/conversations/conversation.service.ts` to also derive `temperatureSupported: boolean` from the same `features` object already read for `resolveGenerationApi`, without any additional `getDeploymentDetails` call; return both values to `streamCompletion`.
+- [x] 2.2 Update `ResponsesAdapter.buildRequest` to accept `temperatureSupported: boolean` and include `temperature` only when `temperatureSupported === true` and `startConversation.temperature != null` (nullish check, not truthy check).
+- [x] 2.3 Update the `streamCompletion` call site (`conversation.service.ts:1372-1376`) to pass `temperatureSupported` into `buildRequest`.
+- [x] 2.4 Add/extend `responses.adapter.spec.ts` unit tests: supported + `temperature: 0`; supported + non-zero temperature; unsupported (`false`); support absent/unknown — each asserting the exact request body.
+- [x] 2.5 Add/extend a focused `conversation.service.spec.ts` test asserting `getDeploymentDetails` (or the underlying `DeploymentsService` mock) is called exactly once per `streamCompletion` invocation when routed to the Responses adapter, and that the resolved `temperatureSupported` value reaches `buildRequest`.
+- [x] 2.6 Run `npm exec nx test chat-api` and `npm exec nx lint chat-api`.
+
+## 3. maxOutputTokens persistence and Responses mapping
+
+- [x] 3.1 Add optional `maxOutputTokens?: number` to `Conversation` in `libs/chat-shared/src/models/chat.ts`.
+- [x] 3.2 Add optional `maxOutputTokens?: number` (with `@ApiPropertyOptional` and documentation-level class-validator decorators, per DTO convention) to `ConversationResponseDto` in `apps/chat-api/src/openapi/openapi-response.dto.ts`; note in a code comment that persistence-time enforcement lives in the adapter guard (Task 1.2), not in nested DTO validation, per `design.md` Decision 4.
+- [x] 3.3 Update `ResponsesAdapter.buildRequest` to include `max_output_tokens: startConversation.maxOutputTokens` only when `isValidMaxOutputTokens` passes; never gate this on `maxTokensSupported`/`maxCompletionTokensSupported`.
+- [x] 3.4 Add/extend `responses.adapter.spec.ts` unit tests: `maxOutputTokens: 1`; a representative larger positive integer; absent value omits the field; each invalid value (`0`, negative, fractional, `NaN`, `Infinity`, unsafe integer) omits the field; a request with both valid `temperature` and `maxOutputTokens` carries both fields plus the unchanged base body; the built request never contains `max_tokens`, `max_completion_tokens`, `previous_response_id`, or `conversation`.
+- [x] 3.5 Add the minimum necessary round-trip tests for the surfaces enumerated in `design.md` Decision 5 that are not already covered by an equivalent `temperature` test — a `ConversationService` save/duplicate round-trip test for `maxOutputTokens`, plus one existing-conversation-without-the-field regression test. Do not duplicate adapter-level coverage at the service level.
+- [x] 3.6 Run `npm exec nx test chat-api`, `npm exec nx lint chat-api`.
+
+## 4. Generated API artifacts (only if required)
+
+- [x] 4.1 Determine whether the `ConversationResponseDto` change alters the generated OpenAPI schema in a way that requires regeneration (it does, since it's a new documented property on an existing schema referenced by the conversation endpoints).
+- [x] 4.2 Run `npm run openapi` and `npm run openapi:check`; regenerate `libs/chat-api-client` accordingly.
+- [x] 4.3 Verify no generated file under `libs/chat-api-client/src/generated/**` was hand-edited (diff should be generator output only); run `npm exec nx build chat-api-client -- --skip-nx-cache` and `npm exec nx lint chat-api-client`.
+
+## 5. Documentation
+
+- [x] 5.1 Update `docs/responses-api-integration.md`: move `temperature` and `max_output_tokens` from the "Not yet supported" list (around lines 300-313) into the supported scope, describing the capability-gating rule for `temperature` and the validation/omission rule for `max_output_tokens`; keep every other currently-unsupported parameter listed as unsupported.
+- [x] 5.2 Note in the doc (or in this change's proposal, already done) that no UI control exists yet for editing `maxOutputTokens` and that this is a follow-up.
+
+## 6. Full verification
+
+- [x] 6.1 Run `npm exec nx affected --target=test --base=origin/development-1.0`. Result: 18 affected projects, all green except 3 pre-existing/unrelated failures verified against the pre-change tree via `git stash` — `@epam/ai-dial-catalog` (`InlineSelect` export/`ItemDetailsTexts` prop mismatches vs. installed `@epam/ai-dial-ui-kit`), a flaky `ScheduledTaskCreatePage` timeout that passes in isolation, and `@epam/ai-dial-conversation-input`'s pre-existing `AddAttachmentButton.tools` failures. `@epam/chat-api` itself: 1843/1843 passing.
+- [x] 6.2 Run `npm exec nx affected --target=lint --base=origin/development-1.0`. Result: clean for every project this change touches; the only failure (`@epam/ai-dial-catalog:typecheck`, a lint-chain dependency) reproduces identically on the pre-change tree.
+- [x] 6.3 Run `npm exec nx affected --target=typecheck --base=origin/development-1.0` (or the project-level equivalent if no dedicated typecheck target exists for an affected project). Result: `@epam/chat-api:typecheck` and `@epam/chat:typecheck`/`build` are blocked by a pre-existing, repo-wide broken `typecheck` target (563 identical errors on the pre-change tree — stale `dist/**/*.d.ts` project-reference outputs plus an unrelated `@epam/ai-dial-ui-kit` version mismatch in `@epam/ai-dial-catalog`), confirmed via `git stash` on both. `@epam/ai-dial-chat-shared:typecheck` (the one shared-model file this change touches) passes cleanly.
+- [x] 6.4 Run `npm exec nx affected --target=build --base=origin/development-1.0`. Result: `@epam/chat-api:build`, `@epam/chat-api-client:build`, and `@epam/ai-dial-chat-shared:build` all pass cleanly. `@epam/chat:build` is blocked by the same pre-existing `@epam/ai-dial-catalog:typecheck` dependency-chain failure (unrelated to this change, reproduced on the pre-change tree).
+- [x] 6.5 Confirm all existing hardened Responses stream/terminal-state tests and the existing Chat Completions adapter tests still pass unmodified. Confirmed — all 40 `responses.adapter.spec.ts` tests (hardening + new) and all `conversation.service.spec.ts` tests (110) pass; no Chat Completions adapter test was touched.

--- a/openspec/specs/responses-api-generation/spec.md
+++ b/openspec/specs/responses-api-generation/spec.md
@@ -18,6 +18,8 @@
 
 `ConversationService.streamCompletion` SHALL call `DeploymentsService.getDeploymentDetails(sub, model, token)` (the existing cached, user-token-scoped lookup already used by the deployment details endpoint) before issuing any upstream generation call, read `features` off the returned `modelDetails`/`applicationDetails` per the resolved `type`, and pass the result through `resolveGenerationApi` to select the adapter. `ConversationModule` SHALL import `DeploymentsModule` to obtain `DeploymentsService`. When `getDeploymentDetails` resolves the target id to `type: 'toolset'`, `streamCompletion` SHALL reject the request with HTTP 400 before any generation call, since a toolset is not a generation deployment.
 
+The same `features` lookup used to resolve the generation API SHALL also be used to determine whether the resolved deployment explicitly supports the `temperature` parameter (`features.temperature === true`). `ConversationService` SHALL make no additional `getDeploymentDetails` (or equivalent deployment-details) call for this purpose — the boolean SHALL be derived from the `features` object already read while resolving `GenerationApi`, and passed through to whichever adapter's `buildRequest` is invoked for that generation.
+
 #### Scenario: Responses-capable model dispatches to the Responses adapter
 
 - **WHEN** a completion request targets a model whose `getDeploymentDetails` result has `features.responsesApi: true`
@@ -42,6 +44,16 @@
 
 - **WHEN** `getDeploymentDetails` rejects with a 401/403/404/5xx-mapped exception
 - **THEN** `streamCompletion` surfaces the corresponding BFF error and does not call either generation adapter
+
+#### Scenario: Temperature capability is derived from the same lookup used for generation-API resolution
+
+- **WHEN** a completion request targets a Responses-capable deployment whose `getDeploymentDetails` result has `features.temperature: true`
+- **THEN** `streamCompletion` passes `temperatureSupported: true` to `ResponsesAdapter.buildRequest` without issuing a second `getDeploymentDetails` call for that generation
+
+#### Scenario: Missing or false temperature capability is derived without a duplicate lookup
+
+- **WHEN** a completion request targets a Responses-capable deployment whose `getDeploymentDetails` result has `features.temperature: false` or no `temperature` field
+- **THEN** `streamCompletion` passes `temperatureSupported: false` to `ResponsesAdapter.buildRequest` without issuing a second `getDeploymentDetails` call for that generation
 
 ---
 
@@ -233,3 +245,102 @@ Once `responses.adapter.ts` has issued the `createResponse` call, a subsequent 4
 
 - **WHEN** a generation is routed through the Chat Completions adapter
 - **THEN** the saved assistant message has no `responseId` field set
+
+---
+
+### Requirement: Responses request forwards conversation temperature only when explicitly supported
+
+`ResponsesAdapter.buildRequest` SHALL accept a `temperatureSupported: boolean` parameter, computed by `ConversationService` from the deployment `features` already fetched to resolve the generation API. The built `ResponsesApiRequestBody` SHALL include an optional `temperature: number` field set to `startConversation.temperature` only when `temperatureSupported === true` AND `startConversation.temperature` is not `null`/`undefined`. Presence SHALL be checked with a nullish check, not a truthiness check, so that `temperature: 0` is preserved. The field SHALL be omitted entirely — never sent as `null`, `undefined`, or a substituted default — when `temperatureSupported` is `false`, when it was not determined (absent capability), or when the conversation has no usable value. `ResponsesAdapter` SHALL NOT read a default temperature from any frontend constant, environment variable, or DIAL Core configuration, and SHALL NOT alter `ChatCompletionsAdapter.buildRequest`'s existing unconditional temperature forwarding.
+
+#### Scenario: Supported deployment forwards a zero temperature exactly
+
+- **WHEN** `temperatureSupported` is `true` and `startConversation.temperature` is `0`
+- **THEN** the built Responses request body has `temperature: 0`
+
+#### Scenario: Supported deployment forwards a non-zero temperature exactly
+
+- **WHEN** `temperatureSupported` is `true` and `startConversation.temperature` is `0.7`
+- **THEN** the built Responses request body has `temperature: 0.7`
+
+#### Scenario: Temperature is omitted when the deployment does not support it
+
+- **WHEN** `temperatureSupported` is `false` and `startConversation.temperature` is any usable value
+- **THEN** the built Responses request body has no `temperature` field
+
+#### Scenario: Temperature is omitted when support is unknown
+
+- **WHEN** `temperatureSupported` is `false` because the deployment `features` object had no `temperature` field
+- **THEN** the built Responses request body has no `temperature` field
+
+#### Scenario: Chat Completions temperature forwarding is unaffected
+
+- **WHEN** a generation is routed through `ChatCompletionsAdapter` rather than `ResponsesAdapter`
+- **THEN** `ChatCompletionsAdapter.buildRequest`'s existing temperature-forwarding behavior (unconditional on presence, capability-independent) is unchanged
+
+---
+
+### Requirement: Persisted conversation carries an optional Responses output-token limit
+
+The shared `Conversation` model (`@epam/ai-dial-chat-shared`) and `ConversationResponseDto` SHALL each gain an optional `maxOutputTokens?: number` field. The field SHALL be a Chat-side, user/import-settable value distinct from and never derived from `limits.maxCompletionTokens`, `defaultMaxTokens`, `defaults.max_tokens`, token usage, context-window size, or any hard-coded constant. Existing conversations that omit the field SHALL continue to load, save, duplicate, import, and export exactly as before this change, with the field simply absent.
+
+#### Scenario: New field is optional and independently settable
+
+- **WHEN** a conversation payload sets `maxOutputTokens: 4096` without any relation to the deployment's `limits.maxCompletionTokens`
+- **THEN** the conversation persists with `maxOutputTokens: 4096` regardless of the deployment's limit value
+
+#### Scenario: Legacy conversations remain unaffected
+
+- **WHEN** an existing conversation payload has no `maxOutputTokens` field
+- **THEN** the conversation continues to load, save, duplicate, import, and export with identical behavior to before this change, and no `maxOutputTokens` value is invented
+
+---
+
+### Requirement: Responses request maps a valid maxOutputTokens to max_output_tokens
+
+`ResponsesAdapter.buildRequest` SHALL include an optional `max_output_tokens: number` field on the built `ResponsesApiRequestBody`, set to `startConversation.maxOutputTokens` verbatim (no renaming, scaling, or transformation) only when that value passes a runtime validation check: it SHALL be a positive, finite integer within `Number.isSafeInteger` range (equivalently: `Number.isInteger(value) && Number.isSafeInteger(value) && value > 0`). The check SHALL be a real runtime predicate, not solely a TypeScript type assertion. The value `1` SHALL be preserved (checked via this validation, not truthiness). Any other value — absent, `null`, `0`, negative, fractional, `NaN`, `Infinity`, or outside the safe-integer range — SHALL cause `max_output_tokens` to be omitted entirely from the request; it SHALL NOT be sent as `null`, `undefined`, `0`, or a value derived from deployment limits or Chat Completions defaults. `max_output_tokens` mapping SHALL NOT be gated by `maxTokensSupported`, `maxCompletionTokensSupported`, or any other Chat-Completions-scoped capability flag. `ResponsesAdapter` SHALL NOT emit `max_tokens` or `max_completion_tokens` on a Responses request under any circumstance.
+
+#### Scenario: Minimum valid value is preserved
+
+- **WHEN** `startConversation.maxOutputTokens` is `1`
+- **THEN** the built Responses request body has `max_output_tokens: 1`
+
+#### Scenario: A representative larger value is preserved exactly
+
+- **WHEN** `startConversation.maxOutputTokens` is `4096`
+- **THEN** the built Responses request body has `max_output_tokens: 4096`
+
+#### Scenario: Absent value omits the wire field
+
+- **WHEN** `startConversation.maxOutputTokens` is `undefined`
+- **THEN** the built Responses request body has no `max_output_tokens` field, and no substituted value from deployment metadata is sent in its place
+
+#### Scenario: Invalid values are rejected rather than forwarded
+
+- **WHEN** `startConversation.maxOutputTokens` is `0`, a negative number, a fractional number, `NaN`, `Infinity`, or a number exceeding `Number.MAX_SAFE_INTEGER`
+- **THEN** the built Responses request body has no `max_output_tokens` field
+
+#### Scenario: max_output_tokens is not gated by Chat Completions capability flags
+
+- **WHEN** the resolved deployment has `maxTokensSupported: false` and `maxCompletionTokensSupported: false`, and `startConversation.maxOutputTokens` is a valid positive safe integer
+- **THEN** the built Responses request body still includes `max_output_tokens` set to that value
+
+#### Scenario: Legacy Chat Completions field names never appear on a Responses request
+
+- **WHEN** any Responses request is built by `ResponsesAdapter.buildRequest`, with or without `maxOutputTokens` set
+- **THEN** the built request body never contains a `max_tokens` or `max_completion_tokens` key
+
+---
+
+### Requirement: Temperature and max_output_tokens coexist without altering base request or stream semantics
+
+A Responses request MAY include both `temperature` and `max_output_tokens` simultaneously when both are independently eligible per their own requirements above. Adding either or both fields SHALL NOT change `stream: true`, `store: false`, the `input` array, message ordering, system-prompt mapping, status-message filtering, or the omission of `previous_response_id`/`conversation`. Adding either field SHALL NOT alter SSE parsing, terminal-state precedence, partial-message persistence, abort handling, error propagation, or unknown-event handling as specified by the hardened Responses stream behavior; those requirements are unchanged by this capability delta.
+
+#### Scenario: Both parameters present together
+
+- **WHEN** a Responses-capable deployment supports temperature, `startConversation.temperature` is `0.4`, and `startConversation.maxOutputTokens` is `2048`
+- **THEN** the built Responses request body includes `temperature: 0.4` and `max_output_tokens: 2048` alongside the unchanged base fields (`model`, `input`, `stream: true`, `store: false`), with no `previous_response_id` or `conversation` key
+
+#### Scenario: Hardened stream behavior is unaffected by request-construction changes
+
+- **WHEN** a Responses request built with either or both new parameters is relayed through `ResponsesAdapter.relay`
+- **THEN** SSE event handling, terminal-state precedence, partial-message persistence on error, and abort/error outcome reporting behave identically to a request built without the new parameters


### PR DESCRIPTION
## Description of changes

Hardens the Responses API generation adapter's stream/terminal-state handling. Forward `temperature` and add a new `max_output_tokens` parameter.

### 1. Harden Responses stream handling

`ResponsesAdapter.relay` had two correctness gaps that let a failed or truncated Responses generation get persisted as a *completed* assistant message:

- `response.failed` fell through the `default` unknown-event branch instead of being treated as a terminal error.
- A clean upstream socket close (or `data: [DONE]`) with **no** recognized terminal event (`response.completed` / `response.incomplete` / `error` / `[DONE]`) was treated as success by default.

Changes:
- Added a typed `response.failed` event and handle it as a terminal error — extracts a safe message from `response.error`, preserves any assembled partial text, skips the downstream `[DONE]` write, and never triggers a Chat Completions retry.
- Replaced the implicit "loop ended ⇒ success" assumption with an explicit terminal-state precedence model (`response.failed` / `response.incomplete` / in-band `error` / abort / invalid-status `response.completed` / compatibility `[DONE]` / socket EOF), backed by a string enum for the adapter's terminal lifecycle state.
- `[DONE]` is still accepted as a backward-compat signal for legacy/non-standard upstreams, but it can no longer override an already-observed error terminal state, and a canonical Core stream ending in a valid `response.completed` no longer needs `[DONE]` at all.
- Added regression tests locking in two safeguards that already existed: filtering `ConversationMessageRole.Status` messages out of the Responses `input`, and SDK-first non-2xx error extraction with a raw-body fallback (extended to accept a non-empty plain-text body, e.g. Core's `Upstream is missing required id`).
- Updated `docs/responses-api-integration.md` to match the hardened terminal-state/`[DONE]`/EOF behavior.

No changes to `POST /api/v1/conversations/completions`, the browser SSE contract, or Chat Completions behavior. No automatic Responses→Chat Completions fallback (unchanged). This is a bug fix — the only externally observable difference is that streams that previously mis-persisted as "completed" (failed or truncated upstream) now correctly persist as errors.

### 2. Support Responses generation parameters (temperature, max_output_tokens)

`ResponsesAdapter.buildRequest` only sent `model`, `input`, `stream: true`, and `store: false` — so switching a deployment from Chat Completions to Responses silently dropped `temperature`, and there was no way to request a Responses output-token cap at all.

Changes:
- `ResponsesApiRequestBody` gains optional `temperature` and `max_output_tokens` wire fields.
- `temperature` is forwarded from `startConversation.temperature` only when the resolved deployment's `features.temperature` is explicitly `true`, reusing the deployment `features` already fetched by `resolveGenerationApiForDeployment` — **no additional `getDeploymentDetails` call**. Presence is checked with a nullish check (not truthiness), so `temperature: 0` is preserved and never coerced away.
- Added an optional `maxOutputTokens?: number` field to the persisted `Conversation` model and `ConversationResponseDto`, mapped straight through to `max_output_tokens` when present — no capability gate, since no Responses-specific capability flag exists for it. Legacy conversations without the field are unaffected.
- `maxOutputTokens` is validated at the adapter boundary: only a positive, finite, safe integer (`Number.isInteger && Number.isSafeInteger && > 0`) is forwarded as `max_output_tokens`; anything else (absent, `0`, negative, fractional, `NaN`, `Infinity`, unsafe integer) is omitted entirely rather than sent as `null`/`undefined`/a substituted default. `max_output_tokens` is never gated by Chat-Completions-only capability flags (`maxTokensSupported`/`maxCompletionTokensSupported`), and `ResponsesAdapter` never emits legacy `max_tokens`/`max_completion_tokens`.
- Both parameters can coexist on the same request without altering `stream: true`, `store: false`, `input` construction, or any of the hardened stream/terminal-state semantics from part 1.

No new UI control for `maxOutputTokens` (no reusable generic max-tokens control exists in `libs/conversation-input` yet — deferred as a follow-up). No changes to Chat Completions request construction or the completions HTTP contract.

## Applicable issues

- https://github.com/epam/ai-dial-chat/issues/8202


## Checklist

- [X] the pull request name ends with `(Issue #<ISSUE_ID>)` (comma-separated list of issues)
- [X] I confirm that I don't share any confidential information like API keys or any other secrets and private URLs

