### PR TITLE
fix(chat): fix mind map prompt disabling (#4889)

### DIFF
--- a/apps/chat/src/store/conversations/conversations.selectors.ts
+++ b/apps/chat/src/store/conversations/conversations.selectors.ts
@@ -56,6 +56,7 @@ import { DialAIEntityModel } from '@/src/types/models';
 import { EntityFilter, EntityFilters, SearchFilters } from '@/src/types/search';
 import { RootState } from '@/src/types/store';
 
+import { ApplicationTypesSchemasSelectors } from '@/src/store/applicationTypeSchemas/applicationTypeSchemas.selectors';
 import { AuthSelectors } from '@/src/store/auth/auth.selectors';
 import { ChatSelectors } from '@/src/store/chat/chat.selectors';
 import { ModelsSelectors } from '@/src/store/models/models.selectors';
@@ -842,6 +843,7 @@ const selectIsSelectedConversationBlocksInput = createSelector(
     selectAreSelectedConversationsReadOnly,
     AuthSelectors.selectIsAdmin,
     ChatSelectors.selectUploadedConfigurationSchemas,
+    ApplicationTypesSchemasSelectors.selectAllSchemas,
     (state: RootState) => state,
   ],
   (
@@ -851,6 +853,7 @@ const selectIsSelectedConversationBlocksInput = createSelector(
     areReadOnly,
     isAdmin,
     uploadedConfigurationSchemas,
+    applicationTypeSchemas,
     state,
   ) => {
     const conversationsModelsIds = conversations.map(
@@ -875,9 +878,25 @@ const selectIsSelectedConversationBlocksInput = createSelector(
       ),
     )?.schema;
 
+    const isCustomViewerConversation = conversations.some((conversation) => {
+      const model = modelsMap[conversation.model.id];
+
+      if (!model) {
+        return false;
+      }
+
+      return (
+        !!model.viewerUrl ||
+        !!applicationTypeSchemas.find(
+          (schema) => schema.id === model.applicationTypeSchemaId,
+        )?.viewerUrl
+      );
+    });
+
     return conversations.some(
       (conversation) =>
         conversation.sharedWithMe ||
+        isCustomViewerConversation ||
         (!conversation.messages?.length &&
           (isConfigurationBlocksInput || isReplayConversation(conversation))) ||
         isNotAllowedModels ||


### PR DESCRIPTION
## Description of changes

'Use prompt' is active when a chat with Mind Map is selected
Expected: the button should be disabled

## Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #4889

## Checklist

- [x] the pull request name ends with `(Issue #<ISSUE_ID>)` (comma-separated list of issues)
- [x] I confirm that I don't share any confidential information like API keys or any other secrets and private URLs

<details>
  <summary>PR title cheatsheet</summary>

`<type>[optional scope]: <description>`

1. type (required)
    - `feat` - A new feature
    - `fix` - A bug fix
    - `docs` - Documentation only changes
    - `test` - Adding missing tests or correcting existing tests
    - `ci` - Changes to our CI configuration files and scripts
    - `chore` - Other changes that are minor and/or not user-facing
2. scope (optional, current repo suggestions below)
    - `chat`
    - `overlay`
    - `shared`
    - `sandbox-overlay`
    - `visualizer-connector`

</details>
