### PR TITLE
feat(chat): fetch deployment details on load and conditionally send temperature (Issue #8356)

### DIFF
--- a/apps/chat-api/src/conversations/generation/chat-completions.adapter.ts
+++ b/apps/chat-api/src/conversations/generation/chat-completions.adapter.ts
@@ -44,8 +44,14 @@ export class ChatCompletionsAdapter {
     startConversation: ConversationResponseDto;
     messagesForCompletion: ConversationMessageDto[];
     customContent: MessageCustomContentDto | undefined;
+    temperatureSupported: boolean;
   }): unknown {
-    const { startConversation, messagesForCompletion, customContent } = params;
+    const {
+      startConversation,
+      messagesForCompletion,
+      customContent,
+      temperatureSupported,
+    } = params;
 
     const configuration =
       customContent?.configuration_value ??
@@ -81,9 +87,10 @@ export class ChatCompletionsAdapter {
     return {
       messages: [...systemMessages, ...dialMessages],
       stream: true,
-      ...(startConversation.temperature != null && {
-        temperature: startConversation.temperature,
-      }),
+      ...(temperatureSupported &&
+        startConversation.temperature != null && {
+          temperature: startConversation.temperature,
+        }),
       ...(configuration ? { custom_fields: { configuration } } : {}),
     };
   }

--- a/apps/chat-api/src/conversations/streaming/conversation-streaming.service.ts
+++ b/apps/chat-api/src/conversations/streaming/conversation-streaming.service.ts
@@ -495,9 +495,10 @@ export class ConversationStreamingService {
     const requestBody = {
       messages: [...systemMessages, ...dialMessages],
       stream: true,
-      ...(startConversation.temperature != null && {
-        temperature: startConversation.temperature,
-      }),
+      ...(temperatureSupported &&
+        startConversation.temperature != null && {
+          temperature: startConversation.temperature,
+        }),
       ...(configuration ? { custom_fields: { configuration } } : {}),
     };
 

--- a/apps/chat-api/src/conversations/streaming/tests/conversation-streaming.service.spec.ts
+++ b/apps/chat-api/src/conversations/streaming/tests/conversation-streaming.service.spec.ts
@@ -492,6 +492,64 @@ describe('ConversationStreamingService', () => {
       expect(res.getWritten()).not.toBe('');
     });
 
+    it('omits temperature from the Chat Completions request when the deployment does not support it', async () => {
+      vi.mocked(mockDeploymentsService.getDeploymentDetails).mockResolvedValue({
+        id: 'gpt-4o',
+        type: 'model',
+        modelDetails: { features: { temperature: false } },
+      });
+
+      const conversation = {
+        ...baseConversation,
+        temperature: 1,
+        messages: [
+          {
+            id: 'u1',
+            role: ConversationMessageRole.User,
+            content: 'Hello',
+            timestamp: '2024-01-01T00:00:00.000Z',
+          },
+        ],
+      };
+
+      const { sendSpy } = await callStream(
+        conversation,
+        'Next message',
+        'gpt-4o',
+      );
+
+      expect(sendSpy.mock.calls[0][1].body).not.toHaveProperty('temperature');
+    });
+
+    it('includes temperature in the Chat Completions request when the deployment supports it', async () => {
+      vi.mocked(mockDeploymentsService.getDeploymentDetails).mockResolvedValue({
+        id: 'gpt-4o',
+        type: 'model',
+        modelDetails: { features: { temperature: true } },
+      });
+
+      const conversation = {
+        ...baseConversation,
+        temperature: 1,
+        messages: [
+          {
+            id: 'u1',
+            role: ConversationMessageRole.User,
+            content: 'Hello',
+            timestamp: '2024-01-01T00:00:00.000Z',
+          },
+        ],
+      };
+
+      const { sendSpy } = await callStream(
+        conversation,
+        'Next message',
+        'gpt-4o',
+      );
+
+      expect(sendSpy.mock.calls[0][1].body).toMatchObject({ temperature: 1 });
+    });
+
     it('still rejects a toolset target with 400 regardless of the feature flag state', async () => {
       for (const flagEnabled of [true, false]) {
         vi.mocked(mockFeatureFlagsService.isEnabled).mockResolvedValue(

--- a/apps/chat-api/src/deployments/details/deployments-details.service.ts
+++ b/apps/chat-api/src/deployments/details/deployments-details.service.ts
@@ -79,6 +79,9 @@ export class DeploymentsDetailsService {
           headers: getBearerAuthHeaders(accessToken),
         },
       );
+      this.logger.debug(
+        `DIAL Core configurationDeployment for "${name}": ${JSON.stringify(result)}`,
+      );
       if (result.error) {
         return mapDialHttpStatus(
           result.response.status,

--- a/apps/chat/src/components/CatalogView/tests/CatalogView.spec.tsx
+++ b/apps/chat/src/components/CatalogView/tests/CatalogView.spec.tsx
@@ -682,6 +682,8 @@ describe('CatalogView', () => {
       toolsets: [],
       refetchToolsets: vi.fn(),
       refetchDeployments: vi.fn(),
+      selectedDeploymentDetails: null,
+      isDeploymentDetailsLoading: false,
       mergeSharedItem: vi.fn(),
     });
     vi.mocked(getDeploymentLimits).mockResolvedValue({});
@@ -1163,6 +1165,8 @@ describe('CatalogView', () => {
       ],
       refetchToolsets: vi.fn(),
       refetchDeployments: vi.fn(),
+      selectedDeploymentDetails: null,
+      isDeploymentDetailsLoading: false,
       mergeSharedItem: vi.fn(),
     });
 
@@ -1194,6 +1198,8 @@ describe('CatalogView', () => {
       ],
       refetchToolsets: vi.fn(),
       refetchDeployments: vi.fn(),
+      selectedDeploymentDetails: null,
+      isDeploymentDetailsLoading: false,
       mergeSharedItem: vi.fn(),
     });
     vi.mocked(useFavoriteApplications).mockReturnValue({
@@ -1238,6 +1244,8 @@ describe('CatalogView', () => {
       ],
       refetchToolsets: vi.fn(),
       refetchDeployments: vi.fn(),
+      selectedDeploymentDetails: null,
+      isDeploymentDetailsLoading: false,
       mergeSharedItem: vi.fn(),
     });
 
@@ -1275,6 +1283,8 @@ describe('CatalogView', () => {
       toolsets: [],
       refetchToolsets: vi.fn(),
       refetchDeployments: vi.fn(),
+      selectedDeploymentDetails: null,
+      isDeploymentDetailsLoading: false,
       mergeSharedItem: vi.fn(),
     });
 
@@ -1309,6 +1319,8 @@ describe('CatalogView', () => {
       toolsets: [],
       refetchToolsets: vi.fn(),
       refetchDeployments: vi.fn(),
+      selectedDeploymentDetails: null,
+      isDeploymentDetailsLoading: false,
       mergeSharedItem: vi.fn(),
     });
 
@@ -1342,6 +1354,8 @@ describe('CatalogView', () => {
       ],
       refetchToolsets: vi.fn(),
       refetchDeployments: vi.fn(),
+      selectedDeploymentDetails: null,
+      isDeploymentDetailsLoading: false,
       mergeSharedItem: vi.fn(),
     });
 
@@ -1375,6 +1389,8 @@ describe('CatalogView', () => {
       toolsets: [],
       refetchToolsets: vi.fn(),
       refetchDeployments: vi.fn(),
+      selectedDeploymentDetails: null,
+      isDeploymentDetailsLoading: false,
       mergeSharedItem: vi.fn(),
     });
 
@@ -1406,6 +1422,8 @@ describe('CatalogView', () => {
       toolsets: [],
       refetchToolsets: vi.fn(),
       refetchDeployments: vi.fn(),
+      selectedDeploymentDetails: null,
+      isDeploymentDetailsLoading: false,
       mergeSharedItem: vi.fn(),
     });
 
@@ -1434,6 +1452,8 @@ describe('CatalogView', () => {
       toolsets: [],
       refetchToolsets: vi.fn(),
       refetchDeployments: vi.fn(),
+      selectedDeploymentDetails: null,
+      isDeploymentDetailsLoading: false,
       mergeSharedItem: vi.fn(),
     });
 
@@ -1460,6 +1480,8 @@ describe('CatalogView', () => {
       toolsets: [],
       refetchToolsets: vi.fn(),
       refetchDeployments: vi.fn(),
+      selectedDeploymentDetails: null,
+      isDeploymentDetailsLoading: false,
       mergeSharedItem: vi.fn(),
     });
     vi.mocked(getDeploymentDetails).mockResolvedValue({
@@ -1579,6 +1601,8 @@ describe('CatalogView', () => {
       toolsets: [],
       refetchToolsets: vi.fn(),
       refetchDeployments: vi.fn(),
+      selectedDeploymentDetails: null,
+      isDeploymentDetailsLoading: false,
       mergeSharedItem: vi.fn(),
     });
     vi.mocked(getDeploymentDetails).mockResolvedValue({
@@ -1640,6 +1664,8 @@ describe('CatalogView', () => {
       toolsets: [],
       refetchToolsets: vi.fn(),
       refetchDeployments: vi.fn(),
+      selectedDeploymentDetails: null,
+      isDeploymentDetailsLoading: false,
       mergeSharedItem: vi.fn(),
     });
     vi.mocked(getDeploymentDetails).mockResolvedValue({
@@ -1723,6 +1749,8 @@ describe('CatalogView', () => {
       toolsets: [],
       refetchToolsets: vi.fn(),
       refetchDeployments: vi.fn(),
+      selectedDeploymentDetails: null,
+      isDeploymentDetailsLoading: false,
       mergeSharedItem: vi.fn(),
     });
     vi.mocked(getDeploymentDetails).mockRejectedValue(new Error('502'));
@@ -1761,6 +1789,8 @@ describe('CatalogView', () => {
       ],
       refetchToolsets,
       refetchDeployments: vi.fn(),
+      selectedDeploymentDetails: null,
+      isDeploymentDetailsLoading: false,
       mergeSharedItem: vi.fn(),
     });
     vi.mocked(loginToolset).mockResolvedValue({ success: true });
@@ -1805,6 +1835,8 @@ describe('CatalogView', () => {
       ],
       refetchToolsets,
       refetchDeployments: vi.fn(),
+      selectedDeploymentDetails: null,
+      isDeploymentDetailsLoading: false,
       mergeSharedItem: vi.fn(),
     });
     vi.mocked(loginToolset).mockResolvedValue({ success: true });
@@ -1848,6 +1880,8 @@ describe('CatalogView', () => {
       ],
       refetchToolsets,
       refetchDeployments: vi.fn(),
+      selectedDeploymentDetails: null,
+      isDeploymentDetailsLoading: false,
       mergeSharedItem: vi.fn(),
     });
     vi.mocked(logoutToolset).mockResolvedValue({ success: true });
@@ -1892,6 +1926,8 @@ describe('CatalogView', () => {
       ],
       refetchToolsets: vi.fn(),
       refetchDeployments: vi.fn(),
+      selectedDeploymentDetails: null,
+      isDeploymentDetailsLoading: false,
       mergeSharedItem: vi.fn(),
     });
     vi.mocked(loginToolset).mockRejectedValue(new Error('network error'));
@@ -1938,6 +1974,8 @@ describe('CatalogView', () => {
         toolsets: getToolsets(),
         refetchToolsets,
         refetchDeployments: vi.fn(),
+        selectedDeploymentDetails: null,
+        isDeploymentDetailsLoading: false,
         mergeSharedItem: vi.fn(),
       }));
       return render(<CatalogView />);
@@ -2154,6 +2192,8 @@ describe('CatalogView', () => {
       ],
       refetchToolsets,
       refetchDeployments: vi.fn(),
+      selectedDeploymentDetails: null,
+      isDeploymentDetailsLoading: false,
       mergeSharedItem: vi.fn(),
     });
     vi.mocked(deleteToolset).mockResolvedValue(undefined);
@@ -2202,6 +2242,8 @@ describe('CatalogView', () => {
       toolsets: [],
       refetchToolsets: vi.fn(),
       refetchDeployments,
+      selectedDeploymentDetails: null,
+      isDeploymentDetailsLoading: false,
       mergeSharedItem: vi.fn(),
     });
     vi.mocked(deleteApplication).mockResolvedValue(undefined);
@@ -2289,6 +2331,8 @@ describe('CatalogView', () => {
       ],
       refetchToolsets: vi.fn(),
       refetchDeployments: vi.fn(),
+      selectedDeploymentDetails: null,
+      isDeploymentDetailsLoading: false,
       mergeSharedItem: vi.fn(),
     });
     vi.mocked(deleteToolset).mockRejectedValue(new Error('network error'));
@@ -2321,6 +2365,8 @@ describe('CatalogView', () => {
         toolsets: [],
         refetchToolsets: vi.fn(),
         refetchDeployments: vi.fn(),
+        selectedDeploymentDetails: null,
+        isDeploymentDetailsLoading: false,
         mergeSharedItem: vi.fn(),
       });
       vi.mocked(useCatalogSortFilterPreference).mockReturnValue({
@@ -2352,6 +2398,8 @@ describe('CatalogView', () => {
         toolsets: [],
         refetchToolsets: vi.fn(),
         refetchDeployments: vi.fn(),
+        selectedDeploymentDetails: null,
+        isDeploymentDetailsLoading: false,
         mergeSharedItem: vi.fn(),
       });
       vi.mocked(useCatalogSortFilterPreference).mockReturnValue({
@@ -2485,6 +2533,8 @@ describe('CatalogView', () => {
         toolsets: [],
         refetchToolsets: vi.fn(),
         refetchDeployments: vi.fn(),
+        selectedDeploymentDetails: null,
+        isDeploymentDetailsLoading: false,
         mergeSharedItem: vi.fn(),
       });
       const onClose = vi.fn();
@@ -2513,6 +2563,8 @@ describe('CatalogView', () => {
         toolsets: [],
         refetchToolsets: vi.fn(),
         refetchDeployments: vi.fn(),
+        selectedDeploymentDetails: null,
+        isDeploymentDetailsLoading: false,
         mergeSharedItem: vi.fn(),
       });
       const onClose = vi.fn();
@@ -2573,6 +2625,8 @@ describe('CatalogView', () => {
         ],
         refetchToolsets: vi.fn(),
         refetchDeployments: vi.fn(),
+        selectedDeploymentDetails: null,
+        isDeploymentDetailsLoading: false,
         mergeSharedItem: vi.fn(),
       });
       vi.mocked(useUiFeature).mockImplementation(
@@ -2605,6 +2659,8 @@ describe('CatalogView', () => {
         toolsets: [],
         refetchToolsets: vi.fn(),
         refetchDeployments: vi.fn(),
+        selectedDeploymentDetails: null,
+        isDeploymentDetailsLoading: false,
         mergeSharedItem: vi.fn(),
       } as never);
 
@@ -2629,6 +2685,8 @@ describe('CatalogView', () => {
         toolsets: [],
         refetchToolsets: vi.fn(),
         refetchDeployments: vi.fn(),
+        selectedDeploymentDetails: null,
+        isDeploymentDetailsLoading: false,
         mergeSharedItem: vi.fn(),
       } as never);
       vi.mocked(useUiFeature).mockImplementation(
@@ -2658,6 +2716,8 @@ describe('CatalogView', () => {
         toolsets: [],
         refetchToolsets: vi.fn(),
         refetchDeployments: vi.fn(),
+        selectedDeploymentDetails: null,
+        isDeploymentDetailsLoading: false,
         mergeSharedItem: vi.fn(),
       } as never);
       vi.mocked(useUiFeature).mockImplementation(
@@ -2694,6 +2754,8 @@ describe('CatalogView', () => {
         ],
         refetchToolsets: vi.fn(),
         refetchDeployments: vi.fn(),
+        selectedDeploymentDetails: null,
+        isDeploymentDetailsLoading: false,
         mergeSharedItem: vi.fn(),
       });
       vi.mocked(useUiFeature).mockImplementation(
@@ -2742,6 +2804,8 @@ describe('CatalogView', () => {
         toolsets: [],
         refetchToolsets: vi.fn(),
         refetchDeployments: vi.fn(),
+        selectedDeploymentDetails: null,
+        isDeploymentDetailsLoading: false,
         mergeSharedItem: vi.fn(),
         ...overrides,
       } as ReturnType<typeof useDeployments>);
@@ -3526,6 +3590,8 @@ describe('CatalogView', () => {
         toolsets: [],
         refetchToolsets: vi.fn(),
         refetchDeployments: vi.fn(),
+        selectedDeploymentDetails: null,
+        isDeploymentDetailsLoading: false,
         mergeSharedItem: vi.fn(),
         ...overrides,
       } as ReturnType<typeof useDeployments>);

--- a/apps/chat/src/components/DeploymentSelector/tests/useDeploymentSelectorFieldOverlay.spec.tsx
+++ b/apps/chat/src/components/DeploymentSelector/tests/useDeploymentSelectorFieldOverlay.spec.tsx
@@ -44,6 +44,8 @@ const mockDeployments = (items: DeploymentItemDto[]) => {
     toolsets: [],
     refetchToolsets: vi.fn(),
     refetchDeployments: vi.fn(),
+    selectedDeploymentDetails: null,
+    isDeploymentDetailsLoading: false,
     mergeSharedItem: vi.fn(),
   });
 };
@@ -125,6 +127,8 @@ describe('useDeploymentSelectorFieldOverlay', () => {
       toolsets: [],
       refetchToolsets: vi.fn(),
       refetchDeployments: vi.fn(),
+      selectedDeploymentDetails: null,
+      isDeploymentDetailsLoading: false,
       mergeSharedItem: vi.fn(),
     });
 

--- a/apps/chat/src/components/SigninInterruptDialog/tests/SigninInterruptDialog.spec.tsx
+++ b/apps/chat/src/components/SigninInterruptDialog/tests/SigninInterruptDialog.spec.tsx
@@ -108,6 +108,8 @@ const makeDeploymentsValue = (toolsets: unknown[] = []) => ({
   toolsets,
   refetchToolsets: vi.fn().mockResolvedValue(undefined),
   refetchDeployments: vi.fn().mockResolvedValue(undefined),
+  selectedDeploymentDetails: null,
+  isDeploymentDetailsLoading: false,
   mergeSharedItem: vi.fn(),
 });
 

--- a/apps/chat/src/context/DeploymentsContext.tsx
+++ b/apps/chat/src/context/DeploymentsContext.tsx
@@ -1,6 +1,7 @@
 import {
   ListDeploymentsInterfaceTypeEnum,
   type ApplicationSchemaSummaryDto,
+  type DeploymentDetailsDto,
   type DeploymentItemDto,
   type DialToolsetDto,
 } from '@epam/ai-dial-chat-api-client';
@@ -20,7 +21,10 @@ import { DeploymentSelectorI18nKeys } from '../constants/translation-keys';
 import { useLanguage } from '../hooks/language/useLanguage';
 import { getApiErrorDetails } from '../server-api/api-error';
 import { getApplicationSchemas } from '../server-api/application-schemas';
-import { getDeploymentConfiguration } from '../server-api/deployments';
+import {
+  getDeploymentConfiguration,
+  getDeploymentDetails,
+} from '../server-api/deployments';
 import { getDeployments } from '../server-api/deployments.api';
 import { listToolsets } from '../server-api/toolsets';
 import { findDeploymentByIdOrReference } from '../utils/deployment-id';
@@ -54,6 +58,10 @@ export interface DeploymentsContextType {
   restoreDefaultSelection: () => void;
   /** JSON Schema configuration for the currently selected deployment, or null if none selected or unsupported. */
   selectedDeploymentConfiguration: DeploymentConfigurationSchema | null;
+  /** Full per-entity details (model/application/toolset) for the currently selected deployment, or null if none selected or the fetch failed. */
+  selectedDeploymentDetails: DeploymentDetailsDto | null;
+  /** True while selectedDeploymentDetails is being fetched for the current selection. */
+  isDeploymentDetailsLoading: boolean;
   /** True while deployments are being fetched. */
   isLoading: boolean;
   /** Non-null if the deployments fetch failed. */
@@ -169,6 +177,10 @@ export const DeploymentsProvider = ({ children }: { children: ReactNode }) => {
   );
   const [selectedDeploymentConfiguration, setSelectedDeploymentConfiguration] =
     useState<DeploymentConfigurationSchema | null>(null);
+  const [selectedDeploymentDetails, setSelectedDeploymentDetails] =
+    useState<DeploymentDetailsDto | null>(null);
+  const [isDeploymentDetailsLoading, setIsDeploymentDetailsLoading] =
+    useState(false);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
 
@@ -413,27 +425,34 @@ export const DeploymentsProvider = ({ children }: { children: ReactNode }) => {
   useEffect(() => {
     if (!resolvedSelectedDeploymentId) {
       setSelectedDeploymentConfiguration(null);
+      setSelectedDeploymentDetails(null);
+      setIsDeploymentDetailsLoading(false);
       return;
     }
 
     const signal = { isCancelled: false };
+    setIsDeploymentDetailsLoading(true);
 
-    const loadConfiguration = async () => {
-      try {
-        const configuration = await getDeploymentConfiguration(
-          resolvedSelectedDeploymentId,
-        );
-        if (!signal.isCancelled) {
-          setSelectedDeploymentConfiguration(configuration);
-        }
-      } catch {
-        if (!signal.isCancelled) {
-          setSelectedDeploymentConfiguration(null);
-        }
-      }
+    const loadConfigurationAndDetails = async () => {
+      const [configurationResult, detailsResult] = await Promise.allSettled([
+        getDeploymentConfiguration(resolvedSelectedDeploymentId),
+        getDeploymentDetails(resolvedSelectedDeploymentId),
+      ]);
+
+      if (signal.isCancelled) return;
+
+      setSelectedDeploymentConfiguration(
+        configurationResult.status === 'fulfilled'
+          ? configurationResult.value
+          : null,
+      );
+      setSelectedDeploymentDetails(
+        detailsResult.status === 'fulfilled' ? detailsResult.value : null,
+      );
+      setIsDeploymentDetailsLoading(false);
     };
 
-    loadConfiguration();
+    loadConfigurationAndDetails();
 
     return () => {
       signal.isCancelled = true;
@@ -475,6 +494,8 @@ export const DeploymentsProvider = ({ children }: { children: ReactNode }) => {
       restoreSelectedItemId,
       restoreDefaultSelection,
       selectedDeploymentConfiguration,
+      selectedDeploymentDetails,
+      isDeploymentDetailsLoading,
       isLoading,
       error,
       schemas,
@@ -490,6 +511,8 @@ export const DeploymentsProvider = ({ children }: { children: ReactNode }) => {
       restoreSelectedItemId,
       restoreDefaultSelection,
       selectedDeploymentConfiguration,
+      selectedDeploymentDetails,
+      isDeploymentDetailsLoading,
       isLoading,
       error,
       schemas,

--- a/apps/chat/src/context/tests/DeploymentsContext.spec.tsx
+++ b/apps/chat/src/context/tests/DeploymentsContext.spec.tsx
@@ -1,8 +1,10 @@
+import type { DeploymentConfigurationSchema } from '@epam/ai-dial-chat-shared';
 import { NotificationVariant } from '@epam/ai-dial-ui-kit';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { DeploymentSelectorI18nKeys } from '../../constants/translation-keys';
 import * as applicationSchemasApi from '../../server-api/application-schemas';
+import * as deploymentDetailsApi from '../../server-api/deployments';
 import * as deploymentsApi from '../../server-api/deployments.api';
 import * as toolsetsApi from '../../server-api/toolsets';
 import { DeploymentsProvider, useDeployments } from '../DeploymentsContext';
@@ -17,6 +19,7 @@ const contextMocks = vi.hoisted(() => ({
 }));
 
 vi.mock('../../server-api/deployments.api');
+vi.mock('../../server-api/deployments');
 vi.mock('../../server-api/application-schemas');
 vi.mock('../../server-api/toolsets');
 vi.mock('../auth/UserContext', () => ({
@@ -54,6 +57,10 @@ const mockItem2 = {
 };
 const mockResponse = { deployments: [mockItem1, mockItem2] };
 const emptySchemas = { schemas: [] };
+const mockDeploymentDetails = {
+  id: mockItem1.id,
+  type: 'model' as const,
+};
 
 describe('DeploymentsContext', () => {
   const mockGetDeployments = vi.mocked(deploymentsApi.getDeployments);
@@ -61,6 +68,12 @@ describe('DeploymentsContext', () => {
     applicationSchemasApi.getApplicationSchemas,
   );
   const mockListToolsets = vi.mocked(toolsetsApi.listToolsets);
+  const mockGetDeploymentConfiguration = vi.mocked(
+    deploymentDetailsApi.getDeploymentConfiguration,
+  );
+  const mockGetDeploymentDetails = vi.mocked(
+    deploymentDetailsApi.getDeploymentDetails,
+  );
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -71,6 +84,8 @@ describe('DeploymentsContext', () => {
     mockGetDeployments.mockResolvedValue(mockResponse);
     mockGetApplicationSchemas.mockResolvedValue(emptySchemas);
     mockListToolsets.mockResolvedValue({ data: [] });
+    mockGetDeploymentConfiguration.mockResolvedValue({});
+    mockGetDeploymentDetails.mockResolvedValue(mockDeploymentDetails);
   });
 
   describe('identity-keyed refetch', () => {
@@ -840,6 +855,149 @@ describe('DeploymentsContext', () => {
         variant: NotificationVariant.Error,
         message: DeploymentSelectorI18nKeys.RefetchDeploymentsFailed,
       });
+    });
+  });
+
+  describe('selectedDeploymentDetails', () => {
+    it('fetches configuration and details in parallel when a deployment is selected', async () => {
+      let resolveConfiguration: (value: DeploymentConfigurationSchema) => void;
+      const configurationPromise = new Promise<DeploymentConfigurationSchema>(
+        (resolve) => {
+          resolveConfiguration = resolve;
+        },
+      );
+      let resolveDetails: (value: typeof mockDeploymentDetails) => void;
+      const detailsPromise = new Promise<typeof mockDeploymentDetails>(
+        (resolve) => {
+          resolveDetails = resolve;
+        },
+      );
+      mockGetDeploymentConfiguration.mockReturnValueOnce(configurationPromise);
+      mockGetDeploymentDetails.mockReturnValueOnce(detailsPromise);
+
+      renderHook(() => useDeployments(), {
+        wrapper: DeploymentsProvider,
+      });
+
+      await waitFor(() => {
+        expect(mockGetDeploymentConfiguration).toHaveBeenCalledWith(
+          mockItem1.id,
+        );
+        expect(mockGetDeploymentDetails).toHaveBeenCalledWith(mockItem1.id);
+      });
+
+      await act(async () => {
+        resolveConfiguration({});
+        resolveDetails(mockDeploymentDetails);
+        await Promise.all([configurationPromise, detailsPromise]);
+      });
+    });
+
+    it('sets selectedDeploymentDetails on successful fetch', async () => {
+      mockGetDeploymentDetails.mockResolvedValue(mockDeploymentDetails);
+
+      const { result } = renderHook(() => useDeployments(), {
+        wrapper: DeploymentsProvider,
+      });
+
+      await waitFor(() => {
+        expect(result.current.selectedDeploymentDetails).toEqual(
+          mockDeploymentDetails,
+        );
+        expect(result.current.isDeploymentDetailsLoading).toBe(false);
+      });
+    });
+
+    it('sets selectedDeploymentDetails to null on fetch failure without affecting configuration', async () => {
+      mockGetDeploymentDetails.mockRejectedValue(new Error('Details failed'));
+      mockGetDeploymentConfiguration.mockResolvedValue({
+        title: 'GPT-4o config',
+      });
+
+      const { result } = renderHook(() => useDeployments(), {
+        wrapper: DeploymentsProvider,
+      });
+
+      await waitFor(() =>
+        expect(result.current.selectedItemId).toBe(mockItem1.id),
+      );
+      await waitFor(() =>
+        expect(result.current.selectedDeploymentConfiguration).toEqual({
+          title: 'GPT-4o config',
+        }),
+      );
+      expect(result.current.isDeploymentDetailsLoading).toBe(false);
+      expect(result.current.selectedDeploymentDetails).toBeNull();
+    });
+
+    it('clears details and skips the request when no deployment is selected', async () => {
+      mockGetDeployments.mockResolvedValueOnce({ deployments: [] });
+
+      const { result } = renderHook(() => useDeployments(), {
+        wrapper: DeploymentsProvider,
+      });
+
+      await waitFor(() => expect(result.current.selectedItemId).toBeNull());
+
+      expect(result.current.selectedDeploymentConfiguration).toBeNull();
+      expect(result.current.selectedDeploymentDetails).toBeNull();
+      expect(result.current.isDeploymentDetailsLoading).toBe(false);
+      expect(mockGetDeploymentConfiguration).not.toHaveBeenCalled();
+      expect(mockGetDeploymentDetails).not.toHaveBeenCalled();
+    });
+
+    it('discards a stale details response after the selection changes again', async () => {
+      let resolveFirstDetails: (value: typeof mockDeploymentDetails) => void;
+      const firstDetailsPromise = new Promise<typeof mockDeploymentDetails>(
+        (resolve) => {
+          resolveFirstDetails = resolve;
+        },
+      );
+      mockGetDeploymentDetails.mockReturnValueOnce(firstDetailsPromise);
+
+      const { result } = renderHook(() => useDeployments(), {
+        wrapper: DeploymentsProvider,
+      });
+
+      await waitFor(() =>
+        expect(result.current.selectedItemId).toBe(mockItem1.id),
+      );
+
+      const secondDetails = { id: mockItem2.id, type: 'application' as const };
+      mockGetDeploymentDetails.mockResolvedValueOnce(secondDetails);
+
+      act(() => {
+        result.current.setSelectedItemId(mockItem2.id);
+      });
+
+      await waitFor(() =>
+        expect(result.current.selectedDeploymentDetails).toEqual(secondDetails),
+      );
+
+      await act(async () => {
+        resolveFirstDetails(mockDeploymentDetails);
+        await firstDetailsPromise;
+      });
+
+      // The stale first-selection response must not clobber the newer one.
+      expect(result.current.selectedDeploymentDetails).toEqual(secondDetails);
+    });
+
+    it('does not refetch details when the selected deployment id is unchanged', async () => {
+      const { result, rerender } = renderHook(() => useDeployments(), {
+        wrapper: DeploymentsProvider,
+      });
+
+      await waitFor(() =>
+        expect(result.current.selectedDeploymentDetails).toEqual(
+          mockDeploymentDetails,
+        ),
+      );
+      expect(mockGetDeploymentDetails).toHaveBeenCalledOnce();
+
+      rerender();
+
+      expect(mockGetDeploymentDetails).toHaveBeenCalledOnce();
     });
   });
 

--- a/apps/chat/src/hooks/tests/useDeploymentChangeEffect.spec.ts
+++ b/apps/chat/src/hooks/tests/useDeploymentChangeEffect.spec.ts
@@ -23,6 +23,8 @@ const makeDeploymentsContext = (selectedItemId: string | null) => ({
   toolsets: [],
   refetchToolsets: vi.fn(),
   refetchDeployments: vi.fn(),
+  selectedDeploymentDetails: null,
+  isDeploymentDetailsLoading: false,
   mergeSharedItem: vi.fn(),
 });
 

--- a/apps/chat/src/pages/ConversationRoute/ConversationRoute.spec.tsx
+++ b/apps/chat/src/pages/ConversationRoute/ConversationRoute.spec.tsx
@@ -266,6 +266,8 @@ describe('ConversationRoute', () => {
       toolsets: [],
       refetchToolsets: vi.fn(),
       refetchDeployments: vi.fn(),
+      selectedDeploymentDetails: null,
+      isDeploymentDetailsLoading: false,
       mergeSharedItem: vi.fn(),
     });
     mockUseUser.mockReturnValue({
@@ -492,6 +494,8 @@ describe('ConversationRoute', () => {
       toolsets: [],
       refetchToolsets: vi.fn(),
       refetchDeployments: vi.fn(),
+      selectedDeploymentDetails: null,
+      isDeploymentDetailsLoading: false,
       mergeSharedItem: vi.fn(),
     });
 
@@ -521,6 +525,8 @@ describe('ConversationRoute', () => {
       toolsets: [],
       refetchToolsets: vi.fn(),
       refetchDeployments: vi.fn(),
+      selectedDeploymentDetails: null,
+      isDeploymentDetailsLoading: false,
       mergeSharedItem: vi.fn(),
     });
     renderRoute();
@@ -550,6 +556,8 @@ describe('ConversationRoute', () => {
       toolsets: [],
       refetchToolsets: vi.fn(),
       refetchDeployments: vi.fn(),
+      selectedDeploymentDetails: null,
+      isDeploymentDetailsLoading: false,
       mergeSharedItem: vi.fn(),
     });
     renderRoute();
@@ -582,6 +590,8 @@ describe('ConversationRoute', () => {
       toolsets: [],
       refetchToolsets: vi.fn(),
       refetchDeployments: vi.fn(),
+      selectedDeploymentDetails: null,
+      isDeploymentDetailsLoading: false,
       mergeSharedItem: function (
         item: DeploymentItemDto | DialToolsetDto,
       ): void {
@@ -646,6 +656,8 @@ describe('ConversationRoute', () => {
       toolsets: [],
       refetchToolsets: vi.fn(),
       refetchDeployments: vi.fn(),
+      selectedDeploymentDetails: null,
+      isDeploymentDetailsLoading: false,
       mergeSharedItem: vi.fn(),
     });
 
@@ -684,6 +696,8 @@ describe('ConversationRoute', () => {
       toolsets: [],
       refetchToolsets: vi.fn(),
       refetchDeployments: vi.fn(),
+      selectedDeploymentDetails: null,
+      isDeploymentDetailsLoading: false,
       mergeSharedItem: function (
         item: DeploymentItemDto | DialToolsetDto,
       ): void {
@@ -737,6 +751,8 @@ describe('ConversationRoute', () => {
       toolsets: [],
       refetchToolsets: vi.fn(),
       refetchDeployments: vi.fn(),
+      selectedDeploymentDetails: null,
+      isDeploymentDetailsLoading: false,
       mergeSharedItem: vi.fn(),
     });
 
@@ -791,6 +807,8 @@ describe('ConversationRoute', () => {
       toolsets: [],
       refetchToolsets: vi.fn(),
       refetchDeployments: vi.fn(),
+      selectedDeploymentDetails: null,
+      isDeploymentDetailsLoading: false,
       mergeSharedItem: vi.fn(),
     });
 
@@ -850,6 +868,8 @@ describe('ConversationRoute', () => {
       toolsets: [],
       refetchToolsets: vi.fn(),
       refetchDeployments: vi.fn(),
+      selectedDeploymentDetails: null,
+      isDeploymentDetailsLoading: false,
       mergeSharedItem: vi.fn(),
     });
 
@@ -900,6 +920,8 @@ describe('ConversationRoute', () => {
       toolsets: [],
       refetchToolsets: vi.fn(),
       refetchDeployments: vi.fn(),
+      selectedDeploymentDetails: null,
+      isDeploymentDetailsLoading: false,
       mergeSharedItem: vi.fn(),
     });
 
@@ -949,6 +971,8 @@ describe('ConversationRoute', () => {
       toolsets: [],
       refetchToolsets: vi.fn(),
       refetchDeployments: vi.fn(),
+      selectedDeploymentDetails: null,
+      isDeploymentDetailsLoading: false,
       mergeSharedItem: vi.fn(),
     });
     mockCreateConversation.mockRejectedValueOnce({

--- a/apps/chat/src/pages/SharedInvitation/tests/SharedInvitation.spec.tsx
+++ b/apps/chat/src/pages/SharedInvitation/tests/SharedInvitation.spec.tsx
@@ -54,6 +54,8 @@ describe('SharedInvitationPage', () => {
       restoreSelectedItemId: vi.fn(),
       restoreDefaultSelection: vi.fn(),
       selectedDeploymentConfiguration: null,
+      selectedDeploymentDetails: null,
+      isDeploymentDetailsLoading: false,
       isLoading: false,
       error: null,
       schemas: [],

--- a/openspec/changes/archive/2026-08-19-fetch-deployment-details-on-load/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-19-fetch-deployment-details-on-load/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-19

--- a/openspec/changes/archive/2026-08-19-fetch-deployment-details-on-load/design.md
+++ b/openspec/changes/archive/2026-08-19-fetch-deployment-details-on-load/design.md
@@ -1,0 +1,41 @@
+## Context
+
+`DeploymentsContext` (`apps/chat/src/context/DeploymentsContext.tsx`) already owns `selectedDeploymentConfiguration`, fetched via `getDeploymentConfiguration` in an effect keyed on `resolvedSelectedDeploymentId` (lines 413-441). `resolvedSelectedDeploymentId` is derived from `selectedItemId`, which is set either by user selection (`setSelectedItemId`, persists to user config) or by `restoreSelectedItemId` when a conversation page loads and restores its last-used model — so this single effect already covers "conversation page opened."
+
+The backend endpoint and frontend client wrapper for deployment details both already exist and are unmodified by this change:
+- `GET /api/v1/deployments/{deployment}/details` — `apps/chat-api/src/deployments/deployments.controller.ts:159-191`, spec'd in `openspec/specs/deployment-details-api/spec.md`.
+- `getDeploymentDetails(deploymentId): Promise<DeploymentDetailsDto>` — `apps/chat/src/server-api/deployments.ts:12-15`.
+
+Today `getDeploymentDetails` is only called from catalog/editor surfaces (`CatalogView.tsx`, `CustomAppEditor.tsx`, `AppEditorIframe.tsx`), never from the conversation-load path.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Fetch deployment details in parallel with deployment configuration whenever `resolvedSelectedDeploymentId` changes (covers conversation-page open, since that's what drives `restoreSelectedItemId` today).
+- Store the result in `DeploymentsContext` state and expose it via `DeploymentsContextType`, following the same cancellable-effect / race-safety pattern as `selectedDeploymentConfiguration`.
+- Avoid duplicate requests: one fetch per `resolvedSelectedDeploymentId` change, not one per render, and not a second independent effect that could race with the configuration effect's cleanup.
+
+**Non-Goals:**
+- Consuming `selectedDeploymentDetails` anywhere (e.g. omitting `temperature` from chat completion payloads). Tracked as a follow-up once real DIAL Core response shapes for models/applications/toolsets have been reviewed.
+- Removing or altering the separate deployment-limits request (`useDeploymentUsageLimits` / `getDeploymentLimits`). Tracked as a follow-up investigation into whether `DeploymentDetailsDto` already carries limits data.
+- Any backend change — the details endpoint and DTO are already implemented and correct for this purpose.
+
+## Decisions
+
+**Extend the existing configuration effect to also fetch details, in the same effect body, rather than adding a second `useEffect`.**
+Both fetches share the identical trigger (`resolvedSelectedDeploymentId`) and identical cancellation semantics. Firing `getDeploymentConfiguration(id)` and `getDeploymentDetails(id)` together via `Promise.allSettled` (not sequential `await`s) inside one effect body guarantees they run concurrently, guarantees exactly one `signal.isCancelled` guard covers both, and avoids a second cleanup closure that could theoretically be torn down out of sync with the first if they were separate effects. `Promise.allSettled` (rather than `Promise.all`) is used so a details failure doesn't clear an already-successful configuration result, and vice versa — each setter is driven by its own settled result.
+
+Alternative considered: a separate `useEffect` for details, deduplicated only by the same dependency array. Rejected — two effects with identical dependencies but independent cancellation flags is exactly the kind of subtly-divergent-lifecycle bug the existing code comment block (lines 175-183) about request sequencing warns against; one effect keeps the two fetches provably in lockstep.
+
+**Add `selectedDeploymentDetails: DeploymentDetailsDto | null` and `isDeploymentDetailsLoading: boolean` to `DeploymentsContextType`, mirroring `selectedDeploymentConfiguration`'s null-on-error/null-on-no-selection behavior.**
+Consistency with the existing field means downstream consumers (the temperature and limits follow-ups) get a familiar shape. A separate loading flag (rather than reusing the context's top-level `isLoading`, which represents the initial deployments-list load) avoids overloading a flag that already has a different meaning in the existing spec.
+
+Alternative considered: a new dedicated context/hook (`useDeploymentDetails`) similar to `useDeploymentUsageLimits.ts`. Rejected for this step — the details fetch is keyed on exactly the same id as configuration and belongs in the same provider; a separate hook would need to re-derive `resolvedSelectedDeploymentId` independently or import it from `DeploymentsContext`, adding indirection with no present benefit. This can be revisited once real consumers (temperature/limits follow-ups) show a need to decouple it.
+
+**No change to `restoreSelectedItemId`/`setSelectedItemId`/selection-precedence logic.** This change is purely additive to the configuration-fetch effect.
+
+## Risks / Trade-offs
+
+- **[Risk]** Adding a second network call to the same conversation-load path increases requests-per-model-switch from 1 to 2. → **Mitigation:** `getDeploymentDetails` is already 60s-cached and de-duplicated server-side (`pendingDetailsRequests` map in `deployments-details.service.ts`), so repeated switches back to a recently-viewed deployment are cheap; the two calls run concurrently, not sequentially, so wall-clock latency for configuration (which nothing currently blocks on details) is unaffected.
+- **[Risk]** A failing details fetch could be mistaken for a hard error if not isolated from configuration. → **Mitigation:** `Promise.allSettled` plus independent try/catch-equivalent handling per fetch (as decided above) ensures a details failure only nulls `selectedDeploymentDetails`, leaving `selectedDeploymentConfiguration` unaffected.
+- **[Trade-off]** `selectedDeploymentDetails` is added to the codebase now with no consumer, which is normally avoided — justified here because it is explicitly requested as a preparation step for two named, scoped follow-ups (temperature handling, limits redundancy check), and unused-export lint rules do not flag context fields that are part of a public context type.

--- a/openspec/changes/archive/2026-08-19-fetch-deployment-details-on-load/proposal.md
+++ b/openspec/changes/archive/2026-08-19-fetch-deployment-details-on-load/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+When a conversation page opens, `DeploymentsContext` fetches only the selected deployment's configuration (`getDeploymentConfiguration`) via the effect at `apps/chat/src/context/DeploymentsContext.tsx:413-441`. The backend already exposes `GET /api/v1/deployments/{deployment}/details` (`deployment-details-api` spec) and the frontend already has a client wrapper for it (`getDeploymentDetails` in `apps/chat/src/server-api/deployments.ts:12-15`), but today that wrapper is only called from catalog/editor surfaces (`CatalogView.tsx`, `CustomAppEditor.tsx`, `AppEditorIframe.tsx`) — never when a conversation is opened. Follow-up work (per-deployment `temperature` payload handling, and evaluating whether the separate limits request can be dropped) needs deployment details to be available as soon as a conversation's model is selected, so this change adds that fetch now as a preparation step, without yet consuming the result.
+
+## What Changes
+
+- `DeploymentsContext` fetches deployment details (`getDeploymentDetails`) in parallel with the existing deployment configuration fetch, keyed off the same `resolvedSelectedDeploymentId`.
+- The fetched details are stored in new context state (`selectedDeploymentDetails`) and exposed through `DeploymentsContextType`, following the same race-safe, cancellable-effect pattern already used for `selectedDeploymentConfiguration`.
+- Both requests are triggered from the same effect so they run concurrently (not sequentially) and are not duplicated when `resolvedSelectedDeploymentId` is unchanged.
+- No UI consumes `selectedDeploymentDetails` yet — this is preparation only. Temperature-omission logic and the limits-request redundancy check are explicitly out of scope for this change and are tracked as follow-ups once the actual DIAL Core response shape has been reviewed against real deployments.
+
+## Capabilities
+
+### New Capabilities
+
+(none — this extends an existing capability)
+
+### Modified Capabilities
+
+- `deployments-context`: `DeploymentsContext` gains a `selectedDeploymentDetails: DeploymentDetailsDto | null` field (plus loading/error handling consistent with the existing configuration fetch) and fetches it in parallel with `selectedDeploymentConfiguration` whenever `resolvedSelectedDeploymentId` changes.
+
+## Impact
+
+- `apps/chat/src/context/DeploymentsContext.tsx` — new state, new parallel fetch effect, updated `DeploymentsContextType`.
+- No backend changes: `GET /api/v1/deployments/{deployment}/details` and `getDeploymentDetails` already exist and are unmodified.
+- No consumers change behavior in this step; `temperature` payload logic and the limits-request necessity check are deferred to separate follow-up changes once this data is available in practice.

--- a/openspec/changes/archive/2026-08-19-fetch-deployment-details-on-load/specs/deployments-context/spec.md
+++ b/openspec/changes/archive/2026-08-19-fetch-deployment-details-on-load/specs/deployments-context/spec.md
@@ -1,0 +1,148 @@
+## MODIFIED Requirements
+
+### Requirement: DeploymentsContext owns deployment selection for conversation selector
+
+`apps/chat/src/context/DeploymentsContext.tsx` SHALL provide:
+
+- `items: DeploymentItemDto[]` — full deployment list from `GET /api/v1/deployments`
+- `selectedItemId: string | null` — currently selected deployment id
+- `setSelectedItemId: (id: string | null) => void` — persists selection to user config via `setSelectedDeployment` from `useUserConfig()` (user-initiated model change); does NOT write to `localStorage`
+- `restoreSelectedItemId: (id: string) => void` — sets `selectedItemId` in local state **without** calling `setSelectedDeployment`; used when restoring a conversation's last-used model so the user's own new-chat preference is preserved
+- `selectedDeploymentConfiguration: DeploymentConfigurationSchema | null` — JSON Schema configuration for the currently selected deployment
+- `selectedDeploymentDetails: DeploymentDetailsDto | null` — full per-entity details (model/application/toolset) for the currently selected deployment, fetched from `GET /api/v1/deployments/{deployment}/details` via `getDeploymentDetails` (`apps/chat/src/server-api/deployments.ts`)
+- `isDeploymentDetailsLoading: boolean` — true while `selectedDeploymentDetails` is being fetched for the current selection
+- `isLoading: boolean`
+- `error: Error | null`
+
+The provider SHALL:
+- Fetch deployments on mount using `getDeployments([ListDeploymentsInterfaceTypeEnum.Chat, ListDeploymentsInterfaceTypeEnum.Mcp])` from `server-api/deployments.api.ts`, so `items` includes both chat-capable and MCP-capable models/applications.
+- Use a `cancelled` flag inside `useEffect` to guard against setState-on-unmount.
+- Use `useMemo` to memoize the context value.
+- Determine the initial `selectedItemId` using the following precedence (evaluated in order after both deployments and user config are available):
+  1. Current in-memory `selectedItemId` if it is still present in the new `items` list (handles deployment list reload).
+  2. `useUserConfig().selectedDeploymentId` if non-null and present in `items`.
+  3. `useAppConfig().defaultDeploymentId` if non-null and present in `items`.
+  4. `items[0]?.id` (first sorted deployment).
+  5. `null` if `items` is empty.
+- When the deployments reload and the previously selected `id` is no longer in `items`, re-apply the full precedence chain from step 2 onward.
+- **NOT re-trigger the full deployments/schemas/toolsets fetch merely because `setSelectedItemId` is called.** `setSelectedItemId` optimistically updates `useUserConfig().selectedDeploymentId` before its persistence call resolves; the initial-load fetch (and the `isLoading` flag it drives) SHALL NOT react to that value changing after the initial load has already completed. The initial-selection precedence chain MAY still be re-evaluated without a network call if `userConfigSelectedId`/`defaultDeploymentId` become known only after the deployments list already loaded with `selectedItemId` still `null` (e.g. an initially empty list later repopulated via `refetchDeployments`).
+- Export a `useDeployments()` hook that throws a clear error when called outside the provider.
+- NOT read from or write to `localStorage` under any circumstance.
+- Whenever `resolvedSelectedDeploymentId` changes (the same trigger already used for `selectedDeploymentConfiguration`), fetch `selectedDeploymentConfiguration` and `selectedDeploymentDetails` **concurrently** in a single effect via `Promise.allSettled`, so neither fetch blocks or is blocked by the other, and a failure in one does not clear a successful result from the other:
+  - If `resolvedSelectedDeploymentId` is `null`, both `selectedDeploymentConfiguration` and `selectedDeploymentDetails` SHALL be set to `null` and no requests SHALL be made.
+  - On success, `selectedDeploymentDetails` SHALL be set to the resolved `DeploymentDetailsDto`; on failure (rejected settlement), `selectedDeploymentDetails` SHALL be set to `null`.
+  - `isDeploymentDetailsLoading` SHALL be `true` from the start of the effect (when a non-null id is present) until the details fetch settles.
+  - The same single cancellable-effect `signal.isCancelled` guard used for `selectedDeploymentConfiguration` SHALL also guard `selectedDeploymentDetails`/`isDeploymentDetailsLoading` state updates, so a superseded selection change (effect cleanup fired before either fetch resolves) applies neither fetch's result.
+  - A repeated selection of the same `resolvedSelectedDeploymentId` (no change to the effect's dependency) SHALL NOT issue a new details request.
+
+The state management pattern SHALL follow `ThemeContext.tsx` as the reference implementation.
+
+`CatalogContext.tsx` SHALL be deleted — `DeploymentsContext` is its replacement, not an addition.
+
+**i18n impact:** None.
+
+**RTL / UI impact:** None (context logic only).
+
+**Memoisation:** `useMemo` on context value; `setSelectedItemId` and `restoreSelectedItemId` SHALL be wrapped in `useCallback`.
+
+#### Scenario: DeploymentsProvider loads items on mount
+
+- **WHEN** `DeploymentsProvider` mounts
+- **THEN** it calls `getDeployments([ListDeploymentsInterfaceTypeEnum.Chat, ListDeploymentsInterfaceTypeEnum.Mcp])`, sets `isLoading: true` during fetch, sets `items` on success, sets `error` on failure, and sets `isLoading: false` when done
+
+#### Scenario: Initial selectedItemId follows user config preference
+
+- **WHEN** deployments load with items `["dep-a", "dep-b"]` and `useUserConfig().selectedDeploymentId === "dep-b"`
+- **THEN** `selectedItemId` is `"dep-b"`
+
+#### Scenario: User config preference absent — falls back to operator default
+
+- **WHEN** deployments load with items `["dep-a", "dep-b"]` and `useUserConfig().selectedDeploymentId === null` and `useAppConfig().defaultDeploymentId === "dep-b"`
+- **THEN** `selectedItemId` is `"dep-b"`
+
+#### Scenario: User config and operator default absent — falls back to first sorted deployment
+
+- **WHEN** deployments load and both `selectedDeploymentId` and `defaultDeploymentId` are `null`
+- **THEN** `selectedItemId` is `items[0].id`
+
+#### Scenario: User config preference points to unavailable deployment — falls through to operator default
+
+- **WHEN** `useUserConfig().selectedDeploymentId === "removed-dep"` and `"removed-dep"` is not in `items`, and `useAppConfig().defaultDeploymentId === "dep-a"` which is in `items`
+- **THEN** `selectedItemId` is `"dep-a"`
+
+#### Scenario: No deployments exist — selectedItemId is null
+
+- **WHEN** deployments load successfully with an empty list
+- **THEN** `selectedItemId` is `null`
+
+#### Scenario: useDeployments throws outside provider
+
+- **WHEN** `useDeployments()` is called outside a `DeploymentsProvider`
+- **THEN** it throws `Error('useDeployments must be used within a DeploymentsProvider')`
+
+#### Scenario: Unmount before fetch completes — no state update
+
+- **WHEN** `DeploymentsProvider` unmounts before `getDeployments()` resolves
+- **THEN** the `cancelled` flag prevents any `setState` calls
+
+#### Scenario: Previously selected item removed after reload
+
+- **WHEN** `selectedItemId` is `"old-dep"` and deployments reload returning items that do not include `"old-dep"`
+- **THEN** selection re-evaluates precedence: user config → operator default → first item → null
+
+#### Scenario: setSelectedItemId calls user config persistence
+
+- **WHEN** `setSelectedItemId("dep-b")` is called
+- **THEN** `useUserConfig().setSelectedDeployment("dep-b")` is called
+- **AND** `selectedItemId` updates to `"dep-b"` in local state
+
+#### Scenario: restoreSelectedItemId does not call user config persistence
+
+- **WHEN** `restoreSelectedItemId("dep-b")` is called
+- **THEN** `selectedItemId` updates to `"dep-b"` in local state
+- **AND** `useUserConfig().setSelectedDeployment` is NOT called
+
+#### Scenario: localStorage is never read or written
+
+- **WHEN** any interaction with DeploymentsContext occurs (mount, select, restore)
+- **THEN** `localStorage.getItem` and `localStorage.setItem` are never called with `"dial:selectedDeploymentId"`
+
+#### Scenario: Selecting a deployment does not re-trigger the initial-load fetch sequence
+
+- **WHEN** `getDeployments`, `getApplicationSchemas`, and `listToolsets` have each already resolved once after mount, and the user then calls `setSelectedItemId` with a different, valid deployment id (which optimistically updates `useUserConfig().selectedDeploymentId`)
+- **THEN** `selectedItemId` updates immediately, `isLoading` remains `false` throughout, and `getDeployments`, `getApplicationSchemas`, and `listToolsets` are each still called exactly once
+
+#### Scenario: Selection resolves from a later-populated list without a network call
+
+- **WHEN** the initial `getDeployments()` call resolves with an empty list (so `selectedItemId` stays `null`), `useUserConfig().selectedDeploymentId` subsequently becomes a valid id, and `rawDeployments` is later repopulated (e.g. via `refetchDeployments`) to include that id
+- **THEN** `selectedItemId` updates to that id once the repopulated list is available, without the initial-load fetch sequence (`getDeployments`/`getApplicationSchemas`/`listToolsets`) running an additional, unrequested time beyond the explicit `refetchDeployments` call
+
+#### Scenario: Selecting a deployment fetches configuration and details in parallel
+
+- **WHEN** `resolvedSelectedDeploymentId` changes from `null` to `"dep-a"`
+- **THEN** `getDeploymentConfiguration("dep-a")` and `getDeploymentDetails("dep-a")` are both called, without either call awaiting the other's completion first
+
+#### Scenario: Deployment details fetch succeeds
+
+- **WHEN** `resolvedSelectedDeploymentId` is `"dep-a"` and `getDeploymentDetails("dep-a")` resolves with a `DeploymentDetailsDto`
+- **THEN** `selectedDeploymentDetails` is set to that DTO and `isDeploymentDetailsLoading` becomes `false`
+
+#### Scenario: Deployment details fetch fails independently of configuration
+
+- **WHEN** `resolvedSelectedDeploymentId` is `"dep-a"`, `getDeploymentDetails("dep-a")` rejects, and `getDeploymentConfiguration("dep-a")` resolves successfully
+- **THEN** `selectedDeploymentDetails` is `null`, `isDeploymentDetailsLoading` becomes `false`, and `selectedDeploymentConfiguration` reflects the successful configuration result unaffected by the details failure
+
+#### Scenario: No selection — details cleared without a request
+
+- **WHEN** `resolvedSelectedDeploymentId` becomes `null`
+- **THEN** `selectedDeploymentDetails` is set to `null`, `isDeploymentDetailsLoading` is `false`, and no `getDeploymentDetails` call is made
+
+#### Scenario: Unmount before details fetch completes — no state update
+
+- **WHEN** `DeploymentsProvider` unmounts (or `resolvedSelectedDeploymentId` changes again) before `getDeploymentDetails` resolves for the prior id
+- **THEN** the effect's `signal.isCancelled` guard prevents `selectedDeploymentDetails`/`isDeploymentDetailsLoading` from being updated with the stale result
+
+#### Scenario: Repeated selection of the same deployment does not refetch details
+
+- **WHEN** `resolvedSelectedDeploymentId` is already `"dep-a"` and the effect re-runs for an unrelated reason without `resolvedSelectedDeploymentId` changing
+- **THEN** `getDeploymentDetails` is not called again beyond the one call already made for `"dep-a"`

--- a/openspec/changes/archive/2026-08-19-fetch-deployment-details-on-load/tasks.md
+++ b/openspec/changes/archive/2026-08-19-fetch-deployment-details-on-load/tasks.md
@@ -1,0 +1,32 @@
+## 1. DeploymentsContext: state and types
+
+- [x] 1.1 Import `getDeploymentDetails` and `DeploymentDetailsDto` in `apps/chat/src/context/DeploymentsContext.tsx`.
+- [x] 1.2 Add `selectedDeploymentDetails: DeploymentDetailsDto | null` and `isDeploymentDetailsLoading: boolean` state via `useState`, alongside the existing `selectedDeploymentConfiguration` state.
+- [x] 1.3 Add `selectedDeploymentDetails` and `isDeploymentDetailsLoading` to the `DeploymentsContextType` interface with JSDoc comments matching the style of the existing fields.
+
+## 2. DeploymentsContext: parallel fetch effect
+
+- [x] 2.1 Extend the existing effect keyed on `resolvedSelectedDeploymentId` (currently only fetching configuration) to also fetch details via `Promise.allSettled([getDeploymentConfiguration(id), getDeploymentDetails(id)])`, so both requests fire concurrently.
+- [x] 2.2 On `resolvedSelectedDeploymentId === null`, set both `selectedDeploymentConfiguration` and `selectedDeploymentDetails` to `null`, set `isDeploymentDetailsLoading` to `false`, and skip both requests (matching current early-return behavior).
+- [x] 2.3 Set `isDeploymentDetailsLoading` to `true` before the details fetch starts and `false` once it settles (success or failure), guarded by the effect's existing `signal.isCancelled` flag.
+- [x] 2.4 Apply the configuration result and the details result independently from the two settled promises, so a rejection on one does not null out a fulfilled value on the other.
+- [x] 2.5 Confirm the effect's cleanup (`signal.isCancelled = true`) suppresses state updates from both fetches when `resolvedSelectedDeploymentId` changes again or the provider unmounts before either settles.
+
+## 3. Provider value and exports
+
+- [x] 3.1 Add `selectedDeploymentDetails` and `isDeploymentDetailsLoading` to the `useMemo`-wrapped context value and its dependency array.
+
+## 4. Tests
+
+- [x] 4.1 In `apps/chat/src/context/tests/DeploymentsContext.spec.tsx`, add a test asserting `getDeploymentConfiguration` and `getDeploymentDetails` are both called when `resolvedSelectedDeploymentId` changes, without one awaiting the other (e.g. assert both mocks were invoked before either resolves).
+- [x] 4.2 Add a test for successful details fetch: `selectedDeploymentDetails` set to the resolved DTO, `isDeploymentDetailsLoading` becomes `false`.
+- [x] 4.3 Add a test for a details-fetch rejection: `selectedDeploymentDetails` becomes `null`, `isDeploymentDetailsLoading` becomes `false`, and a concurrently successful `selectedDeploymentConfiguration` is unaffected.
+- [x] 4.4 Add a test for `resolvedSelectedDeploymentId === null`: both `selectedDeploymentConfiguration` and `selectedDeploymentDetails` are `null`, and neither `getDeploymentConfiguration` nor `getDeploymentDetails` is called.
+- [x] 4.5 Add a test for unmount/selection-change before the details fetch resolves: the stale result does not update state (mirror the existing configuration cancellation test).
+- [x] 4.6 Add a test confirming a re-render with the same `resolvedSelectedDeploymentId` does not call `getDeploymentDetails` again.
+
+## 5. Verification
+
+- [x] 5.1 Run `npm exec nx test chat` (or the scoped test file) and confirm all `DeploymentsContext` tests pass.
+- [x] 5.2 Run `npm exec nx lint chat` and fix any violations.
+- [x] 5.3 Manually open a conversation in the running app and confirm, via the network tab, that `GET /api/v1/deployments/{id}/details` fires alongside `GET /api/v1/deployments/{id}/configuration` when the conversation's model is selected.

--- a/openspec/specs/deployments-context/spec.md
+++ b/openspec/specs/deployments-context/spec.md
@@ -12,6 +12,9 @@ Owns the deployments (models/applications), toolsets, and selected-deployment st
 - `selectedItemId: string | null` — currently selected deployment id
 - `setSelectedItemId: (id: string | null) => void` — persists selection to user config via `setSelectedDeployment` from `useUserConfig()` (user-initiated model change); does NOT write to `localStorage`
 - `restoreSelectedItemId: (id: string) => void` — sets `selectedItemId` in local state **without** calling `setSelectedDeployment`; used when restoring a conversation's last-used model so the user's own new-chat preference is preserved
+- `selectedDeploymentConfiguration: DeploymentConfigurationSchema | null` — JSON Schema configuration for the currently selected deployment
+- `selectedDeploymentDetails: DeploymentDetailsDto | null` — full per-entity details (model/application/toolset) for the currently selected deployment, fetched from `GET /api/v1/deployments/{deployment}/details` via `getDeploymentDetails` (`apps/chat/src/server-api/deployments.ts`)
+- `isDeploymentDetailsLoading: boolean` — true while `selectedDeploymentDetails` is being fetched for the current selection
 - `isLoading: boolean`
 - `error: Error | null`
 
@@ -29,6 +32,12 @@ The provider SHALL:
 - **NOT re-trigger the full deployments/schemas/toolsets fetch merely because `setSelectedItemId` is called.** `setSelectedItemId` optimistically updates `useUserConfig().selectedDeploymentId` before its persistence call resolves; the initial-load fetch (and the `isLoading` flag it drives) SHALL NOT react to that value changing after the initial load has already completed. The initial-selection precedence chain MAY still be re-evaluated without a network call if `userConfigSelectedId`/`defaultDeploymentId` become known only after the deployments list already loaded with `selectedItemId` still `null` (e.g. an initially empty list later repopulated via `refetchDeployments`).
 - Export a `useDeployments()` hook that throws a clear error when called outside the provider.
 - NOT read from or write to `localStorage` under any circumstance.
+- Whenever `resolvedSelectedDeploymentId` changes (the same trigger already used for `selectedDeploymentConfiguration`), fetch `selectedDeploymentConfiguration` and `selectedDeploymentDetails` **concurrently** in a single effect via `Promise.allSettled`, so neither fetch blocks or is blocked by the other, and a failure in one does not clear a successful result from the other:
+  - If `resolvedSelectedDeploymentId` is `null`, both `selectedDeploymentConfiguration` and `selectedDeploymentDetails` SHALL be set to `null` and no requests SHALL be made.
+  - On success, `selectedDeploymentDetails` SHALL be set to the resolved `DeploymentDetailsDto`; on failure (rejected settlement), `selectedDeploymentDetails` SHALL be set to `null`.
+  - `isDeploymentDetailsLoading` SHALL be `true` from the start of the effect (when a non-null id is present) until the details fetch settles.
+  - The same single cancellable-effect `signal.isCancelled` guard used for `selectedDeploymentConfiguration` SHALL also guard `selectedDeploymentDetails`/`isDeploymentDetailsLoading` state updates, so a superseded selection change (effect cleanup fired before either fetch resolves) applies neither fetch's result.
+  - A repeated selection of the same `resolvedSelectedDeploymentId` (no change to the effect's dependency) SHALL NOT issue a new details request.
 
 The state management pattern SHALL follow `ThemeContext.tsx` as the reference implementation.
 
@@ -111,6 +120,36 @@ The state management pattern SHALL follow `ThemeContext.tsx` as the reference im
 
 - **WHEN** the initial `getDeployments()` call resolves with an empty list (so `selectedItemId` stays `null`), `useUserConfig().selectedDeploymentId` subsequently becomes a valid id, and `rawDeployments` is later repopulated (e.g. via `refetchDeployments`) to include that id
 - **THEN** `selectedItemId` updates to that id once the repopulated list is available, without the initial-load fetch sequence (`getDeployments`/`getApplicationSchemas`/`listToolsets`) running an additional, unrequested time beyond the explicit `refetchDeployments` call
+
+#### Scenario: Selecting a deployment fetches configuration and details in parallel
+
+- **WHEN** `resolvedSelectedDeploymentId` changes from `null` to `"dep-a"`
+- **THEN** `getDeploymentConfiguration("dep-a")` and `getDeploymentDetails("dep-a")` are both called, without either call awaiting the other's completion first
+
+#### Scenario: Deployment details fetch succeeds
+
+- **WHEN** `resolvedSelectedDeploymentId` is `"dep-a"` and `getDeploymentDetails("dep-a")` resolves with a `DeploymentDetailsDto`
+- **THEN** `selectedDeploymentDetails` is set to that DTO and `isDeploymentDetailsLoading` becomes `false`
+
+#### Scenario: Deployment details fetch fails independently of configuration
+
+- **WHEN** `resolvedSelectedDeploymentId` is `"dep-a"`, `getDeploymentDetails("dep-a")` rejects, and `getDeploymentConfiguration("dep-a")` resolves successfully
+- **THEN** `selectedDeploymentDetails` is `null`, `isDeploymentDetailsLoading` becomes `false`, and `selectedDeploymentConfiguration` reflects the successful configuration result unaffected by the details failure
+
+#### Scenario: No selection — details cleared without a request
+
+- **WHEN** `resolvedSelectedDeploymentId` becomes `null`
+- **THEN** `selectedDeploymentDetails` is set to `null`, `isDeploymentDetailsLoading` is `false`, and no `getDeploymentDetails` call is made
+
+#### Scenario: Unmount before details fetch completes — no state update
+
+- **WHEN** `DeploymentsProvider` unmounts (or `resolvedSelectedDeploymentId` changes again) before `getDeploymentDetails` resolves for the prior id
+- **THEN** the effect's `signal.isCancelled` guard prevents `selectedDeploymentDetails`/`isDeploymentDetailsLoading` from being updated with the stale result
+
+#### Scenario: Repeated selection of the same deployment does not refetch details
+
+- **WHEN** `resolvedSelectedDeploymentId` is already `"dep-a"` and the effect re-runs for an unrelated reason without `resolvedSelectedDeploymentId` changing
+- **THEN** `getDeploymentDetails` is not called again beyond the one call already made for `"dep-a"`
 
 ---
 


### PR DESCRIPTION
**Description:**

Add deployment details fetching to the DeploymentsContext so that deployment-specific metadata (like `temperatureSupported`) is available during conversation initialization. Update chat-api to respect the `temperatureSupported` flag when building completion requests, so temperature is only sent for deployments that support it. This reduces API errors for deployments that don't handle the temperature parameter.

Issues:

- Issue #8356

**UI changes**

No UI changes

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `feat(chat):`
- [x] the pull request name ends with `(Issue #8356)`
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs