### PR TITLE
feat: Autocenter PDF pages in the attachment canvas

### DIFF
--- a/libs/attachment-canvas/src/components/PdfContent/PdfContent.tsx
+++ b/libs/attachment-canvas/src/components/PdfContent/PdfContent.tsx
@@ -36,6 +36,15 @@ const THUMBNAIL_ITEM_HEIGHT_FALLBACK = 172;
 const THUMBNAIL_PANEL_HEIGHT_FALLBACK = 400;
 /** Debounce (ms) before requesting thumbnails for a newly scrolled-to range, so rapid scrolling doesn't restart the vendor's internal batch fetch on every frame. */
 const THUMBNAIL_SCROLL_REQUEST_DEBOUNCE_MS = 150;
+/**
+ * Number of animation frames to keep re-centering horizontal scroll after a
+ * detected zoom change. The vendor viewer re-renders pages asynchronously
+ * (`reRenderVisiblePages` awaits per-page dimensions one at a time) and
+ * exposes no `onZoomChange` callback, so the new page width isn't known the
+ * instant `getZoom()` changes — polling for a short window catches it once
+ * layout settles.
+ */
+const ZOOM_RECENTER_CORRECTION_FRAMES = 60;
 
 /** User-visible strings for the collapsible thumbnails section. */
 export interface PdfContentLabels {
@@ -242,6 +251,65 @@ export const PdfContent: FC<PdfContentProps> = ({
     setIsViewerReady(true);
   }, []);
 
+  const viewerContainerRef = useRef<HTMLDivElement>(null);
+
+  /*
+   * Auto zoom can render the page wider than the panel, which produces a
+   * horizontal scrollbar on the vendor's `.pdf-highlight-viewer` element
+   * (see PdfContent.module.scss). Center that overflow by width:
+   * - `ResizeObserver` on `.pdf-container`/`.pdf-highlight-viewer` catches
+   *   layout-driven changes (panel resize, page width changes once rendered).
+   * - Polling `viewerApiRef.current.getZoom()` catches a zoom change itself —
+   *   `PdfViewerApi` exposes no `onZoomChange` callback, so this is the only
+   *   way to detect it — and keeps re-centering for a short window afterward
+   *   since the vendor's re-render is asynchronous, so the new width isn't
+   *   final the instant the zoom value changes.
+   */
+  useEffect(() => {
+    if (!isViewerReady) return;
+    const root = viewerContainerRef.current;
+    const pdfContainer = root?.querySelector<HTMLElement>('.pdf-container');
+    const scrollContainer = root?.querySelector<HTMLElement>(
+      '.pdf-highlight-viewer',
+    );
+    if (!pdfContainer || !scrollContainer) return;
+
+    const centerHorizontally = () => {
+      const overflow =
+        scrollContainer.scrollWidth - scrollContainer.clientWidth;
+      if (overflow > 0) {
+        scrollContainer.scrollLeft = overflow / 2;
+      }
+    };
+
+    centerHorizontally();
+    const observer = new ResizeObserver(centerHorizontally);
+    observer.observe(pdfContainer);
+    observer.observe(scrollContainer);
+
+    let lastZoom = viewerApiRef.current?.getZoom();
+    let correctionFramesLeft = 0;
+    let rafId: number;
+    const tick = () => {
+      const zoom = viewerApiRef.current?.getZoom();
+      if (zoom !== lastZoom) {
+        lastZoom = zoom;
+        correctionFramesLeft = ZOOM_RECENTER_CORRECTION_FRAMES;
+      }
+      if (correctionFramesLeft > 0) {
+        centerHorizontally();
+        correctionFramesLeft -= 1;
+      }
+      rafId = requestAnimationFrame(tick);
+    };
+    rafId = requestAnimationFrame(tick);
+
+    return () => {
+      cancelAnimationFrame(rafId);
+      observer.disconnect();
+    };
+  }, [isViewerReady]);
+
   /*
    * On initial load with no highlight/page requested, explicitly scroll to
    * the top of page 1 instead of trusting wherever the viewer's own initial
@@ -374,6 +442,7 @@ export const PdfContent: FC<PdfContentProps> = ({
         </div>
       )}
       <div
+        ref={viewerContainerRef}
         className={mergeClasses(
           'min-w-0 flex-1 overflow-hidden',
           styles.viewer,


### PR DESCRIPTION
## Description of changes

Small enchancement for PDF Viewer for case when there are pages with different width. Viewer now does autocenter by middle, so UX is a little better

## Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- related to #8330, #8143

## UI changes

<img width="1910" height="1030" alt="image" src="https://github.com/user-attachments/assets/4f3a4474-3126-4468-aacd-1ac01a1bbeb5" />
<img width="1907" height="1005" alt="image" src="https://github.com/user-attachments/assets/3ef7588a-6bb0-478f-9668-438d8b815cf1" />


## Checklist

- [ ] the pull request name ends with `(Issue #<ISSUE_ID>)` (comma-separated list of issues)
- [X] I confirm that I don't share any confidential information like API keys or any other secrets and private URLs

<details>
  <summary>PR title cheatsheet</summary>

`<type>[optional scope]: <description>`

1. type (required)
    - `feat` - A new feature
    - `fix` - A bug fix
    - `docs` - Documentation only changes
    - `test` - Adding missing tests or correcting existing tests
    - `ci` - Changes to our CI configuration files and scripts
    - `chore` - Other changes that are minor and/or not user-facing
2. scope (optional, current repo suggestions below)
    - `chat`
    - `overlay`
    - `shared`
    - `sandbox-overlay`
    - `visualizer-connector`

</details>
