### PR TITLE
fix(chat): route skill deletion to the skills endpoint

### DIFF
--- a/apps/chat/src/components/CatalogView/CatalogView.tsx
+++ b/apps/chat/src/components/CatalogView/CatalogView.tsx
@@ -77,6 +77,7 @@ import {
   revokeSharedAccess,
 } from '../../server-api/share.api';
 import {
+  deleteSkill,
   downloadSkill,
   downloadSkillFile,
   listSkillFiles,
@@ -1207,6 +1208,13 @@ const CatalogView: FC<Props> = ({
         } else if (item.type === CatalogEntityType.Toolset) {
           await deleteToolset(item.id);
           await refetchToolsets();
+        } else if (item.type === CatalogEntityType.Skill) {
+          const parsed = parseSkillResourceUrl(item.id);
+          if (parsed == null) {
+            throw new Error(`Invalid skill resource url: ${item.id}`);
+          }
+          await deleteSkill(parsed.bucket, parsed.path);
+          await refetchSkills();
         } else {
           await deleteApplication(item.id);
           await refetchDeployments();
@@ -1234,6 +1242,7 @@ const CatalogView: FC<Props> = ({
       refetchToolsets,
       refetchDeployments,
       refetchPrompts,
+      refetchSkills,
       notifyOperationSuccess,
       showErrorNotification,
       t,

--- a/apps/chat/src/components/CatalogView/tests/CatalogView.spec.tsx
+++ b/apps/chat/src/components/CatalogView/tests/CatalogView.spec.tsx
@@ -61,6 +61,7 @@ import {
   revokeSharedAccess,
 } from '../../../server-api/share.api';
 import {
+  deleteSkill,
   downloadSkill,
   downloadSkillFile,
   listSkillFiles,
@@ -573,6 +574,7 @@ vi.mock('../../../server-api/skills.api', () => ({
   downloadSkill: vi.fn(),
   downloadSkillFile: vi.fn(),
   listSkillFiles: vi.fn(),
+  deleteSkill: vi.fn(),
 }));
 
 /* Only the download trigger is stubbed; the mappers still need the real helpers. */
@@ -4116,6 +4118,61 @@ describe('CatalogView', () => {
 
       /* Create options render as buttons labelled with the option's own label. */
       expect(screen.queryByRole('button', { name: 'Skill' })).toBeNull();
+    });
+
+    it('deletes a skill via the skills endpoint, refetches skills, and shows a success notification', async () => {
+      enableSkills();
+      const refetchSkills = vi.fn().mockResolvedValue(undefined);
+      const showNotification = vi.fn();
+      vi.mocked(useNotification).mockReturnValue(
+        createNotificationContextValue(showNotification),
+      );
+      mockSkills({ skills: [personalSkill], publicSkills: [], refetchSkills });
+      vi.mocked(deleteSkill).mockResolvedValue({ success: true });
+
+      render(<CatalogView />);
+
+      await user.click(
+        screen.getByRole('button', { name: `delete ${personalSkill.url}` }),
+      );
+
+      expect(deleteSkill).toHaveBeenCalledWith(
+        'my-bucket',
+        'analysis/revenue-skill',
+      );
+      expect(deleteApplication).not.toHaveBeenCalled();
+      expect(refetchSkills).toHaveBeenCalledOnce();
+      expect(showNotification).toHaveBeenCalledWith(
+        expect.objectContaining({ variant: 'success' }),
+      );
+    });
+
+    it('shows an error notification and does not call deleteSkill or deleteApplication for a malformed skill resource id', async () => {
+      enableSkills();
+      const refetchSkills = vi.fn().mockResolvedValue(undefined);
+      const showNotification = vi.fn();
+      vi.mocked(useNotification).mockReturnValue(
+        createNotificationContextValue(showNotification),
+      );
+      const malformedSkill = { ...personalSkill, url: 'skills/onlybucket' };
+      mockSkills({
+        skills: [malformedSkill],
+        publicSkills: [],
+        refetchSkills,
+      });
+
+      render(<CatalogView />);
+
+      await user.click(
+        screen.getByRole('button', { name: `delete ${malformedSkill.url}` }),
+      );
+
+      expect(deleteSkill).not.toHaveBeenCalled();
+      expect(deleteApplication).not.toHaveBeenCalled();
+      expect(refetchSkills).not.toHaveBeenCalled();
+      expect(showNotification).toHaveBeenCalledWith(
+        expect.objectContaining({ variant: 'error' }),
+      );
     });
 
     it('removes a shared skill via Remove from My List, refetches skills, and shows a success notification', async () => {

--- a/openspec/changes/archive/2026-08-18-fix-skill-delete-endpoint/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-18-fix-skill-delete-endpoint/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-18

--- a/openspec/changes/archive/2026-08-18-fix-skill-delete-endpoint/design.md
+++ b/openspec/changes/archive/2026-08-18-fix-skill-delete-endpoint/design.md
@@ -1,0 +1,96 @@
+## Context
+
+`CatalogView.tsx`'s `handleDelete` (the implementation behind the details
+panel's `onDelete` callback, see `catalog-details-confirmation-subview`)
+branches on `item.type`:
+
+```ts
+if (item.type === CatalogEntityType.Prompt) { ... }
+else if (item.type === CatalogEntityType.Toolset) { ... }
+else { await deleteApplication(item.id); await refetchDeployments(); }
+```
+
+There is no `CatalogEntityType.Skill` branch, so skill items fall into the
+`else` and call `deleteApplication(item.id)` — chat-api's
+`DELETE /api/v1/applications/:id`, which proxies DIAL Core's custom-
+application delete. DIAL Core 404s because a skill is not a custom
+application.
+
+A correct path already exists end-to-end and is exercised elsewhere (the
+Skill Editor's own delete action):
+- `apps/chat/src/server-api/skills.api.ts:deleteSkill(bucket, path, ifMatch?)`
+  → `skillsApi.deleteSkill` (generated client)
+  → chat-api `DELETE /api/v1/skills` (`apps/chat-api/src/skills/skills.controller.ts`)
+  → `SkillsMutationService.deleteSkill` → DIAL SDK
+    `dialClient.client.deleteSkillFolder(bucket, encodeDialResourcePath(path))`
+  → DIAL Core `/v2/skills/{bucket}/{path}`.
+
+`CatalogItem.id` for a skill is the full `skills/{bucket}/{path}` resource
+URL (set in `map-skill-to-catalog-item.ts`), and `CatalogView.tsx` already
+has a util for turning that back into `{ bucket, path }` —
+`parseSkillResourceUrl` (`apps/chat/src/types/skill.ts`) — used at
+`CatalogView.tsx:454` for the item-details fetch and imported again at
+`CatalogView.tsx:90`. The sibling `catalog-unshare` capability's `onUnshare`
+implementation already refetches skills via the existing `refetchSkills()`
+from `useSkills()` for a `Skill` item, mirroring the pattern this fix needs
+for `onDelete`.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Route `handleDelete` for `item.type === CatalogEntityType.Skill` to
+  `deleteSkill(bucket, path)` instead of `deleteApplication(item.id)`.
+- Refresh the right list after a successful skill delete (`refetchSkills()`,
+  not `refetchDeployments()`), matching the existing `onUnshare` pattern.
+- Keep existing behavior for Prompt, Toolset, and all non-Skill/Toolset/Prompt
+  types (applications/deployments) unchanged.
+
+**Non-Goals:**
+- No changes to chat-api, `libs/chat-api-client`, or DIAL Core — the skills
+  delete endpoint already exists, is tested, and is documented in Swagger.
+- No changes to the confirmation UI, `DetailsPanel`, or `Header` — this is
+  purely what `onDelete` does once confirmed.
+- No change to `If-Match`/etag handling — Catalog delete (unlike the Skill
+  Editor's update flow) does not currently pass an `ifMatch`, and this change
+  does not introduce one; `deleteSkill`'s `ifMatch` parameter stays optional
+  and unset here, matching how `deleteApplication` is called today (no
+  precondition check).
+
+## Decisions
+
+- **Reuse `parseSkillResourceUrl` rather than introduce new parsing logic.**
+  It's already imported into this file and used for the identical
+  `item.id` → `{ bucket, path }` conversion at the item-details fetch site.
+  Alternative considered: adding a bucket/path pair directly onto
+  `CatalogItem` at mapping time — rejected because `CatalogItem` is a shared
+  `libs/catalog` (via `@epam/ai-dial-catalog`) type used across entity types,
+  and bucket/path splitting is Skill-specific parsing that belongs at the
+  app edge, not in the shared item shape.
+- **Mirror the `onUnshare` branch structure exactly** (`if
+  (item.type === CatalogEntityType.Skill) { ...; await refetchSkills(); }`)
+  rather than restructuring the whole `handleDelete` if/else chain. Keeps the
+  diff minimal and consistent with the already-reviewed unshare pattern in
+  the same file.
+- **No `ifMatch` on this delete call.** The existing generic
+  `deleteApplication(item.id)` call has no precondition/concurrency check
+  today, so parity is maintained; adding one would be a behavior change
+  outside this bug fix's scope.
+
+## Risks / Trade-offs
+
+- [Risk] `parseSkillResourceUrl` returns `null` for a malformed `item.id` (as
+  the item-details fetch site already accounts for) → Mitigation: guard the
+  same way the existing usage does — treat a `null` parse as the delete
+  failing, going through the existing `catch` block's error notification
+  path (this is already how `deleteApplication` failures surface).
+- [Risk] Regressing the Prompt/Toolset/application delete branches while
+  editing this function → Mitigation: the change is additive (one new
+  `else if` branch inserted before the final `else`), and existing Vitest
+  coverage for `CatalogView`'s delete flow (if present) plus manual
+  verification of Prompt/Toolset/application delete in the running app
+  during the slice.
+
+## Migration Plan
+
+Single frontend-only commit; no data migration, no backend deploy
+coordination, no feature flag. Rollback is a plain revert.

--- a/openspec/changes/archive/2026-08-18-fix-skill-delete-endpoint/proposal.md
+++ b/openspec/changes/archive/2026-08-18-fix-skill-delete-endpoint/proposal.md
@@ -1,0 +1,56 @@
+## Why
+
+Deleting a skill from Catalog → Skills fails with HTTP 404. `CatalogView.tsx`'s
+`handleDelete` has no branch for `CatalogEntityType.Skill`, so skill items fall
+through to the generic `else` branch and call `deleteApplication(item.id)` —
+routing the request through chat-api's `DELETE /api/v1/applications/:id`,
+which calls DIAL Core's custom-application delete endpoint. A skill isn't
+stored as a custom application, so DIAL Core rejects it with 404. This blocks
+all skill deletion in the Catalog.
+
+A correct, already-implemented path exists and is unused here: chat-api's
+dedicated skills module (`DELETE /api/v1/skills`) and the frontend's
+`deleteSkill(bucket, path)` wrapper in `apps/chat/src/server-api/skills.api.ts`
+proxy DIAL Core's `/v2/skills/{bucket}/{path}` correctly, and are already used
+by the Skill Editor's own delete flow.
+
+## What Changes
+
+- Add a `CatalogEntityType.Skill` branch to `CatalogView.tsx`'s `handleDelete`
+  that parses `item.id` (the `skills/{bucket}/{path}` resource URL) with the
+  existing `parseSkillResourceUrl` util and calls `deleteSkill(bucket, path)`
+  instead of `deleteApplication(item.id)`.
+- After a successful skill delete, refresh the Skills list via the existing
+  `refetchSkills()` (already used by this component's discard/unshare flow)
+  instead of `refetchDeployments()`.
+- No backend, `chat-api-client`, or DIAL Core changes are needed — the
+  `/v2/skills/{bucket}/{path}` proxy path already exists and is exercised
+  elsewhere in the app.
+
+## Capabilities
+
+### New Capabilities
+
+- `catalog-delete-routing`: how `CatalogView`'s owner-side Delete action
+  (`onDelete`) dispatches to the correct backend delete call per catalog
+  item type — Prompt, Toolset, Skill, or generic application/deployment —
+  and which refetch runs afterward. No such spec exists today (the sibling
+  `catalog-unshare` capability documents this routing for the "Remove from
+  My List" action, but the owner-side Delete routing was never specified,
+  which is how the missing Skill branch went unnoticed).
+
+### Modified Capabilities
+
+(none)
+
+## Impact
+
+- Affected code: `apps/chat/src/components/CatalogView/CatalogView.tsx`
+  (`handleDelete`) only.
+- No API contract changes — the fix uses server-api/backend surface that
+  already exists (`apps/chat/src/server-api/skills.api.ts:deleteSkill`,
+  `apps/chat-api/src/skills/skills.controller.ts` `DELETE /api/v1/skills`).
+- No new dependencies, no DB/schema/config changes.
+- Risk is low and localized to one delete branch in one component; existing
+  skill delete flow from the Skill Editor is unaffected (it already uses the
+  correct endpoint).

--- a/openspec/changes/archive/2026-08-18-fix-skill-delete-endpoint/specs/catalog-delete-routing/spec.md
+++ b/openspec/changes/archive/2026-08-18-fix-skill-delete-endpoint/specs/catalog-delete-routing/spec.md
@@ -1,0 +1,60 @@
+## ADDED Requirements
+
+### Requirement: CatalogView routes owner-side delete by item type
+
+`CatalogView` (`apps/chat/src/components/CatalogView/CatalogView.tsx`) SHALL
+implement the details panel's `onDelete` callback (see
+`catalog-details-confirmation-subview` for the confirmation mechanics that
+precede this call) by dispatching on `item.type`:
+
+- `CatalogEntityType.Prompt`: call `deletePrompt(item.id)`, then
+  `refetchPrompts()`.
+- `CatalogEntityType.Toolset`: call `deleteToolset(item.id)`, then
+  `refetchToolsets()`.
+- `CatalogEntityType.Skill`: parse `item.id` (the `skills/{bucket}/{path}`
+  resource URL) with `parseSkillResourceUrl` and call
+  `deleteSkill(bucket, path)` (`apps/chat/src/server-api/skills.api.ts`),
+  then `refetchSkills()` from `useSkills()`. `deleteSkill` is called with no
+  `ifMatch` (no precondition/concurrency check), matching this action's
+  existing behavior for every other entity type.
+- Any other type (application/deployment): call `deleteApplication(item.id)`,
+  then `refetchDeployments()` — unchanged from current behavior.
+
+A `Skill` item SHALL NOT be routed to `deleteApplication`. This mirrors the
+routing `catalog-unshare` already documents for `onUnshare` (Toolset →
+`refetchToolsets`, Skill → `refetchSkills`, otherwise →
+`refetchDeployments`), keeping the two owner-facing mutation paths
+(Delete, Unshare) structurally consistent.
+
+On success, a success notification is shown via
+`notifyOperationSuccess`/`EntityOperation.Deleted` (see
+`entity-operation-notifications`), unchanged for all types. On rejection —
+including a `null` parse from `parseSkillResourceUrl` for a malformed
+skill `item.id` — the existing error-notification path in `handleDelete`'s
+`catch` block runs (trace id surfaced), and the error is re-thrown so the
+confirmation sub-view stays open per `catalog-details-confirmation-subview`.
+
+#### Scenario: Deleting a skill calls the skills endpoint
+
+- **GIVEN** a catalog item with `type: CatalogEntityType.Skill` and
+  `id: 'skills/{bucket}/{path}'`
+- **WHEN** the delete confirmation is confirmed for that item
+- **THEN** `deleteSkill` is called once with the parsed `bucket` and `path`,
+  `deleteApplication` is not called, `refetchSkills` is called, and
+  `refetchDeployments` is not called
+
+#### Scenario: Deleting a non-skill item is unaffected
+
+- **GIVEN** a catalog item with `type` other than `Prompt`, `Toolset`, or
+  `Skill`
+- **WHEN** the delete confirmation is confirmed for that item
+- **THEN** `deleteApplication` is called once with the item id and
+  `refetchDeployments` is called, exactly as before this change
+
+#### Scenario: A malformed skill resource id fails without calling deleteApplication
+
+- **GIVEN** a catalog item with `type: CatalogEntityType.Skill` and an
+  `id` that `parseSkillResourceUrl` cannot parse
+- **WHEN** the delete confirmation is confirmed for that item
+- **THEN** `deleteSkill` and `deleteApplication` are both not called, an
+  error notification is shown, and the confirmation sub-view remains open

--- a/openspec/changes/archive/2026-08-18-fix-skill-delete-endpoint/tasks.md
+++ b/openspec/changes/archive/2026-08-18-fix-skill-delete-endpoint/tasks.md
@@ -1,0 +1,43 @@
+## 1. Fix `CatalogView.handleDelete` skill routing
+
+- [x] 1.1 In `apps/chat/src/components/CatalogView/CatalogView.tsx`, add an
+      `else if (item.type === CatalogEntityType.Skill)` branch to
+      `handleDelete` (before the final generic `else`) that parses `item.id`
+      via `parseSkillResourceUrl`, calls `deleteSkill(bucket, path)` from
+      `apps/chat/src/server-api/skills.api.ts`, and calls `refetchSkills()`.
+- [x] 1.2 Import `deleteSkill` from `../../server-api/skills.api` (extend
+      the existing `downloadSkillFile, listSkillFiles` import) in
+      `CatalogView.tsx`.
+- [x] 1.3 Guard the `parseSkillResourceUrl` failure case (`null` return) so
+      it falls into the existing error path (thrown/caught by
+      `handleDelete`'s surrounding `try`/`catch`) rather than calling
+      `deleteSkill` with `undefined` bucket/path.
+- [x] 1.4 Add `refetchSkills` to `handleDelete`'s `useCallback` dependency
+      array alongside the existing `refetchToolsets`, `refetchDeployments`,
+      `refetchPrompts`.
+
+## 2. Tests
+
+- [x] 2.1 In `apps/chat/src/components/CatalogView/tests/CatalogView.spec.tsx`,
+      add a test asserting that deleting a `CatalogEntityType.Skill` item
+      calls `deleteSkill` with the bucket/path parsed from `item.id`, does
+      not call `deleteApplication`, and calls `refetchSkills` (not
+      `refetchDeployments`) — mirroring the existing `deleteApplication`
+      assertions around line 2167 and the `onUnshare`/skill test pattern
+      already in this file.
+- [x] 2.2 Add a test asserting a malformed skill `item.id` results in an
+      error notification, no call to `deleteSkill` or `deleteApplication`,
+      and the confirmation sub-view remaining open (re-thrown rejection).
+- [x] 2.3 Confirm existing Prompt/Toolset/application delete tests in the
+      same file still pass unchanged (no regressions from the added
+      branch).
+
+## 3. Verification
+
+- [x] 3.1 Run `npm exec nx test chat` (or the narrower CatalogView spec) and
+      confirm all tests pass.
+- [x] 3.2 Run `npm exec nx lint chat` and fix any lint issues introduced.
+- [x] 3.3 Manually verify in the running app (`npm run start:all`): open
+      Catalog → Skills, delete a skill, confirm it succeeds (no 404) and
+      disappears from the list; also spot-check that deleting a Prompt,
+      Toolset, and a custom application/deployment still work.

--- a/openspec/specs/catalog-delete-routing/spec.md
+++ b/openspec/specs/catalog-delete-routing/spec.md
@@ -1,0 +1,64 @@
+# catalog-delete-routing Specification
+
+## Purpose
+Defines how `CatalogView` (`apps/chat/src/components/CatalogView/CatalogView.tsx`) routes the details panel's owner-side delete action to the correct backend mutation and refetch based on the catalog item's type, so that deleting a skill hits the skills API rather than being misrouted to the applications/deployments delete path.
+
+## Requirements
+### Requirement: CatalogView routes owner-side delete by item type
+
+`CatalogView` (`apps/chat/src/components/CatalogView/CatalogView.tsx`) SHALL
+implement the details panel's `onDelete` callback (see
+`catalog-details-confirmation-subview` for the confirmation mechanics that
+precede this call) by dispatching on `item.type`:
+
+- `CatalogEntityType.Prompt`: call `deletePrompt(item.id)`, then
+  `refetchPrompts()`.
+- `CatalogEntityType.Toolset`: call `deleteToolset(item.id)`, then
+  `refetchToolsets()`.
+- `CatalogEntityType.Skill`: parse `item.id` (the `skills/{bucket}/{path}`
+  resource URL) with `parseSkillResourceUrl` and call
+  `deleteSkill(bucket, path)` (`apps/chat/src/server-api/skills.api.ts`),
+  then `refetchSkills()` from `useSkills()`. `deleteSkill` is called with no
+  `ifMatch` (no precondition/concurrency check), matching this action's
+  existing behavior for every other entity type.
+- Any other type (application/deployment): call `deleteApplication(item.id)`,
+  then `refetchDeployments()` — unchanged from current behavior.
+
+A `Skill` item SHALL NOT be routed to `deleteApplication`. This mirrors the
+routing `catalog-unshare` already documents for `onUnshare` (Toolset →
+`refetchToolsets`, Skill → `refetchSkills`, otherwise →
+`refetchDeployments`), keeping the two owner-facing mutation paths
+(Delete, Unshare) structurally consistent.
+
+On success, a success notification is shown via
+`notifyOperationSuccess`/`EntityOperation.Deleted` (see
+`entity-operation-notifications`), unchanged for all types. On rejection —
+including a `null` parse from `parseSkillResourceUrl` for a malformed
+skill `item.id` — the existing error-notification path in `handleDelete`'s
+`catch` block runs (trace id surfaced), and the error is re-thrown so the
+confirmation sub-view stays open per `catalog-details-confirmation-subview`.
+
+#### Scenario: Deleting a skill calls the skills endpoint
+
+- **GIVEN** a catalog item with `type: CatalogEntityType.Skill` and
+  `id: 'skills/{bucket}/{path}'`
+- **WHEN** the delete confirmation is confirmed for that item
+- **THEN** `deleteSkill` is called once with the parsed `bucket` and `path`,
+  `deleteApplication` is not called, `refetchSkills` is called, and
+  `refetchDeployments` is not called
+
+#### Scenario: Deleting a non-skill item is unaffected
+
+- **GIVEN** a catalog item with `type` other than `Prompt`, `Toolset`, or
+  `Skill`
+- **WHEN** the delete confirmation is confirmed for that item
+- **THEN** `deleteApplication` is called once with the item id and
+  `refetchDeployments` is called, exactly as before this change
+
+#### Scenario: A malformed skill resource id fails without calling deleteApplication
+
+- **GIVEN** a catalog item with `type: CatalogEntityType.Skill` and an
+  `id` that `parseSkillResourceUrl` cannot parse
+- **WHEN** the delete confirmation is confirmed for that item
+- **THEN** `deleteSkill` and `deleteApplication` are both not called, an
+  error notification is shown, and the confirmation sub-view remains open


### PR DESCRIPTION
**Description:**

Deleting a skill from Catalog → Skills failed with HTTP 404. `CatalogView`'s delete handler had no branch for `Skill` items, so they fell through to the generic applications-delete path (`deleteApplication` → `/api/v1/applications`), which DIAL Core rejects since a skill isn't a custom application. This routes skill deletes through the existing, already-correct skills endpoint (`deleteSkill` → `/api/v1/skills` → DIAL Core `/v2/skills/{bucket}/{path}`) instead — no backend or generated-client changes needed, that path already existed and is used by the Skill Editor.

**UI changes**

No UI changes — same delete confirmation flow, now wired to the correct endpoint for skills.

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(chat):`
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (no ticket available)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs