### PR TITLE
fix(chat): do not restart the conversation when overlay options change (Issue #2841)

### DIFF
--- a/apps/chat-e2e/src/ui/webElements/overlay/configuration.ts
+++ b/apps/chat-e2e/src/ui/webElements/overlay/configuration.ts
@@ -1,4 +1,3 @@
-import { API } from '@/src/testData';
 import { EventSelectors } from '@/src/ui/selectors';
 import { BaseElement } from '@/src/ui/webElements';
 import { Page } from '@playwright/test';
@@ -12,14 +11,10 @@ export class Configuration extends BaseElement {
     EventSelectors.setConfigurationButton,
   );
 
+  // Setting overlay options no longer re-reads the selected conversation, so
+  // there is no response to wait for; the assertions that follow retry on their
+  // own until the options are applied.
   public async clickSetConfigurationButton() {
-    const respPromise = this.page.waitForResponse(
-      (response) =>
-        response.request().method() === 'GET' &&
-        response.status() === 200 &&
-        response.url().includes(API.conversationHost),
-    );
     await this.setConfigurationButton.click();
-    await respPromise;
   }
 }

--- a/apps/chat/src/store/overlay/overlay.epics.ts
+++ b/apps/chat/src/store/overlay/overlay.epics.ts
@@ -1388,9 +1388,12 @@ const setOverlayOptionsEpic: AppEpic = (action$, state$) =>
       actions.push(
         of(OverlayActions.setOverlayOptionsSuccess(options)),
         iif(
-          () =>
-            !shouldLogIn &&
-            (!isOverlayOptionsReceived || isOptionChanged('modelId')),
+          // Only the very first options delivery initializes the selection.
+          // Initialization starts a fresh conversation when the selected one
+          // has history, so repeating it on a later options update would throw
+          // away the conversation the user is in. A model set at that point
+          // applies to the conversations created afterwards.
+          () => !shouldLogIn && !isOverlayOptionsReceived,
           of(ConversationsActions.initSelectedConversations()),
           EMPTY,
         ),


### PR DESCRIPTION
## Description of changes

Changing overlay options at runtime replaced the conversation the user was in with a fresh one.

`setOverlayOptions` re-initialized the selected conversations whenever `modelId` differed from the previously received options:

```ts
() => !shouldLogIn && (!isOverlayOptionsReceived || isOptionChanged('modelId'))
```

`initSelectedConversationsEpic` is the cold start path: it filters out selected conversations that have messages and, when nothing is left, creates a new conversation. Re-running it on a later options update therefore threw away the open chat with history. For an empty selected conversation the re-initialization did nothing useful either — the conversation was just re-selected and its model stayed as it was — so the `modelId` condition only ever had the destructive effect.

The selection is now initialized only when the options arrive for the first time. A model set later still goes into recent models and into the overlay default model reference, so it applies to the conversations created afterwards, which is what the issue expects.

### E2E

The `Configuration` page object waited for the `GET /api/conversations` request that this re-initialization used to make. That request no longer happens, so the wait is removed; the `assertOverlayTheme` call that follows the click uses `expect(locator).toHaveAttribute` and retries on its own. The overlay tests themselves are unchanged — their expectations (the previously selected agent stays after the options change, the new model is applied to a conversation created afterwards) already match the fixed behaviour.

## Applicable issues

- fixes #2841

## UI changes

No layout changes. Setting overlay options no longer starts a new conversation.

## Checklist

- [x] the pull request name ends with `(Issue #<ISSUE_ID>)` (comma-separated list of issues)
- [x] I confirm that I don't share any confidential information like API keys or any other secrets and private URLs
