### PR TITLE
feat(chat): add deployments catalog with MCP interface filtering

### DIFF
--- a/apps/chat-api/src/deployments/listing/deployments-listing.service.ts
+++ b/apps/chat-api/src/deployments/listing/deployments-listing.service.ts
@@ -72,25 +72,25 @@ export class DeploymentsListingService {
   }
 
   /**
-   * Resolves every resource of the given type shared with the current user
-   * (READ or WRITE) — separate calls for `APPLICATION` and `TOOL_SET` since
-   * `getSharedResources` is scoped to one `resourceTypes` filter per call.
-   * Best-effort: a DIAL Core error here degrades to "nothing shared" rather
-   * than failing the whole deployments list.
+   * Resolves every APPLICATION-type resource shared with the current user
+   * (READ or WRITE). Toolsets never appear in this list's items (see
+   * `listDeployments`), so only the APPLICATION scope is needed here — a
+   * TOOL_SET-scoped equivalent lives in `DeploymentsLookupService` for
+   * single-toolset lookups. Best-effort: a DIAL Core error here degrades to
+   * "nothing shared" rather than failing the whole deployments list.
    */
   private async getSharedResources(
     accessToken: string,
-    resourceType: 'APPLICATION' | 'TOOL_SET',
   ): Promise<{ url?: string; permissions?: string[] }[]> {
     try {
       const { data, error, response } =
         await this.dialClient.client.getSharedResources({
           headers: getBearerAuthHeaders(accessToken),
-          body: { resourceTypes: [resourceType], with: 'me' },
+          body: { resourceTypes: ['APPLICATION'], with: 'me' },
         });
       if (error) {
         this.logger.warn(
-          `Failed to resolve shared ${resourceType} resources: status=${response.status}`,
+          `Failed to resolve shared APPLICATION resources: status=${response.status}`,
         );
         return [];
       }
@@ -100,26 +100,19 @@ export class DeploymentsListingService {
         permissions?: string[];
       }[];
     } catch (err) {
-      this.logger.warn(
-        `Failed to resolve shared ${resourceType} resources`,
-        err,
-      );
+      this.logger.warn('Failed to resolve shared APPLICATION resources', err);
       return [];
     }
   }
 
   /**
    * Splits `getSharedResources`'s flat resource list into the two URL sets
-   * ownership enrichment needs, shared by both this service's
-   * `listDeployments` and `DeploymentsLookupService.resolveDeploymentItem` so
-   * a just-accepted share resolves to the same `sharedWithMe`/`canEdit`
-   * flags a subsequent full list refresh would produce.
+   * ownership enrichment needs.
    */
   private async getSharedResourceUrlSets(
     accessToken: string,
-    resourceType: 'APPLICATION' | 'TOOL_SET',
   ): Promise<ResourceOwnershipUrlSets> {
-    const resources = await this.getSharedResources(accessToken, resourceType);
+    const resources = await this.getSharedResources(accessToken);
     return splitResourcesByPermission(resources);
   }
 
