### PR TITLE
fix(chat): order folders and entities character by character (Issue #8240)

### DIFF
--- a/apps/chat/src/utils/app/__tests__/folders.test.ts
+++ b/apps/chat/src/utils/app/__tests__/folders.test.ts
@@ -412,7 +412,7 @@ describe('sortByName', () => {
       folderId: 'folder',
     }));
 
-  it('orders numeric suffixes naturally instead of lexicographically', () => {
+  it('orders numeric suffixes character by character', () => {
     const entities = toEntities([
       'New folder 10',
       'New folder 2',
@@ -423,10 +423,20 @@ describe('sortByName', () => {
 
     expect(sortByName(entities).map(({ name }) => name)).toEqual([
       'New folder 1',
-      'New folder 2',
-      'New folder 3',
       'New folder 10',
+      'New folder 2',
       'New folder 20',
+      'New folder 3',
+    ]);
+  });
+
+  it('compares leading digits as characters', () => {
+    const entities = toEntities(['4eQvn2SpLI', '16EgORK_file', '16EgORK_1_2']);
+
+    expect(sortByName(entities).map(({ name }) => name)).toEqual([
+      '16EgORK_1_2',
+      '16EgORK_file',
+      '4eQvn2SpLI',
     ]);
   });
 

--- a/apps/chat/src/utils/app/folders.ts
+++ b/apps/chat/src/utils/app/folders.ts
@@ -529,19 +529,24 @@ export const getEntitiesFoldersFromEntities = (
   return featuresFolders;
 };
 
-const naturalNameCollator = new Intl.Collator(undefined, {
-  numeric: true,
-  sensitivity: 'base',
-});
-
 /**
- * Compares entity names in natural order, so that numeric suffixes are ordered
- * by value instead of lexicographically ("Folder 2" before "Folder 10").
+ * Compares entity names character by character, case insensitively. Digits are
+ * compared as characters and not as numbers, so "Folder 10" comes before
+ * "Folder 2" and "16Folder" before "4Folder".
  */
 export const compareEntitiesByName = (
   a: { name: string },
   b: { name: string },
-): number => naturalNameCollator.compare(a.name, b.name);
+): number => {
+  const aName = a.name.toLowerCase();
+  const bName = b.name.toLowerCase();
+
+  if (aName === bName) {
+    return 0;
+  }
+
+  return aName < bName ? -1 : 1;
+};
 
 export const sortByName = <T extends Entity>(entities: T[]): T[] =>
   [...entities].sort(compareEntitiesByName);


### PR DESCRIPTION
## Description of changes

Reverts the ordering rule introduced for #8240 in #8245, as requested in [this review comment](https://github.com/epam/ai-dial-chat/issues/8240#issuecomment-5254644205).

Natural numeric ordering does not only affect numeric suffixes: it also reorders names that merely start with digits, so the Change path modal listed `4eQvn2SpLI` before `16EgORK_1_2`. Folders are expected to be ordered character by character instead.

`compareEntitiesByName` compares lower-cased names with `<` again, the way they were compared before the natural collator was added. The sidebar, the folder pickers and the file manager all go through that comparator, so both places from the comment are covered by the single change.

Ordering after the change:

```
New folder 1, New folder 10, New folder 2, New folder 20, New folder 3
16EgORK_1_2, 16EgORK_file, 4eQvn2SpLI
```

The unit test that pinned the natural order is updated to the character-by-character expectation, and a case with leading digits is added.

## Applicable issues

- fixes #8240

## UI changes

Folders and entities are listed in character-by-character order in the side panels, the folder pickers and the Change path modal.

## Checklist

- [x] the pull request name ends with `(Issue #<ISSUE_ID>)` (comma-separated list of issues)
- [x] I confirm that I don't share any confidential information like API keys or any other secrets and private URLs
