### PR TITLE
fix(chat): stop resolved duplicate uploads leaking into an edited message (Issue #7876)

### DIFF
--- a/apps/chat/src/store/files/__tests__/files.epics.test.ts
+++ b/apps/chat/src/store/files/__tests__/files.epics.test.ts
@@ -4,11 +4,17 @@ import { Subject, lastValueFrom, of, toArray } from 'rxjs';
 
 import { StateObservable } from 'redux-observable';
 
-import { FilesEpics } from '../files.epics';
-import { FilesActions } from '../files.reducers';
+import { ReplaceOptions } from '@/src/types/common';
 
-const runEpic = (action: ReturnType<typeof FilesActions.getFoldersList>) => {
-  const state$ = new StateObservable(new Subject(), {} as never);
+import { FilesEpics } from '../files.epics';
+import { FilesActions, filesSlice } from '../files.reducers';
+import { UploadReplaceDialogState } from '../files.types';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const runEpic = (action: any, filesState = filesSlice.getInitialState()) => {
+  const state$ = new StateObservable(new Subject(), {
+    files: filesState,
+  } as never);
 
   return lastValueFrom(
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -53,5 +59,62 @@ describe('files.epics getFoldersList', () => {
     expect(
       await runEpic(FilesActions.getFoldersList({ withFiles: true })),
     ).toEqual([FilesActions.getFolders({}), FilesActions.getFiles({})]);
+  });
+});
+
+describe('files.epics continueUploadReplaceDialog', () => {
+  const folderId = 'files/test-bucket/uploads';
+  const fileId = `${folderId}/sun.jpg`;
+
+  const openDialog = (selectFileIds: boolean) => {
+    const dialog: UploadReplaceDialogState = {
+      isOpen: false,
+      duplicatedFiles: [],
+      nonDuplicatedFiles: [
+        {
+          id: fileId,
+          name: 'sun.jpg',
+          fileContent: new File(['content'], 'sun.jpg', { type: 'image/jpeg' }),
+        },
+      ],
+      folderId,
+      folderPath: 'uploads',
+      bucket: 'test-bucket',
+      showSuccessMessage: true,
+      selectFileIds,
+      mappedActions: { [fileId]: ReplaceOptions.Postfix },
+    };
+
+    return { ...filesSlice.getInitialState(), uploadReplaceDialog: dialog };
+  };
+
+  const run = (selectFileIds: boolean) =>
+    runEpic(
+      FilesActions.continueUploadReplaceDialog({
+        mappedActions: { [fileId]: ReplaceOptions.Postfix },
+      }),
+      openDialog(selectFileIds),
+    );
+
+  it('selects the resolved files for an uploader that selects into the store', async () => {
+    const types = (await run(true)).map(({ type }) => type);
+
+    expect(types).toContain(FilesActions.selectFiles.type);
+    // Broadcasting the ids as well attached a file uploaded from the chat
+    // input to any message open in edit mode. Issue #7876
+    expect(types).not.toContain(FilesActions.setResolvedUploadIds.type);
+  });
+
+  it('publishes the resolved ids for an uploader that opted out of selecting', async () => {
+    const emitted = await run(false);
+    const types = emitted.map(({ type }) => type);
+
+    expect(types).toContain(FilesActions.setResolvedUploadIds.type);
+    expect(types).not.toContain(FilesActions.selectFiles.type);
+    expect(
+      emitted.find(
+        ({ type }) => type === FilesActions.setResolvedUploadIds.type,
+      ),
+    ).toEqual(FilesActions.setResolvedUploadIds({ ids: [fileId] }));
   });
 });

--- a/apps/chat/src/store/files/files.epics.ts
+++ b/apps/chat/src/store/files/files.epics.ts
@@ -1392,19 +1392,19 @@ const continueUploadReplaceDialogEpic: AppEpic = (action$, state$) =>
         ),
       ];
 
-      if (dialog.selectFileIds && resolvedFiles.length) {
-        actions.push(
-          FilesActions.selectFiles({
-            ids: resolvedFiles.map(({ id }) => id),
-          }),
-        );
-      }
-
       if (resolvedFiles.length) {
+        const ids = resolvedFiles.map(({ id }) => id);
+
+        // Hand the resolved files back to whoever opened the dialog, one way
+        // only. The chat input reads them off the store selection, while an
+        // editor that opted out of selecting picks them up from
+        // `resolvedUploadIds`. Doing both attached a file dropped on the chat
+        // input to any message that happened to be open in edit mode.
+        // Issue #7876
         actions.push(
-          FilesActions.setResolvedUploadIds({
-            ids: resolvedFiles.map(({ id }) => id),
-          }),
+          dialog.selectFileIds
+            ? FilesActions.selectFiles({ ids })
+            : FilesActions.setResolvedUploadIds({ ids }),
         );
       }
 


### PR DESCRIPTION
## Description of changes

When an upload hits a name collision, the pending files go through the replace dialog and are re-dispatched from `continueUploadReplaceDialogEpic`. The epic handed the resolved files back through **two** channels at once:

- `selectFiles` — only when `dialog.selectFileIds`, i.e. the uploader wants them in the store selection (chat input, drop area);
- `setResolvedUploadIds` — unconditionally.

`resolvedUploadIds` is a broadcast, and its only consumers are the edit-mode message components (`UserMessage`, `AssistantMessage`), which concat whatever arrives into their own attachment list. So a file dropped or pasted on the **chat input** got selected into the store *and* attached to any message sitting in edit mode — the postfixed duplicate showing up in both places.

That also explains the "ok" case from the issue: pasting into the message in edit mode uses `skipSelect: true`, so `selectFileIds` is false, `selectFiles` never fires, and only the message picks the file up.

The two channels are complements, not a pair — the conflict-free path in `dispatchPreparedFileUploads` already selects only when asked and otherwise returns the ids to its caller. The conflict path now mirrors it: `selectFiles` when `selectFileIds`, `setResolvedUploadIds` otherwise, never both.

Note on the earlier fix for this issue: `droppable={false}` on the edit block stops the message from *receiving* a drop. This leak comes back through the store afterwards, so it bypassed that guard entirely — which is why it only surfaced once the duplicate-name popup was involved.

### Tests

Two cases added to `files.epics.test.ts`: a store-selecting uploader must not also broadcast (fails against the previous code), and a `skipSelect` uploader must still get its ids.

## Applicable issues

- fixes #7876

## UI changes

No visual changes — a file uploaded from the chat input no longer appears in a message open in edit mode.

## Checklist

- [x] the pull request name ends with `(Issue #<ISSUE_ID>)` (comma-separated list of issues)
- [x] I confirm that I don't share any confidential information like API keys or any other secrets and private URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)