### PR TITLE
feat: Show warning about nested items on QuickApp share, Issue #8362

### DIFF
--- a/apps/chat/src/components/CatalogView/CatalogView.tsx
+++ b/apps/chat/src/components/CatalogView/CatalogView.tsx
@@ -245,6 +245,18 @@ const CatalogView: FC<Props> = ({
     [schemas],
   );
 
+  const quickAppDeploymentIds = useMemo(
+    () =>
+      new Set(
+        quickAppSchemaId
+          ? deployments
+              .filter((d) => d.applicationTypeSchemaId === quickAppSchemaId)
+              .map((d) => d.id)
+          : [],
+      ),
+    [deployments, quickAppSchemaId],
+  );
+
   const isCatalogEnabled = useUiFeature(OverlayFeature.Catalog);
   const isCatalogTableViewEnabled = useUiFeature(
     OverlayFeature.CatalogTableView,
@@ -1532,7 +1544,11 @@ const CatalogView: FC<Props> = ({
         accessRulesLabels: getAccessRulesLabels(t),
       }}
       shareOverlay={(item, onClose) => (
-        <SharePopoverContainer item={item} onClose={onClose} />
+        <SharePopoverContainer
+          item={item}
+          isQuickApp={quickAppDeploymentIds.has(item.id)}
+          onClose={onClose}
+        />
       )}
       isShareVisible={isShareVisible}
       styles={{

--- a/apps/chat/src/components/SharePopoverContainer/SharePopoverContainer.tsx
+++ b/apps/chat/src/components/SharePopoverContainer/SharePopoverContainer.tsx
@@ -28,6 +28,8 @@ const EDITABLE_ACCESS_TYPES = new Set<CatalogEntityType>([
 interface Props {
   /** The catalog item being shared. */
   item: CatalogItem;
+  /** Whether the item being shared is a QuickApp; shows the nested-items warning note when true. */
+  isQuickApp?: boolean;
   /** Called when the popover should close. */
   onClose: () => void;
 }
@@ -37,7 +39,11 @@ interface Props {
  * `@epam/ai-dial-share`, resolving all runtime data and i18n strings the lib
  * receives as flat props.
  */
-const SharePopoverContainer: FC<Props> = ({ item, onClose }) => {
+const SharePopoverContainer: FC<Props> = ({
+  item,
+  isQuickApp = false,
+  onClose,
+}) => {
   const { t } = useTranslation();
   /*
    * A prompt's `item.id` is a bucket-relative path, so the backend has to be
@@ -73,6 +79,9 @@ const SharePopoverContainer: FC<Props> = ({ item, onClose }) => {
         accessEditLabel: t(BasicI18nKeys.CanEdit),
         visibilityNote: t(ShareI18nKeys.VisibilityNote),
         visibilityNoteEdit: t(ShareI18nKeys.VisibilityNoteEdit),
+        nestedItemsNote: isQuickApp
+          ? t(ShareI18nKeys.NestedItemsNote)
+          : undefined,
         copyButtonLabel: t(ButtonsI18nKeys.Copy),
         copiedButtonLabel: t(ShareI18nKeys.CopiedButtonLabel),
         linkAriaLabel: t(ShareI18nKeys.LinkAriaLabel),

--- a/apps/chat/src/components/SharePopoverContainer/tests/SharePopoverContainer.spec.tsx
+++ b/apps/chat/src/components/SharePopoverContainer/tests/SharePopoverContainer.spec.tsx
@@ -130,6 +130,43 @@ describe('SharePopoverContainer', () => {
     );
   });
 
+  it('omits the nested-items note by default', () => {
+    mockUseShareLink();
+    render(
+      <SharePopoverContainer
+        item={makeItem(CatalogEntityType.Agent)}
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(mockSharePopover).toHaveBeenCalledWith(
+      expect.objectContaining({
+        labels: expect.objectContaining({ nestedItemsNote: undefined }),
+      }),
+      undefined,
+    );
+  });
+
+  it('passes the nested-items note when isQuickApp is true', () => {
+    mockUseShareLink();
+    render(
+      <SharePopoverContainer
+        item={makeItem(CatalogEntityType.Agent)}
+        isQuickApp
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(mockSharePopover).toHaveBeenCalledWith(
+      expect.objectContaining({
+        labels: expect.objectContaining({
+          nestedItemsNote: ShareI18nKeys.NestedItemsNote,
+        }),
+      }),
+      undefined,
+    );
+  });
+
   it('passes canEditAccess false for a prompt', () => {
     mockUseShareLink();
     render(

--- a/apps/chat/src/constants/translation-keys.ts
+++ b/apps/chat/src/constants/translation-keys.ts
@@ -1036,6 +1036,7 @@ export enum ShareI18nKeys {
   VisibilityNote = 'share.visibilityNote',
   VisibilityNoteEdit = 'share.visibilityNoteEdit',
   VisibilityNoteConversation = 'share.visibilityNoteConversation',
+  NestedItemsNote = 'share.nestedItemsNote',
   CopiedButtonLabel = 'share.copiedButtonLabel',
   LinkAriaLabel = 'share.linkAriaLabel',
   ExpiryNote = 'share.expiryNote',

--- a/apps/chat/src/i18n/locales/en.json
+++ b/apps/chat/src/i18n/locales/en.json
@@ -927,6 +927,7 @@
     "visibilityNote": "This deployment and its updates will be visible to users with the link.",
     "visibilityNoteEdit": "Anyone with the link will be able to view and edit this deployment.",
     "visibilityNoteConversation": "This conversation and its updates will be visible to users with the link.",
+    "nestedItemsNote": "Nested items such as prompts and files aren't shared automatically — share them separately so the app works correctly.",
     "copiedButtonLabel": "Copied",
     "linkAriaLabel": "Share link",
     "expiryNote": "This link is active for {{days}} days.",

--- a/libs/share/src/components/SharePopover/SharePopover.tsx
+++ b/libs/share/src/components/SharePopover/SharePopover.tsx
@@ -90,6 +90,7 @@ const SharePopover: FC<SharePopoverProps> = ({
     qrCodeAriaLabel = 'QR code for the share link',
     loadingLabel = 'Creating share link…',
     errorTitle = 'Couldn’t create the share link. Please try again.',
+    nestedItemsNote,
   } = labels ?? {};
 
   const [view, setView] = useState(SharePopoverView.Link);
@@ -284,6 +285,17 @@ const SharePopover: FC<SharePopoverProps> = ({
                 ? visibilityNoteEdit
                 : visibilityNote}
             </p>
+
+            {nestedItemsNote != null && (
+              <p
+                className={mergeClasses(
+                  typography?.nestedItemsNoteClassName ?? 'dial-tiny-semi-text',
+                  styles.note,
+                )}
+              >
+                {nestedItemsNote}
+              </p>
+            )}
 
             {view === SharePopoverView.Qr ? (
               <QrCode value={url} labels={{ ariaLabel: qrCodeAriaLabel }} />

--- a/libs/share/src/components/SharePopover/tests/SharePopover.spec.tsx
+++ b/libs/share/src/components/SharePopover/tests/SharePopover.spec.tsx
@@ -245,6 +245,26 @@ describe('SharePopover', () => {
     ).toBeNull();
   });
 
+  it('shows the nested-items note only when supplied via labels', () => {
+    const NESTED_ITEMS_NOTE =
+      "Nested items such as prompts and files aren't shared automatically — share them separately so the app works correctly.";
+
+    const { rerender } = render(<SharePopover {...makeProps({ onClose })} />);
+    expect(screen.queryByText(NESTED_ITEMS_NOTE)).toBeNull();
+
+    rerender(
+      <SharePopover
+        {...makeProps({
+          onClose,
+          labels: { expiryNote: EXPIRY_NOTE, nestedItemsNote: NESTED_ITEMS_NOTE },
+        })}
+      />,
+    );
+    expect(screen.getByText(NESTED_ITEMS_NOTE).className).toContain(
+      'dial-tiny-semi-text',
+    );
+  });
+
   it('shows a transient Copied confirmation after clicking Copy', async () => {
     render(<SharePopover {...makeProps({ onClose })} />);
 

--- a/libs/share/src/models/share-popover-props.ts
+++ b/libs/share/src/models/share-popover-props.ts
@@ -22,6 +22,8 @@ export interface SharePopoverLabels {
   visibilityNote?: string;
   /** Visibility note shown when access is Edit. */
   visibilityNoteEdit?: string;
+  /** Extra warning shown below the visibility note when the shared item has nested content (e.g. prompts, files) that is not shared automatically. Omitted when not supplied. */
+  nestedItemsNote?: string;
   /** Copy button default label. Defaults to `"Copy"`. */
   copyButtonLabel?: string;
   /** Copy button label after copying. Defaults to `"Copied"`. */
@@ -90,6 +92,8 @@ export interface SharePopoverTypography {
   errorClassName?: string;
   /** CSS class applied to the visibility and expiry notes. Defaults to `'dial-tiny-text'`. */
   noteClassName?: string;
+  /** CSS class applied to the nested-items warning note. Defaults to `'dial-tiny-semi-text'`. */
+  nestedItemsNoteClassName?: string;
   /** CSS class applied to the "Anyone with the link" primary text. Defaults to `'dial-small-semi-text'`. */
   anyoneTitleClassName?: string;
   /** CSS class applied to the "Anyone with the link" secondary text. Defaults to `'dial-tiny-text'`. */


### PR DESCRIPTION
## Description of changes

Warn user that nested items (files, prompts, etc) need to be shared as well for QuickApp

## Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #8362

## UI changes

<img width="1909" height="1003" alt="image" src="https://github.com/user-attachments/assets/a247afe0-ea5b-45ff-9a84-83b2deb183f8" />


## Checklist

- [X] the pull request name ends with `(Issue #<ISSUE_ID>)` (comma-separated list of issues)
- [X] I confirm that I don't share any confidential information like API keys or any other secrets and private URLs

<details>
  <summary>PR title cheatsheet</summary>

`<type>[optional scope]: <description>`

1. type (required)
    - `feat` - A new feature
    - `fix` - A bug fix
    - `docs` - Documentation only changes
    - `test` - Adding missing tests or correcting existing tests
    - `ci` - Changes to our CI configuration files and scripts
    - `chore` - Other changes that are minor and/or not user-facing
2. scope (optional, current repo suggestions below)
    - `chat`
    - `overlay`
    - `shared`
    - `sandbox-overlay`
    - `visualizer-connector`

</details>
