### PR TITLE
chore(chat): update vite alias for renamed chat-api-client package

### DIFF
--- a/apps/chat/vite.config.mts
+++ b/apps/chat/vite.config.mts
@@ -48,7 +48,7 @@ export default defineConfig(() => ({
         __dirname,
         '../../libs/conversation-stages/src/index.ts',
       ),
-      '@epam/chat-api-client': path.resolve(
+      '@epam/ai-dial-chat-api-client': path.resolve(
         __dirname,
         '../../libs/chat-api-client/src/index.ts',
       ),


### PR DESCRIPTION
## Summary

Updates the Vite path alias configuration to use the new `@epam/ai-dial-chat-api-client` package name after the recent rename.

## UI changes

None — configuration change only.

## Checklist:

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `chore(<scope>):`
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs