### PR TITLE
fix: Fix error when attachment name is undefined, Issue #8057

### DIFF
--- a/libs/attachment-input/src/utils/attachment.ts
+++ b/libs/attachment-input/src/utils/attachment.ts
@@ -230,6 +230,9 @@ const getBottomLabel = (
     if (ext) return `.${ext}`;
   }
 
+  // name may be missing on some backend payloads despite the required type
+  if (name == null) return '';
+
   // Fall back to name extension; guard against trailing dots (e.g. sentence endings)
   const lastDot = name.lastIndexOf('.');
   if (lastDot > 0 && lastDot < name.length - 1) {

--- a/openspec/specs/attachment-input-lib/spec.md
+++ b/openspec/specs/attachment-input-lib/spec.md
@@ -73,6 +73,10 @@ The following utility functions SHALL be exported from `libs/attachment-input/sr
 - **WHEN** `isMimeTypeAllowed` is called with a MIME type and an allowlist array
 - **THEN** it returns `true` if the MIME type matches an allowed entry, `false` otherwise
 
+#### Scenario: getAttachmentCardState handles an attachment missing name
+- **WHEN** `getAttachmentCardState` is called with an attachment whose `name` is `undefined` or `null` (a non-conformant runtime payload) and no usable `contentType`
+- **THEN** it returns without throwing, with `typeLabel` falling back to an empty string
+
 #### Scenario: mimeTypesToExtensionLabels converts MIME types
 - **WHEN** `mimeTypesToExtensionLabels` is called with an array of MIME type strings
 - **THEN** it returns an array of human-readable extension label strings


### PR DESCRIPTION
## Description of changes

The audio model returns attachments like this:
{
    "data": "DgAGAA8...",
    "index": 0
}

there is no name, and it causes error "TypeError: Cannot read properties of undefined (reading 'lastIndexOf')"

## Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #8057

## UI changes

<Please, provide Screenshots or Figma links>

## Checklist

- [X] the pull request name ends with `(Issue #<ISSUE_ID>)` (comma-separated list of issues)
- [X] I confirm that I don't share any confidential information like API keys or any other secrets and private URLs

<details>
  <summary>PR title cheatsheet</summary>

`<type>[optional scope]: <description>`

1. type (required)
    - `feat` - A new feature
    - `fix` - A bug fix
    - `docs` - Documentation only changes
    - `test` - Adding missing tests or correcting existing tests
    - `ci` - Changes to our CI configuration files and scripts
    - `chore` - Other changes that are minor and/or not user-facing
2. scope (optional, current repo suggestions below)
    - `chat`
    - `overlay`
    - `shared`
    - `sandbox-overlay`
    - `visualizer-connector`

</details>
