### PR TITLE
fix(scheduled-tasks): disable Active switch for an expired recurring schedule

### DIFF
--- a/apps/chat/src/pages/ScheduledTaskDetailPage/ScheduledTaskDetailPage.tsx
+++ b/apps/chat/src/pages/ScheduledTaskDetailPage/ScheduledTaskDetailPage.tsx
@@ -224,8 +224,21 @@ const ScheduledTaskDetailPage: FC = () => {
     setTaskFetchToken((token) => token + 1);
   };
 
+  /*
+   * A one-time (`date`) schedule with no next run has already fired and
+   * can't produce another run by resuming it. A recurring (`cron`) schedule
+   * whose activity window `endDate` has already passed can't produce a
+   * future run either, even though — unlike a one-time schedule — it may
+   * still be actively paused/resumable in principle; both cases disable
+   * (not hide) the switch so the state stays visible without offering a
+   * dead-end toggle.
+   */
+  const cronWindowEndDate = task?.trigger.cron?.endDate;
   const isActiveDisabled =
-    task?.triggerType === 'date' && task?.nextRunTime == null;
+    (task?.triggerType === 'date' && task?.nextRunTime == null) ||
+    (task?.triggerType === 'cron' &&
+      cronWindowEndDate != null &&
+      new Date(cronWindowEndDate).getTime() <= Date.now());
 
   const handleActiveChange = useCallback(
     async (nextActive: boolean) => {

--- a/apps/chat/src/pages/ScheduledTaskDetailPage/tests/ScheduledTaskDetailPage.spec.tsx
+++ b/apps/chat/src/pages/ScheduledTaskDetailPage/tests/ScheduledTaskDetailPage.spec.tsx
@@ -650,6 +650,54 @@ describe('ScheduledTaskDetailPage', () => {
       expect(resumeScheduledTaskMock).not.toHaveBeenCalled();
     });
 
+    it('renders the switch disabled for a recurring schedule whose activity window has already ended, without calling pause or resume', async () => {
+      useFeatureFlagMock.mockReturnValue(true);
+      getScheduledTaskMock.mockResolvedValue({
+        id: 'sched_123',
+        displayName: 'Daily summary',
+        trigger: {
+          cron: {
+            fields: { hour: '9', minute: '0' },
+            endDate: '2020-01-01T00:00:00.000Z',
+          },
+        },
+        triggerType: 'cron',
+        isActive: false,
+        nextRunTime: undefined,
+      });
+      renderDetailPage();
+
+      const switchEl = await waitFor(() => screen.getByRole('switch'));
+      expect(switchEl).toHaveProperty('checked', false);
+      expect(switchEl).toHaveProperty('disabled', true);
+
+      await userEvent.click(switchEl);
+
+      expect(pauseScheduledTaskMock).not.toHaveBeenCalled();
+      expect(resumeScheduledTaskMock).not.toHaveBeenCalled();
+    });
+
+    it('remains togglable for a recurring schedule whose activity window has not ended yet', async () => {
+      useFeatureFlagMock.mockReturnValue(true);
+      getScheduledTaskMock.mockResolvedValue({
+        id: 'sched_123',
+        displayName: 'Daily summary',
+        trigger: {
+          cron: {
+            fields: { hour: '9', minute: '0' },
+            endDate: '2099-01-01T00:00:00.000Z',
+          },
+        },
+        triggerType: 'cron',
+        isActive: false,
+        nextRunTime: undefined,
+      });
+      renderDetailPage();
+
+      const switchEl = await waitFor(() => screen.getByRole('switch'));
+      expect(switchEl).toHaveProperty('disabled', false);
+    });
+
     it('remains togglable for a recurring schedule with no upcoming run (paused, not completed)', async () => {
       useFeatureFlagMock.mockReturnValue(true);
       getScheduledTaskMock.mockResolvedValue({

--- a/openspec/changes/add-scheduled-task-active-toggle/specs/scheduled-task-detail-page/spec.md
+++ b/openspec/changes/add-scheduled-task-active-toggle/specs/scheduled-task-detail-page/spec.md
@@ -162,16 +162,26 @@ All directional layout in the detail page header, Details/Configuration sections
 - **WHEN** the user navigates away from `/scheduled-tasks/sched_123` (unmount or `scheduleId` change) while a pause/resume call for `sched_123` is still in flight, and that call later resolves
 - **THEN** no component state is updated as a result of that resolution
 
-### Requirement: Active switch is disabled, not hidden, for a completed one-time schedule
+### Requirement: Active switch is disabled, not hidden, when a schedule can no longer produce a future run
 
-When a loaded task's `triggerType` is `date` (one-time) and its `nextRunTime` is `null` (the schedule has already run and cannot be resumed), `ScheduledTaskDetailPage` SHALL still render the Active switch (since `isActive` is defined — `false`, per the "Scheduled task active state field" requirement in `scheduled-tasks-api`), but SHALL pass `isActiveDisabled={true}` so the switch renders checked=false and disabled, rather than omitting the control or offering a resume action that DIAL Scheduler cannot fulfill.
+`ScheduledTaskDetailPage` SHALL pass `isActiveDisabled={true}` to `ScheduledTaskDetailView` whenever the loaded task has permanently exhausted its ability to produce a future run — the switch still renders (since `isActive` is defined), but disabled, rather than offering a resume action DIAL Scheduler cannot fulfill. Two cases qualify:
+
+- **Completed one-time schedule:** `triggerType` is `date` (one-time) and `nextRunTime` is `null` — the schedule has already run once and a `date` trigger cannot be rescheduled.
+- **Expired recurring schedule:** `triggerType` is `cron` and `trigger.cron.endDate` is a past timestamp — the schedule's activity window has closed, so resuming it cannot produce a future run within that window either.
+
+A recurring (`cron`) schedule with no upcoming run but an `endDate` that has not yet passed (or no `endDate` at all) is merely paused, not exhausted, and MUST remain togglable.
 
 #### Scenario: Completed one-time schedule shows a disabled, unchecked switch
 
 - **WHEN** the loaded task has `triggerType: 'date'` and `nextRunTime: null`
 - **THEN** the Active switch renders unchecked and disabled, and toggling it (via pointer or keyboard) has no effect and calls neither `pauseScheduledTask` nor `resumeScheduledTask`
 
+#### Scenario: Recurring schedule whose activity window has ended shows a disabled, unchecked switch
+
+- **WHEN** the loaded task has `triggerType: 'cron'` and `trigger.cron.endDate` in the past
+- **THEN** the Active switch renders unchecked and disabled, and toggling it (via pointer or keyboard) has no effect and calls neither `pauseScheduledTask` nor `resumeScheduledTask`
+
 #### Scenario: Recurring schedule with no upcoming run remains togglable
 
-- **WHEN** the loaded task has `triggerType: 'cron'` and `nextRunTime: null` (paused, not completed)
+- **WHEN** the loaded task has `triggerType: 'cron'`, `nextRunTime: null` (paused, not completed), and `trigger.cron.endDate` is absent or in the future
 - **THEN** the Active switch renders unchecked but NOT disabled, and toggling it on calls `resumeScheduledTask`

--- a/openspec/changes/add-scheduled-task-active-toggle/tasks.md
+++ b/openspec/changes/add-scheduled-task-active-toggle/tasks.md
@@ -87,3 +87,10 @@
 - [x] 12.5 `apps/chat/src/utils/map-scheduled-task-dto.ts`'s `mapScheduledTaskDtoToItem` now sets `isActive: task.isActive` (straight passthrough, no re-derivation — the BFF mapper owns that). Extended `map-scheduled-task-dto.spec.ts` with `isActive: false` / `isActive: true` / missing-`isActive` cases.
 - [x] 12.6 Confirmed by reading `ScheduledTaskCardGrid.tsx` and `ScheduledTasks.tsx` that both forward each `ScheduledTaskItem` (including `isActive`) unchanged into `ScheduledTaskCard` — no intermediate layer narrows the item shape, so no changes were needed there.
 - [x] 12.7 Verify: `npx nx run ai-dial-scheduled-tasks:test --skip-nx-cache` (119/119 pass), `npx nx run ai-dial-scheduled-tasks:lint --skip-nx-cache` (0 errors), `npx nx run chat:test --skip-nx-cache -- map-scheduled-task-dto` (18/18 pass), `npx nx run chat:lint --skip-nx-cache` (0 errors, pre-existing warnings only).
+
+## 13. Detail page: disable Active switch for an expired recurring schedule
+
+- [x] 13.1 Extended `isActiveDisabled` in `ScheduledTaskDetailPage.tsx` to also disable when `triggerType === 'cron'` and `trigger.cron.endDate` is a past timestamp (activity window closed) — previously only the completed-one-time-schedule case disabled the switch, leaving an expired recurring schedule's switch togglable even though resuming it can never produce a future run within its closed window.
+- [x] 13.2 Extended `ScheduledTaskDetailPage.spec.tsx` with: expired-cron-window renders disabled+unchecked and calls neither `pauseScheduledTask` nor `resumeScheduledTask` on click; cron window not yet ended (or no `endDate`) remains togglable.
+- [x] 13.3 Updated `specs/scheduled-task-detail-page/spec.md`'s disabled-switch requirement to cover both cases (renamed from "for a completed one-time schedule" to the general "when a schedule can no longer produce a future run").
+- [x] 13.4 Verify: `npx nx run chat:test --skip-nx-cache -- ScheduledTaskDetailPage` (25/25 pass), `npx nx run chat:lint --skip-nx-cache` (0 errors, pre-existing warnings only).


### PR DESCRIPTION
## Summary
- Extends `isActiveDisabled` on the Scheduled Task detail page to also disable the Active switch when a recurring (`cron`) schedule's activity window (`trigger.cron.endDate`) has already passed — previously only a completed one-time (`date`) schedule disabled the switch, leaving an expired recurring schedule's switch togglable even though resuming it can never produce a future run within its closed window.
- Updates the `scheduled-task-detail-page` OpenSpec delta spec (part of the already-merged `add-scheduled-task-active-toggle` change) to describe both disabling cases.

Follow-up to #8261 (already merged) — this single commit landed after that PR was merged, so it needs its own PR.

## Test plan
- [x] `npx nx run chat:test --skip-nx-cache -- ScheduledTaskDetailPage` (25/25 pass, including 2 new tests for the expired/not-yet-expired cron window)
- [x] `npx nx run chat:lint --skip-nx-cache` (0 errors, pre-existing warnings only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)