### PR TITLE
fix: Fix name and description localization for QuickApp, Issue #8171

### DIFF
--- a/apps/chat/src/pages/AppsEditor/GeneralForm.tsx
+++ b/apps/chat/src/pages/AppsEditor/GeneralForm.tsx
@@ -214,16 +214,18 @@ const GeneralForm = forwardRef<GeneralFormHandle, Props>(function GeneralForm(
     }
   }, [isSubmitting, values, appId, t, onCreated, schemaId]);
 
-  const getValues = useCallback(
-    (): TriggerSaveGeneralPayload => ({
+  const getValues = useCallback((): TriggerSaveGeneralPayload => {
+    const locales = composeLocalePayload(values.otherLocales, PRIMARY_LOCALE);
+    return {
       name: values.name.trim(),
       description: values.description.trim() || undefined,
       iconUrl: values.iconUrl.trim() || undefined,
       topics: values.topics.length > 0 ? values.topics : undefined,
       display_version: values.version.trim() || undefined,
-    }),
-    [values],
-  );
+      locales,
+      primaryLocale: locales ? PRIMARY_LOCALE : undefined,
+    };
+  }, [values]);
 
   useImperativeHandle(ref, () => ({ submit: handleSubmit, getValues }), [
     handleSubmit,

--- a/apps/chat/src/pages/AppsEditor/tests/GeneralForm.spec.tsx
+++ b/apps/chat/src/pages/AppsEditor/tests/GeneralForm.spec.tsx
@@ -8,6 +8,7 @@ import {
   EditorI18nKeys,
 } from '../../../constants/translation-keys';
 import { createApplication } from '../../../server-api/applications';
+import { PRIMARY_LOCALE } from '../../../utils/locale';
 import type { GeneralFormHandle } from '../GeneralForm';
 import GeneralForm from '../GeneralForm';
 
@@ -295,6 +296,8 @@ describe('GeneralForm', () => {
         description: undefined,
         iconUrl: undefined,
         topics: ['a', 'b'],
+        locales: undefined,
+        primaryLocale: undefined,
       });
     });
 
@@ -322,7 +325,40 @@ describe('GeneralForm', () => {
         display_version: '1.0.0',
         iconUrl: undefined,
         topics: undefined,
+        locales: undefined,
+        primaryLocale: undefined,
       });
+    });
+
+    it('includes locales and primaryLocale when additional locales are configured', () => {
+      const ref = createRef<GeneralFormHandle>();
+
+      renderForm(
+        {
+          appId: 'users/u/apps/existing',
+          initialValues: {
+            name: 'My App',
+            otherLocales: [
+              {
+                id: 'row-1',
+                language: 'de',
+                name: 'Meine App',
+                description: 'Meine Beschreibung',
+              },
+            ],
+          },
+        },
+        ref,
+      );
+
+      expect(ref.current?.getValues()).toEqual(
+        expect.objectContaining({
+          locales: [
+            { language: 'de', name: 'Meine App', description: 'Meine Beschreibung' },
+          ],
+          primaryLocale: PRIMARY_LOCALE,
+        }),
+      );
     });
   });
 

--- a/apps/chat/src/types/apps-editor.ts
+++ b/apps/chat/src/types/apps-editor.ts
@@ -1,4 +1,5 @@
 import type { CatalogItemCredentials } from '@epam/ai-dial-catalog';
+import type { LocaleTextEntryDto } from '@epam/ai-dial-chat-api-client';
 import type { ToolsetCredentialsLevel } from '../constants/toolsets';
 
 export enum AppsEditorQuery {
@@ -90,6 +91,10 @@ export interface TriggerSaveGeneralPayload {
   iconUrl?: string;
   topics?: string[];
   display_version?: string;
+  /** Additional-locale name/description entries, keyed by locale code. Omitted when no additional locales are configured — see {@link composeLocalePayload}. */
+  locales?: LocaleTextEntryDto[];
+  /** The content locale `name`/`description` are authored in. Set only alongside `locales`, mirroring {@link composeLocalePayload}'s pairing with `PRIMARY_LOCALE`. */
+  primaryLocale?: string;
 }
 
 /** Payload of a `TriggerSave` message posted to the embedded QuickApps iframe. */


### PR DESCRIPTION
## Description of changes

Fix for QuickApps general fields with localization. Specs are not updated because they were already correct, bug was only in the code.

## Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #8171

## UI changes

<Please, provide Screenshots or Figma links>

## Checklist

- [X] the pull request name ends with `(Issue #<ISSUE_ID>)` (comma-separated list of issues)
- [X] I confirm that I don't share any confidential information like API keys or any other secrets and private URLs

<details>
  <summary>PR title cheatsheet</summary>

`<type>[optional scope]: <description>`

1. type (required)
    - `feat` - A new feature
    - `fix` - A bug fix
    - `docs` - Documentation only changes
    - `test` - Adding missing tests or correcting existing tests
    - `ci` - Changes to our CI configuration files and scripts
    - `chore` - Other changes that are minor and/or not user-facing
2. scope (optional, current repo suggestions below)
    - `chat`
    - `overlay`
    - `shared`
    - `sandbox-overlay`
    - `visualizer-connector`

</details>
