### PR TITLE
fix(chat-api): surface DIAL Core error details in publish failure responses

### DIFF
--- a/apps/chat-api/src/conversations/conversation-publish.service.ts
+++ b/apps/chat-api/src/conversations/conversation-publish.service.ts
@@ -7,6 +7,7 @@ import {
 } from '@nestjs/common';
 import type { Cache } from 'cache-manager';
 import {
+  extractDialErrorMessage,
   handleDialSdkError,
   mapDialHttpStatus,
 } from '../common/dial/dial-error.mapper';
@@ -126,6 +127,8 @@ export class ConversationPublishService {
         result.response.status,
         `publish conversation "${sourceUrl}"`,
         this.logger,
+        result.error,
+        extractDialErrorMessage(result.error),
       );
     }
 
@@ -181,6 +184,8 @@ export class ConversationPublishService {
             result.response.status,
             `get publish history for conversation "${sourceUrl}"`,
             this.logger,
+            result.error,
+            extractDialErrorMessage(result.error),
           );
         }
 

--- a/apps/chat-api/src/publish/publish-rules.service.ts
+++ b/apps/chat-api/src/publish/publish-rules.service.ts
@@ -1,5 +1,8 @@
 import { BadGatewayException, Injectable, Logger } from '@nestjs/common';
-import { mapDialHttpStatus } from '../common/dial/dial-error.mapper';
+import {
+  extractDialErrorMessage,
+  mapDialHttpStatus,
+} from '../common/dial/dial-error.mapper';
 import { getBearerAuthHeaders } from '../common/utils/auth-header';
 import { DialClientService } from '../dial/dial-client.service';
 import type { PublishRuleDto } from './dto/publish-rule.dto';
@@ -56,6 +59,8 @@ export class PublishRulesService {
         result.response.status,
         `get publish rules for "${folderPath}"`,
         this.logger,
+        result.error,
+        extractDialErrorMessage(result.error),
       );
     }
 

--- a/apps/chat-api/src/publish/publish.service.ts
+++ b/apps/chat-api/src/publish/publish.service.ts
@@ -6,7 +6,10 @@ import {
   Logger,
 } from '@nestjs/common';
 import type { Cache } from 'cache-manager';
-import { mapDialHttpStatus } from '../common/dial/dial-error.mapper';
+import {
+  extractDialErrorMessage,
+  mapDialHttpStatus,
+} from '../common/dial/dial-error.mapper';
 import { getBearerAuthHeaders } from '../common/utils/auth-header';
 import { safeDecodeURIComponent } from '../common/utils/uri';
 import { withCachedDialRequest } from '../dial/cached-dial-request.helper';
@@ -119,6 +122,8 @@ export class PublishService {
         result.response.status,
         `publish ${entityType} "${entityId}"`,
         this.logger,
+        result.error,
+        extractDialErrorMessage(result.error),
       );
     }
 
@@ -173,6 +178,8 @@ export class PublishService {
             result.response.status,
             `get publish history for ${entityType} "${entityId}"`,
             this.logger,
+            result.error,
+            extractDialErrorMessage(result.error),
           );
         }
         const { version } = splitEntityNameAndVersion(entityId);

--- a/apps/chat/src/hooks/publish/tests/usePublishErrorNotification.spec.ts
+++ b/apps/chat/src/hooks/publish/tests/usePublishErrorNotification.spec.ts
@@ -57,7 +57,7 @@ describe('usePublishErrorNotification', () => {
     );
   });
 
-  it('shows a generic publish-failed notification with the trace ID for a backend error', async () => {
+  it('shows the server-provided error message with the trace ID for a backend error', async () => {
     const { result } = renderHook(() => usePublishErrorNotification());
 
     result.current(
@@ -71,8 +71,23 @@ describe('usePublishErrorNotification', () => {
       expect(mockShowNotification).toHaveBeenCalledWith({
         variant: NotificationVariant.Error,
         title: 'publish.failedTitle',
-        message: 'publish.failedMessage',
+        message: 'Upstream rejected the request',
         requestId: '4bf92f3577b34da6a3ce929d0e0e4736',
+      }),
+    );
+  });
+
+  it('falls back to the generic message when the error carries no server message', async () => {
+    const { result } = renderHook(() => usePublishErrorNotification());
+
+    result.current({});
+
+    await waitFor(() =>
+      expect(mockShowNotification).toHaveBeenCalledWith({
+        variant: NotificationVariant.Error,
+        title: 'publish.failedTitle',
+        message: 'publish.failedMessage',
+        requestId: undefined,
       }),
     );
   });
@@ -86,7 +101,7 @@ describe('usePublishErrorNotification', () => {
       expect(mockShowNotification).toHaveBeenCalledWith({
         variant: NotificationVariant.Error,
         title: 'publish.failedTitle',
-        message: 'publish.failedMessage',
+        message: 'boom',
         requestId: undefined,
       }),
     );

--- a/apps/chat/src/hooks/publish/usePublishErrorNotification.ts
+++ b/apps/chat/src/hooks/publish/usePublishErrorNotification.ts
@@ -9,7 +9,8 @@ import { getApiErrorDetails } from '../../server-api/api-error';
  * Returns a handler that surfaces a failed publish request as an error
  * notification. Wire it to `usePublishFlow`'s `onPublishError` so a rejected
  * publish is reported outside the panel too, not only through the panel's
- * inline callout.
+ * inline callout. Shows the server-provided error message when the response
+ * carries one, falling back to a generic message otherwise.
  */
 export const usePublishErrorNotification = (): ((error: unknown) => void) => {
   const { t } = useTranslation();
@@ -34,11 +35,11 @@ export const usePublishErrorNotification = (): ((error: unknown) => void) => {
       }
 
       const notify = async () => {
-        const { traceId } = await getApiErrorDetails(error);
+        const { message, traceId } = await getApiErrorDetails(error);
         showNotification({
           variant: NotificationVariant.Error,
           title: t(PublishI18nKeys.FailedTitle),
-          message: t(PublishI18nKeys.FailedMessage),
+          message: message ?? t(PublishI18nKeys.FailedMessage),
           requestId: traceId,
         });
       };

--- a/openspec/specs/catalog-publish-api/spec.md
+++ b/openspec/specs/catalog-publish-api/spec.md
@@ -101,6 +101,10 @@ Authorization: caller SHALL be authenticated (existing session guard). Write acc
 - **WHEN** the Core `createPublication` call fails unexpectedly (network error, 5xx, timeout)
 - **THEN** the service throws `BadGatewayException` or `ServiceUnavailableException` (per `handleDialSdkError`) and logs the failure without logging request bodies containing tokens
 
+#### Scenario: Core rejects the request with a structured error (e.g. the "Bad resource url" 400)
+- **WHEN** `createPublication` resolves with a structured error response (`result.error`), such as the `Bad resource url: public/{folderPath}/` 400 described above
+- **THEN** the service calls `mapDialHttpStatus` with `result.error` as `errorBody` and `extractDialErrorMessage(result.error)` as `upstreamMessage`, so the thrown exception's `message` is Core's own reason instead of a generic placeholder — the client-facing error response reflects why Core rejected the request
+
 #### Scenario: Request omitting rules behaves exactly as before this change
 - **WHEN** a request body has no `rules` field at all (an older client, or a client not using the new UI)
 - **THEN** the DTO normalizes the missing field to `rules: []`, Core receives `rules: []`, and the request succeeds exactly as it did before this change
@@ -221,3 +225,7 @@ Rate limiting: default global throttle applies (read endpoint, no stricter overr
 #### Scenario: Upstream failure
 - **WHEN** the Core `getPublications` call fails unexpectedly
 - **THEN** the service throws `BadGatewayException` or `ServiceUnavailableException` (per `handleDialSdkError`)
+
+#### Scenario: Core rejects the history request with a structured error
+- **WHEN** `getPublications` resolves with a structured error response (`result.error`)
+- **THEN** the service calls `mapDialHttpStatus` with `result.error` and `extractDialErrorMessage(result.error)`, so the thrown exception's `message` is Core's own reason instead of a generic placeholder

--- a/openspec/specs/conversation-publish-api/spec.md
+++ b/openspec/specs/conversation-publish-api/spec.md
@@ -97,6 +97,10 @@ Authorization: caller SHALL be authenticated (existing session guard). The servi
 - **WHEN** the Core `createPublication` call fails unexpectedly (network error, 5xx, timeout)
 - **THEN** the service throws `BadGatewayException` or `ServiceUnavailableException` (per `handleDialSdkError`) and logs the failure without logging request bodies containing tokens
 
+#### Scenario: Core rejects the request with a structured error
+- **WHEN** `createPublication` resolves with a structured error response (`result.error`), e.g. a 400 for an invalid destination
+- **THEN** the service calls `mapDialHttpStatus` with `result.error` as `errorBody` and `extractDialErrorMessage(result.error)` as `upstreamMessage`, so the thrown exception's `message` is Core's own reason instead of a generic placeholder — matching `catalog-publish-api`'s equivalent behavior for `PublishService.publish`
+
 #### Scenario: Request omitting rules behaves exactly as before this change
 - **WHEN** a request body has no `rules` field at all (an older client, or a client not using the new UI)
 - **THEN** the DTO normalizes the missing field to `rules: []`, Core receives `rules: []`, and the request succeeds exactly as it did before this change
@@ -142,6 +146,10 @@ Rate limiting: default global throttle (read endpoint, no stricter override).
 #### Scenario: Upstream failure
 - **WHEN** the Core `getPublications` call fails unexpectedly
 - **THEN** the service throws `BadGatewayException` or `ServiceUnavailableException` (per `handleDialSdkError`)
+
+#### Scenario: Core rejects the history request with a structured error
+- **WHEN** `getPublications` resolves with a structured error response (`result.error`)
+- **THEN** the service calls `mapDialHttpStatus` with `result.error` and `extractDialErrorMessage(result.error)`, so the thrown exception's `message` is Core's own reason instead of a generic placeholder
 
 ### Requirement: Shared publish-target utilities are extracted, not duplicated, between catalog and conversation publish services
 

--- a/openspec/specs/conversation-publish-flow/spec.md
+++ b/openspec/specs/conversation-publish-flow/spec.md
@@ -112,8 +112,8 @@ On failure, the panel SHALL remain open, the submit-error callout (existing `der
 
 The failure notification SHALL:
 
-- use the shared `publish.failedTitle` title and the shared `publish.failedMessage` body, and carry `requestId` set to the trace ID resolved from the failed response via `getApiErrorDetails` when one is available (see `notification-request-id` and `api-error-trace-correlation`);
-- use the connection-specific `publish.networkErrorMessage` body and omit `requestId` when the failure occurred while `navigator.onLine` is `false`, because the request never reached the backend and therefore has no trace ID;
+- use the shared `publish.failedTitle` title, and a body resolved from the failed response's `message` (via `getApiErrorDetails`) when the response carries one — surfacing the backend/DIAL Core reason (e.g. a validation message for a 400) instead of always showing generic copy — falling back to the shared `publish.failedMessage` body only when the response carries no message; it SHALL carry `requestId` set to the trace ID resolved from the same call when one is available (see `notification-request-id` and `api-error-trace-correlation`);
+- use the connection-specific `publish.networkErrorMessage` body and omit `requestId` when the failure occurred while `navigator.onLine` is `false`, because the request never reached the backend and therefore has no trace ID or message;
 - be additive to the inline callout, never a replacement for it — the callout remains the in-context explanation next to the destination picker.
 
 The submit-error callout text SHALL be supplied by the host as `PublishPanelLabels.submitError` (`publish.submitErrorCallout`) rather than left to the library's hardcoded English default, since libraries carry no i18n.
@@ -127,7 +127,7 @@ The failure-notification strings SHALL live in one shared `publish.*` namespace 
 #### Scenario: Publish fails with a backend error
 - **WHEN** the backend returns an error for the publish request
 - **THEN** the panel stays open, the submit-error callout is shown, and no success notification or list refresh occurs
-- **AND** an error notification appears with the `publish.failedTitle` title and `publish.failedMessage` body
+- **AND** an error notification appears with the `publish.failedTitle` title and a body showing the response's own `message` (e.g. the DIAL Core reason for a 400) when the response carries one, or the shared `publish.failedMessage` body otherwise
 - **AND** the notification shows the request ID when the failed response carried a valid `traceparent`
 
 #### Scenario: Publish fails because the connection was lost

--- a/openspec/specs/publish-rules-lookup-api/spec.md
+++ b/openspec/specs/publish-rules-lookup-api/spec.md
@@ -70,6 +70,10 @@ Authorization: caller SHALL be authenticated (existing session guard). No additi
 - **WHEN** the Core `getPublicationRules` call fails unexpectedly (network error, 5xx, timeout)
 - **THEN** the service throws `BadGatewayException` or `ServiceUnavailableException` (per `handleDialSdkError`) and logs the failure without logging request bodies containing tokens
 
+#### Scenario: Core rejects the request with a structured error
+- **WHEN** `getPublicationRules` resolves with a structured error response (`result.error`)
+- **THEN** the service calls `mapDialHttpStatus` with `result.error` and `extractDialErrorMessage(result.error)`, so the thrown exception's `message` is Core's own reason instead of a generic placeholder
+
 #### Scenario: Unauthenticated request is rejected
 - **WHEN** the endpoint is called without a valid session
 - **THEN** the request is rejected with 401 before reaching the service or Core


### PR DESCRIPTION
**Description:**

Publish requests that fail on DIAL Core's `createPublication`/`getPublications`/`getPublicationRules` endpoints were returning a generic backend error message ("Invalid request to DIAL Core") instead of the actual upstream error reason. Fixed by passing `result.error` and `extractDialErrorMessage(result.error)` through to `mapDialHttpStatus` in publish, conversation-publish, and publish-rules services, matching the pattern already used in toolsets-mutation and external-services. The frontend hook now extracts and displays the server-provided error message in the notification, falling back to generic i18n text when unavailable.

**UI changes**

No UI changes (error messaging only — behavior now shows real upstream errors instead of generic text).

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(chat-api):`
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs