### PR TITLE
fix(chat-api): percent-encode prompt resource paths to fix 400 errors in nested folders

### DIFF
--- a/apps/chat-api/src/common/interceptors/metrics.interceptor.ts
+++ b/apps/chat-api/src/common/interceptors/metrics.interceptor.ts
@@ -20,9 +20,9 @@ import { getErrorDetails } from '../utils/error-details';
  * Logs endpoint duration, method, path, and status code, and records the same data on the
  * shared `http.server.request.duration` histogram (see telemetry/http-metrics.ts), which is a
  * no-op when OpenTelemetry metrics are disabled. Infra probe routes
- * (`telemetry/excluded-paths.ts`, e.g. `/api/health`) are still logged but never recorded onto
- * the histogram, mirroring the same routes' exclusion from tracing so probe traffic doesn't
- * pollute business-request dashboards/alerting.
+ * (`telemetry/excluded-paths.ts`, e.g. `/api/health`) are logged at `debug` instead of `log` and
+ * never recorded onto the histogram, mirroring the same routes' exclusion from tracing so probe
+ * traffic doesn't pollute business-request dashboards/alerting or logs at the default level.
  */
 @Injectable()
 export class MetricsInterceptor implements NestInterceptor {
@@ -41,10 +41,14 @@ export class MetricsInterceptor implements NestInterceptor {
           const duration = Date.now() - startTime;
           const response = context.switchToHttp().getResponse();
           const statusCode = response.statusCode;
+          const message = `${method} ${url} ${statusCode} - ${duration}ms`;
 
-          this.logger.log(`${method} ${url} ${statusCode} - ${duration}ms`);
+          if (isExcludedFromMetrics) {
+            this.logger.debug(message);
+            return;
+          }
 
-          if (isExcludedFromMetrics) return;
+          this.logger.log(message);
 
           httpServerRequestDuration.record(duration / 1000, {
             'http.request.method': method,

--- a/apps/chat-api/src/common/interceptors/tests/metrics.interceptor.spec.ts
+++ b/apps/chat-api/src/common/interceptors/tests/metrics.interceptor.spec.ts
@@ -1,8 +1,17 @@
+import { Logger } from '@nestjs/common';
 import type { CallHandler, ExecutionContext } from '@nestjs/common';
 import { metrics } from '@opentelemetry/api';
 import { MeterProvider, MetricReader } from '@opentelemetry/sdk-metrics';
 import { of, throwError } from 'rxjs';
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
 import type { MetricsInterceptor as MetricsInterceptorType } from '../metrics.interceptor';
 
 class TestMetricReader extends MetricReader {
@@ -156,5 +165,59 @@ describe('MetricsInterceptor', () => {
       'http.response.status_code': 200,
     });
     expect(dataPoint).toBeUndefined();
+  });
+
+  describe('log level', () => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('logs the excluded /api/health route at debug level', async () => {
+      const debugSpy = vi.spyOn(Logger.prototype, 'debug');
+      const logSpy = vi.spyOn(Logger.prototype, 'log');
+      const interceptor = new MetricsInterceptor();
+      const context = createExecutionContext(
+        { method: 'GET', url: '/api/health', route: { path: '/api/health' } },
+        { statusCode: 200 },
+      );
+      const handler: CallHandler = { handle: () => of({ status: 'ok' }) };
+
+      await new Promise<void>((resolve) => {
+        interceptor
+          .intercept(context, handler)
+          .subscribe({ complete: resolve });
+      });
+
+      expect(debugSpy).toHaveBeenCalledWith(
+        expect.stringContaining('GET /api/health 200'),
+      );
+      expect(logSpy).not.toHaveBeenCalled();
+    });
+
+    it('logs a non-excluded route at log level', async () => {
+      const debugSpy = vi.spyOn(Logger.prototype, 'debug');
+      const logSpy = vi.spyOn(Logger.prototype, 'log');
+      const interceptor = new MetricsInterceptor();
+      const context = createExecutionContext(
+        {
+          method: 'GET',
+          url: '/api/v1/themes/abc',
+          route: { path: '/api/v1/themes/:id' },
+        },
+        { statusCode: 200 },
+      );
+      const handler: CallHandler = { handle: () => of({ ok: true }) };
+
+      await new Promise<void>((resolve) => {
+        interceptor
+          .intercept(context, handler)
+          .subscribe({ complete: resolve });
+      });
+
+      expect(logSpy).toHaveBeenCalledWith(
+        expect.stringContaining('GET /api/v1/themes/abc 200'),
+      );
+      expect(debugSpy).not.toHaveBeenCalled();
+    });
   });
 });

--- a/apps/chat-api/src/prompts/utils/prompt-mapper.util.spec.ts
+++ b/apps/chat-api/src/prompts/utils/prompt-mapper.util.spec.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { toPromptResourceUrl } from './prompt-mapper.util';
+
+describe('toPromptResourceUrl', () => {
+  it('builds a resource url for a root-level prompt', () => {
+    expect(toPromptResourceUrl('greeting', 'bucket-1')).toBe(
+      'prompts/bucket-1/greeting',
+    );
+  });
+
+  it('percent-encodes each segment of a prompt nested inside a folder', () => {
+    expect(toPromptResourceUrl('New folder 1/Prompt 1', 'bucket-1')).toBe(
+      'prompts/bucket-1/New%20folder%201/Prompt%201',
+    );
+  });
+
+  it('does not double-encode an already-encoded path', () => {
+    expect(toPromptResourceUrl('New%20folder%201/Prompt%201', 'bucket-1')).toBe(
+      'prompts/bucket-1/New%20folder%201/Prompt%201',
+    );
+  });
+});

--- a/apps/chat-api/src/prompts/utils/prompt-mapper.util.ts
+++ b/apps/chat-api/src/prompts/utils/prompt-mapper.util.ts
@@ -1,4 +1,5 @@
 import type { components } from '@epam/ai-dial-typescript-sdk';
+import { encodeDialResourcePath } from '../../common/utils/encode-dial-path';
 import { safeDecodeURIComponent } from '../../common/utils/uri';
 import { HIDDEN_FILE } from '../../constants/dial.constants';
 import { FOLDER_SENTINEL } from '../constants/prompt.constants';
@@ -84,11 +85,15 @@ export const PROMPT_RESOURCE_PREFIX = 'prompts';
  * bucket is re-attached here. Which bucket that is comes from
  * `PromptResponseDto.bucket`: for a prompt shared with the caller it is the
  * owner's, and a path alone would resolve against the caller's own bucket.
+ * Each path segment is percent-encoded via `encodeDialResourcePath` so that
+ * folder or prompt names containing spaces or other reserved characters
+ * resolve to a valid DIAL Core resource link instead of a 400.
  */
 export const toPromptResourceUrl = (
   promptPath: string,
   bucket: string,
-): string => `${PROMPT_RESOURCE_PREFIX}/${bucket}/${promptPath}`;
+): string =>
+  `${PROMPT_RESOURCE_PREFIX}/${bucket}/${encodeDialResourcePath(promptPath)}`;
 
 /** Whether `url` is a DIAL Core prompt resource url, i.e. `prompts/{bucket}/{path}`. */
 export const isPromptResourceUrl = (url: string): boolean =>

--- a/apps/chat-api/src/share/tests/share.service.spec.ts
+++ b/apps/chat-api/src/share/tests/share.service.spec.ts
@@ -202,6 +202,33 @@ describe('ShareService', () => {
       expect(result.url).toBe('https://example.com/catalog/shared/p1');
     });
 
