### PR TITLE
fix(chat-api): handle azure-ad-issuer-mismatch-with-v1-v2-fallback

### DIFF
--- a/apps/chat-api/src/auth/providers/provider-registry.service.spec.ts
+++ b/apps/chat-api/src/auth/providers/provider-registry.service.spec.ts
@@ -264,6 +264,54 @@ describe('ProviderRegistryService', () => {
     });
   });
 
+  describe('findByIssuer', () => {
+    const AZURE_AD_ENV = {
+      AUTH_AZURE_AD_CLIENT_ID: 'azure-client',
+      AUTH_AZURE_AD_SECRET: 'azure-secret',
+      AUTH_AZURE_AD_TENANT_ID: 'tenant-123',
+    };
+
+    it('matches a non-Azure-AD provider by exact issuer', async () => {
+      const module = await buildModule(KEYCLOAK_ENV);
+      await module.init();
+      const svc = module.get(ProviderRegistryService);
+      const { config } = svc.getProvider('keycloak');
+      // eslint-disable-next-line testing-library/await-async-queries -- ProviderRegistryService.findByIssuer is synchronous, not an async testing-library query
+      const entry = svc.findByIssuer(config.issuer);
+      expect(entry?.config.id).toBe('keycloak');
+    });
+
+    it('resolves an Azure AD v1 issuer to the registered v2 provider for the same tenant', async () => {
+      const module = await buildModule(AZURE_AD_ENV);
+      await module.init();
+      const svc = module.get(ProviderRegistryService);
+      // eslint-disable-next-line testing-library/await-async-queries -- ProviderRegistryService.findByIssuer is synchronous, not an async testing-library query
+      const entry = svc.findByIssuer('https://sts.windows.net/tenant-123/');
+      expect(entry?.config.id).toBe('azure-ad');
+      expect(entry?.config.issuer).toBe(
+        'https://login.microsoftonline.com/tenant-123/v2.0',
+      );
+    });
+
+    it('does not match a v1 issuer for a different tenant than the registered v2 provider', async () => {
+      const module = await buildModule(AZURE_AD_ENV);
+      await module.init();
+      const svc = module.get(ProviderRegistryService);
+      // eslint-disable-next-line testing-library/await-async-queries -- ProviderRegistryService.findByIssuer is synchronous, not an async testing-library query
+      const entry = svc.findByIssuer('https://sts.windows.net/other-tenant/');
+      expect(entry).toBeUndefined();
+    });
+
+    it('returns undefined for a v1 issuer when no Azure AD provider is registered', async () => {
+      const module = await buildModule(KEYCLOAK_ENV);
+      await module.init();
+      const svc = module.get(ProviderRegistryService);
+      // eslint-disable-next-line testing-library/await-async-queries -- ProviderRegistryService.findByIssuer is synchronous, not an async testing-library query
+      const entry = svc.findByIssuer('https://sts.windows.net/tenant-123/');
+      expect(entry).toBeUndefined();
+    });
+  });
+
   describe('header-token auth config validation', () => {
     it('boots successfully when the feature is disabled (default) and no allowlist is set', async () => {
       const module = await buildModule({});

--- a/apps/chat-api/src/auth/providers/provider-registry.service.ts
+++ b/apps/chat-api/src/auth/providers/provider-registry.service.ts
@@ -9,7 +9,9 @@ import { validateSync } from 'class-validator';
 import { Issuer, type Client } from 'openid-client';
 import type { EnvironmentVariables } from '../../config/environment.config';
 import { buildProviderConfigs } from './provider-builders';
-import { ProviderConfig } from './provider.types';
+import { AuthProviderId, ProviderConfig } from './provider.types';
+
+const AZURE_AD_V1_ISSUER_PATTERN = /^https:\/\/sts\.windows\.net\/([^/]+)\/?$/;
 
 const PROVIDER_ENV_KEYS = [
   'AUTH_POST_LOGOUT_REDIRECT_URI',
@@ -151,12 +153,36 @@ export class ProviderRegistryService implements OnModuleInit {
    * Finds the registered provider whose OIDC issuer matches `issuer` exactly.
    * Used by header bearer-token verification to resolve the provider whose
    * JWKS should validate a token's signature (see `HeaderTokenStrategy`).
+   *
+   * Azure AD emits both a v1 issuer (`https://sts.windows.net/{tenant}/`)
+   * and a v2 issuer (`https://login.microsoftonline.com/{tenant}/v2.0`) for
+   * the same tenant depending on token version. Since only one Azure AD
+   * provider can be registered per deployment (`buildProviderConfigs` builds
+   * at most one `AuthProviderId.AzureAd` entry), an exact-match miss on a v1
+   * issuer falls back to deriving the v2 issuer for the same tenant and
+   * matching it against the registered Azure AD provider.
    */
   findByIssuer(
     issuer: string,
   ): { client: Client; config: ProviderConfig } | undefined {
-    return Array.from(this.clients.values()).find(
+    const exact = Array.from(this.clients.values()).find(
       (entry) => entry.config.issuer === issuer,
+    );
+    if (exact) {
+      return exact;
+    }
+
+    const stsMatch = AZURE_AD_V1_ISSUER_PATTERN.exec(issuer);
+    if (!stsMatch) {
+      return undefined;
+    }
+
+    const tenantId = stsMatch[1];
+    const azureAdV2Issuer = `https://login.microsoftonline.com/${tenantId}/v2.0`;
+    return Array.from(this.clients.values()).find(
+      (entry) =>
+        entry.config.id === AuthProviderId.AzureAd &&
+        entry.config.issuer === azureAdV2Issuer,
     );
   }
 

--- a/apps/chat-api/src/auth/session/auth-error-code.enum.ts
+++ b/apps/chat-api/src/auth/session/auth-error-code.enum.ts
@@ -2,6 +2,7 @@ export enum AuthErrorCode {
   HeaderTokenExpired = 'AUTH_HEADER_TOKEN_EXPIRED',
   HeaderTokenInvalid = 'AUTH_HEADER_TOKEN_INVALID',
   HeaderTokenUntrustedIssuer = 'AUTH_HEADER_TOKEN_UNTRUSTED_ISSUER',
+  HeaderProviderNotFound = 'AUTH_HEADER_PROVIDER_NOT_FOUND',
   HeaderMalformed = 'AUTH_HEADER_MALFORMED',
   NoCredentials = 'AUTH_NO_CREDENTIALS',
 }

--- a/apps/chat-api/src/auth/strategies/header-token.strategy.ts
+++ b/apps/chat-api/src/auth/strategies/header-token.strategy.ts
@@ -80,15 +80,24 @@ export class HeaderTokenStrategy implements AuthStrategy {
     const token = parseBearerToken(req);
     const claims = this.decodeUnverifiedClaims(token);
 
-    const entry = this.registry.findByIssuer(claims.iss);
     const allowedIssuers =
       this.config.get('AUTH_HEADER_TOKEN_ALLOWED_ISSUERS', { infer: true }) ??
       [];
-    if (!entry || !allowedIssuers.includes(claims.iss)) {
+    if (!allowedIssuers.includes(claims.iss)) {
       throw new UnauthorizedException({
         code: AuthErrorCode.HeaderTokenUntrustedIssuer,
         error: 'Unauthorized',
         message: 'Token issuer is not a trusted, allowlisted provider',
+        statusCode: 401,
+      });
+    }
+
+    const entry = this.registry.findByIssuer(claims.iss);
+    if (!entry) {
+      throw new UnauthorizedException({
+        code: AuthErrorCode.HeaderProviderNotFound,
+        error: 'Unauthorized',
+        message: 'No registered provider matches the token issuer',
         statusCode: 401,
       });
     }

--- a/apps/chat-api/src/auth/strategies/tests/header-token.strategy.spec.ts
+++ b/apps/chat-api/src/auth/strategies/tests/header-token.strategy.spec.ts
@@ -214,7 +214,7 @@ describe('HeaderTokenStrategy', () => {
       });
     });
 
-    it('rejects a token from an issuer with no registered provider', async () => {
+    it('rejects an allowlisted issuer with no matching registered provider using AUTH_HEADER_PROVIDER_NOT_FOUND', async () => {
       registry.findByIssuer.mockReturnValue(undefined);
       const token = await makeToken(privateKey, kid);
       const req = makeReq({ authorization: `Bearer ${token}` });
@@ -223,9 +223,25 @@ describe('HeaderTokenStrategy', () => {
         strategy.authenticate(req, {} as never),
       ).rejects.toMatchObject({
         response: expect.objectContaining({
-          code: AuthErrorCode.HeaderTokenUntrustedIssuer,
+          code: AuthErrorCode.HeaderProviderNotFound,
         }),
       });
+    });
+
+    it('authenticates an Azure AD v1 issuer resolved to the registered v2 provider', async () => {
+      const azureIssuer = 'https://sts.windows.net/tenant-123/';
+      configValues.AUTH_HEADER_TOKEN_ALLOWED_ISSUERS = [azureIssuer];
+      registry.findByIssuer.mockReturnValue({
+        client: { issuer: { metadata: { jwks_uri: JWKS_URI } } },
+        config: { id: 'azure-ad' },
+      });
+      const token = await makeToken(privateKey, kid, { iss: azureIssuer });
+      const req = makeReq({ authorization: `Bearer ${token}` });
+
+      const user = await strategy.authenticate(req, {} as never);
+
+      expect(user).toMatchObject({ providerId: 'azure-ad' });
+      expect(registry.findByIssuer).toHaveBeenCalledWith(azureIssuer);
     });
 
     it.each([

--- a/openspec/changes/archive/2026-08-19-fix-azure-ad-issuer-mismatch/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-19-fix-azure-ad-issuer-mismatch/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-19

--- a/openspec/changes/archive/2026-08-19-fix-azure-ad-issuer-mismatch/design.md
+++ b/openspec/changes/archive/2026-08-19-fix-azure-ad-issuer-mismatch/design.md
@@ -1,0 +1,45 @@
+## Context
+
+`ProviderRegistryService` (`apps/chat-api/src/auth/providers/provider-registry.service.ts`) discovers one OIDC client per configured provider at boot and indexes them by `config.id`. `HeaderTokenStrategy` (`apps/chat-api/src/auth/strategies/header-token.strategy.ts`) decodes an incoming bearer token's claims without verification, calls `registry.findByIssuer(claims.iss)` to find the provider whose JWKS should verify the signature, and separately checks `claims.iss` against `AUTH_HEADER_TOKEN_ALLOWED_ISSUERS`. Both checks must pass or the request is rejected with `AuthErrorCode.HeaderTokenUntrustedIssuer` (401).
+
+Azure AD issues tokens whose `iss` claim can be either the legacy v1 form (`https://sts.windows.net/{tenant}/`) or the v2 form (`https://login.microsoftonline.com/{tenant}/v2.0`), depending on token version / endpoint used, for the *same* tenant and app registration. Operators register exactly one issuer string per provider in `AUTH_AZURE_AD_*` env vars (see `provider-builders.ts`), so a deployment that receives both token shapes for the same tenant currently cannot satisfy `findByIssuer`'s exact match for both.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Let `findByIssuer` resolve a v1 Azure AD issuer to the registered v2 Azure AD provider for the same tenant (and vice versa is naturally covered since exact match already handles v1-registered/v1-token and v2-registered/v2-token cases).
+- Preserve exact-match resolution, unchanged, for every provider and issuer that isn't this Azure AD v1/v2 pair.
+- Give operators a way to distinguish "issuer isn't allowlisted" from "issuer is allowlisted but no provider matches it" in logs/error codes, since these currently collapse into one misleading error.
+
+**Non-Goals:**
+- Broadening the allowlist check itself: `claims.iss` must still appear verbatim in `AUTH_HEADER_TOKEN_ALLOWED_ISSUERS` — this change only affects provider *lookup*, not the allowlist comparison. Operators must still list whichever issuer format(s) they expect to receive.
+- Generalizing v1/v2-style aliasing to other providers (Auth0, Okta, etc.) — no other supported provider is known to emit two issuer formats for one tenant.
+- Changing signature verification: `jwtVerify` continues to be called with `issuer: claims.iss` (the exact string from the incoming token), so a token's signature is still checked against its own claimed issuer, not the provider config's configured issuer.
+
+## Decisions
+
+### Decision 1: Fallback lives in `ProviderRegistryService.findByIssuer`, not in `HeaderTokenStrategy`
+
+`findByIssuer` is the single place that maps an issuer string to a provider entry; keeping the v1→v2 tenant-derivation logic there means `HeaderTokenStrategy` (and any other future caller) gets the fix for free without duplicating regex/parsing logic. Alternative considered: patch the comparison in `HeaderTokenStrategy.authenticate` directly — rejected because it would duplicate provider-matching knowledge that belongs in the registry, and would miss other current/future callers of `findByIssuer`.
+
+### Decision 2: Exact match first, regex fallback second, restricted to `AuthProviderId.AzureAd`
+
+`findByIssuer` tries the existing exact-match `Array.find` first (cheap, covers every non-Azure-AD provider and same-format Azure AD deployments unchanged). Only on a miss does it test the incoming issuer against `^https:\/\/sts\.windows\.net\/([^/]+)\/?$`, extract `{tenant}`, build `https://login.microsoftonline.com/{tenant}/v2.0`, and re-search restricted to entries whose `config.id === AuthProviderId.AzureAd`. Restricting to `AzureAd` avoids accidentally matching an unrelated provider that happens to have been configured with that literal v2-shaped issuer string. This mirrors the reference implementation supplied in the bug report, which the reporter verified locally.
+
+### Decision 3: New `AuthErrorCode.HeaderProviderNotFound`, distinct from `HeaderTokenUntrustedIssuer`
+
+`HeaderTokenStrategy.authenticate` currently throws one combined 401 when `!entry || !allowedIssuers.includes(claims.iss)`. Split into two checks:
+1. If `claims.iss` is not in `allowedIssuers` → `AuthErrorCode.HeaderTokenUntrustedIssuer` (unchanged meaning: "we don't trust this issuer at all").
+2. Else if `entry` is still `undefined` (allowlisted issuer, but no registered provider matches even after the v1/v2 fallback) → new `AuthErrorCode.HeaderProviderNotFound`.
+
+This makes the v1/v2-mismatch failure mode (and any future "allowlisted but unregistered" misconfiguration) diagnosable from the error code and server logs alone, instead of looking identical to a deliberately untrusted issuer. Alternative considered: keep one error code and only improve logging — rejected because the bug report's acceptance criteria explicitly ask for distinguishable error codes, and a machine-readable code is more useful to operators/API consumers than log-only detail.
+
+### Decision 4: No change to JWKS/signature verification call
+
+`verifySignature` receives `entry.client.issuer.metadata['jwks_uri']` (the *matched* provider's JWKS endpoint — correct, since that's where the real keys live) and `issuer: claims.iss` (the *token's own* issuer string, used only as the expected-issuer check inside `jwtVerify`). This is already correct for the fallback case: a v1-issued token's payload really does carry `iss: https://sts.windows.net/{tenant}/`, so asserting `issuer: claims.iss` against that payload still matches. No changes needed here.
+
+## Risks / Trade-offs
+
+- **[Risk]** A deployment could have both a `sts.windows.net` and a `login.microsoftonline.com` issuer independently allowlisted and expect them to resolve to two *different* logical providers → the fallback would collapse them onto whichever single Azure AD provider is registered. **Mitigation:** only one Azure AD provider can be registered per deployment today (`buildProviderConfigs` builds at most one `AuthProviderId.AzureAd` entry from `AUTH_AZURE_AD_*` env vars), so this scenario cannot currently occur; document the assumption in the `findByIssuer` docstring.
+- **[Risk]** Regex-based tenant extraction could be fooled by a malformed/attacker-controlled `iss` claim designed to look like a v1 URL. **Mitigation:** the extracted tenant is used only to build a candidate string that must then exactly equal the *registered* provider's configured issuer — an attacker cannot inject a tenant value that isn't already the operator's own configured Azure AD tenant, and the token still has to pass full `jwtVerify` signature/issuer verification against that provider's real JWKS afterward.
+- **[Trade-off]** Two error codes instead of one is a small API-shape change for any client parsing `code` from 401 responses. Acceptable since this is an internal/BFF-facing error surface (see `apps/chat-api/AGENTS.md` — auth/session endpoints), not a published public contract, and the bug report explicitly requests the split.

--- a/openspec/changes/archive/2026-08-19-fix-azure-ad-issuer-mismatch/proposal.md
+++ b/openspec/changes/archive/2026-08-19-fix-azure-ad-issuer-mismatch/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+Header-based bearer-token authentication rejects valid Azure AD tokens whenever the token's `iss` claim uses the Azure AD v1 issuer format (`https://sts.windows.net/{tenant}/`) but the registered provider was configured with the v2 issuer format (`https://login.microsoftonline.com/{tenant}/v2.0`), or vice versa. Both URLs identify the same tenant, but `ProviderRegistryService.findByIssuer` does an exact string match, so the provider lookup silently fails. The request is rejected with `AUTH_HEADER_TOKEN_UNTRUSTED_ISSUER`, the same code used for a genuinely non-allowlisted issuer, which makes the real cause (a v1/v2 format mismatch, not a missing allowlist entry) hard to diagnose.
+
+## What Changes
+
+- `ProviderRegistryService.findByIssuer` first attempts the existing exact-match lookup; if that misses and the incoming issuer matches the Azure AD v1 pattern (`https://sts.windows.net/{tenant}/`), it derives the tenant's v2 issuer (`https://login.microsoftonline.com/{tenant}/v2.0`) and retries the lookup restricted to the registered `AuthProviderId.AzureAd` provider.
+- `HeaderTokenStrategy.authenticate` passes the token's own `iss` claim as the expected issuer to `jwtVerify` (already does today), so signature verification continues to validate against the exact issuer string presented by the token — only JWKS/provider resolution is affected by the fallback.
+- **BREAKING**: none. Exact-match behavior for every other provider and issuer format is unchanged; this only adds a fallback path.
+- Introduce a distinct error code (`AUTH_HEADER_PROVIDER_NOT_FOUND`) for "issuer is allowlisted but no provider (even after the v1/v2 fallback) is registered for it," separate from `AUTH_HEADER_TOKEN_UNTRUSTED_ISSUER` ("issuer is not allowlisted at all").
+
+## Capabilities
+
+### New Capabilities
+
+_None._
+
+### Modified Capabilities
+
+- `bff-header-token-auth`: header bearer-token authentication now recognizes Azure AD v1 (`sts.windows.net`) and v2 (`login.microsoftonline.com`) issuer URLs for the same tenant as equivalent when resolving the registered provider, and reports a distinct error code when the issuer is allowlisted but still unmatched to any provider.
+
+## Impact
+
+- `apps/chat-api/src/auth/providers/provider-registry.service.ts` — `findByIssuer` gains the v1→v2 fallback.
+- `apps/chat-api/src/auth/strategies/header-token.strategy.ts` — distinguishes "not allowlisted" from "no matching provider" when raising 401s.
+- `apps/chat-api/src/auth/session/auth-error-code.enum.ts` — new `HeaderProviderNotFound` member.
+- Existing/new unit tests for `ProviderRegistryService` and `HeaderTokenStrategy`.
+- No API surface, DTO, or OpenAPI contract changes — this is internal auth-resolution logic, not a public endpoint change.

--- a/openspec/changes/archive/2026-08-19-fix-azure-ad-issuer-mismatch/specs/bff-header-token-auth/spec.md
+++ b/openspec/changes/archive/2026-08-19-fix-azure-ad-issuer-mismatch/specs/bff-header-token-auth/spec.md
@@ -1,0 +1,45 @@
+## MODIFIED Requirements
+
+### Requirement: Header bearer token authentication
+
+When `AUTH_HEADER_TOKEN_ENABLED` is `true`, the system SHALL authenticate requests carrying an `Authorization: Bearer <token>` header by verifying the token's signature locally against the JWKS of a registered OIDC provider matching the token's `iss` claim, and checking `exp`, `nbf`, and `aud` with the configured clock tolerance. The token's issuer MUST also be present in `AUTH_HEADER_TOKEN_ALLOWED_ISSUERS`. When resolving the registered provider for an Azure AD tenant, an `iss` claim in the Azure AD v1 format (`https://sts.windows.net/{tenant}/`) SHALL be treated as equivalent to the same tenant's v2 format (`https://login.microsoftonline.com/{tenant}/v2.0`) if no provider is registered under the exact issuer string presented.
+
+#### Scenario: Valid token from a registered, allowlisted issuer authenticates the request
+
+- **WHEN** a request carries `Authorization: Bearer <token>` where `<token>` is signed by a registered provider whose issuer is in `AUTH_HEADER_TOKEN_ALLOWED_ISSUERS`, and the token is unexpired
+- **THEN** the request is authenticated, `req.user.sub`/`req.user.providerId`/`req.user.claims` are populated from the verified token, and `req.user.at` is the raw bearer token
+
+#### Scenario: Expired header token is rejected with no cookie fallback
+
+- **WHEN** a request carries an `Authorization` header with an expired token, and also carries a valid session cookie
+- **THEN** the response is `401` with error code `AUTH_HEADER_TOKEN_EXPIRED`, and the session cookie is never consulted
+
+#### Scenario: Token with invalid signature is rejected
+
+- **WHEN** a request carries an `Authorization` header whose token fails signature verification against the matched provider's JWKS
+- **THEN** the response is `401` with error code `AUTH_HEADER_TOKEN_INVALID`
+
+#### Scenario: Token from a non-allowlisted issuer is rejected
+
+- **WHEN** a request carries an `Authorization` header whose token's `iss` claim is not present in `AUTH_HEADER_TOKEN_ALLOWED_ISSUERS`
+- **THEN** the response is `401` with error code `AUTH_HEADER_TOKEN_UNTRUSTED_ISSUER`
+
+#### Scenario: Allowlisted issuer with no matching registered provider is rejected with a distinct error code
+
+- **WHEN** a request carries an `Authorization` header whose token's `iss` claim is present in `AUTH_HEADER_TOKEN_ALLOWED_ISSUERS`, but no registered provider's issuer matches it exactly, and (for an Azure AD v1-shaped `iss`) no registered Azure AD provider matches the corresponding v2 issuer either
+- **THEN** the response is `401` with error code `AUTH_HEADER_PROVIDER_NOT_FOUND`, distinct from `AUTH_HEADER_TOKEN_UNTRUSTED_ISSUER`
+
+#### Scenario: Azure AD v1 issuer resolves to the registered v2 Azure AD provider for the same tenant
+
+- **WHEN** a request carries an `Authorization: Bearer <token>` header where `<token>`'s `iss` claim is `https://sts.windows.net/{tenant}/`, `https://sts.windows.net/{tenant}/` is present in `AUTH_HEADER_TOKEN_ALLOWED_ISSUERS`, no provider is registered with that exact issuer string, and an Azure AD provider is registered with issuer `https://login.microsoftonline.com/{tenant}/v2.0` for the same `{tenant}`
+- **THEN** the request is authenticated using that Azure AD provider's JWKS, `req.user.providerId` is the Azure AD provider's id, and the token's signature/claims are verified with `issuer` equal to the token's own `https://sts.windows.net/{tenant}/` value
+
+#### Scenario: Malformed Authorization header is rejected as 401, not 400
+
+- **WHEN** a request carries an `Authorization` header using a non-`Bearer` scheme, an empty token value, or multiple `Authorization` header values
+- **THEN** the response is `401` with error code `AUTH_HEADER_MALFORMED`
+
+#### Scenario: Feature flag off ignores the header entirely
+
+- **WHEN** `AUTH_HEADER_TOKEN_ENABLED` is `false` (the default) and a request carries an `Authorization: Bearer <token>` header along with a valid session cookie
+- **THEN** the request is authenticated via the session cookie exactly as it would be with no `Authorization` header present, and the header's token is never parsed or verified

--- a/openspec/changes/archive/2026-08-19-fix-azure-ad-issuer-mismatch/tasks.md
+++ b/openspec/changes/archive/2026-08-19-fix-azure-ad-issuer-mismatch/tasks.md
@@ -1,0 +1,24 @@
+## 1. Error code
+
+- [x] 1.1 Add `HeaderProviderNotFound = 'AUTH_HEADER_PROVIDER_NOT_FOUND'` to `AuthErrorCode` in `apps/chat-api/src/auth/session/auth-error-code.enum.ts`.
+
+## 2. Provider registry lookup fallback
+
+- [x] 2.1 In `apps/chat-api/src/auth/providers/provider-registry.service.ts`, update `findByIssuer` to keep the existing exact-match lookup, then on a miss test the issuer against the Azure AD v1 pattern `^https:\/\/sts\.windows\.net\/([^/]+)\/?$`, derive `https://login.microsoftonline.com/{tenant}/v2.0` from the captured tenant, and retry the lookup restricted to entries with `config.id === AuthProviderId.AzureAd`.
+- [x] 2.2 Update the `findByIssuer` docstring to describe the v1/v2 fallback and the single-Azure-AD-provider-per-deployment assumption it relies on.
+
+## 3. Split "untrusted issuer" vs "provider not found"
+
+- [x] 3.1 In `apps/chat-api/src/auth/strategies/header-token.strategy.ts` (`authenticate`), replace the single combined `!entry || !allowedIssuers.includes(claims.iss)` check with two sequential checks: throw `AuthErrorCode.HeaderTokenUntrustedIssuer` when `claims.iss` is not in `allowedIssuers`, then throw the new `AuthErrorCode.HeaderProviderNotFound` when `entry` is still `undefined`.
+- [x] 3.2 Confirm `verifySignature` continues to receive `issuer: claims.iss` (the token's own issuer, unchanged) and the matched `entry`'s JWKS URI — no changes needed there, but re-check after the refactor.
+
+## 4. Tests
+
+- [x] 4.1 Add unit tests to `apps/chat-api/src/auth/providers/provider-registry.service.spec.ts` (or existing test file) covering: exact match unchanged for a non-Azure-AD provider; v1 issuer resolves to a registered v2 Azure AD provider for the same tenant; v1 issuer with a *different* tenant than the registered v2 provider does not match; no Azure AD provider registered at all returns `undefined` for a v1 issuer.
+- [x] 4.2 Update `apps/chat-api/src/auth/strategies/tests/header-token.strategy.spec.ts` to cover: non-allowlisted issuer still yields `AUTH_HEADER_TOKEN_UNTRUSTED_ISSUER`; allowlisted-but-unmatched issuer yields the new `AUTH_HEADER_PROVIDER_NOT_FOUND`; an allowlisted Azure AD v1 issuer with a registered v2 provider authenticates successfully with the correct `providerId`.
+- [x] 4.3 Update `apps/chat-api/src/auth.controller.spec.ts` if it asserts on the old combined untrusted-issuer behavior for this scenario. (No such assertion exists — no change needed.)
+
+## 5. Verification
+
+- [x] 5.1 Run `npm exec nx test chat-api`. (2499/2499 tests pass)
+- [x] 5.2 Run `npm exec nx lint chat-api`. (0 errors; 2 pre-existing unrelated warnings)

--- a/openspec/specs/bff-header-token-auth/spec.md
+++ b/openspec/specs/bff-header-token-auth/spec.md
@@ -54,7 +54,7 @@ The extraction of today's cookie-decrypt, transparent-refresh, CSRF-token-stabil
 
 ### Requirement: Header bearer token authentication
 
-When `AUTH_HEADER_TOKEN_ENABLED` is `true`, the system SHALL authenticate requests carrying an `Authorization: Bearer <token>` header by verifying the token's signature locally against the JWKS of a registered OIDC provider matching the token's `iss` claim, and checking `exp`, `nbf`, and `aud` with the configured clock tolerance. The token's issuer MUST also be present in `AUTH_HEADER_TOKEN_ALLOWED_ISSUERS`.
+When `AUTH_HEADER_TOKEN_ENABLED` is `true`, the system SHALL authenticate requests carrying an `Authorization: Bearer <token>` header by verifying the token's signature locally against the JWKS of a registered OIDC provider matching the token's `iss` claim, and checking `exp`, `nbf`, and `aud` with the configured clock tolerance. The token's issuer MUST also be present in `AUTH_HEADER_TOKEN_ALLOWED_ISSUERS`. When resolving the registered provider for an Azure AD tenant, an `iss` claim in the Azure AD v1 format (`https://sts.windows.net/{tenant}/`) SHALL be treated as equivalent to the same tenant's v2 format (`https://login.microsoftonline.com/{tenant}/v2.0`) if no provider is registered under the exact issuer string presented.
 
 #### Scenario: Valid token from a registered, allowlisted issuer authenticates the request
 
@@ -71,10 +71,20 @@ When `AUTH_HEADER_TOKEN_ENABLED` is `true`, the system SHALL authenticate reques
 - **WHEN** a request carries an `Authorization` header whose token fails signature verification against the matched provider's JWKS
 - **THEN** the response is `401` with error code `AUTH_HEADER_TOKEN_INVALID`
 
-#### Scenario: Token from an unregistered or non-allowlisted issuer is rejected
+#### Scenario: Token from a non-allowlisted issuer is rejected
 
-- **WHEN** a request carries an `Authorization` header whose token's `iss` claim does not match any registered provider, or matches a registered provider not present in `AUTH_HEADER_TOKEN_ALLOWED_ISSUERS`
+- **WHEN** a request carries an `Authorization` header whose token's `iss` claim is not present in `AUTH_HEADER_TOKEN_ALLOWED_ISSUERS`
 - **THEN** the response is `401` with error code `AUTH_HEADER_TOKEN_UNTRUSTED_ISSUER`
+
+#### Scenario: Allowlisted issuer with no matching registered provider is rejected with a distinct error code
+
+- **WHEN** a request carries an `Authorization` header whose token's `iss` claim is present in `AUTH_HEADER_TOKEN_ALLOWED_ISSUERS`, but no registered provider's issuer matches it exactly, and (for an Azure AD v1-shaped `iss`) no registered Azure AD provider matches the corresponding v2 issuer either
+- **THEN** the response is `401` with error code `AUTH_HEADER_PROVIDER_NOT_FOUND`, distinct from `AUTH_HEADER_TOKEN_UNTRUSTED_ISSUER`
+
+#### Scenario: Azure AD v1 issuer resolves to the registered v2 Azure AD provider for the same tenant
+
+- **WHEN** a request carries an `Authorization: Bearer <token>` header where `<token>`'s `iss` claim is `https://sts.windows.net/{tenant}/`, `https://sts.windows.net/{tenant}/` is present in `AUTH_HEADER_TOKEN_ALLOWED_ISSUERS`, no provider is registered with that exact issuer string, and an Azure AD provider is registered with issuer `https://login.microsoftonline.com/{tenant}/v2.0` for the same `{tenant}`
+- **THEN** the request is authenticated using that Azure AD provider's JWKS, `req.user.providerId` is the Azure AD provider's id, and the token's signature/claims are verified with `issuer` equal to the token's own `https://sts.windows.net/{tenant}/` value
 
 #### Scenario: Malformed Authorization header is rejected as 401, not 400
 


### PR DESCRIPTION
**Description:**

Resolve Azure AD provider lookup failures when tokens use the v1 issuer endpoint (sts.windows.net) but only the v2 issuer (login.microsoftonline.com) is registered. Implements a fallback mechanism in `findByIssuer()` that maps v1 tenant IDs to v2 endpoints, enabling support for multi-version Azure AD token formats.

Also adds the new `AUTH_HEADER_PROVIDER_NOT_FOUND` error code for scenarios where header-based authentication fails to locate a matching provider.

**UI changes**

No UI changes

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(chat-api):`
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs