### PR TITLE
fix(chat): publish entity icon next to its entity, not into a folder (Issue #8265)

### DIFF
--- a/apps/chat/src/components/Chat/Publish/PublishDialog.tsx
+++ b/apps/chat/src/components/Chat/Publish/PublishDialog.tsx
@@ -186,7 +186,6 @@ const PublishDialogContainer = ({
         sourceUrl: decodedIconUrl,
         reviewUrl: decodedIconUrl,
         targetUrl: createPublicationIconTargetUrl({
-          entityId: entity.id,
           iconUrl: decodedIconUrl,
           targetFolder: PUBLIC_URL_PREFIX,
         }),

--- a/apps/chat/src/store/publication/publication.epics.ts
+++ b/apps/chat/src/store/publication/publication.epics.ts
@@ -1740,7 +1740,6 @@ const updatePublicationRequestAndApplicationIconEpic: AppEpic = (
         action: PublishActions.ADD_IF_ABSENT,
         sourceUrl: newApplication.iconUrl,
         targetUrl: createPublicationIconTargetUrl({
-          entityId: newApplication.id,
           iconUrl: ApiUtils.decodeApiUrl(newApplication.iconUrl),
           targetFolder: publication.targetFolder,
         }),

--- a/apps/chat/src/store/publication/publication.epics.ts
+++ b/apps/chat/src/store/publication/publication.epics.ts
@@ -1739,13 +1739,11 @@ const updatePublicationRequestAndApplicationIconEpic: AppEpic = (
       resources.push({
         action: PublishActions.ADD_IF_ABSENT,
         sourceUrl: newApplication.iconUrl,
-        targetUrl: ApiUtils.decodeApiUrl(
-          createPublicationIconTargetUrl({
-            entityId: newApplication.id,
-            iconUrl: newApplication.iconUrl,
-            targetFolder: publication.targetFolder,
-          }),
-        ),
+        targetUrl: createPublicationIconTargetUrl({
+          entityId: newApplication.id,
+          iconUrl: ApiUtils.decodeApiUrl(newApplication.iconUrl),
+          targetFolder: publication.targetFolder,
+        }),
       });
 
       return PublicationService.updatePublicationRequest({

--- a/apps/chat/src/utils/app/__tests__/publications.test.ts
+++ b/apps/chat/src/utils/app/__tests__/publications.test.ts
@@ -13,14 +13,14 @@ import { Conversation } from '@epam/ai-dial-shared';
 describe('createPublicationIconTargetUrl', () => {
   const targetFolder = 'public/Organization';
 
-  it('puts the icon into a folder named after the published entity', () => {
+  it('puts the icon next to the published entity and names it after the entity', () => {
     expect(
       createPublicationIconTargetUrl({
         entityId: 'applications/mybucket/myapp__0.0.1',
         iconUrl: 'files/mybucket/folder1/icon.svg',
         targetFolder,
       }),
-    ).toBe('files/public/Organization/myapp__0.0.1/icon.svg');
+    ).toBe('files/public/Organization/myapp__0.0.1.svg');
   });
 
   it('keeps icons of two app versions apart when the file names match', () => {
@@ -38,14 +38,34 @@ describe('createPublicationIconTargetUrl', () => {
     expect(first).not.toBe(second);
   });
 
-  it('drops the source folder of the icon', () => {
+  it('drops the source folder of the icon and creates no folder of its own', () => {
     expect(
       createPublicationIconTargetUrl({
         entityId: 'toolsets/mybucket/folder/mytoolset__1.0.0',
         iconUrl: 'files/mybucket/deeply/nested/folder/icon.svg',
         targetFolder,
       }),
-    ).toBe('files/public/Organization/mytoolset__1.0.0/icon.svg');
+    ).toBe('files/public/Organization/mytoolset__1.0.0.svg');
+  });
+
+  it('keeps the icon extension when the entity has no version', () => {
+    expect(
+      createPublicationIconTargetUrl({
+        entityId: 'applications/mybucket/myapp',
+        iconUrl: 'files/mybucket/folder1/icon.PNG',
+        targetFolder,
+      }),
+    ).toBe('files/public/Organization/myapp.png');
+  });
+
+  it('publishes an icon without an extension under the entity name', () => {
+    expect(
+      createPublicationIconTargetUrl({
+        entityId: 'applications/mybucket/myapp__0.0.1',
+        iconUrl: 'files/mybucket/folder1/icon',
+        targetFolder,
+      }),
+    ).toBe('files/public/Organization/myapp__0.0.1');
   });
 });
 

--- a/apps/chat/src/utils/app/__tests__/publications.test.ts
+++ b/apps/chat/src/utils/app/__tests__/publications.test.ts
@@ -8,64 +8,38 @@ import {
 } from '@/src/utils/app/publications';
 import { ApiUtils } from '@/src/utils/server/api';
 
+import { PUBLIC_URL_PREFIX } from '@/src/constants/publication';
+
 import { Conversation } from '@epam/ai-dial-shared';
 
 describe('createPublicationIconTargetUrl', () => {
   const targetFolder = 'public/Organization';
 
-  it('puts the icon next to the published entity and names it after the entity', () => {
+  it('publishes the icon to the same path as its entity, keeping the file name', () => {
     expect(
       createPublicationIconTargetUrl({
-        entityId: 'applications/mybucket/myapp__0.0.1',
         iconUrl: 'files/mybucket/folder1/icon.svg',
         targetFolder,
       }),
-    ).toBe('files/public/Organization/myapp__0.0.1.svg');
-  });
-
-  it('keeps icons of two app versions apart when the file names match', () => {
-    const first = createPublicationIconTargetUrl({
-      entityId: 'applications/mybucket/myapp__0.0.1',
-      iconUrl: 'files/mybucket/folder1/icon.svg',
-      targetFolder,
-    });
-    const second = createPublicationIconTargetUrl({
-      entityId: 'applications/mybucket/myapp__0.0.2',
-      iconUrl: 'files/mybucket/folder2/icon.svg',
-      targetFolder,
-    });
-
-    expect(first).not.toBe(second);
+    ).toBe('files/public/Organization/icon.svg');
   });
 
   it('drops the source folder of the icon and creates no folder of its own', () => {
     expect(
       createPublicationIconTargetUrl({
-        entityId: 'toolsets/mybucket/folder/mytoolset__1.0.0',
         iconUrl: 'files/mybucket/deeply/nested/folder/icon.svg',
         targetFolder,
       }),
-    ).toBe('files/public/Organization/mytoolset__1.0.0.svg');
+    ).toBe('files/public/Organization/icon.svg');
   });
 
-  it('keeps the icon extension when the entity has no version', () => {
+  it('publishes to the root public folder when nothing else is selected', () => {
     expect(
       createPublicationIconTargetUrl({
-        entityId: 'applications/mybucket/myapp',
-        iconUrl: 'files/mybucket/folder1/icon.PNG',
-        targetFolder,
+        iconUrl: 'files/mybucket/folder1/icon.svg',
+        targetFolder: PUBLIC_URL_PREFIX,
       }),
-    ).toBe('files/public/Organization/myapp.png');
-  });
-
-  it('publishes an icon without an extension under the entity name', () => {
-    expect(
-      createPublicationIconTargetUrl({
-        entityId: 'applications/mybucket/myapp__0.0.1',
-        iconUrl: 'files/mybucket/folder1/icon',
-        targetFolder,
-      }),
-    ).toBe('files/public/Organization/myapp__0.0.1');
+    ).toBe('files/public/icon.svg');
   });
 });
 

--- a/apps/chat/src/utils/app/publications.ts
+++ b/apps/chat/src/utils/app/publications.ts
@@ -41,7 +41,7 @@ import {
 } from './common';
 import { BucketService } from './data/bucket-service';
 import { FileService } from './data/file-service';
-import { constructPath, getFileNameExtension, prepareFileName } from './file';
+import { constructPath } from './file';
 import { getFolderIdFromEntityId } from './folders';
 import {
   getEntityBucket,
@@ -162,34 +162,18 @@ export const createFoldersFilesTargetUrl = (id: string) => {
 };
 
 /**
- * Target path for the icon of a published application or toolset. The icon is
- * published next to its entity, into the selected target folder, and is named
- * after the entity key. The source file name cannot be kept as is, because the
- * source folder of the icon is not a part of the target path: two entities, for
- * instance two versions of the same app, can use different icon files sharing a
- * file name, and a common target would make the second publication silently
- * reuse the icon of the first one. The entity key carries the version
- * (`getMarketplaceEntityApiKey` builds `name__version`), so the targets of two
- * versions can never collide.
+ * Target path for the icon of a published application or toolset: the icon is
+ * published to the same path as its entity, keeping its file name. The source
+ * folder of the icon is not carried over, so private folder names stay out of
+ * the public bucket - conversation attachments are flattened the same way.
  */
 export const createPublicationIconTargetUrl = ({
-  entityId,
   iconUrl,
   targetFolder,
 }: {
-  entityId: string;
   iconUrl: string;
   targetFolder: string;
-}) =>
-  constructPath(
-    ApiKeys.Files,
-    targetFolder,
-    prepareFileName(
-      `${splitEntityId(entityId).name}${getFileNameExtension(
-        splitEntityId(iconUrl).name,
-      )}`,
-    ),
-  );
+}) => constructPath(ApiKeys.Files, targetFolder, splitEntityId(iconUrl).name);
 
 /**
  * Target paths for file attachments when publishing conversations. De-duplicates

--- a/apps/chat/src/utils/app/publications.ts
+++ b/apps/chat/src/utils/app/publications.ts
@@ -41,7 +41,7 @@ import {
 } from './common';
 import { BucketService } from './data/bucket-service';
 import { FileService } from './data/file-service';
-import { constructPath } from './file';
+import { constructPath, getFileNameExtension, prepareFileName } from './file';
 import { getFolderIdFromEntityId } from './folders';
 import {
   getEntityBucket,
@@ -163,11 +163,14 @@ export const createFoldersFilesTargetUrl = (id: string) => {
 
 /**
  * Target path for the icon of a published application or toolset. The icon is
- * put into a folder named after the published entity, because the source
- * folder of the icon is not a part of the target path: two entities, for
- * instance two versions of the same app, can use different icon files sharing
- * a file name, and a common target would make the second publication silently
- * reuse the icon of the first one.
+ * published next to its entity, into the selected target folder, and is named
+ * after the entity key. The source file name cannot be kept as is, because the
+ * source folder of the icon is not a part of the target path: two entities, for
+ * instance two versions of the same app, can use different icon files sharing a
+ * file name, and a common target would make the second publication silently
+ * reuse the icon of the first one. The entity key carries the version
+ * (`getMarketplaceEntityApiKey` builds `name__version`), so the targets of two
+ * versions can never collide.
  */
 export const createPublicationIconTargetUrl = ({
   entityId,
@@ -181,8 +184,11 @@ export const createPublicationIconTargetUrl = ({
   constructPath(
     ApiKeys.Files,
     targetFolder,
-    splitEntityId(entityId).name,
-    splitEntityId(iconUrl).name,
+    prepareFileName(
+      `${splitEntityId(entityId).name}${getFileNameExtension(
+        splitEntityId(iconUrl).name,
+      )}`,
+    ),
   );
 
 /**


### PR DESCRIPTION
…

Publishing an app or toolset icon created a folder named after the entity in the target folder, so every publication request added a new folder to Files/Organization and duplicated the icon inside it.

The icon now goes directly into the selected target folder - the same path the entity itself is published to - and is named after the entity key. The key carries the version (name__version), so two versions whose source icons share a file name still get distinct targets and no longer reuse the icon published first.

The edit-request flow decodes only the icon url instead of the whole constructed path, so the raw entity name is not run through decodeURIComponent.

## Description of changes

<!-- Please explain the changes you made right below this line. -->

## Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #https://github.com/epam/ai-dial-chat/issues/8265

## UI changes

<Please, provide Screenshots or Figma links>

## Checklist

- [ ] the pull request name ends with `(Issue #<ISSUE_ID>)` (comma-separated list of issues)
- [ ] I confirm that I don't share any confidential information like API keys or any other secrets and private URLs

<details>
  <summary>PR title cheatsheet</summary>

`<type>[optional scope]: <description>`

1. type (required)
    - `feat` - A new feature
    - `fix` - A bug fix
    - `docs` - Documentation only changes
    - `test` - Adding missing tests or correcting existing tests
    - `ci` - Changes to our CI configuration files and scripts
    - `chore` - Other changes that are minor and/or not user-facing
2. scope (optional, current repo suggestions below)
    - `chat`
    - `overlay`
    - `shared`
    - `sandbox-overlay`
    - `visualizer-connector`

</details>