+    it('percent-encodes a prompt itemId nested inside a folder with a space in its name', async () => {
+      const { service } = makeService();
+      const spy = vi
+        .spyOn(service['dialClient'].client, 'shareResource')
+        .mockResolvedValue(okResponse({ invitationLink: '/invite/p2' }));
+
+      const result = await service.createShareLink('token-abc', 'my-bucket', {
+        itemId: 'New folder 1/Prompt 1',
+        access: [ShareAccess.View],
+        resourceKind: ShareResourceKind.Prompt,
+      });
+
+      expect(spy).toHaveBeenCalledWith({
+        headers: { Authorization: 'Bearer token-abc' },
+        body: {
+          invitationType: 'LINK',
+          resources: [
+            {
+              url: 'prompts/my-bucket/New%20folder%201/Prompt%201',
+              permissions: ['READ'],
+            },
+          ],
+        },
+      });
+      expect(result.url).toBe('https://example.com/catalog/shared/p2');
+    });
+
     it('leaves itemId untouched when no resourceKind is given', async () => {
       const { service } = makeService();
       const spy = vi

--- a/openspec/changes/archive/2026-08-18-fix-share-prompt-in-folder/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-18-fix-share-prompt-in-folder/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-18

--- a/openspec/changes/archive/2026-08-18-fix-share-prompt-in-folder/design.md
+++ b/openspec/changes/archive/2026-08-18-fix-share-prompt-in-folder/design.md
@@ -1,0 +1,37 @@
+## Context
+
+`POST /api/v1/share` builds a DIAL Core resource link for prompts by calling `toPromptResourceUrl(itemId, bucket)` in `apps/chat-api/src/prompts/utils/prompt-mapper.util.ts`, which concatenates the raw path with no percent-encoding: `` `${PROMPT_RESOURCE_PREFIX}/${bucket}/${promptPath}` ``. Every other DIAL Core path builder in the codebase (conversations, files, toolsets, and the other prompt CRUD services) routes through the shared `encodeDialResourcePath` helper (`apps/chat-api/src/common/utils/encode-dial-path.ts`), which splits the path on `/`, safely decodes and re-encodes each segment with `encodeURIComponent`, then rejoins with `/`. `toPromptResourceUrl` is the one path builder that skips this, so any prompt path with a segment requiring encoding (spaces, folder names) reaches DIAL Core unencoded and is rejected with 400.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Make prompt sharing produce a correctly percent-encoded DIAL Core resource path for prompts at any folder depth, consistent with how conversations/files/toolsets already build their paths.
+- Add regression coverage so this can't silently regress.
+
+**Non-Goals:**
+- No change to the `POST /api/v1/share` request/response contract, DTOs, or route.
+- No change to how conversations, files, toolsets, or other prompt endpoints build their resource paths — they already use `encodeDialResourcePath` correctly.
+- No frontend changes — the frontend already sends the human-readable `itemId`; encoding is a backend concern.
+
+## Decisions
+
+**Fix at `toPromptResourceUrl`, not at the `ShareService` call site.** `toPromptResourceUrl(promptPath, bucket)` becomes:
+```ts
+export const toPromptResourceUrl = (
+  promptPath: string,
+  bucket: string,
+): string =>
+  `${PROMPT_RESOURCE_PREFIX}/${bucket}/${encodeDialResourcePath(promptPath)}`;
+```
+Alternative considered: encode `itemId` inside `ShareService.createShareLink` before calling `toPromptResourceUrl`. Rejected — `toPromptResourceUrl` is also used elsewhere for building prompt resource URLs (other prompt services already call `encodeDialResourcePath` themselves before other DIAL Core calls), so fixing it at the source keeps every caller correct instead of requiring each call site to remember to encode first.
+
+**Reuse the existing `encodeDialResourcePath` utility rather than writing prompt-specific encoding.** It already implements the exact segment-by-segment decode/re-encode semantics DIAL Core expects, and is the established single-encoder convention (`dial-resource-path-encoding` capability). No new utility is introduced.
+
+## Risks / Trade-offs
+
+- [Risk] A prompt path segment that was already relying on being sent unencoded (unlikely, since DIAL Core expects encoded segments) could behave differently. → Mitigation: `encodeDialResourcePath` safely decodes before re-encoding, so already-encoded or plain segments produce the same DIAL Core–compatible result other resource kinds already rely on.
+- [Risk] Regression test only covers `ShareService`; a future new prompt-path builder could reintroduce raw concatenation. → Mitigation: `toPromptResourceUrl` is the single shared builder used by share and other prompt flows, so fixing it in one place covers all current callers.
+
+## Migration Plan
+
+Single backend code change plus a test; no data migration, no rollout sequencing, no feature flag. Deploy as a normal fix; rollback is a plain revert if needed.

--- a/openspec/changes/archive/2026-08-18-fix-share-prompt-in-folder/proposal.md
+++ b/openspec/changes/archive/2026-08-18-fix-share-prompt-in-folder/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+Sharing a prompt nested inside a folder fails with HTTP 400 because the backend builds the DIAL Core resource path for prompts via raw string concatenation (`toPromptResourceUrl` in `apps/chat-api/src/prompts/utils/prompt-mapper.util.ts`) instead of routing it through the shared `encodeDialResourcePath` encoder that every other resource kind (conversations, files, toolsets, other prompt endpoints) already uses. A folder or prompt name containing spaces or other characters needing percent-encoding — e.g. `New folder 1/Prompt 1` — is sent to DIAL Core unencoded, and DIAL Core rejects it as an invalid resource link. Root-level prompts with simple alphanumeric names happen to pass through unencoded, which is why the bug was only surfaced by nested folders.
+
+## What Changes
+
+- Update `toPromptResourceUrl` (or its call site in `ShareService.createShareLink`, `apps/chat-api/src/share/share.service.ts`) to percent-encode each path segment of the prompt path via the existing shared `encodeDialResourcePath` utility (`apps/chat-api/src/common/utils/encode-dial-path.ts`) before building the DIAL Core resource URL, matching the pattern already used by conversations, files, toolsets, and other prompt services.
+- Add a regression test in `apps/chat-api/src/share/tests/share.service.spec.ts` asserting `createShareLink` correctly percent-encodes a multi-segment prompt `itemId` (folder name with a space, nested prompt) before calling DIAL Core.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `prompts-share-api`: the prompt resource-path construction used by `POST /api/v1/share` must percent-encode each path segment (via `encodeDialResourcePath`) instead of concatenating the raw path, so prompts nested inside folders can be shared.
+
+## Impact
+
+- Affected code: `apps/chat-api/src/prompts/utils/prompt-mapper.util.ts` (`toPromptResourceUrl`), `apps/chat-api/src/share/share.service.ts` (`createShareLink`), `apps/chat-api/src/share/tests/share.service.spec.ts`.
+- No DTO, API contract, or route changes — this is a bug fix to internal resource-path construction.
+- No frontend changes required.

--- a/openspec/changes/archive/2026-08-18-fix-share-prompt-in-folder/specs/prompts-share-api/spec.md
+++ b/openspec/changes/archive/2026-08-18-fix-share-prompt-in-folder/specs/prompts-share-api/spec.md
@@ -1,10 +1,4 @@
-# prompts-share-api Specification
-
-## Purpose
-
-Sharing personal prompts through the existing share endpoint.
-
-## Requirements
+## MODIFIED Requirements
 
 ### Requirement: Personal prompts are shareable via the existing share endpoint
 
@@ -57,45 +51,3 @@ On success, `POST /api/v1/share` returns HTTP 201 with the existing
 - **WHEN** `POST /api/v1/share` is called with `{ "itemId": "New folder 1/Prompt 1", "resourceKind": "prompt", "access": ["view"] }`
 - **THEN** the resource path sent to DIAL Core is `prompts/{bucket}/New%20folder%201/Prompt%201`
 - **AND** the response is 201 with `url`, `expiresInDays`, and `access`, not a 400
-
----
-
-### Requirement: Shared prompts appear in the personal prompt list
-
-The `GET /api/v1/prompts` endpoint's `sharedWithMe` field (defined in `prompts-api`) SHALL be populated by querying DIAL Core's shared-resources listing for resources under the `prompts/` path namespace. The service calls DIAL Core's shared-resources API (the same call used by `ConversationService` to populate shared conversations) filtered to prompt paths, maps results to `PromptResponseDto`, and returns them in `sharedWithMe`.
-
-If DIAL Core returns no shared resources or the call fails non-fatally, `sharedWithMe` SHALL default to an empty array (graceful degradation — the personal and org prompts are still returned).
-
-#### Scenario: Shared prompts are included in the list
-
-- **WHEN** another user has shared a prompt with the current user via DIAL Core
-- **AND** `GET /api/v1/prompts` is called
-- **THEN** that prompt appears in `sharedWithMe` with a valid `PromptResponseDto`
-
-#### Scenario: No shared prompts returns empty sharedWithMe
-
-- **WHEN** no prompts have been shared with the current user
-- **THEN** `GET /api/v1/prompts` returns `sharedWithMe: []`
-
-#### Scenario: DIAL Core shared-resources call failure degrades gracefully
-
-- **WHEN** the DIAL Core shared-resources API returns a non-2xx response
-- **THEN** `GET /api/v1/prompts` still returns 200 with personal prompts; `sharedWithMe` is `[]`
-
----
-
-### Requirement: Swagger description for POST /api/v1/share is updated
-
-The `@ApiOperation.description` on `POST /api/v1/share` (`apps/chat-api/src/share/share.controller.ts`) SHALL be updated to state it creates a share link "for a DIAL Core resource (catalog entity, conversation, or prompt)", replacing the previous wording. No DTO, status code, or rate-limit change is required.
-
-#### Scenario: Updated Swagger description reflects prompt support
-
-- **WHEN** the OpenAPI spec is generated
-- **THEN** the `POST /api/v1/share` description mentions prompts alongside conversations and catalog entities
-
----
-
-RTL / direction impact: none (backend only).
-Feature flag gating: none.
-Cache: none — share links are ephemeral and not cached.
-Observability: log `WARN` if the DIAL Core shared-resources call for prompts fails, include the HTTP status returned.

--- a/openspec/changes/archive/2026-08-18-fix-share-prompt-in-folder/tasks.md
+++ b/openspec/changes/archive/2026-08-18-fix-share-prompt-in-folder/tasks.md
@@ -1,0 +1,15 @@
+## 1. Fix resource path encoding
+
+- [x] 1.1 Update `toPromptResourceUrl` in `apps/chat-api/src/prompts/utils/prompt-mapper.util.ts` to percent-encode `promptPath` via `encodeDialResourcePath` (`apps/chat-api/src/common/utils/encode-dial-path.ts`) before building the resource URL.
+- [x] 1.2 Verify `ShareService.createShareLink` (`apps/chat-api/src/share/share.service.ts`) requires no changes now that `toPromptResourceUrl` encodes internally; update the call site only if encoding needs to happen before `toPromptResourceUrl` is invoked.
+
+## 2. Tests
+
+- [x] 2.1 Add a unit test for `toPromptResourceUrl` (or the module containing it) asserting a multi-segment path with a space (e.g. `New folder 1/Prompt 1`) is percent-encoded segment-by-segment in the returned URL.
+- [x] 2.2 Add a test in `apps/chat-api/src/share/tests/share.service.spec.ts` asserting `createShareLink` with `resourceKind: "prompt"` and a nested `itemId` sends a percent-encoded resource path to DIAL Core (e.g. `prompts/{bucket}/New%20folder%201/Prompt%201`) and returns 201 instead of surfacing a 400.
+- [x] 2.3 Run `npm exec nx test chat-api` and confirm the new and existing tests pass.
+
+## 3. Verification
+
+- [x] 3.1 Run `npm exec nx lint chat-api` to confirm no lint regressions.
+- [x] 3.2 Manually verify (or via the new test) that sharing a root-level prompt still works unchanged (no double-encoding regression).


### PR DESCRIPTION
**Description:**

Fix a 400 error when sharing prompts nested inside folders by percent-encoding the prompt resource path segments in the DIAL Core resource URL. Additionally, log probe/excluded routes (health checks, metrics) at debug level instead of log level so they don't pollute default logs while still being available for debugging.

**UI changes**

No UI changes

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):` where `<scope>` is the affected project
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` — no ticket for this fix
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs