### PR TITLE
fix(chat): edit message scrollbar, attachment types MIME error, no-op conversation drag and publish path rules (Issue #7290, Issue #5256, Issue #1565, Issue #7337)

### DIFF
--- a/apps/chat/src/components/AppsEditor/EditorForm/CodeAppForm.tsx
+++ b/apps/chat/src/components/AppsEditor/EditorForm/CodeAppForm.tsx
@@ -36,7 +36,7 @@ import { CommonI18nKeys, MarketplaceI18nKeys } from '@/src/constants/i18n';
 import {
   CodeAppForm as CodeAppFormType,
   MANDATORY_FIELD_PLACEHOLDER,
-  getAttachmentTypeErrorHandlers,
+  getPendingAttachmentTypeProps,
 } from '@/src/components/AppsEditor/form';
 import { FormCodeEditor } from '@/src/components/Common/ApplicationWizard/CodeAppView/FormCodeEditor';
 import { RuntimeVersionSelector } from '@/src/components/Common/ApplicationWizard/CodeAppView/RuntimeVersionSelector';
@@ -88,11 +88,17 @@ export const CodeAppForm = () => {
   const folders = useAppSelector(FilesSelectors.selectFolders);
   const publicationUrl = publicationUrlQuery.toString();
 
-  const { control, setError, clearErrors, setValue } =
-    useFormContext<CodeAppFormType>();
+  const { control, clearErrors, setValue } = useFormContext<CodeAppFormType>();
   const { errors } = useFormState<CodeAppFormType>({ control });
   const sources = useWatch<CodeAppFormType, 'sources'>({
     name: 'sources',
+    control,
+  });
+  const pendingAttachmentType = useWatch<
+    CodeAppFormType,
+    'pendingInputAttachmentType'
+  >({
+    name: 'pendingInputAttachmentType',
     control,
   });
   const filesLoaded = useWatch<CodeAppFormType, 'filesLoaded'>({
@@ -146,7 +152,7 @@ export const CodeAppForm = () => {
             error={errors.inputAttachmentTypes?.message}
             disabled={isAppPublic}
             tooltip={isAppPublic ? PUBLIC_APP_TOOLTIP : ''}
-            {...getAttachmentTypeErrorHandlers(setError, clearErrors)}
+            {...getPendingAttachmentTypeProps(pendingAttachmentType, setValue)}
           />
         )}
       />

--- a/apps/chat/src/components/AppsEditor/EditorForm/CustomAppForm.tsx
+++ b/apps/chat/src/components/AppsEditor/EditorForm/CustomAppForm.tsx
@@ -25,7 +25,7 @@ import { CommonI18nKeys, MarketplaceI18nKeys } from '@/src/constants/i18n';
 import {
   CustomAppForm as CustomAppFormType,
   MANDATORY_FIELD_PLACEHOLDER,
-  getAttachmentTypeErrorHandlers,
+  getPendingAttachmentTypeProps,
 } from '@/src/components/AppsEditor/form';
 import { withController } from '@/src/components/Common/Forms/ControlledFormField';
 import { Field } from '@/src/components/Common/Forms/Field';
@@ -48,11 +48,15 @@ export const CustomAppForm = () => {
     ApplicationSelectors.selectApplicationDetail,
   );
 
-  const { control, register, setError, clearErrors, setValue } =
+  const { control, register, clearErrors, setValue } =
     useFormContext<CustomAppFormType>();
   const { errors } = useFormState<CustomAppFormType>({ control });
   const completionUrl = useWatch({
     name: 'completionUrl',
+    control,
+  });
+  const pendingAttachmentType = useWatch({
+    name: 'pendingInputAttachmentType',
     control,
   });
 
@@ -110,7 +114,7 @@ export const CustomAppForm = () => {
             disabled={isAppPublic}
             tooltip={isAppPublic ? PUBLIC_APP_TOOLTIP : ''}
             dataQa="combobox"
-            {...getAttachmentTypeErrorHandlers(setError, clearErrors)}
+            {...getPendingAttachmentTypeProps(pendingAttachmentType, setValue)}
           />
         )}
       />

--- a/apps/chat/src/components/AppsEditor/EditorForm/QuickApp2Form/QuickApp2Form.tsx
+++ b/apps/chat/src/components/AppsEditor/EditorForm/QuickApp2Form/QuickApp2Form.tsx
@@ -54,7 +54,7 @@ import { ModelField } from '@/src/components/AppsEditor/EditorForm/QuickApp2Form
 import { StartersBehaviourRadioGroup } from '@/src/components/AppsEditor/EditorForm/QuickApp2Form/StartersBehaviourRadioGroup';
 import {
   QuickApp2Form as QuickApp2FormType,
-  getAttachmentTypeErrorHandlers,
+  getPendingAttachmentTypeProps,
 } from '@/src/components/AppsEditor/form';
 import { TemperatureSlider } from '@/src/components/Chat/ChatSettings/Temperature';
 import { FilesSelector } from '@/src/components/Common/FilesSelector/FilesSelector';
@@ -109,11 +109,14 @@ export const QuickApp2Form: FC<AppsEditorProps> = ({ onAutoSave }) => {
   );
   const files = useAppSelector(FilesSelectors.selectFiles);
 
-  const { control, setError, clearErrors, setValue, getValues } =
-    useFormContext<QuickApp2FormType>();
+  const { control, setValue, getValues } = useFormContext<QuickApp2FormType>();
   const { errors } = useFormState<QuickApp2FormType>({ control });
 
   const modelId = useWatch({ control, name: 'model' });
+  const pendingAttachmentType = useWatch({
+    control,
+    name: 'pendingInputAttachmentType',
+  });
   const starters = useWatch({ control, name: 'starters' });
   const autoSubmit = useWatch({ control, name: 'autoSubmit' });
   const chatMessageInputDisabled = useWatch({
@@ -492,7 +495,10 @@ export const QuickApp2Form: FC<AppsEditorProps> = ({ onAutoSave }) => {
               disabled={isAppPublic}
               tooltip={isAppPublicTooltip}
               dataQa="attachment-types-field"
-              {...getAttachmentTypeErrorHandlers(setError, clearErrors)}
+              {...getPendingAttachmentTypeProps(
+                pendingAttachmentType,
+                setValue,
+              )}
             />
           )}
         />

--- a/apps/chat/src/components/AppsEditor/__tests__/form.test.ts
+++ b/apps/chat/src/components/AppsEditor/__tests__/form.test.ts
@@ -8,6 +8,7 @@ import {
   AppsEditorFormType,
   AppsEditorSchemaTypes,
   getApplicationPayload,
+  getValidationSchema,
 } from '../form';
 
 const MODEL_ID = 'gpt-4';
@@ -57,6 +58,48 @@ const getOrchestratorParameters = (
       allEntitiesMap: buildEntitiesMap(allowsTemperature),
     }).applicationProperties as QuickApp2Config
   ).orchestrator.deployment.parameters;
+
+const buildCustomAppFormData = (pendingInputAttachmentType: string) => ({
+  type: AppsEditorSchemaTypes.CustomApp,
+  inputAttachmentTypes: ['image/png'],
+  pendingInputAttachmentType,
+  completionUrl: 'http://application1/chat',
+  features: null,
+  name: 'Test app',
+  version: '0.0.1',
+  description: '',
+  iconUrl: '',
+  topics: [],
+  locales: [],
+});
+
+const getAttachmentTypesErrors = (pendingInputAttachmentType: string) => {
+  const result = getValidationSchema(AppsEditorSchemaTypes.CustomApp).safeParse(
+    buildCustomAppFormData(pendingInputAttachmentType),
+  );
+
+  return result.success
+    ? []
+    : result.error.issues
+        .filter((issue) => issue.path[0] === 'inputAttachmentTypes')
+        .map((issue) => issue.message);
+};
+
+describe('Custom app schema - attachment type that is not added yet', () => {
+  it('reports the MIME error while an invalid type is being typed', () => {
+    expect(getAttachmentTypesErrors('imag')).toEqual([
+      'Please match the MIME format',
+    ]);
+  });
+
+  it('reports no error for a valid type that is being typed', () => {
+    expect(getAttachmentTypesErrors('image/jpeg')).toEqual([]);
+  });
+
+  it('reports no error when nothing is being typed', () => {
+    expect(getAttachmentTypesErrors('')).toEqual([]);
+  });
+});
 
 describe('getApplicationPayload - Quick App 2.0 orchestrator temperature', () => {
   it('saves a temperature of 0', () => {

--- a/apps/chat/src/components/AppsEditor/form.ts
+++ b/apps/chat/src/components/AppsEditor/form.ts
@@ -1,4 +1,4 @@
-import { UseFormClearErrors, UseFormSetError } from 'react-hook-form';
+import { FieldValues, Path, PathValue, UseFormSetValue } from 'react-hook-form';
 
 import {
   fitApplicationNameToStorageLimits,
@@ -71,6 +71,7 @@ import {
   DEFAULT_APPLICATION_NAME,
   DEFAULT_TEMPERATURE,
 } from '@/src/constants/default-ui-settings';
+import { MIME_FORMAT_REGEX } from '@/src/constants/file';
 import { formErrors } from '@/src/constants/form-errors';
 import { ChatI18nKeys, CommonI18nKeys } from '@/src/constants/i18n';
 import { DEFAULT_VERSION } from '@/src/constants/publication';
@@ -89,6 +90,8 @@ import {
   DynamicFieldSchema,
   MarketplaceEntityBaseSchema,
   MaxInputAttachmentsSchema,
+  PendingAttachmentTypeSchema,
+  refinePendingAttachmentType,
 } from '@/src/constants/validation-helpers';
 
 import { ShareEntity } from '@epam/ai-dial-shared';
@@ -113,69 +116,77 @@ export type BaseAppForm = zodValidation.infer<
   typeof MarketplaceEntityBaseSchema
 >;
 
-const CustomAppSchema = zodValidation.object({
-  type: zodValidation.literal(AppsEditorSchemaTypes.CustomApp),
-  inputAttachmentTypes: AttachmentTypesSchema,
-  completionUrl: CompletionUrlSchema.nonempty(formErrors.required).or(
-    zodValidation.literal(MANDATORY_FIELD_PLACEHOLDER),
-  ),
-  features: zodValidation
-    .string()
-    .nullable()
-    .superRefine((data, ctx) => {
-      if (!data?.trim()) return;
-      try {
-        const object = JSON.parse(data);
-        if (typeof object === 'object' && !!object && !Array.isArray(object)) {
-          for (const [key, value] of Object.entries(object)) {
-            if (!key.trim()) {
-              ctx.addIssue({
-                code: 'custom',
-                path: ['features'],
-                message: 'Keys should not be empty',
-              });
-              return;
-            }
-            const valueType = typeof value;
-            if (
-              !(['boolean', 'number'].includes(valueType) || value === null)
-            ) {
-              if (typeof value === 'string' && !value.trim()) {
+const CustomAppSchema = zodValidation
+  .object({
+    type: zodValidation.literal(AppsEditorSchemaTypes.CustomApp),
+    inputAttachmentTypes: AttachmentTypesSchema,
+    pendingInputAttachmentType: PendingAttachmentTypeSchema,
+    completionUrl: CompletionUrlSchema.nonempty(formErrors.required).or(
+      zodValidation.literal(MANDATORY_FIELD_PLACEHOLDER),
+    ),
+    features: zodValidation
+      .string()
+      .nullable()
+      .superRefine((data, ctx) => {
+        if (!data?.trim()) return;
+        try {
+          const object = JSON.parse(data);
+          if (
+            typeof object === 'object' &&
+            !!object &&
+            !Array.isArray(object)
+          ) {
+            for (const [key, value] of Object.entries(object)) {
+              if (!key.trim()) {
                 ctx.addIssue({
                   code: 'custom',
                   path: ['features'],
-                  message: 'String values should not be empty',
+                  message: 'Keys should not be empty',
                 });
                 return;
               }
-              if (!['boolean', 'number', 'string'].includes(valueType)) {
-                ctx.addIssue({
-                  code: 'custom',
-                  path: ['features'],
-                  message: 'Values should be a string, number, boolean or null',
-                });
-                return;
+              const valueType = typeof value;
+              if (
+                !(['boolean', 'number'].includes(valueType) || value === null)
+              ) {
+                if (typeof value === 'string' && !value.trim()) {
+                  ctx.addIssue({
+                    code: 'custom',
+                    path: ['features'],
+                    message: 'String values should not be empty',
+                  });
+                  return;
+                }
+                if (!['boolean', 'number', 'string'].includes(valueType)) {
+                  ctx.addIssue({
+                    code: 'custom',
+                    path: ['features'],
+                    message:
+                      'Values should be a string, number, boolean or null',
+                  });
+                  return;
+                }
               }
             }
+          } else {
+            ctx.addIssue({
+              code: 'custom',
+              path: ['features'],
+              message: 'Data is not a valid JSON object',
+            });
+            return;
           }
-        } else {
+        } catch {
           ctx.addIssue({
             code: 'custom',
             path: ['features'],
-            message: 'Data is not a valid JSON object',
+            message: 'Invalid JSON string',
           });
-          return;
         }
-      } catch {
-        ctx.addIssue({
-          code: 'custom',
-          path: ['features'],
-          message: 'Invalid JSON string',
-        });
-      }
-    }),
-  maxInputAttachments: MaxInputAttachmentsSchema.optional(),
-});
+      }),
+    maxInputAttachments: MaxInputAttachmentsSchema.optional(),
+  })
+  .superRefine(refinePendingAttachmentType);
 export type CustomAppForm = zodValidation.infer<typeof CustomAppSchema>;
 
 const ExternalAppSchema = zodValidation.object({
@@ -270,6 +281,7 @@ export const QuickApp2Schema = zodValidation
     agentsAndToolsets: zodValidation.array(AgentOrToolsetSchema),
     codeInterpreter: zodValidation.boolean(),
     inputAttachmentTypes: AttachmentTypesSchema,
+    pendingInputAttachmentType: PendingAttachmentTypeSchema,
     maxInputAttachments: MaxInputAttachmentsSchema.optional(),
     isJsonView: zodValidation.boolean(),
     agentsAndToolsetsJson: zodValidation.string(),
@@ -295,6 +307,8 @@ export const QuickApp2Schema = zodValidation
     webFetch: zodValidation.boolean(),
   })
   .superRefine((data, ctx) => {
+    refinePendingAttachmentType(data, ctx);
+
     if (data.isJsonView) {
       try {
         const parsed: unknown[] = JSON.parse(data.agentsAndToolsetsJson);
@@ -342,6 +356,7 @@ const CodeAppSchema = zodValidation
   .object({
     type: zodValidation.literal(AppsEditorSchemaTypes.CodeApp),
     inputAttachmentTypes: AttachmentTypesSchema,
+    pendingInputAttachmentType: PendingAttachmentTypeSchema,
     filesLoaded: zodValidation.boolean(),
     sources: zodValidation
       .string()
@@ -372,6 +387,8 @@ const CodeAppSchema = zodValidation
     env: zodValidation.array(DynamicFieldSchema).optional(),
   })
   .superRefine((data, ctx) => {
+    refinePendingAttachmentType(data, ctx);
+
     if (
       data.sources === MANDATORY_FIELD_PLACEHOLDER ||
       !data.sources ||
@@ -441,6 +458,7 @@ const getBaseFormData = ({
 const getCustomAppFormData = (app?: CustomApplicationModel): CustomAppForm => ({
   type: AppsEditorSchemaTypes.CustomApp,
   inputAttachmentTypes: app?.inputAttachmentTypes ?? [],
+  pendingInputAttachmentType: '',
   maxInputAttachments: app?.maxInputAttachments ?? undefined,
   completionUrl:
     app && !app.applicationTypeSchemaId
@@ -583,6 +601,7 @@ const getQuickApp2FormData = (
         (toolset) => toolset.type === ToolsetTypes.CodeInterpreter,
       ) ?? false,
     inputAttachmentTypes: app?.inputAttachmentTypes ?? [],
+    pendingInputAttachmentType: '',
     maxInputAttachments: app?.maxInputAttachments ?? undefined,
     agentsAndToolsetsJson: JSON.stringify(
       appProperties?.tool_sets ?? [],
@@ -631,6 +650,7 @@ const getCodeAppFormData = ({
 }): CodeAppForm => ({
   type: AppsEditorSchemaTypes.CodeApp,
   inputAttachmentTypes: app?.inputAttachmentTypes ?? [],
+  pendingInputAttachmentType: '',
   maxInputAttachments: app?.maxInputAttachments ?? undefined,
   filesLoaded: false,
   sources: getFormSourceFolder(app?.function?.sourceFolder),
@@ -780,25 +800,27 @@ export const getValidationSchema = (
   }
 };
 
-export const getAttachmentTypeErrorHandlers = (
-  setError: UseFormSetError<{ inputAttachmentTypes: string[] }>,
-  clearErrors: UseFormClearErrors<{ inputAttachmentTypes: string[] }>,
-) => {
-  const validationRegExp = new RegExp(
-    '^([a-zA-Z0-9!*\\-.+]+|\\*)\\/([a-zA-Z0-9!*\\-.+]+|\\*)$',
-  );
-  const handleError = () => {
-    setError('inputAttachmentTypes', {
-      type: 'manual',
-      message: 'Please match the MIME format',
-    });
-  };
-  const handleClearError = () => {
-    clearErrors('inputAttachmentTypes');
-  };
-
-  return { validationRegExp, handleError, handleClearError };
-};
+/**
+ * Keeps the not yet added attachment type in the form state, so the schema
+ * reports the MIME error instead of it being set manually. A manual error is
+ * wiped by every form re-validation, which happens on saving and on switching
+ * between the editor steps.
+ */
+export const getPendingAttachmentTypeProps = <
+  T extends FieldValues & { pendingInputAttachmentType: string },
+>(
+  pendingInputAttachmentType: string | undefined,
+  setValue: UseFormSetValue<T>,
+) => ({
+  validationRegExp: MIME_FORMAT_REGEX,
+  inputValue: pendingInputAttachmentType ?? '',
+  onInputValueChange: (value: string) =>
+    setValue(
+      'pendingInputAttachmentType' as Path<T>,
+      value as PathValue<T, Path<T>>,
+      { shouldValidate: true },
+    ),
+});
 
 const getActualSourceFolder = (formSources?: string) => {
   const bucket = BucketService.getBucket();

--- a/apps/chat/src/components/Chat/ChatMessage/ChatMessageContent/UserMessage.tsx
+++ b/apps/chat/src/components/Chat/ChatMessage/ChatMessageContent/UserMessage.tsx
@@ -354,13 +354,15 @@ export const UserMessage = memo(function UserMessage({
     ],
   );
 
-  // Reserves space for the absolutely positioned microphone button so it never
-  // overlaps the textarea text or the attachments grid
-  const micPaddingClass = canRecordAudio
+  // Horizontal padding lives on the scrollable children instead of their
+  // wrapper, so vertical scrollbars are rendered at the field border the same
+  // way as in the send message input. The end padding additionally reserves
+  // space for the absolutely positioned microphone button.
+  const paddingEndClass = canRecordAudio
     ? isOverlay
       ? 'pe-[60px]'
       : 'pe-[72px]'
-    : '';
+    : 'pe-3';
 
   const handleInputChange = useCallback(
     (event: React.ChangeEvent<HTMLTextAreaElement>) => {
@@ -699,15 +701,15 @@ export const UserMessage = memo(function UserMessage({
         {!isInputHidden && (
           <div
             className={classNames(
-              'relative min-h-[100px] rounded border border-primary bg-layer-3 px-3 py-2 focus-within:border-accent-primary',
+              'relative min-h-[100px] rounded border border-primary bg-layer-3 py-2 focus-within:border-accent-primary',
               !isOverlay && 'text-base',
             )}
           >
             <AdjustedTextarea
               ref={textareaRef}
               className={classNames(
-                'w-full grow resize-none whitespace-pre-wrap bg-transparent focus-visible:outline-none',
-                micPaddingClass,
+                'w-full grow resize-none whitespace-pre-wrap bg-transparent ps-3 focus-visible:outline-none',
+                paddingEndClass,
               )}
               value={messageContent}
               onChange={handleInputChange}
@@ -748,8 +750,8 @@ export const UserMessage = memo(function UserMessage({
               selectedDialLinks.length > 0) && (
               <div
                 className={classNames(
-                  'mb-2.5 grid max-h-[100px] grid-cols-1 gap-1 overflow-auto sm:grid-cols-2 md:grid-cols-3',
-                  micPaddingClass,
+                  'mb-2.5 grid max-h-[100px] grid-cols-1 gap-1 overflow-auto ps-3 sm:grid-cols-2 md:grid-cols-3',
+                  paddingEndClass,
                 )}
                 data-qa="attachment-container"
               >

--- a/apps/chat/src/components/Chat/Publish/PublicationHandler/PublicationHandler.tsx
+++ b/apps/chat/src/components/Chat/Publish/PublicationHandler/PublicationHandler.tsx
@@ -264,23 +264,25 @@ export function PublicationHandler({ publication, onSubmit }: Props) {
     PublicationSelectors.selectRulesByPath(state, rulesPath),
   );
 
-  useEffect(() => {
-    if (rules && (!isReview || !isEditMode)) {
-      formMethods.setValue(
-        PublishRequestFieldsNames.RULES,
-        rules[rulesPath] ?? [],
-      );
-    }
-  }, [formMethods, rulesPath, rules, isReview, isEditMode]);
+  // While the request is edited its own rules are shown for the folder it was
+  // requested for, but any other folder must show the rules it already has
+  const shouldKeepRequestedRules =
+    isEditMode && rulesPath === publication.targetFolder;
 
   useEffect(() => {
-    if (isEditMode) {
-      formMethods.setValue(
-        PublishRequestFieldsNames.RULES,
-        publication.rules ?? [],
-      );
-    }
-  }, [formMethods, isEditMode, publication.rules]);
+    formMethods.setValue(
+      PublishRequestFieldsNames.RULES,
+      shouldKeepRequestedRules
+        ? (publication.rules ?? [])
+        : (rules[rulesPath] ?? []),
+    );
+  }, [
+    formMethods,
+    rulesPath,
+    rules,
+    shouldKeepRequestedRules,
+    publication.rules,
+  ]);
 
   useEffect(() => {
     if (!isEditMode) {

--- a/apps/chat/src/components/Chatbar/ChatFolders.tsx
+++ b/apps/chat/src/components/Chatbar/ChatFolders.tsx
@@ -155,7 +155,7 @@ const ChatFolderTemplate = ({
             }),
           );
         }
-      } else if (entity) {
+      } else if (entity && entity.folderId !== currentFolder.id) {
         dispatch(
           ConversationsActions.updateConversation({
             id: entity.id,

--- a/apps/chat/src/components/Chatbar/Chatbar.tsx
+++ b/apps/chat/src/components/Chatbar/Chatbar.tsx
@@ -98,6 +98,12 @@ export const Chatbar = () => {
           const conversation = JSON.parse(conversationData);
           const folderId = getConversationRootId();
 
+          // Dropping a conversation where it already is must not touch it,
+          // otherwise it is marked as updated and jumps to the Today section
+          if (conversation.folderId === folderId) {
+            return;
+          }
+
           if (
             !isEntityNameOnSameLevelUnique(
               conversation.name,

--- a/apps/chat/src/components/Common/MultipleComboBox.tsx
+++ b/apps/chat/src/components/Common/MultipleComboBox.tsx
@@ -11,6 +11,7 @@ import {
   Fragment,
   RefObject,
   createElement,
+  useCallback,
   useLayoutEffect,
   useMemo,
   useRef,
@@ -84,8 +85,9 @@ interface Props<T> {
   getItemLabel: (item: T) => string;
   getItemValue: (item: T) => string;
   onChangeSelectedItems: (value: T[]) => void;
-  handleError?: () => void;
-  handleClearError?: () => void;
+  /** Makes the not yet added input text controlled from the outside. */
+  inputValue?: string;
+  onInputValueChange?: (value: string) => void;
   dataQa?: string;
   /** When set, merged with the internal input ref (e.g. to focus programmatically). */
   inputRef?: RefObject<HTMLInputElement | null>;
@@ -114,8 +116,8 @@ export function MultipleComboBox<T>({
   getItemLabel,
   getItemValue,
   onChangeSelectedItems,
-  handleError,
-  handleClearError,
+  inputValue: inputValueProp,
+  onInputValueChange,
   dataQa,
   inputRef: inputRefProp,
   showConnectorBetweenSelectedItems,
@@ -123,8 +125,20 @@ export function MultipleComboBox<T>({
   isLoading,
 }: Props<T>) {
   const { t } = useTranslation(Translation.Common);
-  const [inputValue, setInputValue] = useState<string | undefined>('');
+  const [ownInputValue, setOwnInputValue] = useState<string | undefined>('');
   const [floatingWidth, setFloatingWidth] = useState(0);
+
+  const isInputValueControlled = inputValueProp !== undefined;
+  const inputValue = isInputValueControlled ? inputValueProp : ownInputValue;
+  const setInputValue = useCallback(
+    (value: string | undefined) => {
+      if (!isInputValueControlled) {
+        setOwnInputValue(value);
+      }
+      onInputValueChange?.(value ?? '');
+    },
+    [isInputValueControlled, onInputValueChange],
+  );
 
   const inputRef = useRef<HTMLInputElement>(null);
   const cursorPositionRef = useRef<number | null>(null);
@@ -243,7 +257,6 @@ export function MultipleComboBox<T>({
             typeof itemToAdd === 'string' &&
             !validationRegExp.test(itemToAdd)
           ) {
-            handleError?.();
             return;
           }
 
@@ -264,7 +277,6 @@ export function MultipleComboBox<T>({
         }
 
         case useCombobox.stateChangeTypes.InputChange:
-          handleClearError?.();
           setInputValue(newInputValue);
           break;
         default:

--- a/apps/chat/src/constants/validation-helpers.ts
+++ b/apps/chat/src/constants/validation-helpers.ts
@@ -107,12 +107,36 @@ export const MarketplaceEntityBaseSchema = zodValidation
     }
   });
 
+export const MIME_FORMAT_ERROR = 'Please match the MIME format';
+
 export const AttachmentTypesSchema = zodValidation
   .array(zodValidation.string())
   .refine(
     (types) => types.every((t) => MIME_FORMAT_REGEX.test(t)),
-    'Please match the MIME format',
+    MIME_FORMAT_ERROR,
   );
+
+/**
+ * A MIME type typed into the attachment types combobox but not added to the
+ * list yet. It is kept in the form state so that its validation is produced by
+ * the schema and survives both form re-validation and switching editor steps.
+ */
+export const PendingAttachmentTypeSchema = zodValidation.string();
+
+export const refinePendingAttachmentType = (
+  data: { pendingInputAttachmentType?: string },
+  ctx: zodValidation.RefinementCtx,
+) => {
+  const pendingType = data.pendingInputAttachmentType?.trim();
+
+  if (pendingType && !MIME_FORMAT_REGEX.test(pendingType)) {
+    ctx.addIssue({
+      code: 'custom',
+      path: ['inputAttachmentTypes'],
+      message: MIME_FORMAT_ERROR,
+    });
+  }
+};
 
 export const MaxInputAttachmentsSchema = zodValidation.coerce
   .number<number>()


### PR DESCRIPTION
## Description of changes

Four unrelated UI bug fixes.

### Edit message scrollbar position (#7290)

The edit message field kept its horizontal padding on the bordered wrapper, so the scrollable attachments grid ended 12px short of the border and its scrollbar collided with the microphone button. The send message input puts that padding on the scrollable children instead.

The padding moved to the textarea and the attachments grid, so the scrollbar is rendered at the field border exactly as in the send message input. `paddingEndClass` got a `pe-3` fallback for the case when the microphone is hidden.

### Attachment types MIME error disappears in the app editor (#5256)

The `Please match the MIME format` error was set manually with `setError`, and the typed text itself lived only in the combobox internal state. Every form re-validation replaced the errors with the resolver output and dropped that manual error, and leaving the `App settings` step unmounted the combobox and lost the text. As a result the error disappeared on switching editor steps and on `Continue editing` in the save confirmation dialog.

The not yet added type is now kept in the form state as `pendingInputAttachmentType` and validated by the schema, so the error is produced by the resolver and survives both re-validation and step switching. The field is added to the custom app, code app and quick app 2.0 schemas and is not part of the application payload. `MultipleComboBox` accepts the input text as an optional controlled prop; the field behaves as before, an invalid value stays in the input and does not become a pill.

### Conversation jumps to Today on a no-op drag (#1565)

Dropping a conversation onto the folder it already belongs to dispatched `updateConversation` anyway. `updateConversationSuccess` stamps `updatedAt` with the current time and the sidebar sections are derived from it, so a conversation dragged and dropped in place jumped from `Yesterday` to `Today`.

The update is now skipped when the drop target folder is the one the conversation is already in, the same way the folder branch of the drop handler already does.

### Folder rules are not shown after changing the publish path (#7337)

While an admin edits a publish request, the rules field was pinned to the rules that came with the request, and the effect that loads the rules of the selected folder was disabled for that mode. Picking another existing folder via `Change` therefore left its rules out of the form and the folder looked like it had none.

Both effects are merged into one: the requested rules are still shown for the folder the request was created for, and any other folder shows the rules it already has, the same way the regular publish flow does.

## Applicable issues

- fixes #7290
- fixes #5256
- fixes #1565
- fixes #7337

## UI changes

No intentional visual changes beyond the fixes above: the edit message scrollbar moves to the field border, the attachment types error no longer disappears, and the publish rules of the selected folder are shown.

## Checklist

- [x] the pull request name ends with `(Issue #<ISSUE_ID>)` (comma-separated list of issues)
- [x] I confirm that I don't share any confidential information like API keys or any other secrets and private URLs
