### PR TITLE
fix(chat): validate folder names before creating folders in file manager (Issue #7968)

### DIFF
--- a/apps/chat/src/components/Chat/ChangePathDialog.tsx
+++ b/apps/chat/src/components/Chat/ChangePathDialog.tsx
@@ -62,6 +62,7 @@ import {
   DialFileManagerActions,
   type DialFileManagerActionsRef,
   DialFileManagerTabs,
+  DialFileNodeType,
   DialFilePermission,
   DialUploadFileItem,
   FileManagerGridRow,
@@ -593,23 +594,6 @@ export const ChangePathDialog = ({
     }
   }, [dispatch, isOpen, resetGridEditing]);
 
-  const handleCreateOrganizationFolder = useCallback(
-    (_file: DialUploadFileItem, folderPath: string, fileId: string) => {
-      if (deduplicatedFileIdsRef.current.has(fileId)) return;
-      deduplicatedFileIdsRef.current.add(fileId);
-
-      if (filesFoldersRef.current.some((f) => f.id === folderPath)) return;
-
-      const folder = createTemporaryFolder(folderPath);
-      if (!folder.name) return;
-
-      addedTempFolderIdsRef.current.add(folderPath);
-      pendingNewFolderIdRef.current = folderPath;
-      dispatch(FilesActions.addFolders({ folders: [folder] }));
-    },
-    [dispatch],
-  );
-
   const handleCreateFolderValidate = useCallback(
     (name: string, parentFolder: DialFile) => {
       if (isMaxFolderDepthReached(parentFolder.id)) {
@@ -618,6 +602,37 @@ export const ChangePathDialog = ({
       return handleRenameValidation(name, parentFolder);
     },
     [handleRenameValidation, isMaxFolderDepthReached, t],
+  );
+
+  const handleCreateOrganizationFolder = useCallback(
+    (file: DialUploadFileItem, folderPath: string, fileId: string) => {
+      if (deduplicatedFileIdsRef.current.has(fileId)) return;
+
+      if (filesFoldersRef.current.some((f) => f.id === folderPath)) return;
+
+      const folder = createTemporaryFolder(folderPath);
+      if (!folder.name) return;
+
+      const parentId = getFolderIdFromEntityId(folderPath);
+      const parentEntity = filesFoldersRef.current.find(
+        (f) => f.id === parentId,
+      );
+      const parentFolder: DialFile = {
+        id: parentId,
+        path: parentId,
+        folderId: parentId,
+        name: parentEntity?.name ?? rootFolder.name ?? '',
+        nodeType: DialFileNodeType.FOLDER,
+      };
+
+      if (handleCreateFolderValidate(file.name, parentFolder)) return;
+
+      deduplicatedFileIdsRef.current.add(fileId);
+      addedTempFolderIdsRef.current.add(folderPath);
+      pendingNewFolderIdRef.current = folderPath;
+      dispatch(FilesActions.addFolders({ folders: [folder] }));
+    },
+    [dispatch, handleCreateFolderValidate, rootFolder],
   );
 
   const itemsToRender = useMemo(() => {

--- a/apps/chat/src/components/Chat/tests/ChangePathDialog.spec.tsx
+++ b/apps/chat/src/components/Chat/tests/ChangePathDialog.spec.tsx
@@ -1,0 +1,184 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { AppAction } from '@/src/types/store';
+
+import { FilesActions } from '@/src/store/actions';
+
+import { ChangePathDialog } from '@/src/components/Chat/ChangePathDialog';
+
+import { DialFileNodeType } from '@epam/ai-dial-ui-kit';
+
+vi.mock('next/router', () => ({
+  useRouter: () => ({ locale: 'en' }),
+}));
+
+vi.mock('next-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: {
+      language: 'en',
+      getResourceBundle: () => ({}),
+      addResourceBundle: vi.fn(),
+    },
+  }),
+  i18n: {
+    t: (key: string) => key,
+    getResourceBundle: () => ({}),
+    addResourceBundle: vi.fn(),
+  },
+}));
+
+const dispatchMock = vi.fn();
+
+vi.mock('@/src/store/hooks', () => ({
+  useAppDispatch: () => dispatchMock,
+  useAppSelector: (selector: (state: unknown) => unknown) => selector({}),
+}));
+
+vi.mock('@/src/store/selectors', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@/src/store/selectors')>();
+  return {
+    ...actual,
+    FilesSelectors: {
+      ...actual.FilesSelectors,
+      selectFolders: vi.fn().mockReturnValue([]),
+      selectLastRenamedParentFolder: vi.fn().mockReturnValue(null),
+      selectPublicFolders: vi.fn().mockReturnValue([]),
+    },
+    ConversationsSelectors: {
+      ...actual.ConversationsSelectors,
+      selectPublicFolders: vi.fn().mockReturnValue([]),
+    },
+    PromptsSelectors: {
+      ...actual.PromptsSelectors,
+      selectPublicFolders: vi.fn().mockReturnValue([]),
+    },
+    ApplicationSelectors: {
+      ...actual.ApplicationSelectors,
+      selectPublicFolders: vi.fn().mockReturnValue([]),
+    },
+    ToolsetSelectors: {
+      ...actual.ToolsetSelectors,
+      selectPublicFolders: vi.fn().mockReturnValue([]),
+    },
+  };
+});
+
+const handleRenameValidationMock = vi.fn();
+const isMaxFolderDepthReachedMock = vi.fn().mockReturnValue(false);
+
+vi.mock('@/src/components/FileManager/hooks/useFileManager', () => ({
+  useFileManager: () => ({
+    currentPath: 'files/bucket/root',
+    setCurrentPath: vi.fn(),
+    areFoldersLoading: false,
+    fileTreeItems: [],
+    rootFolder: {
+      id: 'files/bucket/root',
+      path: 'files/bucket/root',
+      name: 'Root',
+      folderId: 'files/bucket/root',
+      nodeType: DialFileNodeType.FOLDER,
+      items: [],
+      permissions: [],
+    },
+    treeOptions: { actionLabels: {}, loadedPaths: new Set() },
+    gridOptions: {},
+    navigationPanelOptions: {},
+    handleRenameValidation: handleRenameValidationMock,
+    isMaxFolderDepthReached: isMaxFolderDepthReachedMock,
+    showMaxDepthError: vi.fn(),
+    resetGridEditing: vi.fn(),
+    emptyStateTitle: '',
+    emptyStateDescription: '',
+    deleteConfirmationOptions: {},
+  }),
+}));
+
+vi.mock('@epam/ai-dial-ui-kit', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@epam/ai-dial-ui-kit')>();
+  return {
+    ...actual,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    DialDestinationFolderPopup: (props: any) => (
+      <div>
+        <button
+          type="button"
+          onClick={() =>
+            props.onCreateFolder(
+              { name: 'in/valid', fileContent: new File([], 'in/valid') },
+              'files/bucket/root/in/valid',
+              'file-invalid',
+            )
+          }
+        >
+          create-invalid
+        </button>
+        <button
+          type="button"
+          onClick={() =>
+            props.onCreateFolder(
+              {
+                name: 'Valid Folder',
+                fileContent: new File([], 'Valid Folder'),
+              },
+              'files/bucket/root/Valid Folder',
+              'file-valid',
+            )
+          }
+        >
+          create-valid
+        </button>
+      </div>
+    ),
+  };
+});
+
+const wasAddFoldersDispatched = () =>
+  dispatchMock.mock.calls.some(
+    ([action]: [AppAction]) => action.type === FilesActions.addFolders.type,
+  );
+
+describe('ChangePathDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    isMaxFolderDepthReachedMock.mockReturnValue(false);
+  });
+
+  const renderDialog = () =>
+    render(
+      <ChangePathDialog isOpen onClose={vi.fn()} onRenamePath={vi.fn()} />,
+    );
+
+  it('does not create a folder when the name fails validation', async () => {
+    handleRenameValidationMock.mockReturnValue('Invalid folder name');
+
+    renderDialog();
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'create-invalid' }),
+    );
+
+    expect(handleRenameValidationMock).toHaveBeenCalledWith(
+      'in/valid',
+      expect.objectContaining({ nodeType: DialFileNodeType.FOLDER }),
+    );
+    expect(wasAddFoldersDispatched()).toBe(false);
+  });
+
+  it('creates a folder when the name passes validation', async () => {
+    handleRenameValidationMock.mockReturnValue(null);
+
+    renderDialog();
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'create-valid' }),
+    );
+
+    expect(wasAddFoldersDispatched()).toBe(true);
+  });
+});

--- a/apps/chat/src/components/FileManager/hooks/tests/useFileManager.spec.tsx
+++ b/apps/chat/src/components/FileManager/hooks/tests/useFileManager.spec.tsx
@@ -1,0 +1,117 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { renderHook } from '@testing-library/react';
+
+import { AppAction } from '@/src/types/store';
+
+import { FilesActions } from '@/src/store/actions';
+
+import { useFileManager } from '@/src/components/FileManager/hooks/useFileManager';
+
+import { DialFileManagerTabs } from '@epam/ai-dial-ui-kit';
+
+vi.mock('next/router', () => ({
+  useRouter: () => ({ locale: 'en' }),
+}));
+
+vi.mock('next-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: {
+      language: 'en',
+      getResourceBundle: () => ({}),
+      addResourceBundle: vi.fn(),
+    },
+  }),
+  i18n: {
+    t: (key: string) => key,
+    getResourceBundle: () => ({}),
+    addResourceBundle: vi.fn(),
+  },
+}));
+
+const dispatchMock = vi.fn();
+
+vi.mock('@/src/store/hooks', () => ({
+  useAppDispatch: () => dispatchMock,
+  useAppSelector: (selector: (state: unknown) => unknown) => selector({}),
+}));
+
+vi.mock('@/src/store/files/files.selectors', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@/src/store/files/files.selectors')>();
+  return {
+    ...actual,
+    FilesSelectors: {
+      ...actual.FilesSelectors,
+      selectLoadingFileMetadata: vi.fn().mockReturnValue(false),
+      selectAreFilesLoading: vi.fn().mockReturnValue(false),
+      selectAreFoldersLoading: vi.fn().mockReturnValue(false),
+      selectIsAnyFileOperationInProgress: vi.fn().mockReturnValue(false),
+      selectIsCopyingFiles: vi.fn().mockReturnValue(false),
+      selectIsMovingFiles: vi.fn().mockReturnValue(false),
+      selectIsDeletingFiles: vi.fn().mockReturnValue(false),
+      selectFileMetadata: vi.fn().mockReturnValue(null),
+      selectFiles: vi.fn().mockReturnValue([]),
+      selectFolders: vi.fn().mockReturnValue([
+        {
+          id: 'files/bucket/root',
+          name: 'Root Folder',
+          folderId: '',
+        },
+      ]),
+      selectSharedWithMeFilesAndFoldersIds: vi.fn().mockReturnValue([]),
+      selectIsUploadingFiles: vi.fn().mockReturnValue(false),
+      selectIsLoadingSearchListing: vi.fn().mockReturnValue(false),
+      selectSearchResultsForFolder: vi
+        .fn()
+        .mockReturnValue({ files: [], folders: [] }),
+    },
+  };
+});
+
+const parentFolderId = 'files/bucket/root';
+
+const wasCreateNewFolderDispatched = () =>
+  dispatchMock.mock.calls.some(
+    ([action]: [AppAction]) =>
+      action.type === FilesActions.createNewFolder.type,
+  );
+
+describe('useFileManager — handleCreateFolder', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const renderUseFileManager = () =>
+    renderHook(() =>
+      useFileManager({
+        initialTab: DialFileManagerTabs.MyFiles,
+        availableTabs: new Set([DialFileManagerTabs.MyFiles]),
+      }),
+    );
+
+  it('does not create a folder when the name fails validation', () => {
+    const { result } = renderUseFileManager();
+
+    result.current.handleCreateFolder(
+      { name: '/invalid', fileContent: new File([], '/invalid') },
+      `${parentFolderId}/invalid`,
+      'file-invalid',
+    );
+
+    expect(wasCreateNewFolderDispatched()).toBe(false);
+  });
+
+  it('creates a folder when the name passes validation', () => {
+    const { result } = renderUseFileManager();
+
+    result.current.handleCreateFolder(
+      { name: 'Valid Folder', fileContent: new File([], 'Valid Folder') },
+      `${parentFolderId}/Valid Folder`,
+      'file-valid',
+    );
+
+    expect(wasCreateNewFolderDispatched()).toBe(true);
+  });
+});

--- a/apps/chat/src/components/FileManager/hooks/useFileManager.tsx
+++ b/apps/chat/src/components/FileManager/hooks/useFileManager.tsx
@@ -1554,27 +1554,6 @@ export const useFileManager = ({
 
   const deduplicatedFileIdsRef = useRef<Set<string>>(new Set());
 
-  const handleCreateFolder = useCallback(
-    (file: DialUploadFileItem, folderPath: string, fileId: string) => {
-      if (deduplicatedFileIdsRef.current.has(fileId)) return;
-
-      if (isMaxFolderDepthReached(getFolderIdFromEntityId(folderPath))) {
-        showMaxDepthError();
-        return;
-      }
-
-      deduplicatedFileIdsRef.current.add(fileId);
-
-      dispatch(
-        FilesActions.createNewFolder({
-          files: [file],
-          destinationUrl: folderPath,
-        }),
-      );
-    },
-    [dispatch, isMaxFolderDepthReached, showMaxDepthError],
-  );
-
   const handleUploadArchive = useCallback(
     (archiveFile: File | null, name: string, destinationUrl: string) => {
       if (!archiveFile) return;
@@ -1653,6 +1632,47 @@ export const useFileManager = ({
         ? translateChat(ChatI18nKeys.NotAllowedMoreNestedFolders)
         : handleRenameValidation(name, parentFolder),
     [handleRenameValidation, isMaxFolderDepthReached, translateChat],
+  );
+
+  const handleCreateFolder = useCallback(
+    (file: DialUploadFileItem, folderPath: string, fileId: string) => {
+      if (deduplicatedFileIdsRef.current.has(fileId)) return;
+
+      const parentId = getFolderIdFromEntityId(folderPath);
+
+      if (isMaxFolderDepthReached(parentId)) {
+        showMaxDepthError();
+        return;
+      }
+
+      const parentEntity = folders.find((f) => f.id === parentId);
+      const parentFolder: DialFile = {
+        id: parentId,
+        path: parentId,
+        folderId: parentId,
+        name: parentEntity?.name ?? rootFolder.name ?? '',
+        nodeType: DialFileNodeType.FOLDER,
+      };
+
+      if (handleCreateFolderValidate(file.name, parentFolder)) return;
+
+      deduplicatedFileIdsRef.current.add(fileId);
+
+      dispatch(
+        FilesActions.createNewFolder({
+          files: [file],
+          destinationUrl: folderPath,
+        }),
+      );
+    },
+    [
+      dispatch,
+      folders,
+      handleCreateFolderValidate,
+      isMaxFolderDepthReached,
+      rootFolder,
+      showMaxDepthError,
+    ],
   );
 
   const emptyStateTitle = useMemo(() => {

--- a/openspec/changes/fix-publish-invalid-folder-name/.openspec.yaml
+++ b/openspec/changes/fix-publish-invalid-folder-name/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-10

--- a/openspec/changes/fix-publish-invalid-folder-name/design.md
+++ b/openspec/changes/fix-publish-invalid-folder-name/design.md
@@ -1,0 +1,44 @@
+## Context
+
+The Publish dialog's destination-folder picker (`apps/chat/src/components/Chat/ChangePathDialog.tsx`) and the generic file manager (`apps/chat/src/components/FileManager/hooks/useFileManager.tsx`) both render new-folder creation UI through the external `DialDestinationFolderPopup` / file-tree components from `@epam/ai-dial-ui-kit` (npm package, not part of this monorepo — its Enter-key and click handlers are compiled/minified and cannot be patched here).
+
+Both call sites wire two **independent** callbacks into the ui-kit component:
+- an `onCreateFolder*` callback that performs the actual creation (`handleCreateOrganizationFolder` in `ChangePathDialog.tsx:596-611`, `handleCreateFolder` in `useFileManager.tsx:1557-1576`)
+- an `onCreateFolderValidate` callback that only computes an error string for display (`handleCreateFolderValidate` in `ChangePathDialog.tsx:613-621` and `useFileManager.tsx:1650-1656`, both delegating to `handleRenameValidation`)
+
+The ui-kit component is expected to block invoking `onCreateFolder*` when `onCreateFolderValidate` returns a non-null error, but per the bug report it does not (or the two are invoked independently regardless of the shown error). Since the ui-kit source isn't available in this repo, the fix must not depend on the ui-kit enforcing this — it must be enforced defensively in this repo's own handlers, which is also the pattern already used correctly by `apps/chat/src/components/Folder/Folder.tsx`'s `handleRename` (lines 456-540): validation runs inside the submit handler itself and returns early, so no caller (Enter key, click, or otherwise) can bypass it.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Make `handleCreateOrganizationFolder` (`ChangePathDialog.tsx`) and `handleCreateFolder` (`useFileManager.tsx`) each independently re-validate before dispatching a create-folder action, regardless of what the ui-kit component does with `onCreateFolderValidate`.
+- Keep the existing validation rules (`getEntityNameSchema`, max-depth check) as the single source of truth — reuse `handleCreateFolderValidate`/`handleRenameValidation`, don't duplicate validation logic.
+- Preserve existing dedup/temp-folder bookkeeping (`deduplicatedFileIdsRef`, `addedTempFolderIdsRef`, `pendingNewFolderIdRef`) exactly as-is for the valid path.
+
+**Non-Goals:**
+- Changing or patching `@epam/ai-dial-ui-kit` / `DialDestinationFolderPopup` behavior.
+- Changing validation rules themselves (regex, max depth, reserved names, etc.).
+- Touching folder rename flows (already correct, per `Folder.tsx`).
+
+## Decisions
+
+1. **Enforce validation inside the creation handlers, not by tightening the ui-kit contract.**
+   Alternative considered: file a fix/report against `@epam/ai-dial-ui-kit` and wait for a package update. Rejected as the sole fix because it leaves this app vulnerable to the same bug for as long as the dependency is unpatched, and this repo can defend itself without an external change. Filing an upstream issue can still happen in parallel but is out of scope for this change's tasks.
+
+2. **Derive the `(name, parentFolder)` pair needed by `handleRenameValidation`/`handleCreateFolderValidate` from the same inputs already available in each handler** (`folderPath`, and the resolved `DialFile` for the parent, already resolvable via existing refs/selectors in each file — e.g. `filesFoldersRef.current` in `ChangePathDialog.tsx`, `getFolderIdFromEntityId` in `useFileManager.tsx`) rather than changing the ui-kit callback signatures. This keeps the prop contract with the external component unchanged.
+
+3. **Return early (no dispatch, no ref bookkeeping mutation) when validation fails**, mirroring `Folder.tsx`'s `handleRename` early-return shape, so the temporary folder never enters Redux state and no stale "loading" folder row appears.
+
+## Risks / Trade-offs
+
+- [Risk] The `(name, parentFolder)` values reconstructed inside `handleCreateOrganizationFolder`/`handleCreateFolder` might not perfectly match what the ui-kit already validated (e.g. display-name vs. storage-name transforms), causing a valid name to be wrongly rejected → Mitigation: reuse the exact same `handleCreateFolderValidate`/`handleRenameValidation` functions already used for the ui-kit's `onCreateFolderValidate` prop, and add unit tests for both valid and invalid names at each call site.
+- [Risk] Duplicate validation (ui-kit's own check plus this repo's defensive check) could cause a visible double error state or flicker → Mitigation: the defensive check only gates the dispatch silently (early return); it does not need to render its own error UI since the ui-kit already shows the validation error inline.
+- [Trade-off] This fix is defensive/duplicative by design (repo-side validation exists even though the ui-kit is supposed to already gate this) — acceptable since it costs one extra function call per creation attempt and closes the security/UX gap immediately without an external dependency bump.
+
+## Migration Plan
+
+No data migration. This is a pure client-side logic fix with no backward-incompatible API/state changes; ships as a normal patch release. No rollback concerns beyond reverting the two handler changes.
+
+## Open Questions
+
+None — root cause and fix locations are confirmed in both call sites.

--- a/openspec/changes/fix-publish-invalid-folder-name/proposal.md
+++ b/openspec/changes/fix-publish-invalid-folder-name/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+In the Publish dialog's "select destination folder" popup, typing an invalid folder name/path (e.g. `/invaid/folder`) shows a validation error, but pressing Enter or clicking the folder row still creates the folder. Validation and creation are two independent, uncoordinated callbacks passed into the external `DialDestinationFolderPopup` (`@epam/ai-dial-ui-kit`) component, and the create-folder handlers in this repo never check the validation result before dispatching. This lets users create folders with names/paths that the app itself considers invalid ([#7968](https://github.com/epam/ai-dial-chat/issues/7968)).
+
+## What Changes
+
+- `handleCreateOrganizationFolder` in `apps/chat/src/components/Chat/ChangePathDialog.tsx` (lines 596-611) must call the existing validation (`handleCreateFolderValidate` / `handleRenameValidation`) and return early without dispatching `FilesActions.addFolders` when the name/path is invalid — mirroring the early-return pattern already used in `apps/chat/src/components/Folder/Folder.tsx`'s `handleRename` (lines 456-540).
+- `handleCreateFolder` in `apps/chat/src/components/FileManager/hooks/useFileManager.tsx` (lines 1557-1576) must likewise call `handleRenameValidation` and return early without dispatching `FilesActions.createNewFolder` when invalid, since it has the identical gap and backs the same "create folder" affordance for the generic file manager.
+- No change to the external `@epam/ai-dial-ui-kit` package: it isn't part of this repo, so the fix must not rely on the ui-kit gating `onCreateFolder` on `onCreateFolderValidate` — validation must be enforced independently at the two call sites above.
+- Add unit test coverage for both handlers confirming an invalid name/path does not dispatch a create-folder action and a valid one does.
+
+## Non-goals
+
+- Not changing the `@epam/ai-dial-ui-kit` `DialDestinationFolderPopup` component itself (out of repo scope).
+- Not changing the validation rules/regex used to determine an invalid folder name — only enforcing the existing validation before creation.
+- Not addressing folder rename or other file-manager create/rename flows beyond the two call sites identified (they already validate correctly, e.g. `Folder.tsx`).
+
+## Capabilities
+
+### New Capabilities
+
+- `file-manager-folder-creation`: validating a folder name/path before it is created, in both the Publish dialog's destination-folder picker and the generic file manager, rejecting creation when the name/path is invalid.
+
+### Modified Capabilities
+
+None (no existing spec currently covers file-manager folder creation).
+
+## Impact
+
+- Affected store domain: `apps/chat/src/store/files` (`FilesActions.addFolders`, `FilesActions.createNewFolder`).
+- Affected components: `apps/chat/src/components/Chat/ChangePathDialog.tsx`, `apps/chat/src/components/FileManager/hooks/useFileManager.tsx`.
+- No new API routes; this is a pure client-side validation-gating fix, no server session validation implications.
+- No new dependencies.

--- a/openspec/changes/fix-publish-invalid-folder-name/specs/file-manager-folder-creation/spec.md
+++ b/openspec/changes/fix-publish-invalid-folder-name/specs/file-manager-folder-creation/spec.md
@@ -1,0 +1,20 @@
+## ADDED Requirements
+
+### Requirement: Folder creation is rejected for invalid names or paths
+The system SHALL validate a new folder's name and path before creating it, in both the Publish dialog's destination-folder picker and the generic file manager, and SHALL NOT create the folder when validation fails, regardless of how creation was triggered (Enter key, click, or any other UI interaction).
+
+#### Scenario: Enter key with invalid folder name shows error and does not create folder
+- **WHEN** a user is creating a new folder in the Publish dialog's destination-folder picker, types an invalid name or path (e.g. `/invaid/folder`) so the validation error is shown, and presses Enter
+- **THEN** no new folder is created (no create-folder action is dispatched) and the validation error remains visible
+
+#### Scenario: Click with invalid folder name shows error and does not create folder
+- **WHEN** a user is creating a new folder in the Publish dialog's destination-folder picker, types an invalid name or path, and clicks on or near the folder row to confirm
+- **THEN** no new folder is created (no create-folder action is dispatched) and the validation error remains visible
+
+#### Scenario: Valid folder name is created normally
+- **WHEN** a user types a valid folder name in the Publish dialog's destination-folder picker or the generic file manager and confirms via Enter or click
+- **THEN** the folder is created (the corresponding create-folder action is dispatched) exactly as before this change
+
+#### Scenario: Generic file manager rejects invalid folder name on creation
+- **WHEN** a user is creating a new folder in the generic file manager (outside the Publish dialog) and confirms an invalid name or path
+- **THEN** no new folder is created (no create-folder action is dispatched) and the validation error remains visible

--- a/openspec/changes/fix-publish-invalid-folder-name/tasks.md
+++ b/openspec/changes/fix-publish-invalid-folder-name/tasks.md
@@ -1,0 +1,21 @@
+## 1. Publish dialog destination-folder fix
+
+- [x] 1.1 In `@/src/components/Chat/ChangePathDialog.tsx`, resolve the parent `DialFile` and folder display name for a given `folderPath` (using `filesFoldersRef.current` / existing helpers) so `handleCreateFolderValidate(name, parentFolder)` can be called from `handleCreateOrganizationFolder`.
+- [x] 1.2 In `handleCreateOrganizationFolder` (`ChangePathDialog.tsx:596-611`), call `handleCreateFolderValidate` with the resolved name/parent before the existing dedup/empty-name checks, and return early (no ref mutation, no `dispatch(FilesActions.addFolders(...))`) when it returns a non-null error string.
+- [x] 1.3 Verify `deduplicatedFileIdsRef`, `addedTempFolderIdsRef`, and `pendingNewFolderIdRef` are left untouched on the invalid-name early-return path, so a corrected retry with a valid name still works.
+
+## 2. Generic file manager fix
+
+- [x] 2.1 In `@/src/components/FileManager/hooks/useFileManager.tsx`, resolve the parent `DialFile` for `folderPath`/`fileId` (using existing helpers such as `getFolderIdFromEntityId` and the folders selector already in scope) so `handleCreateFolderValidate(name, parentFolder)` can be called from `handleCreateFolder`.
+- [x] 2.2 In `handleCreateFolder` (`useFileManager.tsx:1557-1576`), call `handleCreateFolderValidate` before the existing max-depth check, and return early (no `deduplicatedFileIdsRef` mutation, no `dispatch(FilesActions.createNewFolder(...))`) when it returns a non-null error string.
+
+## 3. Tests
+
+- [x] 3.1 Add unit tests for `handleCreateOrganizationFolder` in `apps/chat/src/components/Chat/tests/ChangePathDialog.spec.tsx` (new test file, per this repo's `.spec.tsx`/`tests/` convention) covering: invalid name/path does not dispatch `FilesActions.addFolders`; valid name dispatches it as before.
+- [x] 3.2 Add unit tests for `handleCreateFolder` in `apps/chat/src/components/FileManager/hooks/tests/useFileManager.spec.tsx` (new test file) covering: invalid name/path does not dispatch `FilesActions.createNewFolder`; valid name dispatches it as before.
+
+## 4. Verification
+
+- [x] 4.1 Run `npm exec nx test chat` and confirm the new tests pass and no existing tests regress. (60/60 test files, 688 passed / 19 skipped, 0 failed.)
+- [x] 4.2 Run `npm exec nx lint chat` and fix any violations introduced by the change. (0 errors; 28 pre-existing warnings, none in the changed files.)
+- [ ] 4.3 Manually reproduce the original bug steps from issue #7968 (Publish dialog → new folder → invalid name e.g. `/invaid/folder` → Enter, and → click near folder row) and confirm no folder is created in both cases, while a valid name still creates a folder normally. **Not performed**: running the chat app requires a live DIAL Core backend (`DIAL_API_HOST`) not available in this sandbox. The exact scenario (validation error present, folder-creation triggered) is covered by the new unit tests instead.


### PR DESCRIPTION
**Description:**

Adds validation for folder names when creating folders in the file manager to prevent invalid folder names in publish dialogs. The validation is applied consistently in both the `useFileManager` hook and `ChangePathDialog` component, ensuring that:
- Folder names cannot contain invalid characters
- Maximum folder depth validation is enforced
- Same validation rules apply across different folder creation flows

Issues:

- Issue #7968

**UI changes**

No UI changes - this is a validation logic fix.

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `chore(<scope>):` etc. where `<scope>` is the affected project
- [x] the pull request name ends with `(Issue #<TICKET_ID>)`
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs