### PR TITLE
chore(chat-api-client): rename package to @epam/ai-dial-chat-api-client and make publishable

### DIFF
--- a/apps/chat-api/src/files/dto/dial-file-node-type.ts
+++ b/apps/chat-api/src/files/dto/dial-file-node-type.ts
@@ -4,7 +4,7 @@
  * files DTOs (`CopyItemNodeType`, `DeleteItemNodeType`, `MoveItemNodeType`,
  * `RenameItemNodeType`, `ArchiveItemNodeType`, `FileNodeType`). Each DTO file
  * keeps its own exported name as an alias to this enum so Swagger schema
- * names (and therefore `@epam/chat-api-client`) do not change.
+ * names (and therefore `@epam/ai-dial-chat-api-client`) do not change.
  */
 export enum DialFileNodeType {
   Item = 'item',

--- a/apps/chat/src/components/CatalogView/CatalogView.tsx
+++ b/apps/chat/src/components/CatalogView/CatalogView.tsx
@@ -7,10 +7,10 @@ import {
   CredentialsLevel,
   CredentialStatus,
 } from '@epam/ai-dial-catalog';
+import type { ToolsetLogoutBodyDto } from '@epam/ai-dial-chat-api-client';
 import { OverlayFeature } from '@epam/ai-dial-chat-overlay';
 import type { PublicationRule } from '@epam/ai-dial-publish-panel';
 import { DropdownItem, NotificationVariant } from '@epam/ai-dial-ui-kit';
-import type { ToolsetLogoutBodyDto } from '@epam/ai-dial-chat-api-client';
 import type { FC } from 'react';
 import { memo, useCallback, useEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/apps/chat/src/components/CatalogView/CatalogView.tsx
+++ b/apps/chat/src/components/CatalogView/CatalogView.tsx
@@ -10,7 +10,7 @@ import {
 import { OverlayFeature } from '@epam/ai-dial-chat-overlay';
 import type { PublicationRule } from '@epam/ai-dial-publish-panel';
 import { DropdownItem, NotificationVariant } from '@epam/ai-dial-ui-kit';
-import type { ToolsetLogoutBodyDto } from '@epam/chat-api-client';
+import type { ToolsetLogoutBodyDto } from '@epam/ai-dial-chat-api-client';
 import type { FC } from 'react';
 import { memo, useCallback, useEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/apps/chat/src/components/CatalogView/tests/CatalogView.spec.tsx
+++ b/apps/chat/src/components/CatalogView/tests/CatalogView.spec.tsx
@@ -7,10 +7,10 @@ import {
   getCredentialsBadgeState,
   getCredentialsUiState,
 } from '@epam/ai-dial-catalog';
+import type { DialToolsetDto } from '@epam/ai-dial-chat-api-client';
 import { OverlayFeature } from '@epam/ai-dial-chat-overlay';
 import type { PublicationRule } from '@epam/ai-dial-publish-panel';
 import { DropdownItem } from '@epam/ai-dial-ui-kit';
-import type { DialToolsetDto } from '@epam/ai-dial-chat-api-client';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { useState } from 'react';

--- a/apps/chat/src/components/CatalogView/tests/CatalogView.spec.tsx
+++ b/apps/chat/src/components/CatalogView/tests/CatalogView.spec.tsx
@@ -10,7 +10,7 @@ import {
 import { OverlayFeature } from '@epam/ai-dial-chat-overlay';
 import type { PublicationRule } from '@epam/ai-dial-publish-panel';
 import { DropdownItem } from '@epam/ai-dial-ui-kit';
-import type { DialToolsetDto } from '@epam/chat-api-client';
+import type { DialToolsetDto } from '@epam/ai-dial-chat-api-client';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { useState } from 'react';

--- a/apps/chat/src/components/ConversationPanel/get-conversation-source.ts
+++ b/apps/chat/src/components/ConversationPanel/get-conversation-source.ts
@@ -1,5 +1,5 @@
 import { FilterTab } from '@epam/ai-dial-conversation-panel';
-import { type ConversationListItemDto } from '@epam/chat-api-client';
+import { type ConversationListItemDto } from '@epam/ai-dial-chat-api-client';
 
 export const getConversationSource = (
   item: Pick<ConversationListItemDto, 'sharedWithMe' | 'publishedWithMe'>,

--- a/apps/chat/src/components/ConversationPanel/get-conversation-source.ts
+++ b/apps/chat/src/components/ConversationPanel/get-conversation-source.ts
@@ -1,5 +1,5 @@
-import { FilterTab } from '@epam/ai-dial-conversation-panel';
 import { type ConversationListItemDto } from '@epam/ai-dial-chat-api-client';
+import { FilterTab } from '@epam/ai-dial-conversation-panel';
 
 export const getConversationSource = (
   item: Pick<ConversationListItemDto, 'sharedWithMe' | 'publishedWithMe'>,

--- a/apps/chat/src/components/ConversationPanel/tests/ConversationPanelView.spec.tsx
+++ b/apps/chat/src/components/ConversationPanel/tests/ConversationPanelView.spec.tsx
@@ -2,7 +2,7 @@ import { OverlayFeature } from '@epam/ai-dial-chat-overlay';
 import {
   ConversationDeletionFailureDtoCodeEnum,
   type ConversationDeletionResultDto,
-} from '@epam/chat-api-client';
+} from '@epam/ai-dial-chat-api-client';
 import {
   act,
   fireEvent,

--- a/apps/chat/src/components/ConversationPanel/tests/ConversationPanelView.spec.tsx
+++ b/apps/chat/src/components/ConversationPanel/tests/ConversationPanelView.spec.tsx
@@ -1,8 +1,8 @@
-import { OverlayFeature } from '@epam/ai-dial-chat-overlay';
 import {
   ConversationDeletionFailureDtoCodeEnum,
   type ConversationDeletionResultDto,
 } from '@epam/ai-dial-chat-api-client';
+import { OverlayFeature } from '@epam/ai-dial-chat-overlay';
 import {
   act,
   fireEvent,

--- a/apps/chat/src/components/ConversationSourcesPanel/tests/ConversationSourcesPanel.spec.tsx
+++ b/apps/chat/src/components/ConversationSourcesPanel/tests/ConversationSourcesPanel.spec.tsx
@@ -3,7 +3,7 @@ import { AttachmentType, RequestStatus } from '@epam/ai-dial-chat-shared';
 import type {
   ScheduledTaskDto,
   ScheduledTaskRunDto,
-} from '@epam/chat-api-client';
+} from '@epam/ai-dial-chat-api-client';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type { ReactNode } from 'react';

--- a/apps/chat/src/components/ConversationSourcesPanel/tests/ConversationSourcesPanel.spec.tsx
+++ b/apps/chat/src/components/ConversationSourcesPanel/tests/ConversationSourcesPanel.spec.tsx
@@ -1,9 +1,9 @@
-import type { DisplayAttachment } from '@epam/ai-dial-chat-shared';
-import { AttachmentType, RequestStatus } from '@epam/ai-dial-chat-shared';
 import type {
   ScheduledTaskDto,
   ScheduledTaskRunDto,
 } from '@epam/ai-dial-chat-api-client';
+import type { DisplayAttachment } from '@epam/ai-dial-chat-shared';
+import { AttachmentType, RequestStatus } from '@epam/ai-dial-chat-shared';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type { ReactNode } from 'react';

--- a/apps/chat/src/components/NewConversationComposer/NewConversationComposer.tsx
+++ b/apps/chat/src/components/NewConversationComposer/NewConversationComposer.tsx
@@ -12,7 +12,7 @@ import {
   type ToolsChipLabels,
 } from '@epam/ai-dial-conversation-input';
 import { NotificationVariant } from '@epam/ai-dial-ui-kit';
-import type { DeploymentItemDto } from '@epam/chat-api-client';
+import type { DeploymentItemDto } from '@epam/ai-dial-chat-api-client';
 import type { FC, ReactNode } from 'react';
 import { lazy, memo, useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/apps/chat/src/components/NewConversationComposer/NewConversationComposer.tsx
+++ b/apps/chat/src/components/NewConversationComposer/NewConversationComposer.tsx
@@ -1,3 +1,4 @@
+import type { DeploymentItemDto } from '@epam/ai-dial-chat-api-client';
 import { OverlayFeature } from '@epam/ai-dial-chat-overlay';
 import {
   ResponseFormat,
@@ -12,7 +13,6 @@ import {
   type ToolsChipLabels,
 } from '@epam/ai-dial-conversation-input';
 import { NotificationVariant } from '@epam/ai-dial-ui-kit';
-import type { DeploymentItemDto } from '@epam/ai-dial-chat-api-client';
 import type { FC, ReactNode } from 'react';
 import { lazy, memo, useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/apps/chat/src/components/ScheduledTaskConversationBanner/tests/ScheduledTaskConversationBanner.spec.tsx
+++ b/apps/chat/src/components/ScheduledTaskConversationBanner/tests/ScheduledTaskConversationBanner.spec.tsx
@@ -1,4 +1,4 @@
-import type { ScheduledTaskRunDto } from '@epam/chat-api-client';
+import type { ScheduledTaskRunDto } from '@epam/ai-dial-chat-api-client';
 import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router';
 import { beforeEach, describe, expect, it, vi } from 'vitest';

--- a/apps/chat/src/components/SigninInterruptDialog/SigninInterruptDialog.tsx
+++ b/apps/chat/src/components/SigninInterruptDialog/SigninInterruptDialog.tsx
@@ -1,3 +1,4 @@
+import type { DialToolsetDto } from '@epam/ai-dial-chat-api-client';
 import { OverlayFeature } from '@epam/ai-dial-chat-overlay';
 import {
   DIAL_ICON_SIZE,
@@ -9,7 +10,6 @@ import {
   PrimaryButton,
   Input,
 } from '@epam/ai-dial-ui-kit';
-import type { DialToolsetDto } from '@epam/ai-dial-chat-api-client';
 import { IconAlertCircleFilled } from '@tabler/icons-react';
 import {
   memo,

--- a/apps/chat/src/components/SigninInterruptDialog/SigninInterruptDialog.tsx
+++ b/apps/chat/src/components/SigninInterruptDialog/SigninInterruptDialog.tsx
@@ -9,7 +9,7 @@ import {
   PrimaryButton,
   Input,
 } from '@epam/ai-dial-ui-kit';
-import type { DialToolsetDto } from '@epam/chat-api-client';
+import type { DialToolsetDto } from '@epam/ai-dial-chat-api-client';
 import { IconAlertCircleFilled } from '@tabler/icons-react';
 import {
   memo,

--- a/apps/chat/src/context/ActiveScheduledTaskContext.tsx
+++ b/apps/chat/src/context/ActiveScheduledTaskContext.tsx
@@ -1,4 +1,4 @@
-import type { ScheduledTaskDto } from '@epam/chat-api-client';
+import type { ScheduledTaskDto } from '@epam/ai-dial-chat-api-client';
 import {
   createContext,
   type ReactNode,

--- a/apps/chat/src/context/ConversationsContext.tsx
+++ b/apps/chat/src/context/ConversationsContext.tsx
@@ -2,7 +2,7 @@ import type {
   ConversationDeletionResultDto,
   ConversationListItemDto,
   ConversationResponseDto,
-} from '@epam/chat-api-client';
+} from '@epam/ai-dial-chat-api-client';
 import {
   createContext,
   type ReactNode,

--- a/apps/chat/src/context/DeploymentsContext.tsx
+++ b/apps/chat/src/context/DeploymentsContext.tsx
@@ -1,11 +1,11 @@
-import type { DeploymentConfigurationSchema } from '@epam/ai-dial-chat-shared';
-import { NotificationVariant } from '@epam/ai-dial-ui-kit';
 import {
   ListDeploymentsInterfaceTypeEnum,
   type ApplicationSchemaSummaryDto,
   type DeploymentItemDto,
   type DialToolsetDto,
 } from '@epam/ai-dial-chat-api-client';
+import type { DeploymentConfigurationSchema } from '@epam/ai-dial-chat-shared';
+import { NotificationVariant } from '@epam/ai-dial-ui-kit';
 import {
   createContext,
   ReactNode,

--- a/apps/chat/src/context/DeploymentsContext.tsx
+++ b/apps/chat/src/context/DeploymentsContext.tsx
@@ -5,7 +5,7 @@ import {
   type ApplicationSchemaSummaryDto,
   type DeploymentItemDto,
   type DialToolsetDto,
-} from '@epam/chat-api-client';
+} from '@epam/ai-dial-chat-api-client';
 import {
   createContext,
   ReactNode,

--- a/apps/chat/src/context/auth/UserContext.spec.tsx
+++ b/apps/chat/src/context/auth/UserContext.spec.tsx
@@ -1,4 +1,4 @@
-import type { UserProfileDto } from '@epam/chat-api-client';
+import type { UserProfileDto } from '@epam/ai-dial-chat-api-client';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { ReactNode } from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';

--- a/apps/chat/src/context/tests/ActiveScheduledTaskContext.spec.tsx
+++ b/apps/chat/src/context/tests/ActiveScheduledTaskContext.spec.tsx
@@ -1,4 +1,4 @@
-import type { ConversationListItemDto } from '@epam/chat-api-client';
+import type { ConversationListItemDto } from '@epam/ai-dial-chat-api-client';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import * as scheduledTasksApi from '../../server-api/scheduled-tasks.api';

--- a/apps/chat/src/context/tests/AppConfigContext.spec.tsx
+++ b/apps/chat/src/context/tests/AppConfigContext.spec.tsx
@@ -1,4 +1,4 @@
-import type { ClientConfigResponseDto } from '@epam/chat-api-client';
+import type { ClientConfigResponseDto } from '@epam/ai-dial-chat-api-client';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { createElement, ReactNode } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';

--- a/apps/chat/src/context/tests/ConversationsContext.spec.tsx
+++ b/apps/chat/src/context/tests/ConversationsContext.spec.tsx
@@ -5,7 +5,7 @@ import {
 import {
   ConversationDeletionFailureDtoCodeEnum,
   type ConversationDeletionResultDto,
-} from '@epam/chat-api-client';
+} from '@epam/ai-dial-chat-api-client';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { createElement, type ReactNode } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';

--- a/apps/chat/src/context/tests/ConversationsContext.spec.tsx
+++ b/apps/chat/src/context/tests/ConversationsContext.spec.tsx
@@ -1,11 +1,11 @@
 import {
-  OverlayEventType,
-  OverlayRequestType,
-} from '@epam/ai-dial-chat-overlay';
-import {
   ConversationDeletionFailureDtoCodeEnum,
   type ConversationDeletionResultDto,
 } from '@epam/ai-dial-chat-api-client';
+import {
+  OverlayEventType,
+  OverlayRequestType,
+} from '@epam/ai-dial-chat-overlay';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { createElement, type ReactNode } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';

--- a/apps/chat/src/hooks/auth/useOverlayProviderLogin.ts
+++ b/apps/chat/src/hooks/auth/useOverlayProviderLogin.ts
@@ -1,5 +1,5 @@
 import { OverlayAuthUiMode } from '@epam/ai-dial-chat-overlay';
-import type { ProviderInfoDto } from '@epam/chat-api-client';
+import type { ProviderInfoDto } from '@epam/ai-dial-chat-api-client';
 import { useCallback, useEffect, useState } from 'react';
 import { useOptionalOverlay } from '../../context/overlay/OverlayContext';
 import { getProviders } from '../../server-api/auth.api';

--- a/apps/chat/src/hooks/auth/useOverlayProviderLogin.ts
+++ b/apps/chat/src/hooks/auth/useOverlayProviderLogin.ts
@@ -1,5 +1,5 @@
-import { OverlayAuthUiMode } from '@epam/ai-dial-chat-overlay';
 import type { ProviderInfoDto } from '@epam/ai-dial-chat-api-client';
+import { OverlayAuthUiMode } from '@epam/ai-dial-chat-overlay';
 import { useCallback, useEffect, useState } from 'react';
 import { useOptionalOverlay } from '../../context/overlay/OverlayContext';
 import { getProviders } from '../../server-api/auth.api';

--- a/apps/chat/src/hooks/conversation/tests/useConversationListBridge.spec.ts
+++ b/apps/chat/src/hooks/conversation/tests/useConversationListBridge.spec.ts
@@ -1,4 +1,4 @@
-import type { ConversationListItemDto } from '@epam/chat-api-client';
+import type { ConversationListItemDto } from '@epam/ai-dial-chat-api-client';
 import { renderHook } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type {

--- a/apps/chat/src/hooks/conversation/useActiveConversationBridge.ts
+++ b/apps/chat/src/hooks/conversation/useActiveConversationBridge.ts
@@ -1,5 +1,5 @@
-import type { Conversation } from '@epam/ai-dial-chat-shared';
 import type { ConversationResponseDto } from '@epam/ai-dial-chat-api-client';
+import type { Conversation } from '@epam/ai-dial-chat-shared';
 import { type MutableRefObject, useEffect } from 'react';
 import { useOptionalOverlay } from '../../context/overlay/OverlayContext';
 import { saveConversation } from '../../server-api/conversations.api';

--- a/apps/chat/src/hooks/conversation/useActiveConversationBridge.ts
+++ b/apps/chat/src/hooks/conversation/useActiveConversationBridge.ts
@@ -1,5 +1,5 @@
 import type { Conversation } from '@epam/ai-dial-chat-shared';
-import type { ConversationResponseDto } from '@epam/chat-api-client';
+import type { ConversationResponseDto } from '@epam/ai-dial-chat-api-client';
 import { type MutableRefObject, useEffect } from 'react';
 import { useOptionalOverlay } from '../../context/overlay/OverlayContext';
 import { saveConversation } from '../../server-api/conversations.api';

--- a/apps/chat/src/hooks/conversation/useConversationHandlers.ts
+++ b/apps/chat/src/hooks/conversation/useConversationHandlers.ts
@@ -10,7 +10,7 @@ import {
 import type {
   ConversationResponseDto,
   SendCompletionDtoModeEnum,
-} from '@epam/chat-api-client';
+} from '@epam/ai-dial-chat-api-client';
 import {
   type Dispatch,
   type MutableRefObject,

--- a/apps/chat/src/hooks/conversation/useConversationHandlers.ts
+++ b/apps/chat/src/hooks/conversation/useConversationHandlers.ts
@@ -1,3 +1,7 @@
+import type {
+  ConversationResponseDto,
+  SendCompletionDtoModeEnum,
+} from '@epam/ai-dial-chat-api-client';
 import {
   type Attachment,
   type Conversation,
@@ -7,10 +11,6 @@ import {
   MessageRole,
   type StarterOption,
 } from '@epam/ai-dial-chat-shared';
-import type {
-  ConversationResponseDto,
-  SendCompletionDtoModeEnum,
-} from '@epam/ai-dial-chat-api-client';
 import {
   type Dispatch,
   type MutableRefObject,

--- a/apps/chat/src/hooks/conversation/useConversationListBridge.ts
+++ b/apps/chat/src/hooks/conversation/useConversationListBridge.ts
@@ -9,7 +9,7 @@ import type {
 import type {
   ConversationListItemDto,
   ConversationResponseDto,
-} from '@epam/chat-api-client';
+} from '@epam/ai-dial-chat-api-client';
 import { useEffect } from 'react';
 import { useNavigate } from 'react-router';
 import { getConversationRoute } from '../../constants/routes';

--- a/apps/chat/src/hooks/conversation/useConversationListBridge.ts
+++ b/apps/chat/src/hooks/conversation/useConversationListBridge.ts
@@ -1,4 +1,8 @@
 import type {
+  ConversationListItemDto,
+  ConversationResponseDto,
+} from '@epam/ai-dial-chat-api-client';
+import type {
   CreateConversationResponse,
   DeleteConversationResponse,
   OverlayConversation,
@@ -6,10 +10,6 @@ import type {
   RenameConversationResponse,
   SelectConversationResponse,
 } from '@epam/ai-dial-chat-overlay';
-import type {
-  ConversationListItemDto,
-  ConversationResponseDto,
-} from '@epam/ai-dial-chat-api-client';
 import { useEffect } from 'react';
 import { useNavigate } from 'react-router';
 import { getConversationRoute } from '../../constants/routes';

--- a/apps/chat/src/hooks/conversation/useConversationStream.ts
+++ b/apps/chat/src/hooks/conversation/useConversationStream.ts
@@ -2,7 +2,7 @@ import {
   type Conversation,
   type MessageCustomContent,
 } from '@epam/ai-dial-chat-shared';
-import type { SendCompletionDtoModeEnum } from '@epam/chat-api-client'; // type-only is fine here — used only as a type annotation
+import type { SendCompletionDtoModeEnum } from '@epam/ai-dial-chat-api-client'; // type-only is fine here — used only as a type annotation
 import {
   type Dispatch,
   type MutableRefObject,

--- a/apps/chat/src/hooks/conversation/useConversationStream.ts
+++ b/apps/chat/src/hooks/conversation/useConversationStream.ts
@@ -1,8 +1,8 @@
+import type { SendCompletionDtoModeEnum } from '@epam/ai-dial-chat-api-client'; // type-only is fine here — used only as a type annotation
 import {
   type Conversation,
   type MessageCustomContent,
 } from '@epam/ai-dial-chat-shared';
-import type { SendCompletionDtoModeEnum } from '@epam/ai-dial-chat-api-client'; // type-only is fine here — used only as a type annotation
 import {
   type Dispatch,
   type MutableRefObject,

--- a/apps/chat/src/hooks/files/dial-file-manager-copy-move.util.ts
+++ b/apps/chat/src/hooks/files/dial-file-manager-copy-move.util.ts
@@ -1,5 +1,3 @@
-import type { DialCopiedItem } from '@epam/ai-dial-react-file-manager';
-import { DialFileNodeType } from '@epam/ai-dial-react-file-manager';
 import type {
   CopyItemDto,
   MoveItemDto,
@@ -10,6 +8,8 @@ import {
   MoveItemDtoNodeTypeEnum,
   RenameItemDtoNodeTypeEnum,
 } from '@epam/ai-dial-chat-api-client';
+import type { DialCopiedItem } from '@epam/ai-dial-react-file-manager';
+import { DialFileNodeType } from '@epam/ai-dial-react-file-manager';
 import {
   getParentFolderPath,
   virtualPathToApiPath,

--- a/apps/chat/src/hooks/files/dial-file-manager-copy-move.util.ts
+++ b/apps/chat/src/hooks/files/dial-file-manager-copy-move.util.ts
@@ -4,12 +4,12 @@ import type {
   CopyItemDto,
   MoveItemDto,
   RenameItemDto,
-} from '@epam/chat-api-client';
+} from '@epam/ai-dial-chat-api-client';
 import {
   CopyItemDtoNodeTypeEnum,
   MoveItemDtoNodeTypeEnum,
   RenameItemDtoNodeTypeEnum,
-} from '@epam/chat-api-client';
+} from '@epam/ai-dial-chat-api-client';
 import {
   getParentFolderPath,
   virtualPathToApiPath,

--- a/apps/chat/src/hooks/files/dial-file-manager-mapping.util.ts
+++ b/apps/chat/src/hooks/files/dial-file-manager-mapping.util.ts
@@ -1,14 +1,14 @@
-import type { DialFile } from '@epam/ai-dial-react-file-manager';
-import {
-  DialFileManagerTabs,
-  DialFileNodeType,
-} from '@epam/ai-dial-react-file-manager';
 import type {
   CreateFolderResponseDto,
   FileMetadataResponseDto,
   ListFilesItemDto,
 } from '@epam/ai-dial-chat-api-client';
 import { ListFilesItemDtoNodeTypeEnum } from '@epam/ai-dial-chat-api-client';
+import type { DialFile } from '@epam/ai-dial-react-file-manager';
+import {
+  DialFileManagerTabs,
+  DialFileNodeType,
+} from '@epam/ai-dial-react-file-manager';
 import type {
   FileUploadBatchState,
   FileUploadEntry,

--- a/apps/chat/src/hooks/files/dial-file-manager-mapping.util.ts
+++ b/apps/chat/src/hooks/files/dial-file-manager-mapping.util.ts
@@ -7,8 +7,8 @@ import type {
   CreateFolderResponseDto,
   FileMetadataResponseDto,
   ListFilesItemDto,
-} from '@epam/chat-api-client';
-import { ListFilesItemDtoNodeTypeEnum } from '@epam/chat-api-client';
+} from '@epam/ai-dial-chat-api-client';
+import { ListFilesItemDtoNodeTypeEnum } from '@epam/ai-dial-chat-api-client';
 import type {
   FileUploadBatchState,
   FileUploadEntry,

--- a/apps/chat/src/hooks/files/tests/listing/useDialFileListing.spec.tsx
+++ b/apps/chat/src/hooks/files/tests/listing/useDialFileListing.spec.tsx
@@ -1,6 +1,6 @@
-import { DialFileManagerTabs } from '@epam/ai-dial-react-file-manager';
 import type { ListFilesItemDto } from '@epam/ai-dial-chat-api-client';
 import { ListFilesItemDtoNodeTypeEnum } from '@epam/ai-dial-chat-api-client';
+import { DialFileManagerTabs } from '@epam/ai-dial-react-file-manager';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import * as filesApi from '../../../../server-api/files.api';

--- a/apps/chat/src/hooks/files/tests/listing/useDialFileListing.spec.tsx
+++ b/apps/chat/src/hooks/files/tests/listing/useDialFileListing.spec.tsx
@@ -1,6 +1,6 @@
 import { DialFileManagerTabs } from '@epam/ai-dial-react-file-manager';
-import type { ListFilesItemDto } from '@epam/chat-api-client';
-import { ListFilesItemDtoNodeTypeEnum } from '@epam/chat-api-client';
+import type { ListFilesItemDto } from '@epam/ai-dial-chat-api-client';
+import { ListFilesItemDtoNodeTypeEnum } from '@epam/ai-dial-chat-api-client';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import * as filesApi from '../../../../server-api/files.api';

--- a/apps/chat/src/hooks/files/tests/upload/useDialFileUploadBatch.spec.tsx
+++ b/apps/chat/src/hooks/files/tests/upload/useDialFileUploadBatch.spec.tsx
@@ -1,7 +1,7 @@
-import { DialFileManagerTabs } from '@epam/ai-dial-react-file-manager';
-import { NotificationVariant } from '@epam/ai-dial-ui-kit';
 import type { ListFilesItemDto } from '@epam/ai-dial-chat-api-client';
 import { ListFilesItemDtoNodeTypeEnum } from '@epam/ai-dial-chat-api-client';
+import { DialFileManagerTabs } from '@epam/ai-dial-react-file-manager';
+import { NotificationVariant } from '@epam/ai-dial-ui-kit';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import * as filesApi from '../../../../server-api/files.api';

--- a/apps/chat/src/hooks/files/tests/upload/useDialFileUploadBatch.spec.tsx
+++ b/apps/chat/src/hooks/files/tests/upload/useDialFileUploadBatch.spec.tsx
@@ -1,7 +1,7 @@
 import { DialFileManagerTabs } from '@epam/ai-dial-react-file-manager';
 import { NotificationVariant } from '@epam/ai-dial-ui-kit';
-import type { ListFilesItemDto } from '@epam/chat-api-client';
-import { ListFilesItemDtoNodeTypeEnum } from '@epam/chat-api-client';
+import type { ListFilesItemDto } from '@epam/ai-dial-chat-api-client';
+import { ListFilesItemDtoNodeTypeEnum } from '@epam/ai-dial-chat-api-client';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import * as filesApi from '../../../../server-api/files.api';

--- a/apps/chat/src/hooks/files/tests/useDialFileManager.spec.tsx
+++ b/apps/chat/src/hooks/files/tests/useDialFileManager.spec.tsx
@@ -7,8 +7,8 @@ import {
   FileManagerColumnKey,
 } from '@epam/ai-dial-react-file-manager';
 import { NotificationVariant } from '@epam/ai-dial-ui-kit';
-import type { ListFilesItemDto } from '@epam/chat-api-client';
-import { ListFilesItemDtoNodeTypeEnum } from '@epam/chat-api-client';
+import type { ListFilesItemDto } from '@epam/ai-dial-chat-api-client';
+import { ListFilesItemDtoNodeTypeEnum } from '@epam/ai-dial-chat-api-client';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import * as filesApi from '../../../server-api/files.api';

--- a/apps/chat/src/hooks/files/tests/useDialFileManager.spec.tsx
+++ b/apps/chat/src/hooks/files/tests/useDialFileManager.spec.tsx
@@ -1,3 +1,5 @@
+import type { ListFilesItemDto } from '@epam/ai-dial-chat-api-client';
+import { ListFilesItemDtoNodeTypeEnum } from '@epam/ai-dial-chat-api-client';
 import { HIDDEN_FILE } from '@epam/ai-dial-chat-shared';
 import {
   DialFileManagerActions,
@@ -7,8 +9,6 @@ import {
   FileManagerColumnKey,
 } from '@epam/ai-dial-react-file-manager';
 import { NotificationVariant } from '@epam/ai-dial-ui-kit';
-import type { ListFilesItemDto } from '@epam/ai-dial-chat-api-client';
-import { ListFilesItemDtoNodeTypeEnum } from '@epam/ai-dial-chat-api-client';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import * as filesApi from '../../../server-api/files.api';

--- a/apps/chat/src/hooks/files/useDialFileListing.ts
+++ b/apps/chat/src/hooks/files/useDialFileListing.ts
@@ -7,8 +7,8 @@ import { NotificationVariant } from '@epam/ai-dial-ui-kit';
 import type {
   CreateFolderResponseDto,
   ListFilesItemDto,
-} from '@epam/chat-api-client';
-import { ListFilesItemDtoNodeTypeEnum } from '@epam/chat-api-client';
+} from '@epam/ai-dial-chat-api-client';
+import { ListFilesItemDtoNodeTypeEnum } from '@epam/ai-dial-chat-api-client';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { DialFileManagerI18nKeys } from '../../constants/translation-keys';

--- a/apps/chat/src/hooks/files/useDialFileListing.ts
+++ b/apps/chat/src/hooks/files/useDialFileListing.ts
@@ -1,14 +1,14 @@
+import type {
+  CreateFolderResponseDto,
+  ListFilesItemDto,
+} from '@epam/ai-dial-chat-api-client';
+import { ListFilesItemDtoNodeTypeEnum } from '@epam/ai-dial-chat-api-client';
 import type { DialFile } from '@epam/ai-dial-react-file-manager';
 import {
   DialFileManagerTabs,
   DialFileNodeType,
 } from '@epam/ai-dial-react-file-manager';
 import { NotificationVariant } from '@epam/ai-dial-ui-kit';
-import type {
-  CreateFolderResponseDto,
-  ListFilesItemDto,
-} from '@epam/ai-dial-chat-api-client';
-import { ListFilesItemDtoNodeTypeEnum } from '@epam/ai-dial-chat-api-client';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { DialFileManagerI18nKeys } from '../../constants/translation-keys';

--- a/apps/chat/src/hooks/files/useDialFileMutations.ts
+++ b/apps/chat/src/hooks/files/useDialFileMutations.ts
@@ -1,4 +1,13 @@
 import type {
+  CreateFolderResponseDto,
+  DeleteItemDto,
+} from '@epam/ai-dial-chat-api-client';
+import {
+  ArchiveItemDtoNodeTypeEnum,
+  DeleteItemDtoNodeTypeEnum,
+  RenameItemDtoNodeTypeEnum,
+} from '@epam/ai-dial-chat-api-client';
+import type {
   DialCopiedItem,
   DialDeletedItem,
   DialFile,
@@ -9,15 +18,6 @@ import {
   DialFileNodeType,
 } from '@epam/ai-dial-react-file-manager';
 import { NOT_ALLOWED_SYMBOLS, NotificationVariant } from '@epam/ai-dial-ui-kit';
-import type {
-  CreateFolderResponseDto,
-  DeleteItemDto,
-} from '@epam/ai-dial-chat-api-client';
-import {
-  ArchiveItemDtoNodeTypeEnum,
-  DeleteItemDtoNodeTypeEnum,
-  RenameItemDtoNodeTypeEnum,
-} from '@epam/ai-dial-chat-api-client';
 import { useCallback, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { DialFileManagerI18nKeys } from '../../constants/translation-keys';

--- a/apps/chat/src/hooks/files/useDialFileMutations.ts
+++ b/apps/chat/src/hooks/files/useDialFileMutations.ts
@@ -12,12 +12,12 @@ import { NOT_ALLOWED_SYMBOLS, NotificationVariant } from '@epam/ai-dial-ui-kit';
 import type {
   CreateFolderResponseDto,
   DeleteItemDto,
-} from '@epam/chat-api-client';
+} from '@epam/ai-dial-chat-api-client';
 import {
   ArchiveItemDtoNodeTypeEnum,
   DeleteItemDtoNodeTypeEnum,
   RenameItemDtoNodeTypeEnum,
-} from '@epam/chat-api-client';
+} from '@epam/ai-dial-chat-api-client';
 import { useCallback, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { DialFileManagerI18nKeys } from '../../constants/translation-keys';

--- a/apps/chat/src/hooks/files/useDialFileSharing.ts
+++ b/apps/chat/src/hooks/files/useDialFileSharing.ts
@@ -3,7 +3,7 @@ import { NotificationVariant } from '@epam/ai-dial-ui-kit';
 import type {
   DiscardSharedItemDto,
   RevokeAccessItemDto,
-} from '@epam/chat-api-client';
+} from '@epam/ai-dial-chat-api-client';
 import { useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { DialFileManagerI18nKeys } from '../../constants/translation-keys';

--- a/apps/chat/src/hooks/files/useDialFileSharing.ts
+++ b/apps/chat/src/hooks/files/useDialFileSharing.ts
@@ -1,9 +1,9 @@
-import type { DialFile } from '@epam/ai-dial-react-file-manager';
-import { NotificationVariant } from '@epam/ai-dial-ui-kit';
 import type {
   DiscardSharedItemDto,
   RevokeAccessItemDto,
 } from '@epam/ai-dial-chat-api-client';
+import type { DialFile } from '@epam/ai-dial-react-file-manager';
+import { NotificationVariant } from '@epam/ai-dial-ui-kit';
 import { useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { DialFileManagerI18nKeys } from '../../constants/translation-keys';

--- a/apps/chat/src/hooks/files/useDialFileUploadBatch.ts
+++ b/apps/chat/src/hooks/files/useDialFileUploadBatch.ts
@@ -1,13 +1,13 @@
 import type {
+  ListFilesItemDto,
+  UploadArchiveEntryResultDto,
+} from '@epam/ai-dial-chat-api-client';
+import type {
   DialFile,
   DialUploadFileItem,
 } from '@epam/ai-dial-react-file-manager';
 import { DialFileManagerTabs } from '@epam/ai-dial-react-file-manager';
 import { NotificationVariant } from '@epam/ai-dial-ui-kit';
-import type {
-  ListFilesItemDto,
-  UploadArchiveEntryResultDto,
-} from '@epam/ai-dial-chat-api-client';
 import { useCallback, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type {

--- a/apps/chat/src/hooks/files/useDialFileUploadBatch.ts
+++ b/apps/chat/src/hooks/files/useDialFileUploadBatch.ts
@@ -7,7 +7,7 @@ import { NotificationVariant } from '@epam/ai-dial-ui-kit';
 import type {
   ListFilesItemDto,
   UploadArchiveEntryResultDto,
-} from '@epam/chat-api-client';
+} from '@epam/ai-dial-chat-api-client';
 import { useCallback, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type {

--- a/apps/chat/src/hooks/publish/tests/usePublishFolders.spec.ts
+++ b/apps/chat/src/hooks/publish/tests/usePublishFolders.spec.ts
@@ -1,4 +1,4 @@
-import { ListFilesItemDtoNodeTypeEnum } from '@epam/chat-api-client';
+import { ListFilesItemDtoNodeTypeEnum } from '@epam/ai-dial-chat-api-client';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { createFolder, listPublicFiles } from '../../../server-api/files.api';

--- a/apps/chat/src/hooks/publish/usePublishFolders.ts
+++ b/apps/chat/src/hooks/publish/usePublishFolders.ts
@@ -1,11 +1,11 @@
+import type { ListFilesItemDto } from '@epam/ai-dial-chat-api-client';
+import { ListFilesItemDtoNodeTypeEnum } from '@epam/ai-dial-chat-api-client';
 import {
   fromFolderPathKey,
   mergeFolderPaths,
   PublishFolderNode,
   toFolderPathKey,
 } from '@epam/ai-dial-publish-panel';
-import type { ListFilesItemDto } from '@epam/ai-dial-chat-api-client';
-import { ListFilesItemDtoNodeTypeEnum } from '@epam/ai-dial-chat-api-client';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { listPublicFiles } from '../../server-api/files.api';
 import { StorageKey } from '../../types/storage-key';

--- a/apps/chat/src/hooks/publish/usePublishFolders.ts
+++ b/apps/chat/src/hooks/publish/usePublishFolders.ts
@@ -4,8 +4,8 @@ import {
   PublishFolderNode,
   toFolderPathKey,
 } from '@epam/ai-dial-publish-panel';
-import type { ListFilesItemDto } from '@epam/chat-api-client';
-import { ListFilesItemDtoNodeTypeEnum } from '@epam/chat-api-client';
+import type { ListFilesItemDto } from '@epam/ai-dial-chat-api-client';
+import { ListFilesItemDtoNodeTypeEnum } from '@epam/ai-dial-chat-api-client';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { listPublicFiles } from '../../server-api/files.api';
 import { StorageKey } from '../../types/storage-key';

--- a/apps/chat/src/hooks/scheduled-tasks/useScheduledTaskRuns.ts
+++ b/apps/chat/src/hooks/scheduled-tasks/useScheduledTaskRuns.ts
@@ -1,4 +1,4 @@
-import type { ScheduledTaskRunDto } from '@epam/chat-api-client';
+import type { ScheduledTaskRunDto } from '@epam/ai-dial-chat-api-client';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { listScheduledTaskRuns } from '../../server-api/scheduled-tasks.api';
 

--- a/apps/chat/src/hooks/scheduled-tasks/useScheduledTasks.ts
+++ b/apps/chat/src/hooks/scheduled-tasks/useScheduledTasks.ts
@@ -1,5 +1,5 @@
 import { ScheduledTasksSortKey } from '@epam/ai-dial-scheduled-tasks';
-import type { ScheduledTaskDto } from '@epam/chat-api-client';
+import type { ScheduledTaskDto } from '@epam/ai-dial-chat-api-client';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { listScheduledTasks } from '../../server-api/scheduled-tasks.api';
 

--- a/apps/chat/src/hooks/scheduled-tasks/useScheduledTasks.ts
+++ b/apps/chat/src/hooks/scheduled-tasks/useScheduledTasks.ts
@@ -1,5 +1,5 @@
-import { ScheduledTasksSortKey } from '@epam/ai-dial-scheduled-tasks';
 import type { ScheduledTaskDto } from '@epam/ai-dial-chat-api-client';
+import { ScheduledTasksSortKey } from '@epam/ai-dial-scheduled-tasks';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { listScheduledTasks } from '../../server-api/scheduled-tasks.api';
 

--- a/apps/chat/src/hooks/tests/useConversationExport.spec.ts
+++ b/apps/chat/src/hooks/tests/useConversationExport.spec.ts
@@ -1,5 +1,5 @@
 import { triggerBlobDownload } from '@epam/ai-dial-chat-shared';
-import { ResponseError } from '@epam/chat-api-client';
+import { ResponseError } from '@epam/ai-dial-chat-api-client';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import {
   afterEach,

--- a/apps/chat/src/hooks/tests/useConversationExport.spec.ts
+++ b/apps/chat/src/hooks/tests/useConversationExport.spec.ts
@@ -1,5 +1,5 @@
-import { triggerBlobDownload } from '@epam/ai-dial-chat-shared';
 import { ResponseError } from '@epam/ai-dial-chat-api-client';
+import { triggerBlobDownload } from '@epam/ai-dial-chat-shared';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import {
   afterEach,

--- a/apps/chat/src/hooks/tests/useConversationImport.spec.ts
+++ b/apps/chat/src/hooks/tests/useConversationImport.spec.ts
@@ -6,7 +6,7 @@ import {
 import {
   ResponseError,
   type ConversationResponseDto,
-} from '@epam/chat-api-client';
+} from '@epam/ai-dial-chat-api-client';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { strToU8, zipSync } from 'fflate';
 import {

--- a/apps/chat/src/hooks/tests/useConversationImport.spec.ts
+++ b/apps/chat/src/hooks/tests/useConversationImport.spec.ts
@@ -1,12 +1,12 @@
 import {
+  ResponseError,
+  type ConversationResponseDto,
+} from '@epam/ai-dial-chat-api-client';
+import {
   MessageRole,
   type Conversation,
   type ExportFormat,
 } from '@epam/ai-dial-chat-shared';
-import {
-  ResponseError,
-  type ConversationResponseDto,
-} from '@epam/ai-dial-chat-api-client';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { strToU8, zipSync } from 'fflate';
 import {

--- a/apps/chat/src/hooks/toolsets/useToolsetLogin.ts
+++ b/apps/chat/src/hooks/toolsets/useToolsetLogin.ts
@@ -1,7 +1,7 @@
 import type {
   ToolsetLoginBodyDto,
   ToolsetLogoutBodyDto,
-} from '@epam/chat-api-client';
+} from '@epam/ai-dial-chat-api-client';
 import { useCallback } from 'react';
 import {
   ToolsetAuthTypes,

--- a/apps/chat/src/hooks/useConversationExport.ts
+++ b/apps/chat/src/hooks/useConversationExport.ts
@@ -6,7 +6,7 @@ import { NotificationVariant } from '@epam/ai-dial-ui-kit';
 import {
   ResponseError,
   type ConversationListItemDto,
-} from '@epam/chat-api-client';
+} from '@epam/ai-dial-chat-api-client';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { normalizeConversationId } from '../constants/routes';

--- a/apps/chat/src/hooks/useConversationExport.ts
+++ b/apps/chat/src/hooks/useConversationExport.ts
@@ -1,12 +1,12 @@
 import {
+  ResponseError,
+  type ConversationListItemDto,
+} from '@epam/ai-dial-chat-api-client';
+import {
   triggerBlobDownload,
   type Conversation,
 } from '@epam/ai-dial-chat-shared';
 import { NotificationVariant } from '@epam/ai-dial-ui-kit';
-import {
-  ResponseError,
-  type ConversationListItemDto,
-} from '@epam/ai-dial-chat-api-client';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { normalizeConversationId } from '../constants/routes';

--- a/apps/chat/src/hooks/useConversationImport.ts
+++ b/apps/chat/src/hooks/useConversationImport.ts
@@ -1,9 +1,9 @@
-import type { Conversation } from '@epam/ai-dial-chat-shared';
-import { NotificationVariant } from '@epam/ai-dial-ui-kit';
 import {
   ResponseError,
   type ConversationResponseDto,
 } from '@epam/ai-dial-chat-api-client';
+import type { Conversation } from '@epam/ai-dial-chat-shared';
+import { NotificationVariant } from '@epam/ai-dial-ui-kit';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import {

--- a/apps/chat/src/hooks/useConversationImport.ts
+++ b/apps/chat/src/hooks/useConversationImport.ts
@@ -3,7 +3,7 @@ import { NotificationVariant } from '@epam/ai-dial-ui-kit';
 import {
   ResponseError,
   type ConversationResponseDto,
-} from '@epam/chat-api-client';
+} from '@epam/ai-dial-chat-api-client';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import {

--- a/apps/chat/src/models/scheduled-tasks.ts
+++ b/apps/chat/src/models/scheduled-tasks.ts
@@ -1,4 +1,4 @@
-import type { ListScheduledTasksSortEnum } from '@epam/chat-api-client';
+import type { ListScheduledTasksSortEnum } from '@epam/ai-dial-chat-api-client';
 
 /** Params for `listScheduledTasks`. */
 export interface ListScheduledTasksParams {

--- a/apps/chat/src/pages/AppsEditor/AppEditorIframe.tsx
+++ b/apps/chat/src/pages/AppsEditor/AppEditorIframe.tsx
@@ -1,6 +1,6 @@
 import type { CatalogItemCredentials } from '@epam/ai-dial-catalog';
 import { Spinner } from '@epam/ai-dial-ui-kit';
-import type { ApplicationSchemaSummaryDto } from '@epam/chat-api-client';
+import type { ApplicationSchemaSummaryDto } from '@epam/ai-dial-chat-api-client';
 import {
   forwardRef,
   memo,

--- a/apps/chat/src/pages/AppsEditor/AppEditorIframe.tsx
+++ b/apps/chat/src/pages/AppsEditor/AppEditorIframe.tsx
@@ -1,6 +1,6 @@
 import type { CatalogItemCredentials } from '@epam/ai-dial-catalog';
-import { Spinner } from '@epam/ai-dial-ui-kit';
 import type { ApplicationSchemaSummaryDto } from '@epam/ai-dial-chat-api-client';
+import { Spinner } from '@epam/ai-dial-ui-kit';
 import {
   forwardRef,
   memo,

--- a/apps/chat/src/pages/AppsEditor/AppPreviewChat.tsx
+++ b/apps/chat/src/pages/AppsEditor/AppPreviewChat.tsx
@@ -1,3 +1,4 @@
+import type { ConversationResponseDto } from '@epam/ai-dial-chat-api-client';
 import {
   MessageRating,
   MessageRole,
@@ -12,7 +13,6 @@ import {
   ConfirmationPopup,
   NotificationVariant,
 } from '@epam/ai-dial-ui-kit';
-import type { ConversationResponseDto } from '@epam/ai-dial-chat-api-client';
 import type { FC } from 'react';
 import {
   memo,

--- a/apps/chat/src/pages/AppsEditor/AppPreviewChat.tsx
+++ b/apps/chat/src/pages/AppsEditor/AppPreviewChat.tsx
@@ -12,7 +12,7 @@ import {
   ConfirmationPopup,
   NotificationVariant,
 } from '@epam/ai-dial-ui-kit';
-import type { ConversationResponseDto } from '@epam/chat-api-client';
+import type { ConversationResponseDto } from '@epam/ai-dial-chat-api-client';
 import type { FC } from 'react';
 import {
   memo,

--- a/apps/chat/src/pages/AppsEditor/AppsEditor.tsx
+++ b/apps/chat/src/pages/AppsEditor/AppsEditor.tsx
@@ -3,7 +3,7 @@ import {
   ErrorMessageNotification,
   StepStatus,
 } from '@epam/ai-dial-ui-kit';
-import type { ApplicationSchemaSummaryDto } from '@epam/chat-api-client';
+import type { ApplicationSchemaSummaryDto } from '@epam/ai-dial-chat-api-client';
 import type { FC } from 'react';
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/apps/chat/src/pages/AppsEditor/AppsEditor.tsx
+++ b/apps/chat/src/pages/AppsEditor/AppsEditor.tsx
@@ -1,9 +1,9 @@
+import type { ApplicationSchemaSummaryDto } from '@epam/ai-dial-chat-api-client';
 import {
   Spinner,
   ErrorMessageNotification,
   StepStatus,
 } from '@epam/ai-dial-ui-kit';
-import type { ApplicationSchemaSummaryDto } from '@epam/ai-dial-chat-api-client';
 import type { FC } from 'react';
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/apps/chat/src/pages/AppsEditor/SettingsStep.tsx
+++ b/apps/chat/src/pages/AppsEditor/SettingsStep.tsx
@@ -1,5 +1,5 @@
 import { mergeClasses } from '@epam/ai-dial-chat-shared';
-import type { ApplicationSchemaSummaryDto } from '@epam/chat-api-client';
+import type { ApplicationSchemaSummaryDto } from '@epam/ai-dial-chat-api-client';
 import { forwardRef, memo, useImperativeHandle, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { AppsEditorI18nKeys } from '../../constants/translation-keys';

--- a/apps/chat/src/pages/AppsEditor/SettingsStep.tsx
+++ b/apps/chat/src/pages/AppsEditor/SettingsStep.tsx
@@ -1,5 +1,5 @@
-import { mergeClasses } from '@epam/ai-dial-chat-shared';
 import type { ApplicationSchemaSummaryDto } from '@epam/ai-dial-chat-api-client';
+import { mergeClasses } from '@epam/ai-dial-chat-shared';
 import { forwardRef, memo, useImperativeHandle, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { AppsEditorI18nKeys } from '../../constants/translation-keys';

--- a/apps/chat/src/pages/AppsEditor/tests/AppEditorIframe.spec.tsx
+++ b/apps/chat/src/pages/AppsEditor/tests/AppEditorIframe.spec.tsx
@@ -1,4 +1,4 @@
-import type { DialToolsetDto } from '@epam/chat-api-client';
+import type { DialToolsetDto } from '@epam/ai-dial-chat-api-client';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import type { ComponentProps, Ref } from 'react';
 import { createRef } from 'react';

--- a/apps/chat/src/pages/Conversation/Conversation.tsx
+++ b/apps/chat/src/pages/Conversation/Conversation.tsx
@@ -1,3 +1,4 @@
+import type { ConversationResponseDto } from '@epam/ai-dial-chat-api-client';
 import {
   MessageRating,
   MessageRole,
@@ -10,7 +11,6 @@ import {
   Spinner,
   NotificationVariant,
 } from '@epam/ai-dial-ui-kit';
-import type { ConversationResponseDto } from '@epam/ai-dial-chat-api-client';
 import { FC, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate, useParams } from 'react-router';

--- a/apps/chat/src/pages/Conversation/Conversation.tsx
+++ b/apps/chat/src/pages/Conversation/Conversation.tsx
@@ -10,7 +10,7 @@ import {
   Spinner,
   NotificationVariant,
 } from '@epam/ai-dial-ui-kit';
-import type { ConversationResponseDto } from '@epam/chat-api-client';
+import type { ConversationResponseDto } from '@epam/ai-dial-chat-api-client';
 import { FC, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate, useParams } from 'react-router';

--- a/apps/chat/src/pages/ConversationRoute/ConversationRoute.spec.tsx
+++ b/apps/chat/src/pages/ConversationRoute/ConversationRoute.spec.tsx
@@ -1,7 +1,10 @@
+import {
+  DeploymentItemDto,
+  DialToolsetDto,
+} from '@epam/ai-dial-chat-api-client';
 import type { DeploymentConfigurationSchema } from '@epam/ai-dial-chat-shared';
 import { SendOnEnter } from '@epam/ai-dial-conversation-input';
 import { NotificationVariant } from '@epam/ai-dial-ui-kit';
-import { DeploymentItemDto, DialToolsetDto } from '@epam/chat-api-client';
 import { act, render, screen, waitFor } from '@testing-library/react';
 import { ReactNode, useEffect, useState, type Context } from 'react';
 import { MemoryRouter, useNavigate } from 'react-router';

--- a/apps/chat/src/pages/ConversationRoute/ConversationRoute.tsx
+++ b/apps/chat/src/pages/ConversationRoute/ConversationRoute.tsx
@@ -4,7 +4,7 @@ import type {
   StarterOption,
 } from '@epam/ai-dial-chat-shared';
 import { NotificationVariant } from '@epam/ai-dial-ui-kit';
-import type { ConversationResponseDto } from '@epam/chat-api-client';
+import type { ConversationResponseDto } from '@epam/ai-dial-chat-api-client';
 import {
   FC,
   memo,

--- a/apps/chat/src/pages/ConversationRoute/ConversationRoute.tsx
+++ b/apps/chat/src/pages/ConversationRoute/ConversationRoute.tsx
@@ -1,10 +1,10 @@
+import type { ConversationResponseDto } from '@epam/ai-dial-chat-api-client';
 import type {
   Attachment,
   DeploymentItem,
   StarterOption,
 } from '@epam/ai-dial-chat-shared';
 import { NotificationVariant } from '@epam/ai-dial-ui-kit';
-import type { ConversationResponseDto } from '@epam/ai-dial-chat-api-client';
 import {
   FC,
   memo,

--- a/apps/chat/src/pages/ScheduledTaskDetailPage/ScheduledTaskDetailPage.tsx
+++ b/apps/chat/src/pages/ScheduledTaskDetailPage/ScheduledTaskDetailPage.tsx
@@ -2,7 +2,7 @@ import {
   ScheduledTaskDetailView,
   type ScheduledTaskRunItem,
 } from '@epam/ai-dial-scheduled-tasks';
-import type { ScheduledTaskDto } from '@epam/chat-api-client';
+import type { ScheduledTaskDto } from '@epam/ai-dial-chat-api-client';
 import {
   memo,
   useCallback,

--- a/apps/chat/src/pages/ScheduledTaskDetailPage/ScheduledTaskDetailPage.tsx
+++ b/apps/chat/src/pages/ScheduledTaskDetailPage/ScheduledTaskDetailPage.tsx
@@ -1,8 +1,8 @@
+import type { ScheduledTaskDto } from '@epam/ai-dial-chat-api-client';
 import {
   ScheduledTaskDetailView,
   type ScheduledTaskRunItem,
 } from '@epam/ai-dial-scheduled-tasks';
-import type { ScheduledTaskDto } from '@epam/ai-dial-chat-api-client';
 import {
   memo,
   useCallback,

--- a/apps/chat/src/pages/ScheduledTaskEditPage/ScheduledTaskEditPage.tsx
+++ b/apps/chat/src/pages/ScheduledTaskEditPage/ScheduledTaskEditPage.tsx
@@ -1,3 +1,4 @@
+import type { ScheduledTaskDto } from '@epam/ai-dial-chat-api-client';
 import {
   ScheduledTaskCreateForm,
   ScheduledTaskCreateFormErrors,
@@ -5,7 +6,6 @@ import {
   ScheduledTaskRepeat,
 } from '@epam/ai-dial-scheduled-tasks';
 import { GhostButton, NotificationVariant } from '@epam/ai-dial-ui-kit';
-import type { ScheduledTaskDto } from '@epam/ai-dial-chat-api-client';
 import {
   memo,
   useCallback,

--- a/apps/chat/src/pages/ScheduledTaskEditPage/ScheduledTaskEditPage.tsx
+++ b/apps/chat/src/pages/ScheduledTaskEditPage/ScheduledTaskEditPage.tsx
@@ -5,7 +5,7 @@ import {
   ScheduledTaskRepeat,
 } from '@epam/ai-dial-scheduled-tasks';
 import { GhostButton, NotificationVariant } from '@epam/ai-dial-ui-kit';
-import type { ScheduledTaskDto } from '@epam/chat-api-client';
+import type { ScheduledTaskDto } from '@epam/ai-dial-chat-api-client';
 import {
   memo,
   useCallback,

--- a/apps/chat/src/pages/ToolsetAuthCallback/ToolsetAuthCallback.tsx
+++ b/apps/chat/src/pages/ToolsetAuthCallback/ToolsetAuthCallback.tsx
@@ -8,7 +8,7 @@
  * provider, then this route exposes success/failure through the popup URL and
  * a flow-scoped `BroadcastChannel`.
  */
-import type { ToolsetLoginBodyDto } from '@epam/chat-api-client';
+import type { ToolsetLoginBodyDto } from '@epam/ai-dial-chat-api-client';
 import type { FC } from 'react';
 import { memo, useEffect, useRef } from 'react';
 import { useSearchParams } from 'react-router';

--- a/apps/chat/src/pages/ToolsetEditor/CustomAppEditor.tsx
+++ b/apps/chat/src/pages/ToolsetEditor/CustomAppEditor.tsx
@@ -1,5 +1,5 @@
-import { ConfirmationPopup, NotificationVariant } from '@epam/ai-dial-ui-kit';
 import type { CreateApplicationBodyDto } from '@epam/ai-dial-chat-api-client';
+import { ConfirmationPopup, NotificationVariant } from '@epam/ai-dial-ui-kit';
 import type { FC } from 'react';
 import { memo, useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/apps/chat/src/pages/ToolsetEditor/CustomAppEditor.tsx
+++ b/apps/chat/src/pages/ToolsetEditor/CustomAppEditor.tsx
@@ -1,5 +1,5 @@
 import { ConfirmationPopup, NotificationVariant } from '@epam/ai-dial-ui-kit';
-import type { CreateApplicationBodyDto } from '@epam/chat-api-client';
+import type { CreateApplicationBodyDto } from '@epam/ai-dial-chat-api-client';
 import type { FC } from 'react';
 import { memo, useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/apps/chat/src/pages/ToolsetEditor/EditorForm/AuthSection.tsx
+++ b/apps/chat/src/pages/ToolsetEditor/EditorForm/AuthSection.tsx
@@ -1,3 +1,7 @@
+import type {
+  ToolsetLoginBodyDto,
+  ToolsetLogoutBodyDto,
+} from '@epam/ai-dial-chat-api-client';
 import {
   ConfirmationPopupVariant,
   DIAL_ICON_SIZE,
@@ -10,10 +14,6 @@ import {
   mergeClasses,
   PrimaryButton,
 } from '@epam/ai-dial-ui-kit';
-import type {
-  ToolsetLoginBodyDto,
-  ToolsetLogoutBodyDto,
-} from '@epam/ai-dial-chat-api-client';
 import type { FC } from 'react';
 import { memo, useState } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/apps/chat/src/pages/ToolsetEditor/EditorForm/AuthSection.tsx
+++ b/apps/chat/src/pages/ToolsetEditor/EditorForm/AuthSection.tsx
@@ -13,7 +13,7 @@ import {
 import type {
   ToolsetLoginBodyDto,
   ToolsetLogoutBodyDto,
-} from '@epam/chat-api-client';
+} from '@epam/ai-dial-chat-api-client';
 import type { FC } from 'react';
 import { memo, useState } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/apps/chat/src/pages/ToolsetEditor/ToolsetEditor.tsx
+++ b/apps/chat/src/pages/ToolsetEditor/ToolsetEditor.tsx
@@ -1,9 +1,9 @@
+import type { ToolsetLoginBodyDto } from '@epam/ai-dial-chat-api-client';
 import {
   DeploymentCreationFieldErrorCode,
   validateDeploymentCreationFields,
 } from '@epam/ai-dial-deployment-creation-form';
 import { NotificationVariant } from '@epam/ai-dial-ui-kit';
-import type { ToolsetLoginBodyDto } from '@epam/ai-dial-chat-api-client';
 import type { FC } from 'react';
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/apps/chat/src/pages/ToolsetEditor/ToolsetEditor.tsx
+++ b/apps/chat/src/pages/ToolsetEditor/ToolsetEditor.tsx
@@ -3,7 +3,7 @@ import {
   validateDeploymentCreationFields,
 } from '@epam/ai-dial-deployment-creation-form';
 import { NotificationVariant } from '@epam/ai-dial-ui-kit';
-import type { ToolsetLoginBodyDto } from '@epam/chat-api-client';
+import type { ToolsetLoginBodyDto } from '@epam/ai-dial-chat-api-client';
 import type { FC } from 'react';
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/apps/chat/src/pages/ToolsetEditor/tests/ToolsetEditor.spec.tsx
+++ b/apps/chat/src/pages/ToolsetEditor/tests/ToolsetEditor.spec.tsx
@@ -1,5 +1,5 @@
 import { NotificationVariant } from '@epam/ai-dial-ui-kit';
-import { ResponseError } from '@epam/chat-api-client';
+import { ResponseError } from '@epam/ai-dial-chat-api-client';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { useState } from 'react';

--- a/apps/chat/src/pages/ToolsetEditor/tests/ToolsetEditor.spec.tsx
+++ b/apps/chat/src/pages/ToolsetEditor/tests/ToolsetEditor.spec.tsx
@@ -1,5 +1,5 @@
-import { NotificationVariant } from '@epam/ai-dial-ui-kit';
 import { ResponseError } from '@epam/ai-dial-chat-api-client';
+import { NotificationVariant } from '@epam/ai-dial-ui-kit';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { useState } from 'react';

--- a/apps/chat/src/pages/auth/Login.tsx
+++ b/apps/chat/src/pages/auth/Login.tsx
@@ -1,5 +1,5 @@
 import { NeutralButton } from '@epam/ai-dial-ui-kit';
-import type { ProviderInfoDto } from '@epam/chat-api-client';
+import type { ProviderInfoDto } from '@epam/ai-dial-chat-api-client';
 import {
   memo,
   useCallback,

--- a/apps/chat/src/pages/auth/Login.tsx
+++ b/apps/chat/src/pages/auth/Login.tsx
@@ -1,5 +1,5 @@
-import { NeutralButton } from '@epam/ai-dial-ui-kit';
 import type { ProviderInfoDto } from '@epam/ai-dial-chat-api-client';
+import { NeutralButton } from '@epam/ai-dial-ui-kit';
 import {
   memo,
   useCallback,

--- a/apps/chat/src/server-api/api-client.ts
+++ b/apps/chat/src/server-api/api-client.ts
@@ -16,7 +16,7 @@ import {
   ShareApi,
   ToolsetsApi,
   UserConfigApi,
-} from '@epam/chat-api-client';
+} from '@epam/ai-dial-chat-api-client';
 import {
   ApiEndpoints,
   CsrfRefreshStatus,

--- a/apps/chat/src/server-api/api-error.ts
+++ b/apps/chat/src/server-api/api-error.ts
@@ -108,7 +108,7 @@ export const getApiErrorMessage = async (
 };
 
 /*
- * Normalizes any API error — a generated `@epam/chat-api-client` `ResponseError` or a raw
+ * Normalizes any API error — a generated `@epam/ai-dial-chat-api-client` `ResponseError` or a raw
  * `base.ts` `ApiRequestError`, both of which retain the source `Response` — into one
  * `{ status?, message, traceId? }` shape.
  *

--- a/apps/chat/src/server-api/app-config.api.ts
+++ b/apps/chat/src/server-api/app-config.api.ts
@@ -1,4 +1,4 @@
-import type { ClientConfigResponseDto } from '@epam/chat-api-client';
+import type { ClientConfigResponseDto } from '@epam/ai-dial-chat-api-client';
 import { appConfigApi } from './api-client';
 
 export const getClientConfig = (

--- a/apps/chat/src/server-api/application-schemas.ts
+++ b/apps/chat/src/server-api/application-schemas.ts
@@ -1,4 +1,4 @@
-import type { ApplicationSchemasResponseDto } from '@epam/chat-api-client';
+import type { ApplicationSchemasResponseDto } from '@epam/ai-dial-chat-api-client';
 import { applicationsApi } from './api-client';
 
 export const getApplicationSchemas =

--- a/apps/chat/src/server-api/applications.ts
+++ b/apps/chat/src/server-api/applications.ts
@@ -4,7 +4,7 @@ import type {
   CreatedApplicationDto,
   UpdateApplicationBodyDto,
   UpdatedApplicationDto,
-} from '@epam/chat-api-client';
+} from '@epam/ai-dial-chat-api-client';
 import { applicationsApi } from './api-client';
 
 export const getApplications = (): Promise<ApplicationsResponseDto> =>

--- a/apps/chat/src/server-api/auth.api.ts
+++ b/apps/chat/src/server-api/auth.api.ts
@@ -1,4 +1,4 @@
-import type { ProviderInfoDto, UserProfileDto } from '@epam/chat-api-client';
+import type { ProviderInfoDto, UserProfileDto } from '@epam/ai-dial-chat-api-client';
 import { authApi } from './api-client';
 import {
   ApiEndpoints,

--- a/apps/chat/src/server-api/auth.api.ts
+++ b/apps/chat/src/server-api/auth.api.ts
@@ -1,4 +1,7 @@
-import type { ProviderInfoDto, UserProfileDto } from '@epam/ai-dial-chat-api-client';
+import type {
+  ProviderInfoDto,
+  UserProfileDto,
+} from '@epam/ai-dial-chat-api-client';
 import { authApi } from './api-client';
 import {
   ApiEndpoints,

--- a/apps/chat/src/server-api/chat-stream.api.ts
+++ b/apps/chat/src/server-api/chat-stream.api.ts
@@ -1,5 +1,5 @@
-import { MessageCustomContent, StreamChunk } from '@epam/ai-dial-chat-shared';
 import { SendCompletionDtoModeEnum } from '@epam/ai-dial-chat-api-client';
+import { MessageCustomContent, StreamChunk } from '@epam/ai-dial-chat-shared';
 import { JSON_HEADERS } from '../constants/http';
 import { ApiEndpoints, getCsrfToken, setCsrfToken } from './base';
 

--- a/apps/chat/src/server-api/chat-stream.api.ts
+++ b/apps/chat/src/server-api/chat-stream.api.ts
@@ -1,5 +1,5 @@
 import { MessageCustomContent, StreamChunk } from '@epam/ai-dial-chat-shared';
-import { SendCompletionDtoModeEnum } from '@epam/chat-api-client';
+import { SendCompletionDtoModeEnum } from '@epam/ai-dial-chat-api-client';
 import { JSON_HEADERS } from '../constants/http';
 import { ApiEndpoints, getCsrfToken, setCsrfToken } from './base';
 

--- a/apps/chat/src/server-api/client-channel.ts
+++ b/apps/chat/src/server-api/client-channel.ts
@@ -1,7 +1,7 @@
 import {
   ReportClientChannelDto,
   ReportClientChannelDtoResultEnum,
-} from '@epam/chat-api-client';
+} from '@epam/ai-dial-chat-api-client';
 import { JSON_HEADERS } from '../constants/http';
 import { clientChannelApi } from './api-client';
 import { ApiEndpoints, getCsrfToken, setCsrfToken } from './base';

--- a/apps/chat/src/server-api/conversation-publish.api.ts
+++ b/apps/chat/src/server-api/conversation-publish.api.ts
@@ -1,5 +1,5 @@
-import type { PublicationRule } from '@epam/ai-dial-publish-panel';
 import type { PublishConversationResultDto } from '@epam/ai-dial-chat-api-client';
+import type { PublicationRule } from '@epam/ai-dial-publish-panel';
 import { conversationsApi } from './api-client';
 import { toPublishRuleDto } from './publish-rules.api';
 

--- a/apps/chat/src/server-api/conversation-publish.api.ts
+++ b/apps/chat/src/server-api/conversation-publish.api.ts
@@ -1,5 +1,5 @@
 import type { PublicationRule } from '@epam/ai-dial-publish-panel';
-import type { PublishConversationResultDto } from '@epam/chat-api-client';
+import type { PublishConversationResultDto } from '@epam/ai-dial-chat-api-client';
 import { conversationsApi } from './api-client';
 import { toPublishRuleDto } from './publish-rules.api';
 

--- a/apps/chat/src/server-api/conversations.api.ts
+++ b/apps/chat/src/server-api/conversations.api.ts
@@ -1,7 +1,7 @@
 import type {
   AttachmentDto,
   ConversationResponseDto,
-} from '@epam/chat-api-client';
+} from '@epam/ai-dial-chat-api-client';
 import { conversationsApi } from './api-client';
 
 export const createConversation = (

--- a/apps/chat/src/server-api/deployment-limits.ts
+++ b/apps/chat/src/server-api/deployment-limits.ts
@@ -1,4 +1,4 @@
-import type { DeploymentLimitsResponseDto } from '@epam/chat-api-client';
+import type { DeploymentLimitsResponseDto } from '@epam/ai-dial-chat-api-client';
 import { deploymentsApi } from './api-client';
 
 export const getDeploymentLimits = (

--- a/apps/chat/src/server-api/deployments.api.ts
+++ b/apps/chat/src/server-api/deployments.api.ts
@@ -1,7 +1,7 @@
 import type {
   DeploymentsResponseDto,
   ListDeploymentsInterfaceTypeEnum,
-} from '@epam/chat-api-client';
+} from '@epam/ai-dial-chat-api-client';
 import { deploymentsApi } from './api-client';
 
 export const getDeployments = (

--- a/apps/chat/src/server-api/deployments.ts
+++ b/apps/chat/src/server-api/deployments.ts
@@ -1,5 +1,5 @@
 import type { DeploymentConfigurationSchema } from '@epam/ai-dial-chat-shared';
-import type { DeploymentDetailsDto } from '@epam/chat-api-client';
+import type { DeploymentDetailsDto } from '@epam/ai-dial-chat-api-client';
 import { deploymentsApi } from './api-client';
 
 export const getDeploymentConfiguration = (

--- a/apps/chat/src/server-api/deployments.ts
+++ b/apps/chat/src/server-api/deployments.ts
@@ -1,5 +1,5 @@
-import type { DeploymentConfigurationSchema } from '@epam/ai-dial-chat-shared';
 import type { DeploymentDetailsDto } from '@epam/ai-dial-chat-api-client';
+import type { DeploymentConfigurationSchema } from '@epam/ai-dial-chat-shared';
 import { deploymentsApi } from './api-client';
 
 export const getDeploymentConfiguration = (

--- a/apps/chat/src/server-api/external-services.ts
+++ b/apps/chat/src/server-api/external-services.ts
@@ -8,7 +8,7 @@ import { get, post, ApiEndpoints } from './base';
  * `GetExternalServiceResponseDto`/`ExternalServiceSigninBodyDto`/
  * `ExternalServiceLogoutBodyDto` in
  * `apps/chat-api/src/external-services/dto/external-service.dto.ts` exactly;
- * replace this file's request plumbing with generated `@epam/chat-api-client`
+ * replace this file's request plumbing with generated `@epam/ai-dial-chat-api-client`
  * wrappers once that bug is fixed and the client is regenerated.
  */
 

--- a/apps/chat/src/server-api/files.api.ts
+++ b/apps/chat/src/server-api/files.api.ts
@@ -20,7 +20,7 @@ import type {
   RevokeAccessItemDto,
   RevokeAccessResponseDto,
   UploadArchiveResponseDto,
-} from '@epam/chat-api-client';
+} from '@epam/ai-dial-chat-api-client';
 import { filesApi } from './api-client';
 import {
   type UploadFileWithProgressOptions,

--- a/apps/chat/src/server-api/models.ts
+++ b/apps/chat/src/server-api/models.ts
@@ -1,7 +1,7 @@
 import type {
   DialModelDto,
   DialModelListResponseDto,
-} from '@epam/chat-api-client';
+} from '@epam/ai-dial-chat-api-client';
 import { modelsApi } from './api-client';
 
 export const getModels = (): Promise<DialModelListResponseDto> =>

--- a/apps/chat/src/server-api/publish-rules.api.ts
+++ b/apps/chat/src/server-api/publish-rules.api.ts
@@ -2,7 +2,7 @@ import type {
   PublicationRule,
   PublicationRuleFunction,
 } from '@epam/ai-dial-publish-panel';
-import type { PublishRuleDto } from '@epam/chat-api-client';
+import type { PublishRuleDto } from '@epam/ai-dial-chat-api-client';
 import { publishApi } from './api-client';
 
 /** Converts a `PublicationRule` (publish-panel lib model) to the generated client's `PublishRuleDto` shape. */

--- a/apps/chat/src/server-api/publish-rules.api.ts
+++ b/apps/chat/src/server-api/publish-rules.api.ts
@@ -1,8 +1,8 @@
+import type { PublishRuleDto } from '@epam/ai-dial-chat-api-client';
 import type {
   PublicationRule,
   PublicationRuleFunction,
 } from '@epam/ai-dial-publish-panel';
-import type { PublishRuleDto } from '@epam/ai-dial-chat-api-client';
 import { publishApi } from './api-client';
 
 /** Converts a `PublicationRule` (publish-panel lib model) to the generated client's `PublishRuleDto` shape. */

--- a/apps/chat/src/server-api/publish.api.ts
+++ b/apps/chat/src/server-api/publish.api.ts
@@ -2,8 +2,8 @@ import type {
   PublishCatalogEntityDto,
   PublishHistoryEntryDto,
   PublishResultDto,
-} from '@epam/chat-api-client';
-import { PublishCatalogEntityEntityTypeEnum } from '@epam/chat-api-client';
+} from '@epam/ai-dial-chat-api-client';
+import { PublishCatalogEntityEntityTypeEnum } from '@epam/ai-dial-chat-api-client';
 import { publishApi } from './api-client';
 
 /** Catalog entity kinds that can be published. */

--- a/apps/chat/src/server-api/rate.api.ts
+++ b/apps/chat/src/server-api/rate.api.ts
@@ -1,4 +1,4 @@
-import type { RateMessageDto } from '@epam/chat-api-client';
+import type { RateMessageDto } from '@epam/ai-dial-chat-api-client';
 import { rateApi } from './api-client';
 
 /**

--- a/apps/chat/src/server-api/scheduled-tasks.api.ts
+++ b/apps/chat/src/server-api/scheduled-tasks.api.ts
@@ -6,7 +6,7 @@ import type {
   ScheduledTaskDto,
   UpdateScheduledTaskBodyDto,
   UpdatedScheduledTaskDto,
-} from '@epam/chat-api-client';
+} from '@epam/ai-dial-chat-api-client';
 import type {
   ListScheduledTaskRunsParams,
   ListScheduledTasksParams,

--- a/apps/chat/src/server-api/share.api.ts
+++ b/apps/chat/src/server-api/share.api.ts
@@ -3,7 +3,7 @@ import type {
   CreateShareLinkDto,
   DiscardSharedCatalogItemResponseDto,
   ShareLinkResponseDto,
-} from '@epam/chat-api-client';
+} from '@epam/ai-dial-chat-api-client';
 import { shareApi } from './api-client';
 
 export const createShareLink = (

--- a/apps/chat/src/server-api/tests/api-client.spec.ts
+++ b/apps/chat/src/server-api/tests/api-client.spec.ts
@@ -1,4 +1,4 @@
-import { ConversationsApi, ModelsApi } from '@epam/chat-api-client';
+import { ConversationsApi, ModelsApi } from '@epam/ai-dial-chat-api-client';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { createApiConfiguration } from '../api-client';
 import {

--- a/apps/chat/src/server-api/tests/files.api.spec.ts
+++ b/apps/chat/src/server-api/tests/files.api.spec.ts
@@ -1,7 +1,7 @@
 import type {
   FileMetadataResponseDto,
   ListFilesResponseDto,
-} from '@epam/chat-api-client';
+} from '@epam/ai-dial-chat-api-client';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { filesApi } from '../api-client';
 import { downloadFile, getFileMetadata, listFiles } from '../files.api';

--- a/apps/chat/src/server-api/tests/publish.api.spec.ts
+++ b/apps/chat/src/server-api/tests/publish.api.spec.ts
@@ -1,5 +1,5 @@
-import type { PublishRuleDto } from '@epam/chat-api-client';
-import { PublishRuleDtoFunctionEnum } from '@epam/chat-api-client';
+import type { PublishRuleDto } from '@epam/ai-dial-chat-api-client';
+import { PublishRuleDtoFunctionEnum } from '@epam/ai-dial-chat-api-client';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { publishApi } from '../api-client';
 import { CatalogPublishEntityType, publishCatalogEntity } from '../publish.api';

--- a/apps/chat/src/server-api/tests/scheduled-tasks.api.spec.ts
+++ b/apps/chat/src/server-api/tests/scheduled-tasks.api.spec.ts
@@ -1,7 +1,7 @@
 import {
   ScheduledTaskRunDtoStatusEnum,
   type ListScheduledTaskRunsResponseDto,
-} from '@epam/chat-api-client';
+} from '@epam/ai-dial-chat-api-client';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { scheduledTasksApi } from '../api-client';
 import {

--- a/apps/chat/src/server-api/tests/toolsets.api.spec.ts
+++ b/apps/chat/src/server-api/tests/toolsets.api.spec.ts
@@ -1,7 +1,7 @@
 import type {
   DialToolsetDto,
   DialToolsetListResponseDto,
-} from '@epam/chat-api-client';
+} from '@epam/ai-dial-chat-api-client';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { toolsetsApi } from '../api-client';
 import { getToolset, listToolsets } from '../toolsets';

--- a/apps/chat/src/server-api/tests/upload-file-with-progress.spec.ts
+++ b/apps/chat/src/server-api/tests/upload-file-with-progress.spec.ts
@@ -1,4 +1,4 @@
-import type { FileUploadResponseDto } from '@epam/chat-api-client';
+import type { FileUploadResponseDto } from '@epam/ai-dial-chat-api-client';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { uploadFileWithProgress } from '../upload-file-with-progress';
 

--- a/apps/chat/src/server-api/toolsets.ts
+++ b/apps/chat/src/server-api/toolsets.ts
@@ -6,7 +6,7 @@ import type {
   ToolsetBodyDto,
   ToolsetLoginBodyDto,
   ToolsetLogoutBodyDto,
-} from '@epam/chat-api-client';
+} from '@epam/ai-dial-chat-api-client';
 import { toolsetsApi } from './api-client';
 
 export const listToolsets = (): Promise<DialToolsetListResponseDto> =>

--- a/apps/chat/src/server-api/upload-file-with-progress.ts
+++ b/apps/chat/src/server-api/upload-file-with-progress.ts
@@ -1,4 +1,4 @@
-import type { FileUploadResponseDto } from '@epam/chat-api-client';
+import type { FileUploadResponseDto } from '@epam/ai-dial-chat-api-client';
 import {
   UnauthorizedError,
   getCsrfToken,

--- a/apps/chat/src/types/scheduled-task-mapping.ts
+++ b/apps/chat/src/types/scheduled-task-mapping.ts
@@ -1,5 +1,5 @@
-import type { ScheduledTaskCreateFormValues } from '@epam/ai-dial-scheduled-tasks';
 import type { ScheduledTaskDto } from '@epam/ai-dial-chat-api-client';
+import type { ScheduledTaskCreateFormValues } from '@epam/ai-dial-scheduled-tasks';
 
 /** Why a {@link ScheduledTaskDto} could not be mapped back to editable form values. */
 export enum UnsupportedTriggerReason {

--- a/apps/chat/src/types/scheduled-task-mapping.ts
+++ b/apps/chat/src/types/scheduled-task-mapping.ts
@@ -1,5 +1,5 @@
 import type { ScheduledTaskCreateFormValues } from '@epam/ai-dial-scheduled-tasks';
-import type { ScheduledTaskDto } from '@epam/chat-api-client';
+import type { ScheduledTaskDto } from '@epam/ai-dial-chat-api-client';
 
 /** Why a {@link ScheduledTaskDto} could not be mapped back to editable form values. */
 export enum UnsupportedTriggerReason {

--- a/apps/chat/src/utils/attachment-to-dto.ts
+++ b/apps/chat/src/utils/attachment-to-dto.ts
@@ -1,5 +1,5 @@
 import type { Attachment } from '@epam/ai-dial-chat-shared';
-import type { AttachmentDto } from '@epam/chat-api-client';
+import type { AttachmentDto } from '@epam/ai-dial-chat-api-client';
 
 export const attachmentToDto = (attachment: Attachment): AttachmentDto => {
   if (!attachment.url) {

--- a/apps/chat/src/utils/attachment-to-dto.ts
+++ b/apps/chat/src/utils/attachment-to-dto.ts
@@ -1,5 +1,5 @@
-import type { Attachment } from '@epam/ai-dial-chat-shared';
 import type { AttachmentDto } from '@epam/ai-dial-chat-api-client';
+import type { Attachment } from '@epam/ai-dial-chat-shared';
 
 export const attachmentToDto = (attachment: Attachment): AttachmentDto => {
   if (!attachment.url) {

--- a/apps/chat/src/utils/deployment-id.ts
+++ b/apps/chat/src/utils/deployment-id.ts
@@ -1,4 +1,4 @@
-import type { DeploymentItemDto } from '@epam/chat-api-client';
+import type { DeploymentItemDto } from '@epam/ai-dial-chat-api-client';
 
 /**
  * Percent-encodes each `/`-separated segment of a deployment/application id

--- a/apps/chat/src/utils/display-name-watch.ts
+++ b/apps/chat/src/utils/display-name-watch.ts
@@ -1,6 +1,6 @@
 import type { Conversation } from '@epam/ai-dial-chat-shared';
 import { MessageRole } from '@epam/ai-dial-chat-shared';
-import type { ConversationResponseDto } from '@epam/chat-api-client';
+import type { ConversationResponseDto } from '@epam/ai-dial-chat-api-client';
 
 /** True when the first user/assistant exchange is complete and LLM naming may still run. */
 export const shouldWatchForDisplayNameUpdate = (

--- a/apps/chat/src/utils/display-name-watch.ts
+++ b/apps/chat/src/utils/display-name-watch.ts
@@ -1,6 +1,6 @@
+import type { ConversationResponseDto } from '@epam/ai-dial-chat-api-client';
 import type { Conversation } from '@epam/ai-dial-chat-shared';
 import { MessageRole } from '@epam/ai-dial-chat-shared';
-import type { ConversationResponseDto } from '@epam/ai-dial-chat-api-client';
 
 /** True when the first user/assistant exchange is complete and LLM naming may still run. */
 export const shouldWatchForDisplayNameUpdate = (

--- a/apps/chat/src/utils/locale.ts
+++ b/apps/chat/src/utils/locale.ts
@@ -1,9 +1,9 @@
+import type { LocaleTextEntryDto } from '@epam/ai-dial-chat-api-client';
 import type {
   DeploymentCreationFormLocaleEntry,
   DeploymentCreationFormLocaleLabels,
   DeploymentCreationFormLocaleOption,
 } from '@epam/ai-dial-deployment-creation-form';
-import type { LocaleTextEntryDto } from '@epam/ai-dial-chat-api-client';
 import type { TFunction } from 'i18next';
 import { ButtonsI18nKeys, EditorI18nKeys } from '../constants/translation-keys';
 import { SUPPORTED_LANGUAGES } from '../hooks/language/useLanguage';

--- a/apps/chat/src/utils/locale.ts
+++ b/apps/chat/src/utils/locale.ts
@@ -3,7 +3,7 @@ import type {
   DeploymentCreationFormLocaleLabels,
   DeploymentCreationFormLocaleOption,
 } from '@epam/ai-dial-deployment-creation-form';
-import type { LocaleTextEntryDto } from '@epam/chat-api-client';
+import type { LocaleTextEntryDto } from '@epam/ai-dial-chat-api-client';
 import type { TFunction } from 'i18next';
 import { ButtonsI18nKeys, EditorI18nKeys } from '../constants/translation-keys';
 import { SUPPORTED_LANGUAGES } from '../hooks/language/useLanguage';

--- a/apps/chat/src/utils/map-deployment-limits-to-catalog.ts
+++ b/apps/chat/src/utils/map-deployment-limits-to-catalog.ts
@@ -5,7 +5,7 @@ import type {
 import type {
   DeploymentLimitsResponseDto,
   LimitStatsDto,
-} from '@epam/chat-api-client';
+} from '@epam/ai-dial-chat-api-client';
 import type { TFunction } from 'i18next';
 import { CatalogI18nKeys } from '../constants/translation-keys';
 

--- a/apps/chat/src/utils/map-deployment-limits-to-input.ts
+++ b/apps/chat/src/utils/map-deployment-limits-to-input.ts
@@ -1,4 +1,4 @@
-import type { DeploymentLimitsResponseDto } from '@epam/chat-api-client';
+import type { DeploymentLimitsResponseDto } from '@epam/ai-dial-chat-api-client';
 
 /** Normalized monthly token usage consumed by the conversation input control. */
 export interface MonthlyUsageLimit {

--- a/apps/chat/src/utils/map-deployment-to-catalog-item.ts
+++ b/apps/chat/src/utils/map-deployment-to-catalog-item.ts
@@ -10,7 +10,7 @@ import type {
   DeploymentItemDto,
   DialToolsetAuthSettingsDto,
   DialToolsetDto,
-} from '@epam/chat-api-client';
+} from '@epam/ai-dial-chat-api-client';
 import type { TFunction } from 'i18next';
 import { CatalogI18nKeys } from '../constants/translation-keys';
 import type { EntitySpecificDetails } from '../types/entity-details';

--- a/apps/chat/src/utils/map-deployment-to-catalog-item.ts
+++ b/apps/chat/src/utils/map-deployment-to-catalog-item.ts
@@ -5,12 +5,12 @@ import {
   type CatalogItem,
   type CatalogItemCredentials,
 } from '@epam/ai-dial-catalog';
-import { formatLastUsed } from '@epam/ai-dial-chat-shared';
 import type {
   DeploymentItemDto,
   DialToolsetAuthSettingsDto,
   DialToolsetDto,
 } from '@epam/ai-dial-chat-api-client';
+import { formatLastUsed } from '@epam/ai-dial-chat-shared';
 import type { TFunction } from 'i18next';
 import { CatalogI18nKeys } from '../constants/translation-keys';
 import type { EntitySpecificDetails } from '../types/entity-details';

--- a/apps/chat/src/utils/map-entity-details-to-catalog.ts
+++ b/apps/chat/src/utils/map-entity-details-to-catalog.ts
@@ -15,7 +15,7 @@ import {
 import type {
   DeploymentDetailsDto,
   DeploymentFeaturesDetailsDto,
-} from '@epam/chat-api-client';
+} from '@epam/ai-dial-chat-api-client';
 import { AuthenticationType, ModelEndpointType } from '../types/entity-details';
 import type {
   AgentEntityDetails,

--- a/apps/chat/src/utils/map-scheduled-task-dto.ts
+++ b/apps/chat/src/utils/map-scheduled-task-dto.ts
@@ -1,8 +1,8 @@
+import type { ScheduledTaskDto } from '@epam/ai-dial-chat-api-client';
 import {
   ScheduledTaskSectionKey,
   type ScheduledTaskItem,
 } from '@epam/ai-dial-scheduled-tasks';
-import type { ScheduledTaskDto } from '@epam/ai-dial-chat-api-client';
 import type { TFunction } from 'i18next';
 import { ScheduledTasksI18nKeys } from '../constants/translation-keys';
 import { apSchedulerDayToJsDay, jsDayToApSchedulerDay } from './cron-weekday';

--- a/apps/chat/src/utils/map-scheduled-task-dto.ts
+++ b/apps/chat/src/utils/map-scheduled-task-dto.ts
@@ -2,7 +2,7 @@ import {
   ScheduledTaskSectionKey,
   type ScheduledTaskItem,
 } from '@epam/ai-dial-scheduled-tasks';
-import type { ScheduledTaskDto } from '@epam/chat-api-client';
+import type { ScheduledTaskDto } from '@epam/ai-dial-chat-api-client';
 import type { TFunction } from 'i18next';
 import { ScheduledTasksI18nKeys } from '../constants/translation-keys';
 import { apSchedulerDayToJsDay, jsDayToApSchedulerDay } from './cron-weekday';

--- a/apps/chat/src/utils/map-scheduled-task-run-dto.ts
+++ b/apps/chat/src/utils/map-scheduled-task-run-dto.ts
@@ -1,8 +1,8 @@
+import type { ScheduledTaskRunDto } from '@epam/ai-dial-chat-api-client';
 import {
   ScheduledTaskRunStatus,
   type ScheduledTaskRunItem,
 } from '@epam/ai-dial-scheduled-tasks';
-import type { ScheduledTaskRunDto } from '@epam/ai-dial-chat-api-client';
 import type { TFunction } from 'i18next';
 import { ScheduledTasksI18nKeys } from '../constants/translation-keys';
 

--- a/apps/chat/src/utils/map-scheduled-task-run-dto.ts
+++ b/apps/chat/src/utils/map-scheduled-task-run-dto.ts
@@ -2,7 +2,7 @@ import {
   ScheduledTaskRunStatus,
   type ScheduledTaskRunItem,
 } from '@epam/ai-dial-scheduled-tasks';
-import type { ScheduledTaskRunDto } from '@epam/chat-api-client';
+import type { ScheduledTaskRunDto } from '@epam/ai-dial-chat-api-client';
 import type { TFunction } from 'i18next';
 import { ScheduledTasksI18nKeys } from '../constants/translation-keys';
 

--- a/apps/chat/src/utils/publish.ts
+++ b/apps/chat/src/utils/publish.ts
@@ -1,9 +1,9 @@
 import { CatalogEntityType } from '@epam/ai-dial-catalog';
+import type { PublishHistoryEntryDto } from '@epam/ai-dial-chat-api-client';
 import {
   PublishAccessRulesLabels,
   PublishHistoryEntry,
 } from '@epam/ai-dial-publish-panel';
-import type { PublishHistoryEntryDto } from '@epam/ai-dial-chat-api-client';
 import type { TFunction } from 'i18next';
 import {
   ButtonsI18nKeys,

--- a/apps/chat/src/utils/publish.ts
+++ b/apps/chat/src/utils/publish.ts
@@ -3,7 +3,7 @@ import {
   PublishAccessRulesLabels,
   PublishHistoryEntry,
 } from '@epam/ai-dial-publish-panel';
-import type { PublishHistoryEntryDto } from '@epam/chat-api-client';
+import type { PublishHistoryEntryDto } from '@epam/ai-dial-chat-api-client';
 import type { TFunction } from 'i18next';
 import {
   ButtonsI18nKeys,

--- a/apps/chat/src/utils/scheduled-task-trigger.ts
+++ b/apps/chat/src/utils/scheduled-task-trigger.ts
@@ -7,7 +7,7 @@ import type {
   ScheduledTaskDto,
   ScheduleTriggerDto,
   UpdateScheduledTaskBodyDto,
-} from '@epam/chat-api-client';
+} from '@epam/ai-dial-chat-api-client';
 import {
   UnsupportedTriggerReason,
   type ScheduledTaskDtoMappingResult,

--- a/apps/chat/src/utils/scheduled-task-trigger.ts
+++ b/apps/chat/src/utils/scheduled-task-trigger.ts
@@ -1,13 +1,13 @@
-import {
-  ScheduledTaskCreateFormValues,
-  ScheduledTaskRepeat,
-} from '@epam/ai-dial-scheduled-tasks';
 import type {
   CreateScheduledTaskBodyDto,
   ScheduledTaskDto,
   ScheduleTriggerDto,
   UpdateScheduledTaskBodyDto,
 } from '@epam/ai-dial-chat-api-client';
+import {
+  ScheduledTaskCreateFormValues,
+  ScheduledTaskRepeat,
+} from '@epam/ai-dial-scheduled-tasks';
 import {
   UnsupportedTriggerReason,
   type ScheduledTaskDtoMappingResult,

--- a/apps/chat/src/utils/share-link.ts
+++ b/apps/chat/src/utils/share-link.ts
@@ -1,5 +1,5 @@
 import { ShareLinkAccess, ShareLinkData } from '@epam/ai-dial-share';
-import { ShareLinkResponseDtoAccessEnum } from '@epam/chat-api-client';
+import { ShareLinkResponseDtoAccessEnum } from '@epam/ai-dial-chat-api-client';
 import { createShareLink as createShareLinkRequest } from '../server-api/share.api';
 
 const toShareLinkAccess = (

--- a/apps/chat/src/utils/share-link.ts
+++ b/apps/chat/src/utils/share-link.ts
@@ -1,5 +1,5 @@
-import { ShareLinkAccess, ShareLinkData } from '@epam/ai-dial-share';
 import { ShareLinkResponseDtoAccessEnum } from '@epam/ai-dial-chat-api-client';
+import { ShareLinkAccess, ShareLinkData } from '@epam/ai-dial-share';
 import { createShareLink as createShareLinkRequest } from '../server-api/share.api';
 
 const toShareLinkAccess = (

--- a/apps/chat/src/utils/signin-interrupt.ts
+++ b/apps/chat/src/utils/signin-interrupt.ts
@@ -1,4 +1,4 @@
-import type { DialToolsetDto } from '@epam/chat-api-client';
+import type { DialToolsetDto } from '@epam/ai-dial-chat-api-client';
 import { ToolsetCredentialsLevel } from '../constants/toolsets';
 import type { ResolvedRowInfo } from '../models/signin-interrupt';
 import type { GetExternalServiceResponseDto } from '../server-api/external-services';

--- a/apps/chat/src/utils/tests/attachment-dto-to-display.spec.ts
+++ b/apps/chat/src/utils/tests/attachment-dto-to-display.spec.ts
@@ -1,5 +1,5 @@
 import { AttachmentType } from '@epam/ai-dial-chat-shared';
-import type { AttachmentDto } from '@epam/chat-api-client';
+import type { AttachmentDto } from '@epam/ai-dial-chat-api-client';
 import { describe, expect, it, vi } from 'vitest';
 import { attachmentDtoToDisplayAttachment } from '../attachment-dto-to-display';
 

--- a/apps/chat/src/utils/tests/attachment-dto-to-display.spec.ts
+++ b/apps/chat/src/utils/tests/attachment-dto-to-display.spec.ts
@@ -1,5 +1,5 @@
-import { AttachmentType } from '@epam/ai-dial-chat-shared';
 import type { AttachmentDto } from '@epam/ai-dial-chat-api-client';
+import { AttachmentType } from '@epam/ai-dial-chat-shared';
 import { describe, expect, it, vi } from 'vitest';
 import { attachmentDtoToDisplayAttachment } from '../attachment-dto-to-display';
 

--- a/apps/chat/src/utils/tests/deployment-id.spec.ts
+++ b/apps/chat/src/utils/tests/deployment-id.spec.ts
@@ -1,4 +1,4 @@
-import type { DeploymentItemDto } from '@epam/chat-api-client';
+import type { DeploymentItemDto } from '@epam/ai-dial-chat-api-client';
 import { describe, expect, it } from 'vitest';
 import {
   encodeDeploymentId,

--- a/apps/chat/src/utils/tests/display-name-watch.spec.ts
+++ b/apps/chat/src/utils/tests/display-name-watch.spec.ts
@@ -1,6 +1,6 @@
+import type { ConversationResponseDto } from '@epam/ai-dial-chat-api-client';
 import type { Conversation } from '@epam/ai-dial-chat-shared';
 import { MessageRole } from '@epam/ai-dial-chat-shared';
-import type { ConversationResponseDto } from '@epam/ai-dial-chat-api-client';
 import { describe, expect, it } from 'vitest';
 import { shouldWatchForDisplayNameUpdate } from '../display-name-watch';
 

--- a/apps/chat/src/utils/tests/display-name-watch.spec.ts
+++ b/apps/chat/src/utils/tests/display-name-watch.spec.ts
@@ -1,6 +1,6 @@
 import type { Conversation } from '@epam/ai-dial-chat-shared';
 import { MessageRole } from '@epam/ai-dial-chat-shared';
-import type { ConversationResponseDto } from '@epam/chat-api-client';
+import type { ConversationResponseDto } from '@epam/ai-dial-chat-api-client';
 import { describe, expect, it } from 'vitest';
 import { shouldWatchForDisplayNameUpdate } from '../display-name-watch';
 

--- a/apps/chat/src/utils/tests/map-deployment-limits-to-catalog.spec.ts
+++ b/apps/chat/src/utils/tests/map-deployment-limits-to-catalog.spec.ts
@@ -1,4 +1,4 @@
-import type { DeploymentLimitsResponseDto } from '@epam/chat-api-client';
+import type { DeploymentLimitsResponseDto } from '@epam/ai-dial-chat-api-client';
 import type { TFunction } from 'i18next';
 import { describe, expect, it } from 'vitest';
 import { CatalogI18nKeys } from '../../constants/translation-keys';

--- a/apps/chat/src/utils/tests/map-deployment-limits-to-input.spec.ts
+++ b/apps/chat/src/utils/tests/map-deployment-limits-to-input.spec.ts
@@ -1,4 +1,4 @@
-import type { DeploymentLimitsResponseDto } from '@epam/chat-api-client';
+import type { DeploymentLimitsResponseDto } from '@epam/ai-dial-chat-api-client';
 import { describe, expect, it } from 'vitest';
 import { mapDeploymentLimitsToInput } from '../map-deployment-limits-to-input';
 

--- a/apps/chat/src/utils/tests/map-deployment-to-catalog-item.spec.ts
+++ b/apps/chat/src/utils/tests/map-deployment-to-catalog-item.spec.ts
@@ -3,7 +3,7 @@ import {
   CredentialStatus,
   ToolsetAuthenticationType,
 } from '@epam/ai-dial-catalog';
-import type { DeploymentItemDto, DialToolsetDto } from '@epam/chat-api-client';
+import type { DeploymentItemDto, DialToolsetDto } from '@epam/ai-dial-chat-api-client';
 import type { TFunction } from 'i18next';
 import { describe, expect, it } from 'vitest';
 import { CatalogI18nKeys } from '../../constants/translation-keys';

--- a/apps/chat/src/utils/tests/map-deployment-to-catalog-item.spec.ts
+++ b/apps/chat/src/utils/tests/map-deployment-to-catalog-item.spec.ts
@@ -3,7 +3,10 @@ import {
   CredentialStatus,
   ToolsetAuthenticationType,
 } from '@epam/ai-dial-catalog';
-import type { DeploymentItemDto, DialToolsetDto } from '@epam/ai-dial-chat-api-client';
+import type {
+  DeploymentItemDto,
+  DialToolsetDto,
+} from '@epam/ai-dial-chat-api-client';
 import type { TFunction } from 'i18next';
 import { describe, expect, it } from 'vitest';
 import { CatalogI18nKeys } from '../../constants/translation-keys';

--- a/apps/chat/src/utils/tests/map-scheduled-task-dto.spec.ts
+++ b/apps/chat/src/utils/tests/map-scheduled-task-dto.spec.ts
@@ -1,4 +1,4 @@
-import type { ScheduledTaskDto } from '@epam/chat-api-client';
+import type { ScheduledTaskDto } from '@epam/ai-dial-chat-api-client';
 import type { TFunction } from 'i18next';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ScheduledTasksI18nKeys } from '../../constants/translation-keys';

--- a/apps/chat/src/utils/tests/map-scheduled-task-run-dto.spec.ts
+++ b/apps/chat/src/utils/tests/map-scheduled-task-run-dto.spec.ts
@@ -1,5 +1,5 @@
 import { ScheduledTaskRunStatus } from '@epam/ai-dial-scheduled-tasks';
-import type { ScheduledTaskRunDto } from '@epam/chat-api-client';
+import type { ScheduledTaskRunDto } from '@epam/ai-dial-chat-api-client';
 import type { TFunction } from 'i18next';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ScheduledTasksI18nKeys } from '../../constants/translation-keys';

--- a/apps/chat/src/utils/tests/map-scheduled-task-run-dto.spec.ts
+++ b/apps/chat/src/utils/tests/map-scheduled-task-run-dto.spec.ts
@@ -1,5 +1,5 @@
-import { ScheduledTaskRunStatus } from '@epam/ai-dial-scheduled-tasks';
 import type { ScheduledTaskRunDto } from '@epam/ai-dial-chat-api-client';
+import { ScheduledTaskRunStatus } from '@epam/ai-dial-scheduled-tasks';
 import type { TFunction } from 'i18next';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ScheduledTasksI18nKeys } from '../../constants/translation-keys';

--- a/apps/chat/src/utils/tests/publish.spec.ts
+++ b/apps/chat/src/utils/tests/publish.spec.ts
@@ -1,5 +1,5 @@
 import { CatalogEntityType } from '@epam/ai-dial-catalog';
-import type { PublishHistoryEntryDto } from '@epam/chat-api-client';
+import type { PublishHistoryEntryDto } from '@epam/ai-dial-chat-api-client';
 import { describe, expect, it } from 'vitest';
 import { CatalogPublishEntityType } from '../../server-api/publish.api';
 import { mapPublishHistoryEntryDto, toPublishEntityType } from '../publish';

--- a/apps/chat/src/utils/tests/scheduled-task-trigger.spec.ts
+++ b/apps/chat/src/utils/tests/scheduled-task-trigger.spec.ts
@@ -1,8 +1,8 @@
+import type { ScheduledTaskDto } from '@epam/ai-dial-chat-api-client';
 import {
   ScheduledTaskCreateFormValues,
   ScheduledTaskRepeat,
 } from '@epam/ai-dial-scheduled-tasks';
-import type { ScheduledTaskDto } from '@epam/ai-dial-chat-api-client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { UnsupportedTriggerReason } from '../../types/scheduled-task-mapping';
 import {

--- a/apps/chat/src/utils/tests/scheduled-task-trigger.spec.ts
+++ b/apps/chat/src/utils/tests/scheduled-task-trigger.spec.ts
@@ -2,7 +2,7 @@ import {
   ScheduledTaskCreateFormValues,
   ScheduledTaskRepeat,
 } from '@epam/ai-dial-scheduled-tasks';
-import type { ScheduledTaskDto } from '@epam/chat-api-client';
+import type { ScheduledTaskDto } from '@epam/ai-dial-chat-api-client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { UnsupportedTriggerReason } from '../../types/scheduled-task-mapping';
 import {

--- a/apps/chat/src/utils/tests/toolsets.spec.ts
+++ b/apps/chat/src/utils/tests/toolsets.spec.ts
@@ -1,5 +1,5 @@
-import type { DialToolsetDto } from '@epam/chat-api-client';
-import { ResponseError } from '@epam/chat-api-client';
+import type { DialToolsetDto } from '@epam/ai-dial-chat-api-client';
+import { ResponseError } from '@epam/ai-dial-chat-api-client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   ToolsetOAuthCallbackQuery,

--- a/apps/chat/src/utils/toolsets.ts
+++ b/apps/chat/src/utils/toolsets.ts
@@ -1,6 +1,9 @@
+import type {
+  DialToolsetDto,
+  ToolsetBodyDto,
+} from '@epam/ai-dial-chat-api-client';
+import { ResponseError } from '@epam/ai-dial-chat-api-client';
 import { validateDeploymentCreationFields } from '@epam/ai-dial-deployment-creation-form';
-import type { DialToolsetDto, ToolsetBodyDto } from '@epam/chat-api-client';
-import { ResponseError } from '@epam/chat-api-client';
 import {
   DEFAULT_TOOLSET_NAME,
   DEFAULT_TOOLSET_VERSION,

--- a/libs/chat-api-client/package.json
+++ b/libs/chat-api-client/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "@epam/chat-api-client",
+  "name": "@epam/ai-dial-chat-api-client",
   "description": "Generated OpenAPI client for the AI DIAL Chat API",
   "version": "0.0.1",
-  "private": true,
+  "private": false,
   "license": "Apache-2.0",
   "main": "./dist/index.js",
   "module": "./dist/index.js",
@@ -18,7 +18,13 @@
     }
   },
   "nx": {
-    "name": "chat-api-client"
+    "name": "chat-api-client",
+    "tags": ["publishable"],
+    "targets": {
+      "publish": {
+        "command": "node tools/publish-lib.mjs {projectName} --version={args.ver} --dry={args.dry} --tag={args.tag} --development={args.development}"
+      }
+    }
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/libs/chat-api-client/package.json
+++ b/libs/chat-api-client/package.json
@@ -2,7 +2,7 @@
   "name": "@epam/ai-dial-chat-api-client",
   "description": "Generated OpenAPI client for the AI DIAL Chat API",
   "version": "0.0.1",
-  "private": false,
+  "private": true,
   "license": "Apache-2.0",
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -266,7 +266,7 @@
       }
     },
     "libs/chat-api-client": {
-      "name": "@epam/chat-api-client",
+      "name": "@epam/ai-dial-chat-api-client",
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
@@ -2424,6 +2424,10 @@
       "resolved": "libs/catalog",
       "link": true
     },
+    "node_modules/@epam/ai-dial-chat-api-client": {
+      "resolved": "libs/chat-api-client",
+      "link": true
+    },
     "node_modules/@epam/ai-dial-chat-overlay": {
       "resolved": "libs/chat-overlay",
       "link": true
@@ -2598,10 +2602,6 @@
     },
     "node_modules/@epam/chat-api": {
       "resolved": "apps/chat-api",
-      "link": true
-    },
-    "node_modules/@epam/chat-api-client": {
-      "resolved": "libs/chat-api-client",
       "link": true
     },
     "node_modules/@epam/pdf-highlighter-kit": {


### PR DESCRIPTION
**Description:**

Rename the chat-api-client package from @epam/chat-api-client to @epam/ai-dial-chat-api-client and configure it as a publishable package. This aligns the package naming with other EPAM AI DIAL libraries and enables future publishing to npm. The package now has the correct namespace and is marked as public.

**UI changes**

No UI changes

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `chore(chat-api-client):`
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)`
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs