### PR TITLE
fix: tsc project-reference outDir collides with vite build output

### DIFF
--- a/libs/ai-dial-chat-hooks/tsconfig.lib.json
+++ b/libs/ai-dial-chat-hooks/tsconfig.lib.json
@@ -2,8 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "dist",
-    "tsBuildInfoFile": "dist/tsconfig.lib.tsbuildinfo",
+    "outDir": "../../dist/libs/ai-dial-chat-hooks",
+    "tsBuildInfoFile": "../../dist/libs/ai-dial-chat-hooks/tsconfig.lib.tsbuildinfo",
     "emitDeclarationOnly": false,
     "jsx": "react-jsx",
     "module": "esnext",

--- a/libs/chat-overlay/tsconfig.lib.json
+++ b/libs/chat-overlay/tsconfig.lib.json
@@ -2,8 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "dist",
-    "tsBuildInfoFile": "dist/tsconfig.lib.tsbuildinfo",
+    "outDir": "../../dist/libs/chat-overlay",
+    "tsBuildInfoFile": "../../dist/libs/chat-overlay/tsconfig.lib.tsbuildinfo",
     "emitDeclarationOnly": true,
     "module": "esnext",
     "moduleResolution": "bundler",

--- a/libs/chat-shared/tsconfig.lib.json
+++ b/libs/chat-shared/tsconfig.lib.json
@@ -2,8 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "dist",
-    "tsBuildInfoFile": "dist/tsconfig.lib.tsbuildinfo",
+    "outDir": "../../dist/libs/chat-shared",
+    "tsBuildInfoFile": "../../dist/libs/chat-shared/tsconfig.lib.tsbuildinfo",
     "emitDeclarationOnly": false,
     "jsx": "react-jsx",
     "module": "esnext",


### PR DESCRIPTION
## Summary
- The `nx run-many -t build` CI job on `development-1.0` was failing intermittently with `TS6305: Output file '.../libs/chat-shared/dist/index.d.ts' has not been built from source file ...` while typechecking `@epam/ai-dial-attachment-input` (and other downstream consumers).
- Root cause: `libs/chat-shared/tsconfig.lib.json` pointed its tsc project-reference `outDir`/`tsBuildInfoFile` at the lib's local `dist` folder — the same folder `vite.config.mts` builds into with `emptyOutDir: true`. When `chat-shared:typecheck` (tsc, declarations) and `chat-shared:build` (vite, bundle) run concurrently in the Nx task graph, vite wipes the `.d.ts`/`tsbuildinfo` output tsc just wrote, so any project whose `typecheck` depends on `chat-shared:typecheck` sees a stale/missing declaration file.
- Every other lib in the workspace already keeps the tsc project-reference output at `../../dist/libs/<name>`, separate from the lib's own local `dist` used by vite. `chat-shared` was the one place this convention was skipped; `ai-dial-chat-hooks` and `chat-overlay` had the identical misconfiguration, so I fixed all three.

## Test plan
- [x] `rm -rf dist .nx/cache && npm run build:all` — clean full workspace build, 0 errors (repeated twice from a clean state)
- [x] `nx run-many -t typecheck --all` — no new failures (the one remaining failure, `@epam/chat-api:typecheck`, is pre-existing on `development-1.0` and unrelated to this change — verified on `origin/development-1.0` before this fix)
- [x] `nx run-many -t test --projects=@epam/ai-dial-chat-shared,@epam/ai-dial-chat-hooks,@epam/ai-dial-chat-overlay,@epam/ai-dial-attachment-input` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)