@@ -130,6 +123,9 @@ export class DeploymentsListingService {
     interfaceType?: DeploymentInterfaceType[],
     refresh = false,
   ): Promise<DeploymentsResponseDto> {
+    this.logger.debug(
+      `listDeployments requested interfaceType=${JSON.stringify(interfaceType)} (sub: ${userSub})`,
+    );
     const baseCacheKey = `deployments:list:${userSub}`;
     const normalizedTypes = interfaceType?.filter(
       (t) => t !== DeploymentInterfaceType.All,
@@ -139,6 +135,9 @@ export class DeploymentsListingService {
         ? normalizedTypes
         : undefined
     ) as DialDeploymentInterfaceType[] | undefined;
+    this.logger.debug(
+      `Normalized interfaceFilter=${JSON.stringify(interfaceFilter)} (sub: ${userSub})`,
+    );
     const cacheKey = interfaceFilter
       ? `${baseCacheKey}:interface:${interfaceFilter.join(',')}`
       : baseCacheKey;
@@ -155,12 +154,25 @@ export class DeploymentsListingService {
       allItems = cached;
     } else {
       try {
+        this.logger.debug(
+          `Requesting deployments from DIAL Core with interface_type=${JSON.stringify(interfaceFilter)} (sub: ${userSub})`,
+        );
         const result = await this.dialClient.client.listDeployments({
           headers: getBearerAuthHeaders(accessToken),
           params: interfaceFilter
             ? { query: { interface_type: interfaceFilter } }
             : undefined,
+          /*
+           * DIAL Core documents `interface_type` as accepting a
+           * comma-separated list; openapi-fetch's default array serialization
+           * sends repeated keys (`interface_type=chat&interface_type=mcp`)
+           * instead, which Core does not parse as multiple values.
+           */
+          querySerializer: { array: { style: 'form', explode: false } },
         });
+        this.logger.debug(
+          `DIAL Core request URL: ${result.response.url} (sub: ${userSub})`,
+        );
         if (result.error) {
           return mapDialHttpStatus(
             result.response.status,
@@ -174,12 +186,28 @@ export class DeploymentsListingService {
           : ((rawData as { deployments?: RawDeploymentDto[] }).deployments ??
             []);
 
-        allItems = rawItems
+        const mappedItems = rawItems
           .filter((item) => item.id && !item.id.includes(HIDDEN_FILE))
           .map((item) =>
             mapToDeploymentItem(item, this.featuredIds, this.hiddenTags),
           )
           .filter((item): item is DeploymentItemDto => item !== null);
+
+        /*
+         * DIAL Core's /v1/deployments can include toolset entries (e.g. when
+         * filtering by the `mcp` interface), but its payload for them is a
+         * thinner subset than the dedicated /v1/toolsets listing — notably
+         * missing `auth_settings`/`endpoint` — which the toolset catalog
+         * card needs for auth-status display. Toolsets are served
+         * exclusively via ToolsetsListingService/`/v1/toolsets`; drop them
+         * here rather than surface an incomplete duplicate.
+         */
+        allItems = mappedItems.filter(
+          (item) => item.type !== DeploymentItemType.Toolset,
+        );
+        this.logger.debug(
+          `DIAL Core /v1/deployments returned ${mappedItems.length} items (${mappedItems.length - allItems.length} toolsets dropped) (sub: ${userSub})`,
+        );
 
         await this.cacheManager.set(cacheKey, allItems, 30_000);
       } catch (err) {
@@ -187,44 +215,34 @@ export class DeploymentsListingService {
       }
     }
 
-    const { toolsets: toolsetIds, deployments: deploymentIds } =
+    const { deployments: deploymentIds } =
       await this.userConfigService.getInstalledIds(accessToken, bucket);
-    const toolsetsSet = new Set(toolsetIds);
     const deploymentsSet = new Set(deploymentIds);
-    /*
-     * Two separate calls: getSharedResources is scoped to one resourceType
-     * per call, and the combined deployments list mixes applications and
-     * toolsets, each needing its own URL sets (a toolset id can never
-     * appear in the APPLICATION-scoped sets, and vice versa).
-     */
-    const [applicationUrlSets, toolsetUrlSets] = await Promise.all([
-      this.getSharedResourceUrlSets(accessToken, 'APPLICATION'),
-      this.getSharedResourceUrlSets(accessToken, 'TOOL_SET'),
-    ]);
+    const applicationUrlSets = await this.getSharedResourceUrlSets(accessToken);
 
     const withInstalled = allItems.map((item) => ({
       ...item,
-      isInstalled:
-        item.type === DeploymentItemType.Toolset
-          ? toolsetsSet.has(item.id)
-          : deploymentsSet.has(item.id),
-      ...computeItemOwnershipFlags(
-        item.id,
-        bucket,
-        item.type === DeploymentItemType.Toolset
-          ? toolsetUrlSets
-          : applicationUrlSets,
-      ),
+      isInstalled: deploymentsSet.has(item.id),
+      ...computeItemOwnershipFlags(item.id, bucket, applicationUrlSets),
     }));
 
     if (!interfaceFilter) {
       return { deployments: withInstalled };
     }
 
+    /*
+     * TODO: this local re-filter compensates for DIAL Core not reliably
+     * filtering by interface_type server-side. Once Core fixes this
+     * (https://github.com/epam/ai-dial-core/issues/1822), filtering will
+     * happen on Core's side and this step can likely be simplified/removed.
+     */
     const filtered = withInstalled.filter((item) =>
       item.interfaces?.some((iface) =>
         interfaceFilter.includes(iface as DialDeploymentInterfaceType),
       ),
+    );
+    this.logger.debug(
+      `Local interface filter applied: ${withInstalled.length} -> ${filtered.length} items (filter=${JSON.stringify(interfaceFilter)}, sub: ${userSub})`,
     );
     return { deployments: filtered };
   }

--- a/apps/chat-api/src/deployments/listing/deployments-listing.service.ts
+++ b/apps/chat-api/src/deployments/listing/deployments-listing.service.ts
@@ -201,6 +201,12 @@ export class DeploymentsListingService {
          * card needs for auth-status display. Toolsets are served
          * exclusively via ToolsetsListingService/`/v1/toolsets`; drop them
          * here rather than surface an incomplete duplicate.
+         *
+         * TODO: revisit once DIAL Core's interface_type filtering lands
+         * (https://github.com/epam/ai-dial-core/issues/1822) — if Core's
+         * /v1/deployments payload for toolsets is enriched with
+         * auth_settings/endpoint at that point, this exclusion may no
+         * longer be necessary.
          */
         allItems = mappedItems.filter(
           (item) => item.type !== DeploymentItemType.Toolset,

--- a/apps/chat-api/src/deployments/listing/tests/deployments-listing.service.spec.ts
+++ b/apps/chat-api/src/deployments/listing/tests/deployments-listing.service.spec.ts
@@ -106,23 +106,23 @@ describe('DeploymentsListingService', () => {
   });
 
   describe('listDeployments', () => {
-    it('maps model, application, and toolset correctly', async () => {
+    it('maps model and application correctly, excluding toolsets', async () => {
       const { service } = makeService();
       const result = await service.listDeployments(
         'user1',
         'token',
         'bucket-1',
       );
-      expect(result.deployments).toHaveLength(3);
+      expect(result.deployments).toHaveLength(2);
       expect(result.deployments.find((d) => d.id === 'gpt-4o')?.type).toBe(
         'model',
       );
       expect(result.deployments.find((d) => d.id === 'my-app')?.type).toBe(
         'application',
       );
-      expect(result.deployments.find((d) => d.id === 'search-tool')?.type).toBe(
-        'toolset',
-      );
+      expect(
+        result.deployments.find((d) => d.id === 'search-tool'),
+      ).toBeUndefined();
     });
 
     it('skips items without id', async () => {
@@ -422,26 +422,6 @@ describe('DeploymentsListingService', () => {
       expect(
         result.deployments.find((d) => d.id === 'my-app')?.isInstalled,
       ).toBe(true);
-      expect(
-        result.deployments.find((d) => d.id === 'search-tool')?.isInstalled,
-      ).toBe(false);
-    });
-
-    it('sets isInstalled=true for installed toolset', async () => {
-      const { service } = makeService({
-        installedIds: { toolsets: ['search-tool'], deployments: [] },
-      });
-      const result = await service.listDeployments(
-        'user1',
-        'token',
-        'bucket-1',
-      );
-      expect(
-        result.deployments.find((d) => d.id === 'search-tool')?.isInstalled,
-      ).toBe(true);
-      expect(
-        result.deployments.find((d) => d.id === 'gpt-4o')?.isInstalled,
-      ).toBe(false);
     });
 
     it('sets isInstalled=false for all items when nothing is installed', async () => {
@@ -653,7 +633,6 @@ describe('DeploymentsListingService', () => {
 
       expect(result.deployments[0].features?.chatCompletion).toBe(true);
     });
-
     it('maps features.mcp true for an MCP-capable application', async () => {
       const { service, sdkClient } = makeService();
       sdkClient.listDeployments.mockResolvedValue({
@@ -1117,12 +1096,9 @@ describe('DeploymentsListingService', () => {
       expect(warnSpy).toHaveBeenCalledWith(
         'Failed to resolve shared APPLICATION resources: status=503',
       );
-      expect(warnSpy).toHaveBeenCalledWith(
-        'Failed to resolve shared TOOL_SET resources: status=503',
-      );
     });
 
-    it('resolves canEdit and sharedWithMe from exactly one getSharedResources call per resource type', async () => {
+    it('resolves canEdit and sharedWithMe from exactly one getSharedResources call, scoped to APPLICATION', async () => {
       const { service, sdkClient } = makeService();
       sdkClient.listDeployments.mockResolvedValue({
         error: false,
@@ -1145,65 +1121,15 @@ describe('DeploymentsListingService', () => {
 
       await service.listDeployments('user1', 'token', 'BUCKET_HASH');
       /*
-       * One call for APPLICATION-scoped shared resources, one for
-       * TOOL_SET-scoped — getSharedResources is scoped to a single
-       * resourceTypes filter per call, and the combined list mixes both
-       * item types.
+       * Toolsets are excluded from this listing's items entirely, so only
+       * the APPLICATION-scoped shared resources are ever needed here.
        */
-      expect(sdkClient.getSharedResources).toHaveBeenCalledTimes(2);
+      expect(sdkClient.getSharedResources).toHaveBeenCalledOnce();
       expect(sdkClient.getSharedResources).toHaveBeenCalledWith(
         expect.objectContaining({
           body: expect.objectContaining({ resourceTypes: ['APPLICATION'] }),
         }),
       );
-      expect(sdkClient.getSharedResources).toHaveBeenCalledWith(
-        expect.objectContaining({
-          body: expect.objectContaining({ resourceTypes: ['TOOL_SET'] }),
-        }),
-      );
-    });
-
-    it('is true for a READ-only shared toolset in the combined list, using TOOL_SET-scoped resources', async () => {
-      /*
-       * Regression: a toolset id can never appear in the APPLICATION-scoped
-       * shared-resource set, so this only passes if listDeployments fetches
-       * (and uses) a separate TOOL_SET-scoped set for toolset items.
-       */
-      const { service, sdkClient } = makeService();
-      sdkClient.listDeployments.mockResolvedValue({
-        error: false,
-        response: { status: 200 },
-        data: [{ ...mockToolset, id: 'toolsets/OTHER_BUCKET/their-toolset' }],
-      });
-      sdkClient.getSharedResources.mockImplementation(
-        (opts: { body: { resourceTypes: string[] } }) =>
-          Promise.resolve({
-            data: {
-              resources:
-                opts.body.resourceTypes[0] === 'TOOL_SET'
-                  ? [
-                      {
-                        url: 'toolsets/OTHER_BUCKET/their-toolset',
-                        permissions: ['READ'],
-                      },
-                    ]
-                  : [],
-            },
-            error: undefined,
-          }),
-      );
-
-      const result = await service.listDeployments(
-        'user1',
-        'token',
-        'BUCKET_HASH',
-      );
-
-      expect(result.deployments[0]).toMatchObject({
-        isMy: false,
-        sharedWithMe: true,
-        canEdit: false,
-      });
     });
   });
 });

--- a/apps/chat-api/src/deployments/listing/tests/deployments-listing.service.spec.ts
+++ b/apps/chat-api/src/deployments/listing/tests/deployments-listing.service.spec.ts
@@ -551,21 +551,6 @@ describe('DeploymentsListingService', () => {
       expect(result.deployments[0].applicationFolder).toBeUndefined();
     });
 
-    it('leaves applicationFolder absent for toolset deployments', async () => {
-      const { service, sdkClient } = makeService();
-      sdkClient.listDeployments.mockResolvedValue({
-        error: false,
-        response: { status: 200 },
-        data: [{ ...mockToolset, id: 'folder/search-tool' }],
-      });
-      const result = await service.listDeployments(
-        'user1',
-        'token',
-        'bucket-1',
-      );
-      expect(result.deployments[0].applicationFolder).toBeUndefined();
-    });
-
     it('maps features.responsesApi true for a model with responses_api support', async () => {
       const { service, sdkClient } = makeService();
       sdkClient.listDeployments.mockResolvedValue({

--- a/apps/chat/src/components/CatalogView/CatalogView.tsx
+++ b/apps/chat/src/components/CatalogView/CatalogView.tsx
@@ -503,8 +503,9 @@ const CatalogView: FC<Props> = ({ isSelectorMode = false, onClose }) => {
 
   const isPrimaryActionVisible = useCallback(
     (item: CatalogItem) =>
-      item.type === CatalogEntityType.Model ||
-      item.type === CatalogEntityType.Agent,
+      (item.type === CatalogEntityType.Model ||
+        item.type === CatalogEntityType.Agent) &&
+      item.supportsChat !== false,
     [],
   );
 

--- a/apps/chat/src/components/CatalogView/tests/CatalogView.spec.tsx
+++ b/apps/chat/src/components/CatalogView/tests/CatalogView.spec.tsx
@@ -1075,6 +1075,68 @@ describe('CatalogView', () => {
     ).toBeNull();
   });
 
+  it('does not render Use in chat for an Application with no chat interface', () => {
+    vi.mocked(useDeployments).mockReturnValue({
+      items: [
+        {
+          id: 'mcp-only-app',
+          displayName: 'MCP Only App',
+          type: 'application',
+          interfaces: ['mcp'],
+        },
+      ],
+      selectedItemId: null,
+      setSelectedItemId: vi.fn(),
+      restoreSelectedItemId: vi.fn(),
+      restoreDefaultSelection: vi.fn(),
+      selectedDeploymentConfiguration: null,
+      isLoading: false,
+      error: null,
+      schemas: [],
+      toolsets: [],
+      refetchToolsets: vi.fn(),
+      refetchDeployments: vi.fn(),
+      mergeSharedItem: vi.fn(),
+    });
+
+    render(<CatalogView />);
+
+    expect(
+      screen.queryByRole('button', { name: 'use in chat mcp-only-app' }),
+    ).toBeNull();
+  });
+
+  it('renders Use in chat for an Application supporting both chat and mcp interfaces', () => {
+    vi.mocked(useDeployments).mockReturnValue({
+      items: [
+        {
+          id: 'chat-and-mcp-app',
+          displayName: 'Chat And MCP App',
+          type: 'application',
+          interfaces: ['chat', 'mcp'],
+        },
+      ],
+      selectedItemId: null,
+      setSelectedItemId: vi.fn(),
+      restoreSelectedItemId: vi.fn(),
+      restoreDefaultSelection: vi.fn(),
+      selectedDeploymentConfiguration: null,
+      isLoading: false,
+      error: null,
+      schemas: [],
+      toolsets: [],
+      refetchToolsets: vi.fn(),
+      refetchDeployments: vi.fn(),
+      mergeSharedItem: vi.fn(),
+    });
+
+    render(<CatalogView />);
+
+    expect(
+      screen.getByRole('button', { name: 'use in chat chat-and-mcp-app' }),
+    ).toBeTruthy();
+  });
+
   it('updates the selection when Use in chat is clicked on a different deployment', async () => {
     const setSelectedItemId = vi.fn();
     vi.mocked(useDeployments).mockReturnValue({

--- a/apps/chat/src/context/DeploymentsContext.tsx
+++ b/apps/chat/src/context/DeploymentsContext.tsx
@@ -229,7 +229,10 @@ export const DeploymentsProvider = ({ children }: { children: ReactNode }) => {
 
       const [deploymentsResult, schemasResult, toolsetsResult] =
         await Promise.allSettled([
-          getDeployments([ListDeploymentsInterfaceTypeEnum.Chat]),
+          getDeployments([
+            ListDeploymentsInterfaceTypeEnum.Chat,
+            ListDeploymentsInterfaceTypeEnum.Mcp,
+          ]),
           getApplicationSchemas(),
           listToolsets(),
         ]);
@@ -339,7 +342,10 @@ export const DeploymentsProvider = ({ children }: { children: ReactNode }) => {
       const requestId = ++deploymentsRequestIdRef.current;
       try {
         const { deployments } = await getDeployments(
-          [ListDeploymentsInterfaceTypeEnum.Chat],
+          [
+            ListDeploymentsInterfaceTypeEnum.Chat,
+            ListDeploymentsInterfaceTypeEnum.Mcp,
+          ],
           refresh,
         );
         if (deploymentsRequestIdRef.current !== requestId) return;

--- a/apps/chat/src/utils/map-deployment-to-catalog-item.ts
+++ b/apps/chat/src/utils/map-deployment-to-catalog-item.ts
@@ -205,6 +205,8 @@ export const mapDeploymentToCatalogItem = (
         ? mapEntityDetailsToCatalogDetails(entityDetails)
         : undefined,
     supportsMcp: deployment.features?.mcp === true,
+    supportsChat:
+      deployment.interfaces == null || deployment.interfaces.includes('chat'),
   };
 };
 

--- a/apps/chat/src/utils/tests/map-deployment-to-catalog-item.spec.ts
+++ b/apps/chat/src/utils/tests/map-deployment-to-catalog-item.spec.ts
@@ -232,6 +232,30 @@ describe('mapDeploymentToCatalogItem', () => {
 
     expect(result.supportsMcp).toBe(false);
   });
+
+  it('sets supportsChat to true when interfaces includes chat', () => {
+    const result = mapDeploymentToCatalogItem(
+      { ...baseDeployment, interfaces: ['chat', 'mcp'] },
+      { t },
+    );
+
+    expect(result.supportsChat).toBe(true);
+  });
+
+  it('sets supportsChat to false when interfaces does not include chat', () => {
+    const result = mapDeploymentToCatalogItem(
+      { ...baseDeployment, interfaces: ['mcp'] },
+      { t },
+    );
+
+    expect(result.supportsChat).toBe(false);
+  });
+
+  it('sets supportsChat to true when interfaces is absent', () => {
+    const result = mapDeploymentToCatalogItem(baseDeployment, { t });
+
+    expect(result.supportsChat).toBe(true);
+  });
 });
 
 describe('mapToolsetToCatalogItem', () => {

--- a/libs/catalog/src/models/catalog-item.ts
+++ b/libs/catalog/src/models/catalog-item.ts
@@ -48,4 +48,6 @@ export interface CatalogItem {
   credentials?: CatalogItemCredentials;
   /** Whether this application supports the MCP protocol; only meaningful for `Application` items. */
   supportsMcp?: boolean;
+  /** Whether this item can be used in chat. Default: true. Set to false to hide the "Use in chat" primary action for a Model or Application that does not expose a chat interface. */
+  supportsChat?: boolean;
 }

--- a/openspec/changes/archive/2026-08-11-deployments-mcp-interface-filter/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-11-deployments-mcp-interface-filter/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-11

--- a/openspec/changes/archive/2026-08-11-deployments-mcp-interface-filter/design.md
+++ b/openspec/changes/archive/2026-08-11-deployments-mcp-interface-filter/design.md
@@ -1,0 +1,68 @@
+## Context
+
+`GET /api/v1/deployments` (`DeploymentsListingService`) proxies DIAL Core's `GET /v1/deployments`, filtered by an optional `interface_type` value. Today the frontend (`DeploymentsContext`) only ever requests `chat`, so MCP-capable applications and toolsets never surface anywhere in the app (model pickers, catalog). Widening the request to `[chat, mcp]` was attempted directly and surfaced two latent defects before it could work correctly, both discovered via debug logging against a live DIAL Core instance (`core.aks.dev.dial.parts`):
+
+1. **Query serialization bug.** The `@epam/ai-dial-typescript-sdk` client (openapi-fetch under the hood) defaults array query params to repeated keys (`interface_type=chat&interface_type=mcp`, `style: form, explode: true`). Empirical evidence (debug log: `638 -> 638` items whether the filter was `["chat"]` or `["chat","mcp"]` via repeated keys) showed DIAL Core only honors the *first* occurrence of a repeated key, silently ignoring the rest. DIAL Core's own OpenAPI description documents `interface_type` as accepting "multiple values as comma-separated list or array" — the comma-separated form is what actually works.
+2. **Toolset payload gap.** Once the multi-value filter reached Core correctly, `/v1/deployments` started returning toolset entries (confirmed via a raw-payload debug log: 288 toolset items in one response). Comparing that raw payload against `ToolsetsListingService`'s dedicated `/v1/toolsets` response showed `/v1/deployments`'s toolset entries carry only identity/generic fields (`id`, `toolset`, `display_name`, `transport`, `allowed_tools`, `features`, …) and are **missing `auth_settings` and `endpoint`** — fields `mapToolsetToCatalogItem` needs to render a toolset's credential/auth status in the catalog. Letting these thin entries flow into `items` alongside the already-complete `/v1/toolsets`-sourced `toolsets` array would either duplicate every MCP toolset in the catalog (same `id`, two shapes) or — if de-duplicated naively — replace the rich entry with an incomplete one depending on array order.
+
+Separately, once `items` can legitimately contain non-toolset deployments that still don't support `chat` (e.g. an `mcp`-only or `custom_ui`-only application), any UI that assumes "not a toolset ⇒ can be used in chat" is now wrong. The catalog's "Use in chat" primary action currently gates only on `item.type` (`libs/catalog/.../Header.tsx` default, overridden by `CatalogView.tsx`'s `isPrimaryActionVisible`), not on `interfaces`.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make DIAL Core actually receive and honor a multi-value `interface_type` filter.
+- Let MCP-interface applications appear in `items` (model/deployment pickers, catalog) without duplicating or misrepresenting MCP toolsets.
+- Ensure "Use in chat" (and, by extension, any future chat-only affordance) is gated on the deployment's actual interface support, not just its type.
+
+**Non-Goals:**
+
+- Do not change DIAL Core itself or attempt to make `/v1/deployments` return richer toolset data — that is Core's contract to evolve, not this repo's.
+- Do not change the public shape of `DeploymentItemDto`/`DeploymentsResponseDto` (still `{ deployments: DeploymentItemDto[] }`, same fields) — only which items are included.
+- Do not touch `/v1/toolsets` or `ToolsetsListingService` behavior; it remains the sole source of toolset data for the app.
+
+## Decisions
+
+### 1. Comma-joined query serialization, scoped to this one call
+
+Pass a per-request `querySerializer: { array: { style: 'form', explode: false } }` to `this.dialClient.client.listDeployments(...)` in `DeploymentsListingService`, rather than changing the SDK's global client configuration (`createSDK`) or vendoring a patched `openapi-fetch`.
+
+**Alternative considered:** configure a global `querySerializer` on the shared DIAL client. Rejected — other DIAL Core endpoints that also take array query params may rely on (or be unaffected by) the default repeated-key style, and no evidence was gathered that they share Core's "comma-separated" convention; scoping the override to the one call site that is proven to need it avoids an unreviewed behavior change to every other list endpoint.
+
+### 2. Exclude toolsets server-side, not client-side
+
+Filter out `DeploymentItemType.Toolset`-typed entries inside `DeploymentsListingService.listDeployments`, immediately after mapping raw Core items and before caching — not in the frontend (`deployments.api.ts` or `DeploymentsContext`).
+
+**Alternatives considered:**
+- *Filter in the frontend API wrapper.* Works, but every current and future consumer of `GET /api/v1/deployments` (including direct API/Swagger consumers, not just this one frontend) would still receive toolsets unless they also filter, so the endpoint's own documented contract would be misleading.
+- *Filter in each UI list-rendering component.* Rejected outright — an audit found 5+ list-rendering call sites (`DeploymentSelector`, `ConversationView`, `ConversationRoute`, both `ScheduledTask*` pages) that consume `items` unfiltered; patching each is repetitive and any future consumer would inherit the same bug by omission.
+
+Filtering at the service is the single point that makes the endpoint's contract ("deployments, not toolsets") true for every caller, present and future. This also lets the now-dead `TOOL_SET`-scoped ownership/sharing code path (in the same service) be deleted rather than left unreachable.
+
+### 3. Add a derived `supportsChat` boolean to `CatalogItem`, following the existing `supportsMcp` pattern
+
+`CatalogItem` already has `supportsMcp?: boolean`, derived in `mapDeploymentToCatalogItem` from `deployment.features?.mcp === true` and consumed directly by `CatalogView.tsx` (e.g. for the MCP endpoint URL) and `mcp-endpoint-url.ts`. Add `supportsChat?: boolean` the same way — derived from `DeploymentItemDto.interfaces` in the same mapper (`true` when `interfaces` is absent/undefined, matching pre-change behavior for items with no `interfaces` data, or when it includes `'chat'`) — and extend `CatalogView.tsx`'s `isPrimaryActionVisible` callback to also require `item.supportsChat !== false` alongside the existing type check.
+
+**Alternative considered:** expose the raw `interfaces: string[]` array on `CatalogItem` instead of a derived boolean. Rejected — the codebase's established convention for this exact kind of per-capability gate is a derived boolean computed once in the mapper (`supportsMcp`), not a raw array re-interpreted at each call site; following it keeps `CatalogItem`'s public surface consistent and avoids two different idioms for equivalent MCP/chat capability checks.
+
+## Risks / Trade-offs
+
+- **[Risk]** Excluding toolsets from `/v1/deployments` is a behavior change for any *other* consumer of that endpoint that currently expects toolsets in the response (per the existing `deployments-api` spec, which explicitly documents "all deployments (models, applications, toolsets)"). → **Mitigation:** the delta spec updates this documented contract explicitly; grep for other server-side or external consumers before merging, and call this out in the PR description as an intentional breaking change to the endpoint's item set (not its schema).
+- **[Risk]** The comma-joined `querySerializer` override is scoped to one call site; if another endpoint later needs the same multi-value DIAL Core parameter, the fix must be re-applied there rather than inherited. → **Mitigation:** the inline code comment on the override explains why it exists, so the next author copies the pattern deliberately instead of rediscovering the bug via the same debug-log process.
+- **[Risk]** `isPrimaryActionVisible`'s new `interfaces` check assumes `DeploymentItemDto.interfaces` is always populated for chat-capable models/applications; if DIAL Core ever omits `interfaces` for a legitimately chat-capable deployment, "Use in chat" would incorrectly disappear. → **Mitigation:** existing `mapToDeploymentItem` already treats `interfaces` as optional and other code paths (server-side interface filtering) have the same dependency, so this is a pre-existing assumption, not a new one; no additional fallback added.
+
+## Migration Plan
+
+No data migration. Deploy as a normal backend+frontend release:
+
+1. Backend change (query serialization + toolset exclusion + ownership simplification) is backward compatible for well-behaved clients — the only behavior change is toolsets disappearing from `/v1/deployments` responses, which is the intended fix.
+2. Frontend changes (widened interface filter, `CatalogItem.interfaces`, `isPrimaryActionVisible` update) deploy together with the backend change; deploying the frontend change without the backend fix would still work correctly (backend already excludes toolsets and honors multi-value filters independently of which interfaces the frontend asks for).
+3. Rollback: revert both changes together; no persisted state depends on the new behavior (30s server-side cache self-expires).
+
+## Open Questions
+
+- None outstanding — the payload-richness question (does `/v1/deployments` carry toolset auth fields) was resolved empirically via debug log before this design was written; see Context.
+
+## Follow-up (tracked upstream)
+
+The local post-fetch `interface_type` re-filter in `DeploymentsListingService.listDeployments` exists because DIAL Core does not reliably apply this filter server-side today (see decision 1 in Context — Core only honored the first value of a repeated-key query before the comma-joined `querySerializer` fix, and even after that fix Core's own filtering behavior should not be assumed fully correct). Core-side filtering is tracked at [epam/ai-dial-core#1822](https://github.com/epam/ai-dial-core/issues/1822); once resolved there, this repo's local re-filter step can likely be simplified or removed. A `TODO` comment referencing the issue is left at the re-filter call site.

--- a/openspec/changes/archive/2026-08-11-deployments-mcp-interface-filter/proposal.md
+++ b/openspec/changes/archive/2026-08-11-deployments-mcp-interface-filter/proposal.md
@@ -1,0 +1,34 @@
+## Why
+
+MCP-capable applications and toolsets are not selectable anywhere in the app because the frontend only ever requests the `chat` interface from `GET /api/v1/deployments`. Widening the filter to include `mcp` surfaced two defects that must be fixed in the same change: (1) DIAL Core silently only honored the first of several repeated `interface_type` query values, so multi-value filtering never actually reached Core, and (2) DIAL Core's `/v1/deployments` payload for toolset entries omits `auth_settings`/`endpoint`, so passing MCP toolsets through this endpoint would duplicate them (with an incomplete shape) against the already-correct `/v1/toolsets` listing the catalog uses. Additionally, once non-chat-interface deployments (e.g. `mcp`-only or `custom_ui`-only applications) can appear in `items`, UI surfaces that assume every item supports chat (model pickers, the catalog's "Use in chat" action) must gate on the deployment's actual `interfaces` instead of just its `type`.
+
+## What Changes
+
+- Frontend requests `interface_type=chat,mcp` (both interfaces) instead of `chat` only, in both the initial deployments load and `refetchDeployments`.
+- Backend forwards multi-value `interface_type` to DIAL Core as a single comma-joined query parameter instead of repeated query keys, fixing a bug where Core only honored the first repeated value.
+- **BREAKING** (internal contract only, no external API shape change): `GET /api/v1/deployments` no longer includes toolset-typed entries in its response, for any `interface_type` filter (including no filter / `all`). Toolsets remain available exclusively via the existing `GET /api/v1/toolsets` listing.
+- `DeploymentsListingService`'s ownership/installed-state enrichment is simplified to the single `APPLICATION` resource-sharing scope, since toolset entries can no longer reach that code path.
+- The catalog's "Use in chat" primary-action visibility rule is extended: in addition to the existing type-based exclusion (never for Toolset items), it is also hidden for Model/Application items whose `interfaces` does not include `'chat'`.
+- Unrelated fix found along the way: a stale Vite alias in `apps/chat/vite.config.mts` referencing the pre-rename `@epam/chat-api-client` package name is corrected to `@epam/ai-dial-chat-api-client`.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `deployments-api`: `GET /api/v1/deployments` SHALL exclude toolset-typed entries from its response regardless of `interface_type` filter; multi-value `interface_type` SHALL be forwarded to DIAL Core as one comma-joined parameter.
+- `deployments-context`: the deployments provider SHALL request `[Chat, Mcp]` interfaces (not `[Chat]` only) on both initial load and `refetchDeployments`.
+- `catalog-use-in-chat`: the "Use in chat" primary action SHALL also be hidden for Model/Application items that do not support the `chat` interface, not only for Toolset-typed items.
+
+## Impact
+
+- `apps/chat-api/src/deployments/listing/deployments-listing.service.ts` — query serialization fix, toolset exclusion, ownership-enrichment simplification.
+- `apps/chat-api/src/deployments/listing/tests/deployments-listing.service.spec.ts` — tests asserting toolset pass-through/ownership need updating to reflect exclusion.
+- `apps/chat/src/context/DeploymentsContext.tsx` — interface filter widened to `[Chat, Mcp]` in two call sites.
+- `apps/chat/src/components/CatalogView/CatalogView.tsx` — `isPrimaryActionVisible` gains an `interfaces`-based check.
+- `libs/catalog/src/models/*` and `apps/chat/src/utils/map-deployment-to-catalog-item.ts` — `CatalogItem` needs an `interfaces` (or equivalent chat-support) field threaded through from `DeploymentItemDto.interfaces` for the above check to work.
+- `apps/chat/vite.config.mts` — stale package alias fix (unrelated bug, bundled here since found during this work).
+- No DIAL Core, database, or public REST contract changes — `DeploymentItemDto`'s shape is unchanged; only which items appear in the array changes.

--- a/openspec/changes/archive/2026-08-11-deployments-mcp-interface-filter/specs/catalog-use-in-chat/spec.md
+++ b/openspec/changes/archive/2026-08-11-deployments-mcp-interface-filter/specs/catalog-use-in-chat/spec.md
@@ -1,0 +1,29 @@
+## MODIFIED Requirements
+
+### Requirement: Use in chat is not available for Toolset items or non-chat deployments
+
+The catalog details panel SHALL NOT render the "Use in chat" primary action button when either:
+- the displayed item's `type` is `CatalogEntityType.Toolset`, or
+- the displayed item's `type` is `Model` or `Agent` but its `supportsChat` field (a `CatalogItem` boolean derived from `DeploymentItemDto.interfaces`, `true` when `interfaces` is absent or includes `'chat'`) is `false`.
+
+#### Scenario: Toolset details panel has no Use in chat button
+
+- **WHEN** the user opens the catalog, selects the Toolsets tab, and opens a toolset's details panel
+- **THEN** the "Use in chat" button is not rendered
+- **AND** other actions available for the toolset (e.g. Share) remain rendered and functional
+
+#### Scenario: Model and Application details panels still show Use in chat when chat-capable
+
+- **WHEN** the user opens a details panel for an item of type Model or Application whose `interfaces` includes `'chat'`
+- **THEN** the "Use in chat" button is rendered as before
+
+#### Scenario: MCP-only application has no Use in chat button
+
+- **WHEN** the user opens the catalog and opens the details panel for an Application whose `interfaces` is `['mcp']` (no `'chat'`)
+- **THEN** the "Use in chat" button is not rendered
+- **AND** other actions available for the application (e.g. Share, credentials) remain rendered and functional
+
+#### Scenario: Application supporting both chat and mcp interfaces still shows Use in chat
+
+- **WHEN** the user opens the details panel for an Application whose `interfaces` is `['chat', 'mcp']`
+- **THEN** the "Use in chat" button is rendered

--- a/openspec/changes/archive/2026-08-11-deployments-mcp-interface-filter/specs/deployments-api/spec.md
+++ b/openspec/changes/archive/2026-08-11-deployments-mcp-interface-filter/specs/deployments-api/spec.md
@@ -1,0 +1,97 @@
+## MODIFIED Requirements
+
+### Requirement: GET /api/v1/deployments endpoint
+
+The system SHALL expose `GET /api/v1/deployments` that proxies DIAL Core `GET /v1/deployments` and returns all models and applications (excluding toolsets) visible to the authenticated session user, optionally filtered by interface type.
+
+The endpoint:
+- MUST require authentication via `SessionGuard`; respond 401 when no valid session is present.
+- SHALL accept an optional `interface_type` query parameter as a repeatable string value validated against `('chat' | 'embedding' | 'mcp' | 'custom_ui' | 'all')`; passing an unrecognised value MUST respond 400.
+- SHALL accept an optional `refresh` query parameter validated as a boolean (`true` or `false` after DTO transformation); passing any other value MUST respond 400.
+- SHALL forward the `interface_type` values to DIAL Core `GET /v1/deployments` as a single comma-joined query parameter (e.g. `interface_type=chat,mcp`) when more than one value is provided, not as repeated query keys — DIAL Core only honors the first occurrence of a repeated key.
+- SHALL call DIAL Core using the `@epam/ai-dial-typescript-sdk` client (`listDeployments`), passing the session access token.
+- SHALL map the DIAL Core response `deployments` array to `DeploymentItemDto[]` using the normalisation rules in the `DeploymentItemDto shape` requirement below.
+- SHALL exclude toolset-typed entries (DIAL Core items with a `toolset` field present) from the mapped response, regardless of the `interface_type` filter applied — toolsets are served exclusively by the dedicated `GET /api/v1/toolsets` listing, whose payload carries fields (`auth_settings`, `endpoint`) that DIAL Core's `/v1/deployments` toolset entries do not include.
+- SHALL respond 200 with `{ deployments: DeploymentItemDto[] }` on success.
+- SHALL respond 502 when DIAL Core returns a non-2xx response.
+- SHALL respond 503 when DIAL Core is unreachable or times out.
+- SHALL apply `@Throttle({ default: { limit: 60, ttl: 60000 } })`.
+- SHALL cache the unfiltered DIAL Core response under key `deployments:list:<userSub>` for 30 000 ms and filtered DIAL Core responses under key `deployments:list:<userSub>:interface:<type[,type]>` for 30 000 ms.
+- SHALL, when a filtered cache entry is absent but the unfiltered cache entry is present, apply `interface_type` filtering in-process after cache retrieval without calling DIAL Core.
+- SHALL bypass server-side deployments cache entirely when `refresh=true`, call DIAL Core, and replace the relevant cache entry with the fresh mapped response.
+- SHALL set response header `Cache-Control: private, max-age=30` for normal requests.
+- SHALL set response header `Cache-Control: private, no-store` when `refresh=true`.
+- MUST NOT log the session access token.
+
+#### Scenario: Authenticated user receives all deployments without filter
+
+- **WHEN** `GET /api/v1/deployments` is called with a valid session and no `interface_type` parameter
+- **THEN** the endpoint responds 200 with `{ deployments: DeploymentItemDto[] }` containing all models and applications from DIAL Core, with no toolset-typed entries
+
+#### Scenario: Authenticated user filters by single interface type
+
+- **WHEN** `GET /api/v1/deployments?interface_type=chat` is called with a valid session
+- **THEN** the endpoint responds 200 with `{ deployments: DeploymentItemDto[] }` containing only deployments whose DIAL Core `interfaces` array includes `'chat'`
+
+#### Scenario: New fields present on response items
+
+- **WHEN** `GET /api/v1/deployments` returns items with DIAL Core `owner` populated
+- **THEN** each item in the response includes `owner`, `isMy`, and (for folder-nested applications) `applicationFolder`
+
+#### Scenario: Backward compatibility — clients ignoring new fields are unaffected
+
+- **WHEN** an existing client calls `GET /api/v1/deployments` and does not read `owner`, `isMy`, or `applicationFolder`
+- **THEN** the response is identical to the prior behavior for all pre-existing fields
+
+#### Scenario: Authenticated user filters by multiple interface types
+
+- **WHEN** `GET /api/v1/deployments?interface_type=chat&interface_type=mcp` is called with a valid session
+- **THEN** the endpoint forwards `interface_type=chat,mcp` to DIAL Core as one comma-joined parameter
+- **AND** the endpoint responds 200 with deployments matching either `'chat'` or `'mcp'` interface types
+
+#### Scenario: MCP-interface applications are included, MCP toolsets are excluded
+
+- **WHEN** `GET /api/v1/deployments?interface_type=mcp` is called and DIAL Core's response includes both an application with `dial:applicationTypeMcp` and a toolset, both exposing the `mcp` interface
+- **THEN** the response includes the MCP-capable application
+- **AND** the response does NOT include the toolset, even though it matches the requested interface
+
+#### Scenario: Invalid interface_type value returns 400
+
+- **WHEN** `GET /api/v1/deployments?interface_type=unknown` is called
+- **THEN** the endpoint responds 400 with a validation error referencing `interface_type`
+
+#### Scenario: Invalid refresh value returns 400
+
+- **WHEN** `GET /api/v1/deployments?refresh=maybe` is called
+- **THEN** the endpoint responds 400 with a validation error referencing `refresh`
+
+#### Scenario: Unauthenticated request rejected
+
+- **WHEN** `GET /api/v1/deployments` is called without a valid session cookie
+- **THEN** the endpoint responds 401
+
+#### Scenario: Rate limit exceeded
+
+- **WHEN** the request rate exceeds 60 per minute for the client IP
+- **THEN** the endpoint responds 429
+
+#### Scenario: DIAL Core unreachable
+
+- **WHEN** DIAL Core does not respond within the SDK timeout
+- **THEN** the endpoint responds 503
+
+#### Scenario: DIAL Core returns error
+
+- **WHEN** DIAL Core returns a non-2xx response to `GET /v1/deployments`
+- **THEN** the endpoint responds 502
+
+#### Scenario: Cache hit — interface_type filter applied to cached list
+
+- **WHEN** `deployments:list:<userSub>` is present in cache and `interface_type=chat` is requested
+- **THEN** the service returns cached deployments filtered in-process without calling DIAL Core
+
+#### Scenario: Refresh bypasses deployments cache
+
+- **WHEN** `deployments:list:<userSub>:interface:chat` is present in cache and `GET /api/v1/deployments?interface_type=chat&refresh=true` is requested
+- **THEN** the service calls DIAL Core instead of returning the cached entry
+- **AND** the response header is `Cache-Control: private, no-store`

--- a/openspec/changes/archive/2026-08-11-deployments-mcp-interface-filter/specs/deployments-context/spec.md
+++ b/openspec/changes/archive/2026-08-11-deployments-mcp-interface-filter/specs/deployments-context/spec.md
@@ -1,0 +1,144 @@
+## MODIFIED Requirements
+
+### Requirement: DeploymentsContext owns deployment selection for conversation selector
+
+`apps/chat/src/context/DeploymentsContext.tsx` SHALL provide:
+
+- `items: DeploymentItemDto[]` — full deployment list from `GET /api/v1/deployments`
+- `selectedItemId: string | null` — currently selected deployment id
+- `setSelectedItemId: (id: string | null) => void` — persists selection to user config via `setSelectedDeployment` from `useUserConfig()` (user-initiated model change); does NOT write to `localStorage`
+- `restoreSelectedItemId: (id: string) => void` — sets `selectedItemId` in local state **without** calling `setSelectedDeployment`; used when restoring a conversation's last-used model so the user's own new-chat preference is preserved
+- `isLoading: boolean`
+- `error: Error | null`
+
+The provider SHALL:
+- Fetch deployments on mount using `getDeployments([ListDeploymentsInterfaceTypeEnum.Chat, ListDeploymentsInterfaceTypeEnum.Mcp])` from `server-api/deployments.api.ts`, so `items` includes both chat-capable and MCP-capable models/applications.
+- Use a `cancelled` flag inside `useEffect` to guard against setState-on-unmount.
+- Use `useMemo` to memoize the context value.
+- Determine the initial `selectedItemId` using the following precedence (evaluated in order after both deployments and user config are available):
+  1. Current in-memory `selectedItemId` if it is still present in the new `items` list (handles deployment list reload).
+  2. `useUserConfig().selectedDeploymentId` if non-null and present in `items`.
+  3. `useAppConfig().defaultDeploymentId` if non-null and present in `items`.
+  4. `items[0]?.id` (first sorted deployment).
+  5. `null` if `items` is empty.
+- When the deployments reload and the previously selected `id` is no longer in `items`, re-apply the full precedence chain from step 2 onward.
+- **NOT re-trigger the full deployments/schemas/toolsets fetch merely because `setSelectedItemId` is called.** `setSelectedItemId` optimistically updates `useUserConfig().selectedDeploymentId` before its persistence call resolves; the initial-load fetch (and the `isLoading` flag it drives) SHALL NOT react to that value changing after the initial load has already completed. The initial-selection precedence chain MAY still be re-evaluated without a network call if `userConfigSelectedId`/`defaultDeploymentId` become known only after the deployments list already loaded with `selectedItemId` still `null` (e.g. an initially empty list later repopulated via `refetchDeployments`).
+- Export a `useDeployments()` hook that throws a clear error when called outside the provider.
+- NOT read from or write to `localStorage` under any circumstance.
+
+The state management pattern SHALL follow `ThemeContext.tsx` as the reference implementation.
+
+`CatalogContext.tsx` SHALL be deleted — `DeploymentsContext` is its replacement, not an addition.
+
+**i18n impact:** None.
+
+**RTL / UI impact:** None (context logic only).
+
+**Memoisation:** `useMemo` on context value; `setSelectedItemId` and `restoreSelectedItemId` SHALL be wrapped in `useCallback`.
+
+#### Scenario: DeploymentsProvider loads items on mount
+
+- **WHEN** `DeploymentsProvider` mounts
+- **THEN** it calls `getDeployments([ListDeploymentsInterfaceTypeEnum.Chat, ListDeploymentsInterfaceTypeEnum.Mcp])`, sets `isLoading: true` during fetch, sets `items` on success, sets `error` on failure, and sets `isLoading: false` when done
+
+#### Scenario: Initial selectedItemId follows user config preference
+
+- **WHEN** deployments load with items `["dep-a", "dep-b"]` and `useUserConfig().selectedDeploymentId === "dep-b"`
+- **THEN** `selectedItemId` is `"dep-b"`
+
+#### Scenario: User config preference absent — falls back to operator default
+
+- **WHEN** deployments load with items `["dep-a", "dep-b"]` and `useUserConfig().selectedDeploymentId === null` and `useAppConfig().defaultDeploymentId === "dep-b"`
+- **THEN** `selectedItemId` is `"dep-b"`
+
+#### Scenario: User config and operator default absent — falls back to first sorted deployment
+
+- **WHEN** deployments load and both `selectedDeploymentId` and `defaultDeploymentId` are `null`
+- **THEN** `selectedItemId` is `items[0].id`
+
+#### Scenario: User config preference points to unavailable deployment — falls through to operator default
+
+- **WHEN** `useUserConfig().selectedDeploymentId === "removed-dep"` and `"removed-dep"` is not in `items`, and `useAppConfig().defaultDeploymentId === "dep-a"` which is in `items`
+- **THEN** `selectedItemId` is `"dep-a"`
+
+#### Scenario: No deployments exist — selectedItemId is null
+
+- **WHEN** deployments load successfully with an empty list
+- **THEN** `selectedItemId` is `null`
+
+#### Scenario: useDeployments throws outside provider
+
+- **WHEN** `useDeployments()` is called outside a `DeploymentsProvider`
+- **THEN** it throws `Error('useDeployments must be used within a DeploymentsProvider')`
+
+#### Scenario: Unmount before fetch completes — no state update
+
+- **WHEN** `DeploymentsProvider` unmounts before `getDeployments()` resolves
+- **THEN** the `cancelled` flag prevents any `setState` calls
+
+#### Scenario: Previously selected item removed after reload
+
+- **WHEN** `selectedItemId` is `"old-dep"` and deployments reload returning items that do not include `"old-dep"`
+- **THEN** selection re-evaluates precedence: user config → operator default → first item → null
+
+#### Scenario: setSelectedItemId calls user config persistence
+
+- **WHEN** `setSelectedItemId("dep-b")` is called
+- **THEN** `useUserConfig().setSelectedDeployment("dep-b")` is called
+- **AND** `selectedItemId` updates to `"dep-b"` in local state
+
+#### Scenario: restoreSelectedItemId does not call user config persistence
+
+- **WHEN** `restoreSelectedItemId("dep-b")` is called
+- **THEN** `selectedItemId` updates to `"dep-b"` in local state
+- **AND** `useUserConfig().setSelectedDeployment` is NOT called
+
+#### Scenario: localStorage is never read or written
+
+- **WHEN** any interaction with DeploymentsContext occurs (mount, select, restore)
+- **THEN** `localStorage.getItem` and `localStorage.setItem` are never called with `"dial:selectedDeploymentId"`
+
+#### Scenario: Selecting a deployment does not re-trigger the initial-load fetch sequence
+
+- **WHEN** `getDeployments`, `getApplicationSchemas`, and `listToolsets` have each already resolved once after mount, and the user then calls `setSelectedItemId` with a different, valid deployment id (which optimistically updates `useUserConfig().selectedDeploymentId`)
+- **THEN** `selectedItemId` updates immediately, `isLoading` remains `false` throughout, and `getDeployments`, `getApplicationSchemas`, and `listToolsets` are each still called exactly once
+
+#### Scenario: Selection resolves from a later-populated list without a network call
+
+- **WHEN** the initial `getDeployments()` call resolves with an empty list (so `selectedItemId` stays `null`), `useUserConfig().selectedDeploymentId` subsequently becomes a valid id, and `rawDeployments` is later repopulated (e.g. via `refetchDeployments`) to include that id
+- **THEN** `selectedItemId` updates to that id once the repopulated list is available, without the initial-load fetch sequence (`getDeployments`/`getApplicationSchemas`/`listToolsets`) running an additional, unrequested time beyond the explicit `refetchDeployments` call
+
+### Requirement: `refetchDeployments`/`refetchToolsets` guard against stale in-flight responses
+
+`DeploymentsContext` SHALL expose `refetchToolsets(): Promise<void>` and `refetchDeployments(): Promise<void>` (already part of `DeploymentsContextType`) that re-fetch and replace `toolsets`/`rawDeployments` respectively. The provider SHALL maintain two monotonic per-resource request-id counters (one for deployments, one for toolsets). Every call site that can set `rawDeployments` (the initial mount-time `loadDeployments`, and `refetchDeployments`) SHALL increment the deployments counter at dispatch time and only apply its result if the counter is unchanged when the response arrives; the same pattern applies to `toolsets` (initial load's toolsets fetch and `refetchToolsets`) against the toolsets counter. A response whose captured id no longer matches the current counter SHALL be silently discarded (no state update, no error surfaced) — it does not represent an error, only a superseded request.
+
+This prevents a race where the initial mount-time list fetch (unavoidably in flight before any resource could have been shared to the user) resolves *after* a later, deliberate `refetchDeployments()`/`refetchToolsets()` call (e.g. one triggered right after accepting a share invitation) and overwrites its fresher result with the stale pre-share snapshot.
+
+`refetchDeployments()` SHALL call `getDeployments([ListDeploymentsInterfaceTypeEnum.Chat, ListDeploymentsInterfaceTypeEnum.Mcp], true)` so app create/delete/share/save flows that need a just-written Quick App deployment bypass the deployments endpoint's 30-second browser/server cache window.
+
+#### Scenario: A later refetch's result is not clobbered by a slower initial load
+
+- **WHEN** the initial mount-time deployments fetch is still in flight and `refetchDeployments()` is called and resolves first with a fresh list
+- **AND** the initial fetch's response subsequently arrives
+- **THEN** `items` reflects the `refetchDeployments()` result, not the initial fetch's result
+
+#### Scenario: A later refetch's result is not clobbered by a slower initial toolsets load
+
+- **WHEN** the initial mount-time toolsets fetch is still in flight and `refetchToolsets()` is called and resolves first with a fresh list
+- **AND** the initial fetch's response subsequently arrives
+- **THEN** `toolsets` reflects the `refetchToolsets()` result, not the initial fetch's result
+
+#### Scenario: Normal sequential refetch still applies
+
+- **WHEN** `refetchDeployments()` (or `refetchToolsets()`) is called with no other in-flight request for that resource
+- **THEN** its result is applied to `items`/`toolsets` as before, unaffected by the request-id guard
+
+#### Scenario: Explicit deployments refetch requests a fresh backend list
+
+- **WHEN** `refetchDeployments()` is called after a Quick App save or other deployment-mutating flow
+- **THEN** it calls `getDeployments([ListDeploymentsInterfaceTypeEnum.Chat, ListDeploymentsInterfaceTypeEnum.Mcp], true)` so the backend receives `refresh=true`
+
+#### Scenario: A superseded response does not trigger an error notification
+
+- **WHEN** a stale response for a since-superseded request arrives (successfully, from the network's perspective)
+- **THEN** no `showNotification` error call is made and no state changes — the response is discarded because it is stale, not because it failed

--- a/openspec/changes/archive/2026-08-11-deployments-mcp-interface-filter/tasks.md
+++ b/openspec/changes/archive/2026-08-11-deployments-mcp-interface-filter/tasks.md
@@ -1,0 +1,35 @@
+## 1. Backend: DIAL Core query serialization fix
+
+- [x] 1.1 In `apps/chat-api/src/deployments/listing/deployments-listing.service.ts`, pass `querySerializer: { array: { style: 'form', explode: false } }` on the `listDeployments` call so multi-value `interface_type` reaches DIAL Core as one comma-joined parameter instead of repeated query keys.
+- [x] 1.2 Add debug logging around the requested/normalized `interfaceType`, the DIAL Core request URL, and the local post-filter item counts (kept as ongoing operational debug logging, not removed after diagnosis).
+
+## 2. Backend: exclude toolsets from deployments listing
+
+- [x] 2.1 In `mapToDeploymentItem`/`listDeployments`, filter out `DeploymentItemType.Toolset`-typed items from `allItems` immediately after mapping, before caching.
+- [x] 2.2 Simplify the ownership/`isInstalled` enrichment block to only handle the `APPLICATION` resource-sharing scope (drop the now-unreachable `TOOL_SET`-scoped `getSharedResourceUrlSets` call, `toolsetsSet`, and `toolsetUrlSets`); narrow `getSharedResources`/`getSharedResourceUrlSets` to no longer take a `resourceType` parameter.
+- [x] 2.3 Update `apps/chat-api/src/deployments/listing/tests/deployments-listing.service.spec.ts`: remove or rewrite the tests that assert toolset pass-through (`maps model, application, and toolset correctly`, `sets isInstalled=true for installed toolset`, `leaves applicationFolder absent for toolset deployments`, the `TOOL_SET`-scoped `sharedWithMe` tests, and the `getSharedResources` call-count assertion expecting 2 calls) so they instead assert toolsets are absent from `result.deployments` and only one `getSharedResources` call (`APPLICATION`) is made.
+- [x] 2.4 Run `npm exec nx test chat-api` and confirm all tests pass with zero failures.
+
+## 3. Frontend: widen the interface filter
+
+- [x] 3.1 In `apps/chat/src/context/DeploymentsContext.tsx`, change the initial `loadDeployments` call and `refetchDeployments` to request `[ListDeploymentsInterfaceTypeEnum.Chat, ListDeploymentsInterfaceTypeEnum.Mcp]` instead of `[ListDeploymentsInterfaceTypeEnum.Chat]` only.
+- [x] 3.2 Update `openspec/specs/deployments-context/spec.md`-equivalent expectations are covered by this change's delta spec — no additional code task, confirmed via `openspec/changes/deployments-mcp-interface-filter/specs/deployments-context/spec.md`.
+
+## 4. Frontend: gate "Use in chat" on the `chat` interface
+
+- [x] 4.1 Add a `supportsChat?: boolean` field to `CatalogItem` (`libs/catalog/src/models/catalog-item.ts`), following the existing `supportsMcp` pattern, documented per `libs.md` JSDoc rules. (Design updated from the original `interfaces: string[]` plan to match this established codebase convention — see `design.md` decision 3.)
+- [x] 4.2 Populate `supportsChat` in `mapDeploymentToCatalogItem` (`apps/chat/src/utils/map-deployment-to-catalog-item.ts`) as `deployment.interfaces == null || deployment.interfaces.includes('chat')`; add unit tests in `map-deployment-to-catalog-item.spec.ts`.
+- [x] 4.3 In `apps/chat/src/components/CatalogView/CatalogView.tsx`, extend `isPrimaryActionVisible` to require `item.supportsChat !== false` in addition to the existing `Model`/`Agent` type check.
+- [x] 4.4 Add component tests for `CatalogView` covering: MCP-only Application does not show "Use in chat"; Application supporting both `chat` and `mcp` still shows it; existing Toolset-hides-button and Model/Application-shows-button tests still pass.
+
+## 5. Cleanup
+
+- [x] 5.1 Fix the stale Vite alias in `apps/chat/vite.config.mts` (`@epam/chat-api-client` → `@epam/ai-dial-chat-api-client`), found while debugging this change.
+- [x] 5.2 Confirm no leftover redundant toolset-filtering code remains in `apps/chat/src/server-api/deployments.api.ts` or `apps/chat/src/components/CatalogView/CatalogView.tsx` (both were tried and reverted once the backend-side exclusion was settled on — verify current state matches design decision #2). Found and removed a leftover frontend filter in `deployments.api.ts` that had not been reverted.
+
+## 6. Verification
+
+- [x] 6.1 `npm exec nx lint chat-api` and `npm exec nx lint chat` — zero errors.
+- [x] 6.2 `npm exec nx typecheck chat-api` and `npm exec nx typecheck chat` — no new errors introduced by this change (pre-existing `TS6305` stale-dist-cache errors in unrelated test files are a pre-existing baseline issue, not caused by this change).
+- [x] 6.3 `npm exec nx test chat-api` and `npm exec nx test chat` — all green (one unrelated flaky timeout in `conversation.controller.integration.spec.ts` on first run, passed clean on re-run; confirmed unrelated to this change's files).
+- [x] 6.4 Manual smoke test: with the dev server running, confirm the chat-api debug log shows `DIAL Core request URL: .../v1/deployments?interface_type=chat,mcp`, confirm MCP-capable applications appear in the deployment/model picker, confirm toolsets do not appear twice (once via picker/catalog "Applications", once via catalog "Toolsets"), and confirm the "Use in chat" button is absent for an MCP-only application's catalog details panel.

--- a/openspec/specs/catalog-use-in-chat/spec.md
+++ b/openspec/specs/catalog-use-in-chat/spec.md
@@ -31,9 +31,11 @@ The selection SHALL be persisted to user config as part of `setSelectedItemId`'s
 - **WHEN** the user selects a deployment via "Use in chat" and then reloads the page
 - **THEN** the same deployment remains selected, restored from user config
 
-### Requirement: Use in chat is not available for Toolset items
+### Requirement: Use in chat is not available for Toolset items or non-chat deployments
 
-The catalog details panel SHALL NOT render the "Use in chat" primary action button when the displayed item's `type` is `CatalogEntityType.Toolset`.
+The catalog details panel SHALL NOT render the "Use in chat" primary action button when either:
+- the displayed item's `type` is `CatalogEntityType.Toolset`, or
+- the displayed item's `type` is `Model` or `Agent` but its `supportsChat` field (a `CatalogItem` boolean derived from `DeploymentItemDto.interfaces`, `true` when `interfaces` is absent or includes `'chat'`) is `false`.
 
 #### Scenario: Toolset details panel has no Use in chat button
 
@@ -41,7 +43,18 @@ The catalog details panel SHALL NOT render the "Use in chat" primary action butt
 - **THEN** the "Use in chat" button is not rendered
 - **AND** other actions available for the toolset (e.g. Share) remain rendered and functional
 
-#### Scenario: Model and Application details panels still show Use in chat
+#### Scenario: Model and Application details panels still show Use in chat when chat-capable
 
-- **WHEN** the user opens a details panel for an item of type Model or Application
+- **WHEN** the user opens a details panel for an item of type Model or Application whose `interfaces` includes `'chat'`
 - **THEN** the "Use in chat" button is rendered as before
+
+#### Scenario: MCP-only application has no Use in chat button
+
+- **WHEN** the user opens the catalog and opens the details panel for an Application whose `interfaces` is `['mcp']` (no `'chat'`)
+- **THEN** the "Use in chat" button is not rendered
+- **AND** other actions available for the application (e.g. Share, credentials) remain rendered and functional
+
+#### Scenario: Application supporting both chat and mcp interfaces still shows Use in chat
+
+- **WHEN** the user opens the details panel for an Application whose `interfaces` is `['chat', 'mcp']`
+- **THEN** the "Use in chat" button is rendered

--- a/openspec/specs/deployments-api/spec.md
+++ b/openspec/specs/deployments-api/spec.md
@@ -1,14 +1,15 @@
 ### Requirement: GET /api/v1/deployments endpoint
 
-The system SHALL expose `GET /api/v1/deployments` that proxies DIAL Core `GET /v1/deployments` and returns all deployments (models, applications, toolsets) visible to the authenticated session user, optionally filtered by interface type.
+The system SHALL expose `GET /api/v1/deployments` that proxies DIAL Core `GET /v1/deployments` and returns all models and applications (excluding toolsets) visible to the authenticated session user, optionally filtered by interface type.
 
 The endpoint:
 - MUST require authentication via `SessionGuard`; respond 401 when no valid session is present.
 - SHALL accept an optional `interface_type` query parameter as a repeatable string value validated against `('chat' | 'embedding' | 'mcp' | 'custom_ui' | 'all')`; passing an unrecognised value MUST respond 400.
 - SHALL accept an optional `refresh` query parameter validated as a boolean (`true` or `false` after DTO transformation); passing any other value MUST respond 400.
-- SHALL forward the `interface_type` values to DIAL Core `GET /v1/deployments` when provided.
+- SHALL forward the `interface_type` values to DIAL Core `GET /v1/deployments` as a single comma-joined query parameter (e.g. `interface_type=chat,mcp`) when more than one value is provided, not as repeated query keys — DIAL Core only honors the first occurrence of a repeated key.
 - SHALL call DIAL Core using the `@epam/ai-dial-typescript-sdk` client (`listDeployments`), passing the session access token.
 - SHALL map the DIAL Core response `deployments` array to `DeploymentItemDto[]` using the normalisation rules in the `DeploymentItemDto shape` requirement below.
+- SHALL exclude toolset-typed entries (DIAL Core items with a `toolset` field present) from the mapped response, regardless of the `interface_type` filter applied — toolsets are served exclusively by the dedicated `GET /api/v1/toolsets` listing, whose payload carries fields (`auth_settings`, `endpoint`) that DIAL Core's `/v1/deployments` toolset entries do not include.
 - SHALL respond 200 with `{ deployments: DeploymentItemDto[] }` on success.
 - SHALL respond 502 when DIAL Core returns a non-2xx response.
 - SHALL respond 503 when DIAL Core is unreachable or times out.
@@ -23,7 +24,7 @@ The endpoint:
 #### Scenario: Authenticated user receives all deployments without filter
 
 - **WHEN** `GET /api/v1/deployments` is called with a valid session and no `interface_type` parameter
-- **THEN** the endpoint responds 200 with `{ deployments: DeploymentItemDto[] }` containing all models, applications, and toolsets from DIAL Core
+- **THEN** the endpoint responds 200 with `{ deployments: DeploymentItemDto[] }` containing all models and applications from DIAL Core, with no toolset-typed entries
 
 #### Scenario: Authenticated user filters by single interface type
 
@@ -43,7 +44,14 @@ The endpoint:
 #### Scenario: Authenticated user filters by multiple interface types
 
 - **WHEN** `GET /api/v1/deployments?interface_type=chat&interface_type=mcp` is called with a valid session
-- **THEN** the endpoint responds 200 with deployments matching either `'chat'` or `'mcp'` interface types
+- **THEN** the endpoint forwards `interface_type=chat,mcp` to DIAL Core as one comma-joined parameter
+- **AND** the endpoint responds 200 with deployments matching either `'chat'` or `'mcp'` interface types
+
+#### Scenario: MCP-interface applications are included, MCP toolsets are excluded
+
+- **WHEN** `GET /api/v1/deployments?interface_type=mcp` is called and DIAL Core's response includes both an application with `dial:applicationTypeMcp` and a toolset, both exposing the `mcp` interface
+- **THEN** the response includes the MCP-capable application
+- **AND** the response does NOT include the toolset, even though it matches the requested interface
 
 #### Scenario: Invalid interface_type value returns 400
 

--- a/openspec/specs/deployments-context/spec.md
+++ b/openspec/specs/deployments-context/spec.md
@@ -16,7 +16,7 @@ Owns the deployments (models/applications), toolsets, and selected-deployment st
 - `error: Error | null`
 
 The provider SHALL:
-- Fetch deployments on mount using `getDeployments()` from `server-api/deployments.api.ts` with no `interface_type` filter (all deployments).
+- Fetch deployments on mount using `getDeployments([ListDeploymentsInterfaceTypeEnum.Chat, ListDeploymentsInterfaceTypeEnum.Mcp])` from `server-api/deployments.api.ts`, so `items` includes both chat-capable and MCP-capable models/applications.
 - Use a `cancelled` flag inside `useEffect` to guard against setState-on-unmount.
 - Use `useMemo` to memoize the context value.
 - Determine the initial `selectedItemId` using the following precedence (evaluated in order after both deployments and user config are available):
@@ -43,7 +43,7 @@ The state management pattern SHALL follow `ThemeContext.tsx` as the reference im
 #### Scenario: DeploymentsProvider loads items on mount
 
 - **WHEN** `DeploymentsProvider` mounts
-- **THEN** it calls `getDeployments()`, sets `isLoading: true` during fetch, sets `items` on success, sets `error` on failure, and sets `isLoading: false` when done
+- **THEN** it calls `getDeployments([ListDeploymentsInterfaceTypeEnum.Chat, ListDeploymentsInterfaceTypeEnum.Mcp])`, sets `isLoading: true` during fetch, sets `items` on success, sets `error` on failure, and sets `isLoading: false` when done
 
 #### Scenario: Initial selectedItemId follows user config preference
 
@@ -286,7 +286,7 @@ The raw `'dial:chatMessageInputDisabled'` field SHALL be removed — the backend
 
 This prevents a race where the initial mount-time list fetch (unavoidably in flight before any resource could have been shared to the user) resolves *after* a later, deliberate `refetchDeployments()`/`refetchToolsets()` call (e.g. one triggered right after accepting a share invitation) and overwrites its fresher result with the stale pre-share snapshot.
 
-`refetchDeployments()` SHALL call `getDeployments([ListDeploymentsInterfaceTypeEnum.Chat], true)` so app create/delete/share/save flows that need a just-written Quick App deployment bypass the deployments endpoint's 30-second browser/server cache window.
+`refetchDeployments()` SHALL call `getDeployments([ListDeploymentsInterfaceTypeEnum.Chat, ListDeploymentsInterfaceTypeEnum.Mcp], true)` so app create/delete/share/save flows that need a just-written Quick App deployment bypass the deployments endpoint's 30-second browser/server cache window.
 
 #### Scenario: A later refetch's result is not clobbered by a slower initial load
 
@@ -308,7 +308,7 @@ This prevents a race where the initial mount-time list fetch (unavoidably in fli
 #### Scenario: Explicit deployments refetch requests a fresh backend list
 
 - **WHEN** `refetchDeployments()` is called after a Quick App save or other deployment-mutating flow
-- **THEN** it calls `getDeployments([ListDeploymentsInterfaceTypeEnum.Chat], true)` so the backend receives `refresh=true`
+- **THEN** it calls `getDeployments([ListDeploymentsInterfaceTypeEnum.Chat, ListDeploymentsInterfaceTypeEnum.Mcp], true)` so the backend receives `refresh=true`
 
 #### Scenario: A superseded response does not trigger an error notification
 


### PR DESCRIPTION
**Description:**

Integrate MCP-capable deployments into the catalog UI with interface-based filtering. This work adds support for displaying deployments in the catalog view with MCP interface filtering, excluding non-MCP toolsets from the listing. Backend services are updated to support deployment filtering based on interfaces, and the frontend components now properly handle displaying filtered deployments in the catalog context.

**UI changes**

No UI changes (integration of existing components).

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `feat(chat):`
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (no ticket for this work)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs