### PR TITLE
fix(chat-api): stabilize NestJS integration tests and fix CatalogView unshare notification

### DIFF
--- a/apps/chat-api/src/app-config/tests/app-config.controller.spec.ts
+++ b/apps/chat-api/src/app-config/tests/app-config.controller.spec.ts
@@ -73,6 +73,7 @@ async function buildApp(
     }),
   );
   await app.init();
+  await app.listen(0, '127.0.0.1');
   return app;
 }
 

--- a/apps/chat-api/src/applications/tests/applications.controller.spec.ts
+++ b/apps/chat-api/src/applications/tests/applications.controller.spec.ts
@@ -58,6 +58,7 @@ async function buildApp(
     }),
   );
   await app.init();
+  await app.listen(0, '127.0.0.1');
   return app;
 }
 

--- a/apps/chat-api/src/auth/auth.controller.spec.ts
+++ b/apps/chat-api/src/auth/auth.controller.spec.ts
@@ -215,6 +215,7 @@ async function buildApp(): Promise<INestApplication> {
   app.enableVersioning({ type: VersioningType.URI });
   app.setGlobalPrefix('api');
   await app.init();
+  await app.listen(0, '127.0.0.1');
   return app;
 }
 

--- a/apps/chat-api/src/chat/tests/chat.controller.integration.spec.ts
+++ b/apps/chat-api/src/chat/tests/chat.controller.integration.spec.ts
@@ -38,6 +38,7 @@ describe('ChatController (integration)', () => {
       }),
     );
     await app.init();
+    await app.listen(0, '127.0.0.1');
   });
 
   afterEach(async () => {

--- a/apps/chat-api/src/client-channel/tests/client-channel.controller.spec.ts
+++ b/apps/chat-api/src/client-channel/tests/client-channel.controller.spec.ts
@@ -58,6 +58,7 @@ async function buildApp(service: unknown): Promise<INestApplication> {
     }),
   );
   await app.init();
+  await app.listen(0, '127.0.0.1');
   return app;
 }
 
@@ -252,6 +253,7 @@ describe('ClientChannelController — FeatureGuard wiring', () => {
     app.setGlobalPrefix('api');
     app.enableVersioning({ type: VersioningType.URI });
     await app.init();
+    await app.listen(0, '127.0.0.1');
   });
 
   afterEach(async () => {

--- a/apps/chat-api/src/config/tests/csp.spec.ts
+++ b/apps/chat-api/src/config/tests/csp.spec.ts
@@ -26,6 +26,7 @@ const createTestApp = async (
   const app = await NestFactory.create(CspTestModule, { logger: false });
   app.use(helmet(createHelmetOptions(allowedIframeOrigins)));
   await app.init();
+  await app.listen(0, '127.0.0.1');
   return app;
 };
 

--- a/apps/chat-api/src/conversations/tests/completions.integration.spec.ts
+++ b/apps/chat-api/src/conversations/tests/completions.integration.spec.ts
@@ -104,6 +104,7 @@ describe('POST /conversations/completions (integration)', () => {
       }),
     );
     await app.init();
+    await app.listen(0, '127.0.0.1');
   });
 
   afterEach(async () => {
@@ -243,6 +244,7 @@ describe('POST /conversations/completions/stop (integration)', () => {
       }),
     );
     await app.init();
+    await app.listen(0, '127.0.0.1');
   });
 
   afterEach(async () => {

--- a/apps/chat-api/src/conversations/tests/conversation-publish.controller.spec.ts
+++ b/apps/chat-api/src/conversations/tests/conversation-publish.controller.spec.ts
@@ -66,6 +66,7 @@ describe('ConversationPublishController (integration)', () => {
       }),
     );
     await app.init();
+    await app.listen(0, '127.0.0.1');
   });
 
   afterEach(async () => {

--- a/apps/chat-api/src/conversations/tests/conversation.controller.integration.spec.ts
+++ b/apps/chat-api/src/conversations/tests/conversation.controller.integration.spec.ts
@@ -99,6 +99,7 @@ describe('ConversationController (integration)', () => {
       }),
     );
     await app.init();
+    await app.listen(0, '127.0.0.1');
   });
 
   afterEach(async () => {

--- a/apps/chat-api/src/deployments/tests/deployments.controller.integration.spec.ts
+++ b/apps/chat-api/src/deployments/tests/deployments.controller.integration.spec.ts
@@ -61,6 +61,7 @@ async function buildApp(service: unknown): Promise<INestApplication> {
     }),
   );
   await app.init();
+  await app.listen(0, '127.0.0.1');
   return app;
 }
 

--- a/apps/chat-api/src/external-services/tests/external-services.controller.spec.ts
+++ b/apps/chat-api/src/external-services/tests/external-services.controller.spec.ts
@@ -58,6 +58,7 @@ async function buildApp(
     }),
   );
   await app.init();
+  await app.listen(0, '127.0.0.1');
   return app;
 }
 

--- a/apps/chat-api/src/files/tests/files.controller.spec.ts
+++ b/apps/chat-api/src/files/tests/files.controller.spec.ts
@@ -91,6 +91,7 @@ async function buildApp(
     }),
   );
   await app.init();
+  await app.listen(0, '127.0.0.1');
   return app;
 }
 

--- a/apps/chat-api/src/models/tests/models.controller.spec.ts
+++ b/apps/chat-api/src/models/tests/models.controller.spec.ts
@@ -56,6 +56,7 @@ async function buildApp(
     }),
   );
   await app.init();
+  await app.listen(0, '127.0.0.1');
   return app;
 }
 

--- a/apps/chat-api/src/prompts/tests/prompt.controller.spec.ts
+++ b/apps/chat-api/src/prompts/tests/prompt.controller.spec.ts
@@ -74,6 +74,7 @@ async function buildApp(
     }),
   );
   await app.init();
+  await app.listen(0, '127.0.0.1');
   return app;
 }
 

--- a/apps/chat-api/src/publish/tests/publish-rules.controller.spec.ts
+++ b/apps/chat-api/src/publish/tests/publish-rules.controller.spec.ts
@@ -43,6 +43,7 @@ async function buildApp(service: unknown): Promise<INestApplication> {
     }),
   );
   await app.init();
+  await app.listen(0, '127.0.0.1');
   return app;
 }
 

--- a/apps/chat-api/src/publish/tests/publish.controller.spec.ts
+++ b/apps/chat-api/src/publish/tests/publish.controller.spec.ts
@@ -55,6 +55,7 @@ async function buildApp(service: unknown): Promise<INestApplication> {
     }),
   );
   await app.init();
+  await app.listen(0, '127.0.0.1');
   return app;
 }
 

--- a/apps/chat-api/src/rate/tests/rate.controller.spec.ts
+++ b/apps/chat-api/src/rate/tests/rate.controller.spec.ts
@@ -44,6 +44,7 @@ describe('RateController (integration)', () => {
       }),
     );
     await app.init();
+    await app.listen(0, '127.0.0.1');
   });
 
   afterEach(async () => {

--- a/apps/chat-api/src/scheduled-tasks/tests/scheduled-tasks.controller.spec.ts
+++ b/apps/chat-api/src/scheduled-tasks/tests/scheduled-tasks.controller.spec.ts
@@ -74,6 +74,7 @@ async function buildApp(
     }),
   );
   await app.init();
+  await app.listen(0, '127.0.0.1');
   return app;
 }
 

--- a/apps/chat-api/src/share/tests/share.controller.spec.ts
+++ b/apps/chat-api/src/share/tests/share.controller.spec.ts
@@ -63,6 +63,7 @@ async function buildApp(
     }),
   );
   await app.init();
+  await app.listen(0, '127.0.0.1');
   return app;
 }
 

--- a/apps/chat-api/src/telemetry/tests/trace-propagation.spec.ts
+++ b/apps/chat-api/src/telemetry/tests/trace-propagation.spec.ts
@@ -78,6 +78,7 @@ describe('trace propagation', () => {
     });
     app.use(traceparentMiddleware);
     await app.init();
+    await app.listen(0, '127.0.0.1');
   });
 
   afterAll(async () => {

--- a/apps/chat-api/src/themes/tests/theme.controller.spec.ts
+++ b/apps/chat-api/src/themes/tests/theme.controller.spec.ts
@@ -55,6 +55,7 @@ describe('ThemeController (integration)', () => {
     );
 
     await app.init();
+    await app.listen(0, '127.0.0.1');
     themeService = moduleFixture.get<ThemeService>(ThemeService);
   });
 

--- a/apps/chat-api/src/toolsets/tests/toolsets.controller.spec.ts
+++ b/apps/chat-api/src/toolsets/tests/toolsets.controller.spec.ts
@@ -61,6 +61,7 @@ async function buildApp(
     }),
   );
   await app.init();
+  await app.listen(0, '127.0.0.1');
   return app;
 }
 

--- a/apps/chat-api/src/user-config/tests/user-config.controller.integration.spec.ts
+++ b/apps/chat-api/src/user-config/tests/user-config.controller.integration.spec.ts
@@ -108,6 +108,7 @@ describe('UserConfigController (integration)', () => {
       }),
     );
     await app.init();
+    await app.listen(0, '127.0.0.1');
   });
 
   afterEach(async () => {
@@ -390,6 +391,7 @@ describe('PATCH /api/v1/user-config/toolsets — real service', () => {
       }),
     );
     await app.init();
+    await app.listen(0, '127.0.0.1');
   });
 
   afterEach(async () => {

--- a/apps/chat/src/components/CatalogView/CatalogView.tsx
+++ b/apps/chat/src/components/CatalogView/CatalogView.tsx
@@ -710,8 +710,8 @@ const CatalogView: FC<Props> = ({ isSelectorMode = false, onClose }) => {
       }
 
       showNotification({
-        variant: NotificationVariant.Info,
-        title: t(CatalogI18nKeys.DetailsUnshareConfirmTitle),
+        variant: NotificationVariant.Success,
+        title: t(CatalogI18nKeys.DetailsUnshareSuccessTitle),
         message: t(CatalogI18nKeys.DetailsUnshareSuccess, { name: item.name }),
       });
     },

--- a/apps/chat/src/constants/translation-keys.ts
+++ b/apps/chat/src/constants/translation-keys.ts
@@ -216,6 +216,7 @@ export enum CatalogI18nKeys {
   DetailsUnshareRemovingStatus = 'catalog.details.unshare.removingStatus',
   DetailsUnshareErrorTitle = 'catalog.details.unshare.errorTitle',
   DetailsUnshareError = 'catalog.details.unshare.error',
+  DetailsUnshareSuccessTitle = 'catalog.details.unshare.successTitle',
   DetailsUnshareSuccess = 'catalog.details.unshare.success',
   ConnectToolsetTitle = 'catalog.details.connect.toolsetTitle',
   ConnectApplicationTitle = 'catalog.details.connect.applicationTitle',

--- a/apps/chat/src/i18n/locales/en.json
+++ b/apps/chat/src/i18n/locales/en.json
@@ -163,6 +163,7 @@
         "removingStatus": "Removing…",
         "errorTitle": "Removal failed",
         "error": "Failed to remove \"{{name}}\". Please try again.",
+        "successTitle": "Removed from My List",
         "success": "\"{{name}}\" was removed from your list."
       },
       "connect": {


### PR DESCRIPTION
**Description:**

Fixes two related test stability and UX issues. NestJS integration tests now bind HTTP listeners explicitly to loopback (127.0.0.1:0) instead of relying on supertest's lazy binding to all interfaces, eliminating race conditions in test parallelization. Additionally, corrects the CatalogView unshare success notification to display the Success variant with a dedicated success title instead of reusing the confirmation dialog's title key.

**UI changes**

The unshare success notification now displays with the correct visual style (Success variant, green) and title text ("Removed from My List") instead of the Info variant with a generic title.

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(chat-api):`
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` — no ticket
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs