### PR TITLE
fix(chat): normalize OIDC discovery URLs for trailing-slash issuers (Issue #8284)

### DIFF
--- a/apps/chat/src/utils/auth/__tests__/auth-oidc-utils.test.ts
+++ b/apps/chat/src/utils/auth/__tests__/auth-oidc-utils.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+
+import { normalizeOidcWellKnownUrl } from '../auth-oidc-utils';
+
+describe('normalizeOidcWellKnownUrl', () => {
+  it('removes a duplicate separator before the discovery path', () => {
+    expect(
+      normalizeOidcWellKnownUrl(
+        'https://idp.example.com//.well-known/openid-configuration',
+      ),
+    ).toBe('https://idp.example.com/.well-known/openid-configuration');
+  });
+
+  it('normalizes an issuer containing a path', () => {
+    expect(
+      normalizeOidcWellKnownUrl(
+        'https://idp.example.com/realms/example//.well-known/openid-configuration',
+      ),
+    ).toBe(
+      'https://idp.example.com/realms/example/.well-known/openid-configuration',
+    );
+  });
+
+  it('preserves a correctly formed discovery URL', () => {
+    const wellKnown =
+      'https://idp.example.com/.well-known/openid-configuration';
+
+    expect(normalizeOidcWellKnownUrl(wellKnown)).toBe(wellKnown);
+  });
+
+  it('preserves query parameters', () => {
+    expect(
+      normalizeOidcWellKnownUrl(
+        'https://idp.example.com//.well-known/openid-configuration?client_id=test',
+      ),
+    ).toBe(
+      'https://idp.example.com/.well-known/openid-configuration?client_id=test',
+    );
+  });
+
+  it('does not normalize unrelated duplicate path separators', () => {
+    const wellKnown =
+      'https://idp.example.com/tenant//metadata/.well-known/openid-configuration';
+
+    expect(normalizeOidcWellKnownUrl(wellKnown)).toBe(wellKnown);
+  });
+
+  it('returns an invalid URL unchanged', () => {
+    const wellKnown = 'not a valid URL';
+
+    expect(normalizeOidcWellKnownUrl(wellKnown)).toBe(wellKnown);
+  });
+});

--- a/apps/chat/src/utils/auth/__tests__/auth-providers.test.ts
+++ b/apps/chat/src/utils/auth/__tests__/auth-providers.test.ts
@@ -78,9 +78,7 @@ describe('auth-providers tokenConfig.request', () => {
   );
 
   let tokenRequest: TokenEndpointRequest;
-  let configuredAuth0Provider:
-    | OAuthConfig<Record<string, unknown>>
-    | undefined;
+  let configuredAuth0Provider: OAuthConfig<Record<string, unknown>> | undefined;
 
   beforeAll(async () => {
     mockAuth0Provider.mockImplementation((options) => ({

--- a/apps/chat/src/utils/auth/__tests__/auth-providers.test.ts
+++ b/apps/chat/src/utils/auth/__tests__/auth-providers.test.ts
@@ -8,7 +8,7 @@ import {
   vi,
 } from 'vitest';
 
-import type { TokenEndpointHandler } from 'next-auth/providers';
+import type { OAuthConfig, TokenEndpointHandler } from 'next-auth/providers';
 
 const {
   mockAuth0Provider,
@@ -78,11 +78,15 @@ describe('auth-providers tokenConfig.request', () => {
   );
 
   let tokenRequest: TokenEndpointRequest;
+  let configuredAuth0Provider:
+    | OAuthConfig<Record<string, unknown>>
+    | undefined;
 
   beforeAll(async () => {
     mockAuth0Provider.mockImplementation((options) => ({
       id: options.id ?? 'auth0',
       type: 'oauth',
+      wellKnown: `${options.issuer}/.well-known/openid-configuration`,
       options,
     }));
 
@@ -94,10 +98,14 @@ describe('auth-providers tokenConfig.request', () => {
 
     process.env.AUTH_AUTH0_CLIENT_ID = 'test-client';
     process.env.AUTH_AUTH0_SECRET = 'test-secret';
-    process.env.AUTH_AUTH0_HOST = 'https://example.auth0.com';
+    process.env.AUTH_AUTH0_HOST = 'https://example.auth0.com/';
 
     vi.resetModules();
-    await import('../auth-providers');
+    const { authProviders } = await import('../auth-providers');
+    configuredAuth0Provider = authProviders.find(
+      (provider): provider is OAuthConfig<Record<string, unknown>> =>
+        provider.id === 'auth0' && provider.type === 'oauth',
+    );
 
     const auth0Options = mockAuth0Provider.mock.calls[0]?.[0] as
       | { token?: TokenEndpointHandler }
@@ -123,6 +131,15 @@ describe('auth-providers tokenConfig.request', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockGetAuthAdditionalParamsExchangeBody.mockReturnValue(undefined);
+  });
+
+  it('normalizes the discovery URL without changing the exact issuer', () => {
+    expect(configuredAuth0Provider?.options?.issuer).toBe(
+      'https://example.auth0.com/',
+    );
+    expect(configuredAuth0Provider?.wellKnown).toBe(
+      'https://example.auth0.com/.well-known/openid-configuration',
+    );
   });
 
   it('calls callback without extras when idToken is set and no additional params', async () => {

--- a/apps/chat/src/utils/auth/auth-oidc-utils.ts
+++ b/apps/chat/src/utils/auth/auth-oidc-utils.ts
@@ -1,6 +1,5 @@
 const OIDC_DISCOVERY_PATH = '/.well-known/openid-configuration';
-const OIDC_DISCOVERY_PATH_PATTERN =
-  /\/+\.well-known\/openid-configuration$/;
+const OIDC_DISCOVERY_PATH_PATTERN = /\/+\.well-known\/openid-configuration$/;
 
 export const normalizeOidcWellKnownUrl = (wellKnown: string): string => {
   try {

--- a/apps/chat/src/utils/auth/auth-oidc-utils.ts
+++ b/apps/chat/src/utils/auth/auth-oidc-utils.ts
@@ -1,0 +1,16 @@
+const OIDC_DISCOVERY_PATH = '/.well-known/openid-configuration';
+const OIDC_DISCOVERY_PATH_PATTERN =
+  /\/+\.well-known\/openid-configuration$/;
+
+export const normalizeOidcWellKnownUrl = (wellKnown: string): string => {
+  try {
+    const url = new URL(wellKnown);
+    url.pathname = url.pathname.replace(
+      OIDC_DISCOVERY_PATH_PATTERN,
+      OIDC_DISCOVERY_PATH,
+    );
+    return url.toString();
+  } catch {
+    return wellKnown;
+  }
+};

--- a/apps/chat/src/utils/auth/auth-providers.ts
+++ b/apps/chat/src/utils/auth/auth-providers.ts
@@ -23,6 +23,7 @@ import {
 } from '@/src/types/auth';
 
 import { getAuthAdditionalParamsExchangeBody } from './auth-additional-params';
+import { normalizeOidcWellKnownUrl } from './auth-oidc-utils';
 import { GitLab } from './custom-gitlab';
 import NextClient from './nextauth-client';
 import PingId from './ping-identity';
@@ -315,7 +316,16 @@ const providerConfigMethods = {
 };
 
 const getProviderFromConfig = (config: ProviderConfig) => {
-  return providerConfigMethods[config.provider]?.(config);
+  const provider = providerConfigMethods[config.provider]?.(config);
+
+  if (provider?.type !== 'oauth' || !provider.wellKnown) {
+    return provider;
+  }
+
+  return {
+    ...provider,
+    wellKnown: normalizeOidcWellKnownUrl(provider.wellKnown),
+  };
 };
 
 const getProviderEnv = (


### PR DESCRIPTION
## Description of changes

This PR fixes OIDC authentication when the provider's exact issuer ends with a trailing slash.

Several NextAuth OIDC providers construct `wellKnown` by appending `/.well-known/openid-configuration` directly to the configured issuer. For an exact issuer such as:

```text
https://idp.example.com/
```

that produces:

```text
https://idp.example.com//.well-known/openid-configuration
```

The duplicate separator may be rejected by the identity provider. Removing the trailing slash from the configured issuer is not a correct workaround because explicit-token JWT validation compares the issuer exactly and then rejects tokens whose `iss` is `https://idp.example.com/`.

## Applicable issues

- fixes #8284 

## UI changes

No UI changes.

## Checklist

- [x] the pull request name ends with `(Issue #<ISSUE_ID>)` (comma-separated list of issues)
- [x] I confirm that I don't share any confidential information like API keys or any other secrets and private URLs

<details>
  <summary>PR title cheatsheet</summary>

`<type>[optional scope]: <description>`

1. type (required)
    - `feat` - A new feature
    - `fix` - A bug fix
    - `docs` - Documentation only changes
    - `test` - Adding missing tests or correcting existing tests
    - `ci` - Changes to our CI configuration files and scripts
    - `chore` - Other changes that are minor and/or not user-facing
2. scope (optional, current repo suggestions below)
    - `chat`
    - `overlay`
    - `shared`
    - `sandbox-overlay`
    - `visualizer-connector`

</details>
