### PR TITLE
fix(chat): attachment types MIME error and attachment name centering (Issue #5256, Issue #3073)

### DIFF
--- a/apps/chat/src/components/AppsEditor/EditorForm/CodeAppForm.tsx
+++ b/apps/chat/src/components/AppsEditor/EditorForm/CodeAppForm.tsx
@@ -32,6 +32,7 @@ import {
 } from '@/src/constants/applications';
 import { CODE_APPS_ENDPOINTS } from '@/src/constants/code-apps';
 import { CommonI18nKeys, MarketplaceI18nKeys } from '@/src/constants/i18n';
+import { getPendingAttachmentTypeError } from '@/src/constants/validation-helpers';
 
 import {
   CodeAppForm as CodeAppFormType,
@@ -149,7 +150,10 @@ export const CodeAppForm = () => {
             hasDeleteAll
             hideSuggestions
             itemHeightClassName="h-[31px]"
-            error={errors.inputAttachmentTypes?.message}
+            error={
+              errors.inputAttachmentTypes?.message ??
+              getPendingAttachmentTypeError(pendingAttachmentType)
+            }
             disabled={isAppPublic}
             tooltip={isAppPublic ? PUBLIC_APP_TOOLTIP : ''}
             {...getPendingAttachmentTypeProps(pendingAttachmentType, setValue)}

--- a/apps/chat/src/components/AppsEditor/EditorForm/CustomAppForm.tsx
+++ b/apps/chat/src/components/AppsEditor/EditorForm/CustomAppForm.tsx
@@ -21,6 +21,7 @@ import { ApplicationSelectors } from '@/src/store/selectors';
 
 import { PUBLIC_APP_TOOLTIP } from '@/src/constants/applications';
 import { CommonI18nKeys, MarketplaceI18nKeys } from '@/src/constants/i18n';
+import { getPendingAttachmentTypeError } from '@/src/constants/validation-helpers';
 
 import {
   CustomAppForm as CustomAppFormType,
@@ -110,7 +111,10 @@ export const CustomAppForm = () => {
             hasDeleteAll
             hideSuggestions
             itemHeightClassName="h-[31px]"
-            error={errors.inputAttachmentTypes?.message}
+            error={
+              errors.inputAttachmentTypes?.message ??
+              getPendingAttachmentTypeError(pendingAttachmentType)
+            }
             disabled={isAppPublic}
             tooltip={isAppPublic ? PUBLIC_APP_TOOLTIP : ''}
             dataQa="combobox"

--- a/apps/chat/src/components/AppsEditor/EditorForm/QuickApp2Form/QuickApp2Form.tsx
+++ b/apps/chat/src/components/AppsEditor/EditorForm/QuickApp2Form/QuickApp2Form.tsx
@@ -44,6 +44,7 @@ import {
   MarketplaceI18nKeys,
   SettingsI18nKeys,
 } from '@/src/constants/i18n';
+import { getPendingAttachmentTypeError } from '@/src/constants/validation-helpers';
 
 import { FormCollapsibleSection } from '@/src/components/AppsEditor/EditorForm/FormCollapsibleSection';
 import { AgentSkillsField } from '@/src/components/AppsEditor/EditorForm/QuickApp2Form/AgentSkillsField';
@@ -491,7 +492,10 @@ export const QuickApp2Form: FC<AppsEditorProps> = ({ onAutoSave }) => {
               hasDeleteAll
               hideSuggestions
               itemHeightClassName="h-[31px]"
-              error={errors.inputAttachmentTypes?.message}
+              error={
+                errors.inputAttachmentTypes?.message ??
+                getPendingAttachmentTypeError(pendingAttachmentType)
+              }
               disabled={isAppPublic}
               tooltip={isAppPublicTooltip}
               dataQa="attachment-types-field"

--- a/apps/chat/src/components/AppsEditor/__tests__/form.test.ts
+++ b/apps/chat/src/components/AppsEditor/__tests__/form.test.ts
@@ -4,6 +4,8 @@ import { MarketplaceEntity } from '@/src/types/marketplace';
 import { DialAIEntityModel } from '@/src/types/models';
 import { QuickApp2Config } from '@/src/types/quick-apps';
 
+import { getPendingAttachmentTypeError } from '@/src/constants/validation-helpers';
+
 import {
   AppsEditorFormType,
   AppsEditorSchemaTypes,
@@ -84,6 +86,24 @@ const getAttachmentTypesErrors = (pendingInputAttachmentType: string) => {
         .filter((issue) => issue.path[0] === 'inputAttachmentTypes')
         .map((issue) => issue.message);
 };
+
+describe('getPendingAttachmentTypeError', () => {
+  it('reports an invalid type that is being typed', () => {
+    expect(getPendingAttachmentTypeError('imag')).toBe(
+      'Please match the MIME format',
+    );
+  });
+
+  it('reports nothing for a valid type', () => {
+    expect(getPendingAttachmentTypeError('image/jpeg')).toBeUndefined();
+  });
+
+  it('reports nothing when nothing is being typed', () => {
+    expect(getPendingAttachmentTypeError('')).toBeUndefined();
+    expect(getPendingAttachmentTypeError('   ')).toBeUndefined();
+    expect(getPendingAttachmentTypeError(undefined)).toBeUndefined();
+  });
+});
 
 describe('Custom app schema - attachment type that is not added yet', () => {
   it('reports the MIME error while an invalid type is being typed', () => {

--- a/apps/chat/src/components/Chat/ChatInput/ChatInputFileAttachment.tsx
+++ b/apps/chat/src/components/Chat/ChatInput/ChatInputFileAttachment.tsx
@@ -38,7 +38,7 @@ export const ChatInputFileAttachment = ({
         <IconExclamationCircle className="shrink-0 text-error" size={18} />
       )}
 
-      <div className="flex grow justify-between gap-3 overflow-hidden">
+      <div className="flex grow items-center justify-between gap-3 overflow-hidden">
         <Tooltip
           key={file.id}
           tooltip={file.name}

--- a/apps/chat/src/components/Chat/ChatInput/ChatInputFolderAttachment.tsx
+++ b/apps/chat/src/components/Chat/ChatInput/ChatInputFolderAttachment.tsx
@@ -16,7 +16,7 @@ export const ChatInputFolderAttachment = ({ folder, onUnselect }: Props) => {
     <div className="flex items-center gap-3 rounded border border-primary bg-layer-1 px-3 py-2">
       <IconFolder className="shrink-0 text-secondary" size={18} />
 
-      <div className="flex grow justify-between gap-3 overflow-hidden">
+      <div className="flex grow items-center justify-between gap-3 overflow-hidden">
         <div className="flex grow flex-col overflow-hidden text-sm">
           <span
             className="block max-w-full text-start"

--- a/apps/chat/src/components/Chat/ChatInput/ChatInputLinkAttachment.tsx
+++ b/apps/chat/src/components/Chat/ChatInput/ChatInputLinkAttachment.tsx
@@ -60,7 +60,7 @@ export const ChatInputLinkAttachment = ({ link, onUnselect }: Props) => {
         />
       )}
 
-      <div className="flex grow justify-between gap-3 overflow-hidden">
+      <div className="flex grow items-center justify-between gap-3 overflow-hidden">
         <Tooltip
           tooltip={name}
           triggerClassName="truncate text-center flex-1 min-w-0 min-h-0"

--- a/apps/chat/src/constants/validation-helpers.ts
+++ b/apps/chat/src/constants/validation-helpers.ts
@@ -118,18 +118,33 @@ export const AttachmentTypesSchema = zodValidation
 
 /**
  * A MIME type typed into the attachment types combobox but not added to the
- * list yet. It is kept in the form state so that its validation is produced by
- * the schema and survives both form re-validation and switching editor steps.
+ * list yet. It is kept in the form state so that it survives switching editor
+ * steps and so that the form stays invalid while it cannot be added.
  */
 export const PendingAttachmentTypeSchema = zodValidation.string();
+
+/**
+ * The error of the attachment type that is being typed. The field shows it
+ * directly instead of reading it from the form errors: the value is validated
+ * by a cross field rule, and react-hook-form only refreshes the errors of the
+ * field being changed, so a rule reported on another field would stay hidden
+ * until the whole form is validated.
+ */
+export const getPendingAttachmentTypeError = (
+  pendingInputAttachmentType?: string,
+) => {
+  const pendingType = pendingInputAttachmentType?.trim();
+
+  return pendingType && !MIME_FORMAT_REGEX.test(pendingType)
+    ? MIME_FORMAT_ERROR
+    : undefined;
+};
 
 export const refinePendingAttachmentType = (
   data: { pendingInputAttachmentType?: string },
   ctx: zodValidation.RefinementCtx,
 ) => {
-  const pendingType = data.pendingInputAttachmentType?.trim();
-
-  if (pendingType && !MIME_FORMAT_REGEX.test(pendingType)) {
+  if (getPendingAttachmentTypeError(data.pendingInputAttachmentType)) {
     ctx.addIssue({
       code: 'custom',
       path: ['inputAttachmentTypes'],


### PR DESCRIPTION
## Description of changes

Two fixes in the attachment fields.

### The attachment types MIME error is not shown while typing (#5256)

Fixes the regression reported in [this comment](https://github.com/epam/ai-dial-chat/issues/5256#issuecomment-5255230901): typing an invalid attachment type and leaving the field no longer showed `Please match the MIME format`.

The previous fix for #5256 replaced the manual `setError` with a schema rule, so the message would survive form re-validation and switching editor steps. The rule validates the typed but not yet added value (`pendingInputAttachmentType`) and reports on `inputAttachmentTypes`, because that is the field the message belongs to. Typing calls `setValue('pendingInputAttachmentType', …, { shouldValidate: true })`, and react-hook-form refreshes the errors of the changed field only — an error reported on another field never reached `formState.errors` until the whole form was validated. Hence no message while typing or on blur.

The field now derives its message from the typed value directly, via `getPendingAttachmentTypeError`, instead of reading it from the form errors. Nothing else changes:

- the schema keeps the same rule, so the form stays invalid, `Save and exit` still shows the `Only valid data will be saved` dialog, and the invalid state still maps to the `App settings` step;
- the typed value still lives in the form state, so it and its message survive switching to `General info` and back and `Continue editing` in the dialog — the behaviour the original issue asked for.

Both the schema rule and the field message go through the same helper, so they cannot disagree.

### The attachment name is not centered in the input chips (#3073)

Requested in [this comment](https://github.com/epam/ai-dial-chat/issues/3073#issuecomment-5254498648): in the send message input and in a message opened for editing, the remove button of an attachment chip is centered while the file name sits above the center.

The row that holds the name and the remove button had no cross axis alignment, so both were stretched to the row height. The button fills its own box and looks centered, while the name column starts at the top of the stretched row. The row items are now centered, in the file, folder and link chips, which all share that markup.

## Applicable issues

- fixes #5256
- part of #3073

## UI changes

The `Please match the MIME format` message appears again as soon as the typed value is not a MIME type, in the custom app, code app and quick app 2.0 editors. Attachment names are vertically centered in the input chips.

## Checklist

- [x] the pull request name ends with `(Issue #<ISSUE_ID>)` (comma-separated list of issues)
- [x] I confirm that I don't share any confidential information like API keys or any other secrets and private URLs
