### PR TITLE
feat: implement catalog tab persistence with controlled activeTab prop

### DIFF
--- a/apps/chat/src/components/CatalogView/CatalogView.tsx
+++ b/apps/chat/src/components/CatalogView/CatalogView.tsx
@@ -53,6 +53,7 @@ import {
   ToolsetLoginOutcomeType,
   useToolsetLogin,
 } from '../../hooks/toolsets/useToolsetLogin';
+import { useCatalogActiveTabPreference } from '../../hooks/useCatalogActiveTabPreference/useCatalogActiveTabPreference';
 import { useCatalogSortFilterPreference } from '../../hooks/useCatalogSortFilterPreference/useCatalogSortFilterPreference';
 import { useOperationNotification } from '../../hooks/useOperationNotification';
 import { useUiFeature } from '../../hooks/useUiFeature';
@@ -78,7 +79,7 @@ import {
 import { downloadSkillFile, listSkillFiles } from '../../server-api/skills.api';
 import { deleteToolset, logoutToolset } from '../../server-api/toolsets';
 import { AppsEditorQuery, AppsEditorStep } from '../../types/apps-editor';
-import { CatalogQuery } from '../../types/catalog';
+import { CATALOG_TAB_ORDER, CatalogQuery } from '../../types/catalog';
 import { EditorQuery } from '../../types/editor-query';
 import {
   EntityOperation,
@@ -384,6 +385,14 @@ const CatalogView: FC<Props> = ({
       ),
     );
   }, [visibleCatalogItems, persistedFilterTopics]);
+
+  const availableTabIds = useMemo(() => {
+    const presentTypes = new Set(visibleCatalogItems.map((item) => item.type));
+    return CATALOG_TAB_ORDER.filter((type) => presentTypes.has(type));
+  }, [visibleCatalogItems]);
+
+  const { activeTab, setActiveTab } =
+    useCatalogActiveTabPreference(availableTabIds);
 
   const {
     folderItems: publishFolderItems,
@@ -1276,6 +1285,8 @@ const CatalogView: FC<Props> = ({
       onFilterTopicsChange={isSelectorMode ? undefined : setFilterTopics}
       isMyAppsActive={isSelectorMode ? undefined : isMyAppsActive}
       onMyAppsActiveChange={isSelectorMode ? undefined : setIsMyAppsActive}
+      activeTab={isSelectorMode ? undefined : activeTab}
+      onActiveTabChange={isSelectorMode ? undefined : setActiveTab}
       onFetchDetails={handleFetchDetails}
       onToggleFavorite={onToggleFavorite}
       onUseInChat={handleUseInChat}

--- a/apps/chat/src/components/CatalogView/tests/CatalogView.spec.tsx
+++ b/apps/chat/src/components/CatalogView/tests/CatalogView.spec.tsx
@@ -36,6 +36,7 @@ import { usePrompts } from '../../../context/PromptsContext';
 import { useSkills } from '../../../context/SkillsContext';
 import { createNotificationContextValue } from '../../../context/tests/notification-context-mock';
 import { usePublishFolders } from '../../../hooks/publish/usePublishFolders';
+import { useCatalogActiveTabPreference } from '../../../hooks/useCatalogActiveTabPreference/useCatalogActiveTabPreference';
 import { useCatalogSortFilterPreference } from '../../../hooks/useCatalogSortFilterPreference/useCatalogSortFilterPreference';
 import { useUiFeature } from '../../../hooks/useUiFeature';
 import { deleteApplication } from '../../../server-api/applications';
@@ -117,6 +118,8 @@ const capturedPublishProps: {
     onFilterTopicsChange?: (topics: Set<string>) => void;
     isMyAppsActive?: boolean;
     onMyAppsActiveChange?: (isActive: boolean) => void;
+    activeTab?: string;
+    onActiveTabChange?: (tabId: string) => void;
   } | null;
 } = { current: null };
 
@@ -184,6 +187,8 @@ vi.mock('@epam/ai-dial-catalog', async (importOriginal) => ({
     onFilterTopicsChange,
     isMyAppsActive,
     onMyAppsActiveChange,
+    activeTab,
+    onActiveTabChange,
   }: {
     createOptions?: DropdownItem[];
     items?: CatalogItem[];
@@ -230,6 +235,8 @@ vi.mock('@epam/ai-dial-catalog', async (importOriginal) => ({
     onFilterTopicsChange?: (topics: Set<string>) => void;
     isMyAppsActive?: boolean;
     onMyAppsActiveChange?: (isActive: boolean) => void;
+    activeTab?: string;
+    onActiveTabChange?: (tabId: string) => void;
   }) => {
     const [fetchResult, setFetchResult] = useState<string>('');
     const [recipientsCount, setRecipientsCount] = useState<string>('');
@@ -250,6 +257,8 @@ vi.mock('@epam/ai-dial-catalog', async (importOriginal) => ({
       onFilterTopicsChange,
       isMyAppsActive,
       onMyAppsActiveChange,
+      activeTab,
+      onActiveTabChange,
     };
 
     return (
@@ -257,6 +266,10 @@ vi.mock('@epam/ai-dial-catalog', async (importOriginal) => ({
         <output aria-label="Catalog item ids">
           {(items ?? []).map((item) => `${item.id}:${item.type}`).join(',')}
         </output>
+        <output aria-label="Active tab">{activeTab ?? ''}</output>
+        <button type="button" onClick={() => onActiveTabChange?.('PROMPT')}>
+          switch to Prompts tab
+        </button>
         {(items ?? []).map((item) => (
           <output
             key={`credentials-badge-${item.id}`}
@@ -590,6 +603,13 @@ vi.mock(
   }),
 );
 
+vi.mock(
+  '../../../hooks/useCatalogActiveTabPreference/useCatalogActiveTabPreference',
+  () => ({
+    useCatalogActiveTabPreference: vi.fn(),
+  }),
+);
+
 describe('CatalogView', () => {
   const user = userEvent.setup({ delay: null });
   let capturedPopup: ReturnType<typeof makeFakePopup> | undefined;
@@ -674,6 +694,10 @@ describe('CatalogView', () => {
       onCreatePublishFolder: vi.fn(),
       rememberPublishFolder: vi.fn(),
       hasPublishWriteAccess: vi.fn().mockReturnValue(true),
+    });
+    vi.mocked(useCatalogActiveTabPreference).mockReturnValue({
+      activeTab: 'MODEL',
+      setActiveTab: vi.fn(),
     });
     vi.mocked(useCatalogSortFilterPreference).mockReturnValue({
       sortKey: CatalogSortKey.RecentlyUpdated,
@@ -2365,6 +2389,57 @@ describe('CatalogView', () => {
       expect(
         capturedPublishProps.current?.onMyAppsActiveChange,
       ).toBeUndefined();
+    });
+  });
+
+  describe('active tab persistence wiring', () => {
+    it('passes the persisted activeTab through to Catalog', () => {
+      vi.mocked(useCatalogActiveTabPreference).mockReturnValue({
+        activeTab: 'PROMPT',
+        setActiveTab: vi.fn(),
+      });
+
+      render(<CatalogView />);
+
+      expect(capturedPublishProps.current?.activeTab).toBe('PROMPT');
+    });
+
+    it('forwards Catalog tab switches to the persistence hook setter', () => {
+      const setActiveTab = vi.fn();
+      vi.mocked(useCatalogActiveTabPreference).mockReturnValue({
+        activeTab: 'MODEL',
+        setActiveTab,
+      });
+
+      render(<CatalogView />);
+      capturedPublishProps.current?.onActiveTabChange?.('PROMPT');
+
+      expect(setActiveTab).toHaveBeenCalledWith('PROMPT');
+    });
+
+    it('does not forward the activeTab controlled props in selector mode', () => {
+      render(<CatalogView isSelectorMode onClose={vi.fn()} />);
+
+      expect(capturedPublishProps.current?.activeTab).toBeUndefined();
+      expect(capturedPublishProps.current?.onActiveTabChange).toBeUndefined();
+    });
+
+    it('restores the origin tab after remounting with the same persisted value, as happens when an editor navigates back to Catalog', () => {
+      vi.mocked(useCatalogActiveTabPreference).mockReturnValue({
+        activeTab: 'PROMPT',
+        setActiveTab: vi.fn(),
+      });
+
+      const { unmount } = render(<CatalogView />);
+      expect(capturedPublishProps.current?.activeTab).toBe('PROMPT');
+
+      // Simulate the editor's `navigate(returnUrl)` back to the bare
+      // `ROUTES.Catalog`, which remounts `CatalogView`. The hook still
+      // resolves the same persisted value from `localStorage`.
+      unmount();
+      render(<CatalogView />);
+
+      expect(capturedPublishProps.current?.activeTab).toBe('PROMPT');
     });
   });
 

--- a/apps/chat/src/hooks/useCatalogActiveTabPreference/tests/useCatalogActiveTabPreference.spec.ts
+++ b/apps/chat/src/hooks/useCatalogActiveTabPreference/tests/useCatalogActiveTabPreference.spec.ts
@@ -1,0 +1,79 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { StorageKey } from '../../../types/storage-key';
+import { useCatalogActiveTabPreference } from '../useCatalogActiveTabPreference';
+
+describe('useCatalogActiveTabPreference', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('resolves to the first available tab when nothing is persisted', () => {
+    const { result } = renderHook(() =>
+      useCatalogActiveTabPreference(['model', 'agent', 'prompt']),
+    );
+
+    expect(result.current.activeTab).toBe('model');
+  });
+
+  it('restores a persisted tab that is still available', () => {
+    localStorage.setItem(StorageKey.CatalogActiveTab, JSON.stringify('agent'));
+
+    const { result } = renderHook(() =>
+      useCatalogActiveTabPreference(['model', 'agent', 'prompt']),
+    );
+
+    expect(result.current.activeTab).toBe('agent');
+  });
+
+  it('falls back to the first available tab when the persisted tab is stale', () => {
+    localStorage.setItem(StorageKey.CatalogActiveTab, JSON.stringify('skill'));
+
+    const { result } = renderHook(() =>
+      useCatalogActiveTabPreference(['model', 'agent']),
+    );
+
+    expect(result.current.activeTab).toBe('model');
+  });
+
+  it('persists the new tab when setActiveTab is called', () => {
+    const { result } = renderHook(() =>
+      useCatalogActiveTabPreference(['model', 'agent', 'prompt']),
+    );
+
+    act(() => {
+      result.current.setActiveTab('prompt');
+    });
+
+    expect(result.current.activeTab).toBe('prompt');
+    expect(localStorage.getItem(StorageKey.CatalogActiveTab)).toBe(
+      JSON.stringify('prompt'),
+    );
+  });
+
+  it('resolves to undefined when no tabs are available', () => {
+    const { result } = renderHook(() => useCatalogActiveTabPreference([]));
+
+    expect(result.current.activeTab).toBeUndefined();
+  });
+
+  it('does not throw and still updates in-memory state when localStorage.setItem fails', () => {
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('quota exceeded');
+    });
+
+    const { result } = renderHook(() =>
+      useCatalogActiveTabPreference(['model', 'agent']),
+    );
+
+    act(() => {
+      result.current.setActiveTab('agent');
+    });
+
+    expect(result.current.activeTab).toBe('agent');
+  });
+});

--- a/apps/chat/src/hooks/useCatalogActiveTabPreference/useCatalogActiveTabPreference.ts
+++ b/apps/chat/src/hooks/useCatalogActiveTabPreference/useCatalogActiveTabPreference.ts
@@ -1,0 +1,34 @@
+import { useCallback } from 'react';
+import { StorageKey } from '../../types/storage-key';
+import useLocalStorage from '../useLocalStorage';
+
+interface UseCatalogActiveTabPreferenceResult {
+  activeTab: string | undefined;
+  setActiveTab: (tabId: string) => void;
+}
+
+/**
+ * Persists the Catalog page's active entity-type tab to `localStorage` (via
+ * `useLocalStorage`) so it survives reloads and edit-flow round-trips. Lives
+ * at the app edge because `libs/catalog` must not access browser storage
+ * directly (library isolation).
+ */
+export const useCatalogActiveTabPreference = (
+  availableTabIds: string[],
+): UseCatalogActiveTabPreferenceResult => {
+  const [storedActiveTab, setStoredActiveTab] = useLocalStorage<string | null>(
+    StorageKey.CatalogActiveTab,
+    null,
+  );
+
+  const activeTab = availableTabIds.includes(storedActiveTab ?? '')
+    ? (storedActiveTab as string)
+    : availableTabIds[0];
+
+  const setActiveTab = useCallback(
+    (tabId: string) => setStoredActiveTab(tabId),
+    [setStoredActiveTab],
+  );
+
+  return { activeTab, setActiveTab };
+};

--- a/apps/chat/src/types/catalog.ts
+++ b/apps/chat/src/types/catalog.ts
@@ -1,5 +1,21 @@
+import { CatalogEntityType } from '@epam/ai-dial-chat-shared';
+
 /** Query-string params supported on the `/catalog` route. */
 export enum CatalogQuery {
   /** ID of an item whose details panel should open automatically on load. */
   ItemId = 'itemId',
 }
+
+/**
+ * Canonical display order for Catalog entity-type tabs, mirroring
+ * `TAB_ORDER` in `libs/catalog/src/utils/catalog-tabs.ts`. Kept in sync here
+ * because `CatalogView` needs the same ordering to resolve the persisted
+ * active tab against the tabs currently available.
+ */
+export const CATALOG_TAB_ORDER: CatalogEntityType[] = [
+  CatalogEntityType.Model,
+  CatalogEntityType.Agent,
+  CatalogEntityType.Toolset,
+  CatalogEntityType.Prompt,
+  CatalogEntityType.Skill,
+];

--- a/apps/chat/src/types/storage-key.ts
+++ b/apps/chat/src/types/storage-key.ts
@@ -6,6 +6,7 @@ export enum StorageKey {
   CatalogSortKey = 'catalogSortKey',
   CatalogFilterTopics = 'catalogFilterTopics',
   CatalogIsMyAppsActive = 'catalogIsMyAppsActive',
+  CatalogActiveTab = 'catalogActiveTab',
   TextOfClosedAnnouncement = 'textOfClosedAnnouncement',
   PublishDestinationFolders = 'publishDestinationFolders',
 }

--- a/libs/catalog/src/components/Catalog/Catalog.tsx
+++ b/libs/catalog/src/components/Catalog/Catalog.tsx
@@ -77,6 +77,8 @@ export const Catalog: FC<CatalogProps> = ({
   onFilterTopicsChange,
   isMyAppsActive: controlledIsMyAppsActive,
   onMyAppsActiveChange,
+  activeTab: controlledActiveTab,
+  onActiveTabChange,
 }) => {
   const { typography } = catalogStyles ?? {};
   const cssVars = getStyles(catalogStyles);
@@ -170,11 +172,21 @@ export const Catalog: FC<CatalogProps> = ({
   );
 
   const firstTabId = tabs[0]?.id ?? '';
-  const [activeTab, setActiveTab] = useState(firstTabId);
+  const [internalActiveTab, setInternalActiveTab] = useState(firstTabId);
 
   useEffect(() => {
-    setActiveTab((prev) => prev || firstTabId);
+    setInternalActiveTab((prev) => prev || firstTabId);
   }, [firstTabId]);
+
+  const activeTab = controlledActiveTab ?? internalActiveTab;
+
+  const handleActiveTabChange = useCallback(
+    (tabId: string) => {
+      setInternalActiveTab(tabId);
+      onActiveTabChange?.(tabId);
+    },
+    [onActiveTabChange],
+  );
 
   const [isFavoritesRendered, setIsFavoritesRendered] = useState(
     favorites.length > 0,
@@ -454,7 +466,7 @@ export const Catalog: FC<CatalogProps> = ({
                   .length,
               }))}
               activeTabId={activeTab}
-              onTabChange={setActiveTab}
+              onTabChange={handleActiveTabChange}
             />
           </div>
         )}

--- a/libs/catalog/src/components/Catalog/tests/Catalog.spec.tsx
+++ b/libs/catalog/src/components/Catalog/tests/Catalog.spec.tsx
@@ -682,4 +682,59 @@ describe('Catalog', () => {
 
     expect(onMyAppsActiveChange).toHaveBeenCalledWith(true);
   });
+
+  it('defaults the active tab to the first tab when uncontrolled', () => {
+    render(
+      <Catalog
+        items={[
+          makeItem('1', 'Claude', { type: CatalogEntityType.Model }),
+          makeItem('2', 'My Prompt', { type: CatalogEntityType.Prompt }),
+        ]}
+        favorites={[]}
+      />,
+    );
+
+    expect(
+      screen
+        .getByRole('tab', { name: /Models/i })
+        .getAttribute('aria-selected'),
+    ).toBe('true');
+  });
+
+  it('uses the controlled activeTab prop instead of internal state', () => {
+    render(
+      <Catalog
+        items={[
+          makeItem('1', 'Claude', { type: CatalogEntityType.Model }),
+          makeItem('2', 'My Prompt', { type: CatalogEntityType.Prompt }),
+        ]}
+        favorites={[]}
+        activeTab={CatalogEntityType.Prompt}
+      />,
+    );
+
+    expect(
+      screen
+        .getByRole('tab', { name: /Prompts/i })
+        .getAttribute('aria-selected'),
+    ).toBe('true');
+  });
+
+  it('calls onActiveTabChange with the clicked tab id', async () => {
+    const onActiveTabChange = vi.fn();
+    render(
+      <Catalog
+        items={[
+          makeItem('1', 'Claude', { type: CatalogEntityType.Model }),
+          makeItem('2', 'My Prompt', { type: CatalogEntityType.Prompt }),
+        ]}
+        favorites={[]}
+        onActiveTabChange={onActiveTabChange}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole('tab', { name: /Prompts/i }));
+
+    expect(onActiveTabChange).toHaveBeenCalledWith(CatalogEntityType.Prompt);
+  });
 });

--- a/libs/catalog/src/models/catalog-props.ts
+++ b/libs/catalog/src/models/catalog-props.ts
@@ -273,4 +273,12 @@ export interface CatalogProps {
   isMyAppsActive?: boolean;
   /** Called when the user toggles the "My Apps" filter; required to control `isMyAppsActive`. */
   onMyAppsActiveChange?: (isActive: boolean) => void;
+  /**
+   * Externally-controlled active entity-type tab id. When omitted, `Catalog`
+   * manages its own tab state internally, defaulting to the first tab
+   * returned by `buildCatalogTabs`.
+   */
+  activeTab?: string;
+  /** Called when the user switches tabs; required to control `activeTab`. */
+  onActiveTabChange?: (tabId: string) => void;
 }

--- a/openspec/changes/archive/2026-08-18-catalog-tab-persistence/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-18-catalog-tab-persistence/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-18

--- a/openspec/changes/archive/2026-08-18-catalog-tab-persistence/design.md
+++ b/openspec/changes/archive/2026-08-18-catalog-tab-persistence/design.md
@@ -1,0 +1,54 @@
+## Context
+
+`Catalog` (`libs/catalog/src/components/Catalog/Catalog.tsx`) currently owns its active-tab selection as local `useState`, seeded from `buildCatalogTabs()`'s first entry (`libs/catalog/src/utils/catalog-tabs.ts`, `TAB_ORDER = [Model, Agent, Toolset, Prompt, Skill]`). `CatalogView` (`apps/chat/src/components/CatalogView/CatalogView.tsx`) has no visibility into which tab is active and cannot restore it, so a page refresh — or a `navigate()` back from `PromptEditor`, `SkillEditor`, `ToolsetEditor`, or an app/custom-app editor — always remounts `CatalogView` → `Catalog` with no tab context, defaulting to Models.
+
+This repo already solved the equivalent problem for sort key and topic filters (`openspec/specs/catalog-sort-filter-persistence/spec.md`): `Catalog` gained controlled `sortKey`/`onSortChange` and `filterTopics`/`onFilterTopicsChange` props with internal-state fallback, backed by a `useLocalStorage`-based hook (`useCatalogSortFilterPreference`) that `CatalogView` wires in outside selector mode. This change follows the identical shape for the active tab: a controlled prop plus a `localStorage`-backed hook, with no query param and no routing changes.
+
+Because persistence writes on every tab switch (not just on unmount), the tab the user is on at the moment they click "Edit" is already the persisted value. Editor pages already `navigate(returnUrl)` back to the bare `ROUTES.Catalog` on save/cancel; `CatalogView` remounts, reads `localStorage`, and lands back on the same tab automatically. This is the same reasoning that already makes sort/filter "survive" an edit round-trip today (`catalog-sort-filter-persistence` needed no editor-URL changes either) — no `ReturnUrl` changes are needed for tabs either.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Active Catalog tab survives a full page refresh (Case 2, Case 3).
+- Editing/creating a Prompt, Skill, Toolset, or App returns the user to the tab they started from (Case 1, Case 4) — via the same persisted-value mechanism as a refresh, not a URL parameter.
+- First-ever visit (no persisted value) still defaults to the Models tab, unchanged.
+- Follow the existing controlled/uncontrolled prop pattern so `Catalog` remains usable standalone and in `CatalogModal` (selector mode) without behavior change there.
+
+**Non-Goals:**
+- A `tab` query parameter or any change to `/catalog`'s route/URL shape — deliberately rejected in favor of matching the existing sort/filter persistence mechanism exactly (see Decision 1).
+- Persisting the search query text (`query` state in `Catalog.tsx`) — out of scope per the proposal.
+- Per-tab filter/sort state (filters remain global across tabs, matching current `catalog-sort-filter-persistence` behavior) — this change only adds the missing tab dimension.
+- Changing `CatalogModal`'s (selector mode) tab behavior — stays uncontrolled/session-only, consistent with how sort/filter selector-mode is handled today.
+- Deep-linking to a specific tab via a shareable URL — not requested by the bug report; can be layered on later without conflicting with this design if ever needed.
+
+## Decisions
+
+**1. `localStorage` persistence only, no query param — matches `catalog-sort-filter-persistence` exactly.**
+The bug report's four cases (refresh loses tab, edit-return loses tab) are all plain component remounts; a `localStorage`-backed hook that persists on every change already solves all of them, because the persisted value at read-time is always the value most recently written — including "right before navigating to an editor". A query param was initially considered (for the case where an explicit link should override a stale persisted value) but rejected: there is no requirement here for shareable/bookmarkable per-tab URLs, and avoiding the query param keeps this change a pure copy of the already-accepted sort/filter pattern — same hook shape, same storage mechanism, no new route/query-param surface, no `handleEdit`/`createOptions` changes.
+
+**2. Controlled `activeTab`/`onActiveTabChange` props on `Catalog`, mirroring `sortKey`/`onSortChange`.**
+Same rationale as the existing sort/filter props: `Catalog` stays host-agnostic (no `localStorage`) per AGENTS.md §Library isolation, while `CatalogView` supplies the controlled value. Alternative considered: an uncontrolled `initialActiveTab` (set-once) prop — rejected because `CatalogView` also needs to *write* `localStorage` on every tab change, which requires an `onActiveTabChange` callback, not just an initial value.
+
+**3. Resolution order on `CatalogView` mount: persisted `localStorage` value → first available tab.**
+Mirrors the reconciliation step already used for `filterTopics` (validate the persisted value against what's actually available before applying it) rather than trusting it blindly — the tab id must be present in `buildCatalogTabs()`'s current output, or `CatalogView` falls back to the first available tab (Models on a first-ever visit, or if a previously-visible tab type has disappeared from the current item set).
+
+**4. No changes to `handleEdit`/`createOptions`'s `ReturnUrl` construction.**
+Since `setActiveTab` (Decision 2) already persists on every tab switch, the value in `localStorage` at the moment "Edit" is clicked is already correct; the editor's own `navigate(returnUrl)` back to the bare `ROUTES.Catalog` is unchanged and sufficient. This removes an entire class of call-site edits and their associated risk (see Risks).
+
+**5. New hook `useCatalogActiveTabPreference`, structured like `useCatalogSortFilterPreference`.**
+Built on the existing `useLocalStorage` hook, storing under new `StorageKey.CatalogActiveTab`. Kept as a separate hook (not merged into `useCatalogSortFilterPreference`) to match the existing one-hook-per-persisted-concept convention (`apps/chat/src/hooks/`), even though its shape (persist + reconcile-against-available-values) is otherwise identical.
+
+## Risks / Trade-offs
+
+- **[Risk] A tab id becomes stale** (e.g. persisted `Toolset` from a previous session, but the current items no longer include any Toolset item) **→ Mitigation**: `CatalogView` validates the resolved tab id against `buildCatalogTabs(catalogItems)`'s current ids before applying it, falling back to the first available tab, exactly like the existing `filterTopics` reconciliation.
+- **[Risk] Multiple browser tabs/windows on `/catalog` with different active tabs write over each other's `localStorage` entry** — the same risk already exists for `sortKey`/`filterTopics` today and is accepted there; no new mitigation is introduced beyond what the existing pattern already tolerates.
+- **[Risk] `CatalogModal` (selector mode) accidentally becomes controlled and its tab now persists across opens, changing existing UX** **→ Mitigation**: `CatalogView` only forwards `activeTab`/`onActiveTabChange` (and calls the hook's setter) when `isSelectorMode` is falsy, identical to the existing selector-mode gate for `sortKey`/`filterTopics`.
+- **[Risk] Adding a new `StorageKey` member without a migration path for existing persisted users** **→ Mitigation**: none needed; this is a purely additive key, absence simply falls back to the first tab (existing behavior), no read of an old key/shape.
+
+## Migration Plan
+
+No data migration required (new, additive `localStorage` key; no existing persisted state to convert). Roll out as a single frontend change: `libs/catalog` prop additions are backward compatible (optional props, default to current uncontrolled behavior), and `apps/chat` wiring is additive to `CatalogView`. Rollback is a plain revert — no server-side or schema impact.
+
+## Open Questions
+
+None outstanding — the bug report's four cases are all addressed by persistence-on-every-change alone, with `CatalogModal` explicitly and deliberately out of scope.

--- a/openspec/changes/archive/2026-08-18-catalog-tab-persistence/proposal.md
+++ b/openspec/changes/archive/2026-08-18-catalog-tab-persistence/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+The Catalog page's active tab (Models, Prompts, Agents, Skills, Deployments) lives only in `Catalog`'s local `useState`, uncontrolled from the app layer. Any remount — a page refresh, or `navigate()` back from an entity's editor — throws that state away and the tab always resolves to the first entry in `TAB_ORDER` (Models). As more tabs (Skills, Agents) have been added, this context loss is increasingly disruptive.
+
+## What Changes
+
+- Make `Catalog` (`libs/catalog`) accept controlled `activeTab`/`onActiveTabChange` props, following the same controlled/uncontrolled pattern already used for `sortKey`/`filterTopics` (`catalog-sort-filter-persistence`); it keeps working uncontrolled when the props are omitted.
+- Add an `apps/chat` hook, `useCatalogActiveTabPreference`, that persists the active tab to `localStorage` (new `StorageKey.CatalogActiveTab`) and reconciles it against the currently available tabs, mirroring `useCatalogSortFilterPreference` exactly (no query param, no routing changes — same mechanism as sort key and topic filters).
+- Wire the persisted tab into `CatalogView`: on mount it resolves from `localStorage` (falling back to the first available tab, i.e. Models, when nothing is persisted or the persisted tab is no longer available); every tab switch persists immediately.
+- No change is needed to `handleEdit`/`createOptions`'s `ReturnUrl` construction: because every tab switch already persists to `localStorage`, the tab the user was on when they clicked Edit is already the persisted value by the time the editor saves/cancels and navigates back to `ROUTES.Catalog` — `CatalogView` picks it back up from `localStorage` on remount, same as a plain refresh.
+- Leave `CatalogModal` (selector mode) unaffected — it stays uncontrolled/session-only, same as sort/filter persistence.
+
+## Capabilities
+
+### New Capabilities
+
+- `catalog-tab-persistence`: controlled `activeTab` prop on `Catalog`, and a `useCatalogActiveTabPreference` hook (mirroring `useCatalogSortFilterPreference`) that persists the active tab to `localStorage` and reconciles it against the currently available tabs on every mount — covering page refresh and return-from-editor navigation alike, since both are plain remounts that read the same persisted value.
+
+### Modified Capabilities
+
+- none (no existing spec file currently documents the Catalog tab-selection behavior at the requirement level; this is a new capability, not a change to a documented one).
+
+## Impact
+
+- `libs/catalog/src/components/Catalog/Catalog.tsx`, `libs/catalog/src/models/catalog-props.ts` — new optional controlled props, no breaking change to existing consumers.
+- `apps/chat/src/components/CatalogView/CatalogView.tsx` — uses the new persistence hook to control `Catalog`'s active tab; no change to `handleEdit`/`createOptions`.
+- `apps/chat/src/types/storage-key.ts` (new `StorageKey.CatalogActiveTab`).
+- New hook file `apps/chat/src/hooks/useCatalogActiveTabPreference/useCatalogActiveTabPreference.ts` plus co-located tests.

--- a/openspec/changes/archive/2026-08-18-catalog-tab-persistence/specs/catalog-tab-persistence/spec.md
+++ b/openspec/changes/archive/2026-08-18-catalog-tab-persistence/specs/catalog-tab-persistence/spec.md
@@ -1,0 +1,130 @@
+## ADDED Requirements
+
+### Requirement: Catalog accepts a controlled active tab
+
+`CatalogProps` (`libs/catalog/src/models/catalog-props.ts`) SHALL gain two new optional properties:
+
+- `activeTab?: string`
+- `onActiveTabChange?: (tabId: string) => void`
+
+`Catalog` (`libs/catalog/src/components/Catalog/Catalog.tsx`) SHALL use `props.activeTab ?? internalActiveTab` so it remains fully functional when the props are omitted (uncontrolled, current behavior unchanged: defaults to the first tab returned by `buildCatalogTabs`). When `onActiveTabChange` is supplied, `Catalog` SHALL call it on every tab-switch interaction in addition to updating its own internal fallback state.
+
+`Catalog` SHALL NOT read or write `localStorage`, `sessionStorage`, `URLSearchParams`, or any routing API to determine or persist the active tab — it remains host-agnostic per AGENTS.md §Library isolation.
+
+State owner: `Catalog`'s existing internal `activeTab` state remains the fallback owner when uncontrolled; `CatalogView` (via `useCatalogActiveTabPreference`, see below) is the owner when controlled.
+
+Memoisation: no new memoisation is required in `Catalog` beyond the existing `useMemo` for `tabs`.
+
+i18n keys needed: none (no new user-visible strings).
+
+RTL impact: none (tab switching logic only; the existing `Tabs` component already handles its own layout direction).
+
+Accessibility: none — the existing `Tabs` component's `activeTabId`/`onTabChange` props already carry ARIA tab/tabpanel semantics; this requirement only changes which value drives `activeTabId`.
+
+#### Scenario: Uncontrolled Catalog behaves exactly as before
+
+- **WHEN** `Catalog` is rendered without `activeTab` or `onActiveTabChange`
+- **THEN** it defaults to the first tab id returned by `buildCatalogTabs` and tab switching works entirely from internal state, as it does today
+
+#### Scenario: Controlled activeTab overrides internal state
+
+- **WHEN** `Catalog` is rendered with `activeTab="skill"` and a `Skill` tab is present in `buildCatalogTabs`'s output
+- **THEN** the Skill tab is shown as active regardless of any internal default
+
+#### Scenario: Switching tabs calls onActiveTabChange
+
+- **WHEN** the user clicks the "Agents" tab and `onActiveTabChange` is supplied
+- **THEN** `onActiveTabChange` is called with the Agent tab's id
+
+---
+
+### Requirement: useCatalogActiveTabPreference hook persists and reconciles the active tab
+
+A custom hook `useCatalogActiveTabPreference` SHALL be created at `apps/chat/src/hooks/useCatalogActiveTabPreference/useCatalogActiveTabPreference.ts`, built on top of the existing `apps/chat/src/hooks/useLocalStorage.ts` hook — mirroring `useCatalogSortFilterPreference`'s shape.
+
+`apps/chat/src/types/storage-key.ts` SHALL gain a new `StorageKey.CatalogActiveTab` member.
+
+The hook SHALL accept the list of currently available tab ids (`string[]`, derived by the caller from `buildCatalogTabs`), and SHALL:
+
+- Call `useLocalStorage<string | null>(StorageKey.CatalogActiveTab, null)` to obtain the persisted tab id and its setter.
+- Resolve the effective active tab in this order: (1) the persisted `localStorage` value, if it is present in the available tab ids; (2) the first available tab id, or `undefined` if the available tab id list is empty.
+- Expose `activeTab: string | undefined` (the resolved value) and `setActiveTab: (tabId: string) => void`.
+- On every `setActiveTab` call, forward the new value to the underlying `useLocalStorage` setter for `StorageKey.CatalogActiveTab`.
+- Rely on `useLocalStorage`'s own `try`/`catch` handling for `localStorage` read/write failures — the hook does not need its own storage-access error handling.
+
+The hook SHALL NOT call `useTranslation`, `navigate`, `useSearchParams`, or make network requests — no query-param or routing concern is involved; persistence is `localStorage`-only, identical in mechanism to `useCatalogSortFilterPreference`.
+
+i18n keys needed: none.
+
+RTL impact: none.
+
+#### Scenario: No persisted value on first visit
+
+- **WHEN** the hook is called with `availableTabIds: ['model', 'agent', 'prompt']` and `localStorage` has no `dial:catalog:activeTab` entry
+- **THEN** `activeTab` is `'model'` (the first available tab id)
+
+#### Scenario: Persisted tab is restored
+
+- **WHEN** the hook is called with `availableTabIds: ['model', 'agent', 'prompt']` and `localStorage.getItem('dial:catalog:activeTab')` returns `JSON.stringify('agent')`
+- **THEN** `activeTab` is `'agent'`
+
+#### Scenario: Stale persisted tab id falls back to first available tab
+
+- **WHEN** the hook is called with `availableTabIds: ['model', 'agent']` and `localStorage.getItem('dial:catalog:activeTab')` returns `JSON.stringify('skill')` (a tab not present in `availableTabIds`)
+- **THEN** `activeTab` is `'model'`
+
+#### Scenario: setActiveTab persists the new value
+
+- **WHEN** `setActiveTab('prompt')` is called
+- **THEN** `localStorage.getItem(StorageKey.CatalogActiveTab)` returns `JSON.stringify('prompt')` and the hook's `activeTab` updates to `'prompt'`
+
+#### Scenario: Empty available tab list resolves to undefined
+
+- **WHEN** the hook is called with `availableTabIds: []`
+- **THEN** `activeTab` is `undefined`
+
+#### Scenario: localStorage write failure does not throw
+
+- **WHEN** `setActiveTab` is called and the underlying `useLocalStorage` setter's `localStorage.setItem` call throws (e.g. quota exceeded)
+- **THEN** the hook's `activeTab` state still updates in memory and no error propagates out of the hook
+
+---
+
+### Requirement: CatalogView wires the persisted tab into Catalog
+
+`CatalogView` (`apps/chat/src/components/CatalogView/CatalogView.tsx`) SHALL use `useCatalogActiveTabPreference` (passing the current `buildCatalogTabs` output's ids) to obtain `activeTab` and `setActiveTab`.
+
+- `CatalogView` SHALL only forward `activeTab` and an `onActiveTabChange` callback to `Catalog` when it is not rendered in selector mode (`isSelectorMode` is falsy); in selector mode both SHALL be `undefined` so `Catalog` falls back to its own internal, session-only tab state. `CatalogView` SHALL still call `useCatalogActiveTabPreference` unconditionally (the hook read is harmless), but its value is only wired to `Catalog` outside selector mode.
+- Outside selector mode, `CatalogView` SHALL pass `activeTab={activeTab}` to `Catalog`, and its `onActiveTabChange` handler SHALL call `setActiveTab(tabId)` — no URL/query-param update is involved.
+- `CatalogModal` (`apps/chat/src/components/DeploymentSelector/CatalogModal.tsx`) renders `CatalogView` with `isSelectorMode`; because of the selector-mode gating above, `CatalogModal` SHALL NOT be changed and its tab selection remains uncontrolled and session-only (resets whenever the modal is closed and reopened).
+
+Memoisation: the `availableTabIds` array passed into `useCatalogActiveTabPreference` SHALL be derived via the existing `buildCatalogTabs` memoized tab list (`.map(t => t.id)`, wrapped in its own `useMemo` keyed on the existing `tabs` memo).
+
+Feature flag: none required.
+
+Accessibility: no change — the tab list already carries its existing ARIA semantics; this requirement only changes which value drives `activeTabId`.
+
+#### Scenario: Refresh restores the last-used tab
+
+- **WHEN** `CatalogView` mounts and `useCatalogActiveTabPreference` resolves `activeTab: 'prompt'` from `localStorage`
+- **THEN** the rendered `Catalog` shows the Prompts tab as active, with no additional user interaction
+
+#### Scenario: First-ever visit defaults to Models
+
+- **WHEN** `CatalogView` mounts with no persisted `localStorage` value
+- **THEN** the rendered `Catalog` shows the Models tab as active (the first entry in `buildCatalogTabs`'s output)
+
+#### Scenario: Switching tabs persists the new value
+
+- **WHEN** the user clicks the "Agents" tab
+- **THEN** `localStorage` is updated via `setActiveTab` to the Agent tab's id
+
+#### Scenario: Editing an item and returning restores the origin tab
+
+- **WHEN** the user is on the Prompts tab (so `localStorage`'s persisted value is `'prompt'`), clicks Edit on a prompt, and the editor navigates back to the bare `ROUTES.Catalog` on save/cancel
+- **THEN** `CatalogView` remounts, `useCatalogActiveTabPreference` resolves `activeTab: 'prompt'` from the unchanged `localStorage` value, and the rendered `Catalog` shows the Prompts tab as active
+
+#### Scenario: CatalogModal is unaffected
+
+- **WHEN** `CatalogModal` is rendered
+- **THEN** it does not read from or write to `localStorage` for tab selection, and its tab selection resets when the modal is closed and reopened

--- a/openspec/changes/archive/2026-08-18-catalog-tab-persistence/tasks.md
+++ b/openspec/changes/archive/2026-08-18-catalog-tab-persistence/tasks.md
@@ -1,0 +1,28 @@
+## 1. Types and constants
+
+- [x] 1.1 Add `CatalogActiveTab` to `StorageKey` in `apps/chat/src/types/storage-key.ts`
+
+## 2. libs/catalog: controlled activeTab prop
+
+- [x] 2.1 Add `activeTab?: string` and `onActiveTabChange?: (tabId: string) => void` to `CatalogProps` in `libs/catalog/src/models/catalog-props.ts`
+- [x] 2.2 In `Catalog.tsx`, derive the effective active tab as `props.activeTab ?? internalActiveTab`, keep the existing internal `useState` as the uncontrolled fallback, and call `onActiveTabChange` (in addition to updating internal state) from the `Tabs` `onTabChange` handler
+- [x] 2.3 Add/extend `libs/catalog` unit tests covering: uncontrolled default-to-first-tab behavior unchanged, controlled `activeTab` overrides internal state, `onActiveTabChange` is called with the clicked tab's id
+
+## 3. apps/chat: useCatalogActiveTabPreference hook
+
+- [x] 3.1 Create `apps/chat/src/hooks/useCatalogActiveTabPreference/useCatalogActiveTabPreference.ts`, built on `useLocalStorage.ts`, implementing the resolution order (persisted value → first available tab) and `setActiveTab`, mirroring `useCatalogSortFilterPreference`'s shape
+- [x] 3.2 Add unit tests at `apps/chat/src/hooks/useCatalogActiveTabPreference/tests/useCatalogActiveTabPreference.spec.ts` covering: no persisted value, persisted value restored, stale persisted tab falls back to first available, `setActiveTab` persists, empty available-tabs list resolves to `undefined`, `localStorage` write failure doesn't throw
+
+## 4. apps/chat: wire tab state into CatalogView
+
+- [x] 4.1 In `CatalogView.tsx`, derive `availableTabIds` from the existing memoized `buildCatalogTabs` output (wrapped in its own `useMemo`)
+- [x] 4.2 Call `useCatalogActiveTabPreference` with `availableTabIds` to obtain `activeTab`/`setActiveTab`
+- [x] 4.3 Forward `activeTab` and an `onActiveTabChange` handler (calling `setActiveTab(tabId)`) to `Catalog` only when `isSelectorMode` is falsy
+- [x] 4.4 Verify `CatalogModal`/selector-mode rendering of `CatalogView` is unaffected (no `activeTab`/`onActiveTabChange` passed through, no `localStorage` reads/writes triggered by its interactions)
+- [x] 4.5 Confirm no changes are needed to `handleEdit`/`createOptions`'s `ReturnUrl` construction — verify via a `CatalogView` test that editing an item from a given tab and simulating the editor's return navigation (remount with the same persisted `localStorage` value) restores that same tab
+
+## 5. Verification
+
+- [x] 5.1 Run `npm exec nx test catalog` and `npm exec nx test chat` (or the affected equivalents) and fix any failures
+- [x] 5.2 Run `npm exec nx lint catalog` and `npm exec nx lint chat`
+- [x] 5.3 Manually verify in the running app (`npm run start:all`): switch to a non-Models tab, refresh — tab is preserved; edit a Prompt/Skill/Toolset from a non-Models tab and save/cancel — returns to origin tab; open `CatalogModal` (deployment selector) — tab selection is session-only as before

--- a/openspec/specs/catalog-tab-persistence/spec.md
+++ b/openspec/specs/catalog-tab-persistence/spec.md
@@ -1,0 +1,136 @@
+# Spec: catalog-tab-persistence
+
+## Purpose
+
+Persisting the catalog's active tab selection and reconciling it into the controlled `Catalog` component.
+
+## Requirements
+
+### Requirement: Catalog accepts a controlled active tab
+
+`CatalogProps` (`libs/catalog/src/models/catalog-props.ts`) SHALL gain two new optional properties:
+
+- `activeTab?: string`
+- `onActiveTabChange?: (tabId: string) => void`
+
+`Catalog` (`libs/catalog/src/components/Catalog/Catalog.tsx`) SHALL use `props.activeTab ?? internalActiveTab` so it remains fully functional when the props are omitted (uncontrolled, current behavior unchanged: defaults to the first tab returned by `buildCatalogTabs`). When `onActiveTabChange` is supplied, `Catalog` SHALL call it on every tab-switch interaction in addition to updating its own internal fallback state.
+
+`Catalog` SHALL NOT read or write `localStorage`, `sessionStorage`, `URLSearchParams`, or any routing API to determine or persist the active tab — it remains host-agnostic per AGENTS.md §Library isolation.
+
+State owner: `Catalog`'s existing internal `activeTab` state remains the fallback owner when uncontrolled; `CatalogView` (via `useCatalogActiveTabPreference`, see below) is the owner when controlled.
+
+Memoisation: no new memoisation is required in `Catalog` beyond the existing `useMemo` for `tabs`.
+
+i18n keys needed: none (no new user-visible strings).
+
+RTL impact: none (tab switching logic only; the existing `Tabs` component already handles its own layout direction).
+
+Accessibility: none — the existing `Tabs` component's `activeTabId`/`onTabChange` props already carry ARIA tab/tabpanel semantics; this requirement only changes which value drives `activeTabId`.
+
+#### Scenario: Uncontrolled Catalog behaves exactly as before
+
+- **WHEN** `Catalog` is rendered without `activeTab` or `onActiveTabChange`
+- **THEN** it defaults to the first tab id returned by `buildCatalogTabs` and tab switching works entirely from internal state, as it does today
+
+#### Scenario: Controlled activeTab overrides internal state
+
+- **WHEN** `Catalog` is rendered with `activeTab="skill"` and a `Skill` tab is present in `buildCatalogTabs`'s output
+- **THEN** the Skill tab is shown as active regardless of any internal default
+
+#### Scenario: Switching tabs calls onActiveTabChange
+
+- **WHEN** the user clicks the "Agents" tab and `onActiveTabChange` is supplied
+- **THEN** `onActiveTabChange` is called with the Agent tab's id
+
+---
+
+### Requirement: useCatalogActiveTabPreference hook persists and reconciles the active tab
+
+A custom hook `useCatalogActiveTabPreference` SHALL be created at `apps/chat/src/hooks/useCatalogActiveTabPreference/useCatalogActiveTabPreference.ts`, built on top of the existing `apps/chat/src/hooks/useLocalStorage.ts` hook — mirroring `useCatalogSortFilterPreference`'s shape.
+
+`apps/chat/src/types/storage-key.ts` SHALL gain a new `StorageKey.CatalogActiveTab` member.
+
+The hook SHALL accept the list of currently available tab ids (`string[]`, derived by the caller from `buildCatalogTabs`), and SHALL:
+
+- Call `useLocalStorage<string | null>(StorageKey.CatalogActiveTab, null)` to obtain the persisted tab id and its setter.
+- Resolve the effective active tab in this order: (1) the persisted `localStorage` value, if it is present in the available tab ids; (2) the first available tab id, or `undefined` if the available tab id list is empty.
+- Expose `activeTab: string | undefined` (the resolved value) and `setActiveTab: (tabId: string) => void`.
+- On every `setActiveTab` call, forward the new value to the underlying `useLocalStorage` setter for `StorageKey.CatalogActiveTab`.
+- Rely on `useLocalStorage`'s own `try`/`catch` handling for `localStorage` read/write failures — the hook does not need its own storage-access error handling.
+
+The hook SHALL NOT call `useTranslation`, `navigate`, `useSearchParams`, or make network requests — no query-param or routing concern is involved; persistence is `localStorage`-only, identical in mechanism to `useCatalogSortFilterPreference`.
+
+i18n keys needed: none.
+
+RTL impact: none.
+
+#### Scenario: No persisted value on first visit
+
+- **WHEN** the hook is called with `availableTabIds: ['model', 'agent', 'prompt']` and `localStorage` has no `dial:catalog:activeTab` entry
+- **THEN** `activeTab` is `'model'` (the first available tab id)
+
+#### Scenario: Persisted tab is restored
+
+- **WHEN** the hook is called with `availableTabIds: ['model', 'agent', 'prompt']` and `localStorage.getItem('dial:catalog:activeTab')` returns `JSON.stringify('agent')`
+- **THEN** `activeTab` is `'agent'`
+
+#### Scenario: Stale persisted tab id falls back to first available tab
+
+- **WHEN** the hook is called with `availableTabIds: ['model', 'agent']` and `localStorage.getItem('dial:catalog:activeTab')` returns `JSON.stringify('skill')` (a tab not present in `availableTabIds`)
+- **THEN** `activeTab` is `'model'`
+
+#### Scenario: setActiveTab persists the new value
+
+- **WHEN** `setActiveTab('prompt')` is called
+- **THEN** `localStorage.getItem(StorageKey.CatalogActiveTab)` returns `JSON.stringify('prompt')` and the hook's `activeTab` updates to `'prompt'`
+
+#### Scenario: Empty available tab list resolves to undefined
+
+- **WHEN** the hook is called with `availableTabIds: []`
+- **THEN** `activeTab` is `undefined`
+
+#### Scenario: localStorage write failure does not throw
+
+- **WHEN** `setActiveTab` is called and the underlying `useLocalStorage` setter's `localStorage.setItem` call throws (e.g. quota exceeded)
+- **THEN** the hook's `activeTab` state still updates in memory and no error propagates out of the hook
+
+---
+
+### Requirement: CatalogView wires the persisted tab into Catalog
+
+`CatalogView` (`apps/chat/src/components/CatalogView/CatalogView.tsx`) SHALL use `useCatalogActiveTabPreference` (passing the current `buildCatalogTabs` output's ids) to obtain `activeTab` and `setActiveTab`.
+
+- `CatalogView` SHALL only forward `activeTab` and an `onActiveTabChange` callback to `Catalog` when it is not rendered in selector mode (`isSelectorMode` is falsy); in selector mode both SHALL be `undefined` so `Catalog` falls back to its own internal, session-only tab state. `CatalogView` SHALL still call `useCatalogActiveTabPreference` unconditionally (the hook read is harmless), but its value is only wired to `Catalog` outside selector mode.
+- Outside selector mode, `CatalogView` SHALL pass `activeTab={activeTab}` to `Catalog`, and its `onActiveTabChange` handler SHALL call `setActiveTab(tabId)` — no URL/query-param update is involved.
+- `CatalogModal` (`apps/chat/src/components/DeploymentSelector/CatalogModal.tsx`) renders `CatalogView` with `isSelectorMode`; because of the selector-mode gating above, `CatalogModal` SHALL NOT be changed and its tab selection remains uncontrolled and session-only (resets whenever the modal is closed and reopened).
+
+Memoisation: the `availableTabIds` array passed into `useCatalogActiveTabPreference` SHALL be derived via the existing `buildCatalogTabs` memoized tab list (`.map(t => t.id)`, wrapped in its own `useMemo` keyed on the existing `tabs` memo).
+
+Feature flag: none required.
+
+Accessibility: no change — the tab list already carries its existing ARIA semantics; this requirement only changes which value drives `activeTabId`.
+
+#### Scenario: Refresh restores the last-used tab
+
+- **WHEN** `CatalogView` mounts and `useCatalogActiveTabPreference` resolves `activeTab: 'prompt'` from `localStorage`
+- **THEN** the rendered `Catalog` shows the Prompts tab as active, with no additional user interaction
+
+#### Scenario: First-ever visit defaults to Models
+
+- **WHEN** `CatalogView` mounts with no persisted `localStorage` value
+- **THEN** the rendered `Catalog` shows the Models tab as active (the first entry in `buildCatalogTabs`'s output)
+
+#### Scenario: Switching tabs persists the new value
+
+- **WHEN** the user clicks the "Agents" tab
+- **THEN** `localStorage` is updated via `setActiveTab` to the Agent tab's id
+
+#### Scenario: Editing an item and returning restores the origin tab
+
+- **WHEN** the user is on the Prompts tab (so `localStorage`'s persisted value is `'prompt'`), clicks Edit on a prompt, and the editor navigates back to the bare `ROUTES.Catalog` on save/cancel
+- **THEN** `CatalogView` remounts, `useCatalogActiveTabPreference` resolves `activeTab: 'prompt'` from the unchanged `localStorage` value, and the rendered `Catalog` shows the Prompts tab as active
+
+#### Scenario: CatalogModal is unaffected
+
+- **WHEN** `CatalogModal` is rendered
+- **THEN** it does not read from or write to `localStorage` for tab selection, and its tab selection resets when the modal is closed and reopened


### PR DESCRIPTION
## Description of changes

<!-- Please explain the changes you made right below this line. -->

## Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #<ISSUE_ID>

## UI changes

<Please, provide Screenshots or Figma links>

## Checklist

- [ ] the pull request name ends with `(Issue #<ISSUE_ID>)` (comma-separated list of issues)
- [ ] I confirm that I don't share any confidential information like API keys or any other secrets and private URLs

<details>
  <summary>PR title cheatsheet</summary>

`<type>[optional scope]: <description>`

1. type (required)
    - `feat` - A new feature
    - `fix` - A bug fix
    - `docs` - Documentation only changes
    - `test` - Adding missing tests or correcting existing tests
    - `ci` - Changes to our CI configuration files and scripts
    - `chore` - Other changes that are minor and/or not user-facing
2. scope (optional, current repo suggestions below)
    - `chat`
    - `overlay`
    - `shared`
    - `sandbox-overlay`
    - `visualizer-connector`

</details>
