### PR TITLE
feat(chat): redesign catalog Limits tab with capped/unlimited sections and threshold colors

### DIFF
--- a/apps/chat/src/components/CatalogView/tests/CatalogView.spec.tsx
+++ b/apps/chat/src/components/CatalogView/tests/CatalogView.spec.tsx
@@ -80,6 +80,10 @@ import { getToolsetOAuthChannelName } from '../../../utils/toolsets';
 import CatalogView from '../CatalogView';
 import { SkillDetailsFilePreview } from '../SkillDetailsFilePreview';
 
+const formatLimitNumber = new Intl.NumberFormat(undefined, {
+  maximumFractionDigits: 2,
+}).format;
+
 /** Minimal fake popup `Window` — enough surface for `initiateOAuthLogin`/`waitForToolsetOAuthResult`. */
 const makeFakePopup = () => {
   const store = new Map<string, string>();
@@ -1543,6 +1547,8 @@ describe('CatalogView', () => {
           label: CatalogI18nKeys.DetailsLimitsRequestsPerHour,
           used: 2,
           total: 10,
+          usedLabel: formatLimitNumber(2),
+          totalLabel: formatLimitNumber(10),
           valueLabel: CatalogI18nKeys.DetailsLimitsValue,
           ariaLabel: CatalogI18nKeys.DetailsLimitsProgressAriaLabel,
         },
@@ -1550,6 +1556,8 @@ describe('CatalogView', () => {
           label: CatalogI18nKeys.DetailsLimitsTokensPerDay,
           used: 2500,
           total: 10000,
+          usedLabel: formatLimitNumber(2500),
+          totalLabel: formatLimitNumber(10000),
           valueLabel: CatalogI18nKeys.DetailsLimitsValue,
           ariaLabel: CatalogI18nKeys.DetailsLimitsProgressAriaLabel,
         },

--- a/apps/chat/src/utils/map-deployment-limits-to-catalog.ts
+++ b/apps/chat/src/utils/map-deployment-limits-to-catalog.ts
@@ -12,6 +12,8 @@ import { CatalogI18nKeys } from '../constants/translation-keys';
 interface DeploymentLimitMapping {
   key: keyof DeploymentLimitsResponseDto;
   labelKey: CatalogI18nKeys;
+  /** Whether this stat is denominated in cost (USD), formatted with a currency symbol. */
+  isCost?: boolean;
 }
 
 const LIMIT_STAT_MAPPINGS: DeploymentLimitMapping[] = [
@@ -42,24 +44,34 @@ const LIMIT_STAT_MAPPINGS: DeploymentLimitMapping[] = [
   {
     key: 'minuteCostStats',
     labelKey: CatalogI18nKeys.DetailsLimitsCostPerMinute,
+    isCost: true,
   },
   {
     key: 'dayCostStats',
     labelKey: CatalogI18nKeys.DetailsLimitsCostPerDay,
+    isCost: true,
   },
   {
     key: 'weekCostStats',
     labelKey: CatalogI18nKeys.DetailsLimitsCostPerWeek,
+    isCost: true,
   },
   {
     key: 'monthCostStats',
     labelKey: CatalogI18nKeys.DetailsLimitsCostPerMonth,
+    isCost: true,
   },
 ];
 
 const UNLIMITED_TOTAL_THRESHOLD = Number.MAX_SAFE_INTEGER;
 
 const numberFormatter = new Intl.NumberFormat(undefined, {
+  maximumFractionDigits: 2,
+});
+
+const costFormatter = new Intl.NumberFormat(undefined, {
+  style: 'currency',
+  currency: 'USD',
   maximumFractionDigits: 2,
 });
 
@@ -80,25 +92,28 @@ const shouldShowLimitStats = (
   return isUsableLimitStats(stats);
 };
 
-const formatLimitNumber = (value: number): string =>
-  numberFormatter.format(value);
+const formatLimitNumber = (value: number, isCost: boolean): string =>
+  isCost ? costFormatter.format(value) : numberFormatter.format(value);
 
 const mapLimitStatsToRow = (
   stats: LimitStatsDto,
   label: string,
   t: TFunction,
+  isCost: boolean,
 ): UsageLimitProgressRow => {
   const used = Math.max(0, stats.used);
   const total = stats.total;
-  const formattedUsed = formatLimitNumber(used);
-  const formattedTotal = formatLimitNumber(total);
+  const formattedUsed = formatLimitNumber(used, isCost);
+  const formattedTotal = formatLimitNumber(total, isCost);
   const isUnlimited = isUnlimitedTotal(total);
 
   return {
     label,
     used,
     total,
-    ...(isUnlimited ? { isUnlimited: true } : {}),
+    ...(isUnlimited
+      ? { isUnlimited: true }
+      : { usedLabel: formattedUsed, totalLabel: formattedTotal }),
     valueLabel: isUnlimited
       ? t(CatalogI18nKeys.DetailsLimitsUnlimitedValue)
       : t(CatalogI18nKeys.DetailsLimitsValue, {
@@ -129,7 +144,14 @@ export const mapDeploymentLimitsDtoToCatalogLimits = (
       return [];
     }
 
-    return [mapLimitStatsToRow(stats, t(mapping.labelKey), t)];
+    return [
+      mapLimitStatsToRow(
+        stats,
+        t(mapping.labelKey),
+        t,
+        mapping.isCost ?? false,
+      ),
+    ];
   });
 
   return rows.length > 0 ? { rows } : undefined;

--- a/apps/chat/src/utils/tests/map-deployment-limits-to-catalog.spec.ts
+++ b/apps/chat/src/utils/tests/map-deployment-limits-to-catalog.spec.ts
@@ -21,6 +21,12 @@ const format = new Intl.NumberFormat(undefined, {
   maximumFractionDigits: 2,
 }).format;
 
+const costFormat = new Intl.NumberFormat(undefined, {
+  style: 'currency',
+  currency: 'USD',
+  maximumFractionDigits: 2,
+}).format;
+
 const t = ((key: string, params?: Record<string, string>) => {
   if (key === CatalogI18nKeys.DetailsLimitsValue) {
     return `${params?.used} / ${params?.total}`;
@@ -48,6 +54,8 @@ describe('mapDeploymentLimitsDtoToCatalogLimits', () => {
           label: 'Requests per hour',
           used: 2,
           total: 10,
+          usedLabel: '2',
+          totalLabel: '10',
           valueLabel: '2 / 10',
           ariaLabel: 'Requests per hour: 2 of 10 used',
         },
@@ -55,6 +63,8 @@ describe('mapDeploymentLimitsDtoToCatalogLimits', () => {
           label: 'Tokens per day',
           used: 2500,
           total: 10000,
+          usedLabel: format(2500),
+          totalLabel: format(10000),
           valueLabel: `${format(2500)} / ${format(10000)}`,
           ariaLabel: `Tokens per day: ${format(2500)} of ${format(10000)} used`,
         },
@@ -62,8 +72,10 @@ describe('mapDeploymentLimitsDtoToCatalogLimits', () => {
           label: 'Cost per month',
           used: 12.345,
           total: 25,
-          valueLabel: `${format(12.345)} / ${format(25)}`,
-          ariaLabel: `Cost per month: ${format(12.345)} of ${format(25)} used`,
+          usedLabel: costFormat(12.345),
+          totalLabel: costFormat(25),
+          valueLabel: `${costFormat(12.345)} / ${costFormat(25)}`,
+          ariaLabel: `Cost per month: ${costFormat(12.345)} of ${costFormat(25)} used`,
         },
       ],
     });
@@ -110,8 +122,10 @@ describe('mapDeploymentLimitsDtoToCatalogLimits', () => {
           label: 'Cost per day',
           used: 0.003852,
           total: 100,
-          valueLabel: `${format(0.003852)} / 100`,
-          ariaLabel: `Cost per day: ${format(0.003852)} of 100 used`,
+          usedLabel: costFormat(0.003852),
+          totalLabel: costFormat(100),
+          valueLabel: `${costFormat(0.003852)} / ${costFormat(100)}`,
+          ariaLabel: `Cost per day: ${costFormat(0.003852)} of ${costFormat(100)} used`,
         },
         {
           label: 'Cost per week',
@@ -119,14 +133,16 @@ describe('mapDeploymentLimitsDtoToCatalogLimits', () => {
           total: unlimitedTotal,
           isUnlimited: true,
           valueLabel: 'Unlimited',
-          ariaLabel: `Cost per week: ${format(0.11901255)} of Unlimited used`,
+          ariaLabel: `Cost per week: ${costFormat(0.11901255)} of Unlimited used`,
         },
         {
           label: 'Cost per month',
           used: 3.64120297,
           total: 500,
-          valueLabel: `${format(3.64120297)} / 500`,
-          ariaLabel: `Cost per month: ${format(3.64120297)} of 500 used`,
+          usedLabel: costFormat(3.64120297),
+          totalLabel: costFormat(500),
+          valueLabel: `${costFormat(3.64120297)} / ${costFormat(500)}`,
+          ariaLabel: `Cost per month: ${costFormat(3.64120297)} of ${costFormat(500)} used`,
         },
       ],
     });

--- a/libs/catalog/src/components/Details/DetailsPanel.tsx
+++ b/libs/catalog/src/components/Details/DetailsPanel.tsx
@@ -1143,7 +1143,11 @@ export const DetailsPanel: FC<DetailsPanelProps> = ({
                   />
                 )}
                 {activeTab === CatalogDetailsTab.Limits && (
-                  <LimitsTab limits={item.details?.limits} />
+                  <LimitsTab
+                    limits={item.details?.limits}
+                    costCapsSectionLabel={texts?.limitsCostCapsSectionLabel}
+                    unlimitedSectionLabel={texts?.limitsUnlimitedSectionLabel}
+                  />
                 )}
                 {activeTab === CatalogDetailsTab.Api &&
                   item.details?.api?.resource?.endpointUrl != null && (

--- a/libs/catalog/src/components/Details/TabsContent/Limits.module.scss
+++ b/libs/catalog/src/components/Details/TabsContent/Limits.module.scss
@@ -1,0 +1,33 @@
+.sectionHeading {
+  color: var(--lt-section-heading, var(--text-secondary, #57647a));
+}
+
+.label {
+  color: var(--lt-label, var(--text-secondary, #57647a));
+}
+
+.value {
+  color: var(--lt-value, var(--text-secondary, #57647a));
+}
+
+/* !important overrides ProgressBar's own `bg-control-disable` track utility class,
+ * which has equal CSS specificity and is not otherwise reliably out-cascaded. */
+.progressTrack {
+  background: var(--lt-progress-track, var(--bg-layer-sunken, #eef1f7)) !important;
+}
+
+/* Targets ProgressBar's inner fill element (its only child), which has no color-override prop. */
+.progressFillDefault > div {
+  background: var(
+    --lt-progress-fill-default,
+    var(--text-control-blue-hover, #5976e9)
+  ) !important;
+}
+
+.progressFillWarning > div {
+  background: var(--lt-progress-fill-warning, var(--text-warning-icon, #eec840)) !important;
+}
+
+.progressFillDanger > div {
+  background: var(--lt-progress-fill-danger, var(--bg-control-error-active, #cc4545)) !important;
+}

--- a/libs/catalog/src/components/Details/TabsContent/Limits.tsx
+++ b/libs/catalog/src/components/Details/TabsContent/Limits.tsx
@@ -1,10 +1,11 @@
-import { mergeClasses } from '@epam/ai-dial-chat-shared';
+import { buildCssVars, mergeClasses } from '@epam/ai-dial-chat-shared';
 import { ElementSize, ProgressBar } from '@epam/ai-dial-ui-kit';
 import { FC } from 'react';
 import type {
   CatalogItemLimits,
   UsageLimitProgressRow,
 } from '../../../models/item-details-data';
+import styles from './Limits.module.scss';
 
 const getProgressValue = (row: UsageLimitProgressRow): number => {
   if (!Number.isFinite(row.used) || !Number.isFinite(row.total)) {
@@ -28,56 +29,223 @@ const getValueLabel = ({ used, total, valueLabel }: UsageLimitProgressRow) =>
 const hasProgress = ({ total }: UsageLimitProgressRow) =>
   Number.isFinite(total) && total > 0;
 
+const isCapped = (row: UsageLimitProgressRow) =>
+  row.isUnlimited !== true && hasProgress(row);
+
+/** Fraction of the limit consumed so far, clamped to `[0, Infinity)`; `0` when `total` isn't usable. */
+const getUsageRatio = (row: UsageLimitProgressRow): number =>
+  hasProgress(row) ? Math.max(row.used, 0) / row.total : 0;
+
+enum ProgressStatus {
+  Default = 'default',
+  Warning = 'warning',
+  Danger = 'danger',
+}
+
+const getProgressStatus = (row: UsageLimitProgressRow): ProgressStatus => {
+  const ratio = getUsageRatio(row);
+  if (ratio >= 1) {
+    return ProgressStatus.Danger;
+  }
+  if (ratio >= 0.75) {
+    return ProgressStatus.Warning;
+  }
+  return ProgressStatus.Default;
+};
+
+/** Color overrides for `LimitsTab`, applied as CSS custom properties. */
+export interface LimitsTabColors {
+  /** Section heading text color. Fallback: `--text-secondary`. */
+  sectionHeading?: string;
+  /** Row label text color, for both capped and unlimited rows. Fallback: `--text-secondary`. */
+  label?: string;
+  /** Row value text color, for both capped and unlimited rows. Fallback: `--text-secondary`. */
+  value?: string;
+  /** Progress-bar track color for capped rows. Fallback: `--bg-layer-sunken`. */
+  progressTrack?: string;
+  /** Progress-bar fill color below 75% usage. Fallback: `--text-control-blue-hover`. */
+  progressFillDefault?: string;
+  /** Progress-bar fill color once usage reaches 75% of the limit. Fallback: `--text-warning-icon`. */
+  progressFillWarning?: string;
+  /** Progress-bar fill color once usage reaches (or exceeds) the limit. Fallback: `--bg-control-error-active`. */
+  progressFillDanger?: string;
+}
+
 /** Props for `LimitsTab`. */
 export interface LimitsTabProps {
   /** Limits data to render. */
   limits?: CatalogItemLimits;
-  /** CSS class for row labels. Defaults to `'dial-small-semi-text'`. */
+  /** "Cost caps" section heading, shown above capped/progress rows. Defaults to `'Cost caps'`. */
+  costCapsSectionLabel?: string;
+  /** "Unlimited" section heading, shown above unlimited rows. Defaults to `'Unlimited'`. */
+  unlimitedSectionLabel?: string;
+  /** CSS class for capped-row labels. Defaults to `'dial-small-semi-text'`. */
   labelClassName?: string;
-  /** CSS class for row values. Defaults to `'dial-small-text'`. */
+  /** CSS class for unlimited-row labels. Defaults to `'dial-tiny-text'`. */
+  unlimitedLabelClassName?: string;
+  /** CSS class for capped-row values. Defaults to `'dial-small-text'`. */
   valueClassName?: string;
+  /** CSS class for unlimited-row values, including the "Unlimited" text. Defaults to `'dial-tiny-text'`. */
+  unlimitedValueClassName?: string;
+  /** CSS class for section headings. Defaults to `'dial-caption-text'`. */
+  sectionClassName?: string;
+  /** CSS class for a capped row's limit (total) figure, heavier than `valueClassName`. Defaults to `'dial-small-semi-text'`. */
+  limitClassName?: string;
+  /** Color overrides applied as CSS custom properties. */
+  colors?: LimitsTabColors;
 }
 
-/** Renders model usage limits as labeled progress bars. */
+/** Renders model usage limits, split into a "cost caps" progress-bar section and an "unlimited" rows section. */
 export const LimitsTab: FC<LimitsTabProps> = ({
   limits,
+  costCapsSectionLabel = 'Cost caps',
+  unlimitedSectionLabel = 'Unlimited',
   labelClassName = 'dial-small-semi-text',
+  unlimitedLabelClassName = 'dial-tiny-text',
   valueClassName = 'dial-small-text',
+  unlimitedValueClassName = 'dial-tiny-text',
+  sectionClassName = 'dial-caption-text',
+  limitClassName = 'dial-small-semi-text',
+  colors,
 }) => {
   if (limits == null || limits.rows.length === 0) {
     return null;
   }
 
-  return (
-    <ul className="m-0 flex list-none flex-col gap-4 p-0">
-      {limits.rows.map((row) => {
-        const valueLabel = getValueLabel(row);
-        const shouldRenderProgress = hasProgress(row);
+  const cappedRows = limits.rows.filter(isCapped);
+  const unlimitedRows = limits.rows.filter((row) => !isCapped(row));
 
-        return (
-          <li key={row.label} className="flex flex-col gap-2">
-            <div className="flex items-start justify-between gap-3">
-              <span
-                className={mergeClasses('min-w-0 break-words', labelClassName)}
-              >
-                {row.label}
-              </span>
-              <span className={mergeClasses('shrink-0', valueClassName)}>
-                {valueLabel}
-              </span>
-            </div>
-            {shouldRenderProgress && (
-              <ProgressBar
-                value={getProgressValue(row)}
-                max={getProgressMax(row.total)}
-                size={ElementSize.Standard}
-                className="w-full"
-                aria-label={row.ariaLabel ?? `${row.label}: ${valueLabel}`}
-              />
+  const cssVars = buildCssVars({
+    '--lt-section-heading': colors?.sectionHeading,
+    '--lt-label': colors?.label,
+    '--lt-value': colors?.value,
+    '--lt-progress-track': colors?.progressTrack,
+    '--lt-progress-fill-default': colors?.progressFillDefault,
+    '--lt-progress-fill-warning': colors?.progressFillWarning,
+    '--lt-progress-fill-danger': colors?.progressFillDanger,
+  });
+
+  return (
+    <div className="flex flex-col gap-6" style={cssVars}>
+      {cappedRows.length > 0 && (
+        <section>
+          <p
+            className={mergeClasses(
+              'mb-3 mt-0',
+              sectionClassName,
+              styles.sectionHeading,
             )}
-          </li>
-        );
-      })}
-    </ul>
+          >
+            {costCapsSectionLabel}
+          </p>
+          <ul className="m-0 flex list-none flex-col gap-4 p-0">
+            {cappedRows.map((row) => {
+              const valueLabel = getValueLabel(row);
+              const status = getProgressStatus(row);
+
+              return (
+                <li key={row.label}>
+                  <ProgressBar
+                    value={getProgressValue(row)}
+                    max={getProgressMax(row.total)}
+                    size={ElementSize.Small}
+                    className={mergeClasses(
+                      '!h-2 w-full',
+                      styles.progressTrack,
+                      status === ProgressStatus.Default &&
+                        styles.progressFillDefault,
+                      status === ProgressStatus.Warning &&
+                        styles.progressFillWarning,
+                      status === ProgressStatus.Danger &&
+                        styles.progressFillDanger,
+                    )}
+                    labelProps={{
+                      label: (
+                        <span
+                          className={mergeClasses(labelClassName, styles.label)}
+                        >
+                          {row.label}
+                        </span>
+                      ),
+                    }}
+                    valueLabel={
+                      row.usedLabel != null && row.totalLabel != null ? (
+                        <>
+                          <span
+                            className={mergeClasses(
+                              valueClassName,
+                              styles.value,
+                            )}
+                          >
+                            {row.usedLabel}
+                          </span>{' '}
+                          /{' '}
+                          <span
+                            className={mergeClasses(
+                              limitClassName,
+                              styles.value,
+                            )}
+                          >
+                            {row.totalLabel}
+                          </span>
+                        </>
+                      ) : (
+                        <span
+                          className={mergeClasses(valueClassName, styles.value)}
+                        >
+                          {valueLabel}
+                        </span>
+                      )
+                    }
+                    aria-valuetext={row.ariaLabel ?? valueLabel}
+                  />
+                </li>
+              );
+            })}
+          </ul>
+        </section>
+      )}
+
+      {unlimitedRows.length > 0 && (
+        <section>
+          <p
+            className={mergeClasses(
+              'mb-3 mt-0',
+              sectionClassName,
+              styles.sectionHeading,
+            )}
+          >
+            {unlimitedSectionLabel}
+          </p>
+          <ul className="m-0 list-none p-0">
+            {unlimitedRows.map((row) => (
+              <li
+                key={row.label}
+                className="flex items-center justify-between gap-3 py-[4.8px]"
+              >
+                <span
+                  className={mergeClasses(
+                    'min-w-0 break-words',
+                    unlimitedLabelClassName,
+                    styles.label,
+                  )}
+                >
+                  {row.label}
+                </span>
+                <span
+                  className={mergeClasses(
+                    'shrink-0',
+                    unlimitedValueClassName,
+                    styles.value,
+                  )}
+                >
+                  {getValueLabel(row)}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+    </div>
   );
 };

--- a/libs/catalog/src/components/Details/TabsContent/tests/Limits.spec.tsx
+++ b/libs/catalog/src/components/Details/TabsContent/tests/Limits.spec.tsx
@@ -1,6 +1,8 @@
 import { render, screen } from '@testing-library/react';
+import { ReactNode, useId } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import { LimitsTab } from '../Limits';
+import styles from '../Limits.module.scss';
 
 vi.mock('@epam/ai-dial-ui-kit', () => ({
   DIAL_ICON_SIZE: { SM: 16, MD: 20, LG: 24 },
@@ -9,25 +11,41 @@ vi.mock('@epam/ai-dial-ui-kit', () => ({
     value,
     max,
     size,
-    'aria-label': ariaLabel,
+    className,
+    labelProps,
+    valueLabel,
+    'aria-valuetext': ariaValueText,
   }: {
     value: number;
     max?: number;
     size?: string;
-    'aria-label'?: string;
-  }) => (
-    <div
-      role="progressbar"
-      aria-label={ariaLabel}
-      aria-valuenow={value}
-      aria-valuemax={max}
-      data-size={size}
-    />
-  ),
+    className?: string;
+    labelProps?: { label?: ReactNode };
+    valueLabel?: ReactNode;
+    'aria-valuetext'?: string;
+  }) => {
+    const labelId = useId();
+    return (
+      <div>
+        <span id={labelId}>{labelProps?.label}</span>
+        <div
+          role="progressbar"
+          className={className}
+          aria-labelledby={labelId}
+          aria-valuenow={value}
+          aria-valuemax={max}
+          aria-valuetext={ariaValueText}
+          data-size={size}
+        >
+          {valueLabel}
+        </div>
+      </div>
+    );
+  },
 }));
 
 describe('LimitsTab', () => {
-  it('renders limit rows with progress bars and formatted values', () => {
+  it('renders capped rows as progress bars under the "Cost caps" section', () => {
     render(
       <LimitsTab
         limits={{
@@ -37,22 +55,23 @@ describe('LimitsTab', () => {
               used: 12,
               total: 20,
               valueLabel: '12 / 20',
-              ariaLabel: 'Tokens per day usage',
+              ariaLabel: '12 of 20 tokens',
             },
           ],
         }}
       />,
     );
 
-    expect(screen.getByText('Tokens per day')).toBeTruthy();
+    expect(screen.getByText('Cost caps')).toBeTruthy();
     expect(screen.getByText('12 / 20')).toBeTruthy();
 
     const progress = screen.getByRole('progressbar', {
-      name: 'Tokens per day usage',
+      name: 'Tokens per day',
     });
     expect(progress.getAttribute('aria-valuenow')).toBe('12');
     expect(progress.getAttribute('aria-valuemax')).toBe('20');
-    expect(progress.getAttribute('data-size')).toBe('standard');
+    expect(progress.getAttribute('aria-valuetext')).toBe('12 of 20 tokens');
+    expect(progress.getAttribute('data-size')).toBe('small');
   });
 
   it('renders nothing without limit rows', () => {
@@ -63,7 +82,7 @@ describe('LimitsTab', () => {
     expect(container.firstChild).toBeNull();
   });
 
-  it('renders a progress bar for unlimited rows', () => {
+  it('renders unlimited rows as plain label/value rows under the "Unlimited" section, even when total is a large sentinel value', () => {
     render(
       <LimitsTab
         limits={{
@@ -71,23 +90,176 @@ describe('LimitsTab', () => {
             {
               label: 'Cost per week',
               used: 0.119012,
-              total: 9223372036854776000,
+              // Backend reports unlimited rows with a large sentinel total
+              // (see map-deployment-limits-to-catalog.ts), not zero.
+              total: Number.MAX_SAFE_INTEGER,
               isUnlimited: true,
               valueLabel: 'Unlimited',
-              ariaLabel: 'Cost per week: Unlimited',
             },
           ],
         }}
       />,
     );
 
+    expect(screen.getByText('Unlimited', { selector: 'p' })).toBeTruthy();
     expect(screen.getByText('Cost per week')).toBeTruthy();
-    expect(screen.getByText('Unlimited')).toBeTruthy();
+    expect(screen.getByText('Unlimited', { selector: 'span' })).toBeTruthy();
+    expect(screen.queryByRole('progressbar')).toBeNull();
+  });
 
-    const progress = screen.getByRole('progressbar', {
-      name: 'Cost per week: Unlimited',
+  it('renders unlimited rows as plain listitems with no divider or zebra styling', () => {
+    render(
+      <LimitsTab
+        limits={{
+          rows: [
+            {
+              label: 'Requests per hour',
+              used: 0,
+              total: Number.MAX_SAFE_INTEGER,
+              isUnlimited: true,
+              valueLabel: 'Unlimited',
+            },
+            {
+              label: 'Requests per day',
+              used: 0,
+              total: Number.MAX_SAFE_INTEGER,
+              isUnlimited: true,
+              valueLabel: 'Unlimited',
+            },
+          ],
+        }}
+      />,
+    );
+
+    const rows = screen.getAllByRole('listitem');
+    expect(rows).toHaveLength(2);
+    rows.forEach((row) => {
+      expect(row.className).not.toContain('divider');
+      expect(row.className).not.toContain('rowAlt');
     });
-    expect(progress.getAttribute('aria-valuenow')).toBe('0.119012');
-    expect(progress.getAttribute('aria-valuemax')).toBe('9223372036854776000');
+  });
+
+  it('renders unlimited-row labels and values in tiny text by default', () => {
+    render(
+      <LimitsTab
+        limits={{
+          rows: [
+            {
+              label: 'Requests per hour',
+              used: 0,
+              total: Number.MAX_SAFE_INTEGER,
+              isUnlimited: true,
+              valueLabel: 'Unlimited',
+            },
+          ],
+        }}
+      />,
+    );
+
+    const label = screen.getByText('Requests per hour');
+    const value = screen.getByText('Unlimited', { selector: 'span' });
+    expect(label.className).toContain('dial-tiny-text');
+    expect(label.className).not.toContain('dial-small-semi-text');
+    expect(value.className).toContain('dial-tiny-text');
+  });
+
+  it('splits rows into "Cost caps" and "Unlimited" sections using the isUnlimited flag, not just total', () => {
+    render(
+      <LimitsTab
+        limits={{
+          rows: [
+            {
+              label: 'Cost per day',
+              used: 0,
+              total: 100,
+              valueLabel: '$0 / $100',
+            },
+            {
+              label: 'Requests per hour',
+              used: 0,
+              total: Number.MAX_SAFE_INTEGER,
+              isUnlimited: true,
+              valueLabel: 'Unlimited',
+            },
+          ],
+        }}
+      />,
+    );
+
+    expect(screen.getByText('Cost caps')).toBeTruthy();
+    expect(screen.getByText('Unlimited', { selector: 'p' })).toBeTruthy();
+    expect(
+      screen.getByRole('progressbar', { name: 'Cost per day' }),
+    ).toBeTruthy();
+    expect(screen.getByText('Requests per hour')).toBeTruthy();
+    expect(screen.getAllByRole('progressbar')).toHaveLength(1);
+  });
+
+  it('applies the default fill class under 75% usage', () => {
+    render(
+      <LimitsTab
+        limits={{
+          rows: [{ label: 'Cost per day', used: 50, total: 100 }],
+        }}
+      />,
+    );
+
+    const progress = screen.getByRole('progressbar', { name: 'Cost per day' });
+    expect(progress.className).toContain(styles.progressFillDefault);
+    expect(progress.className).not.toContain(styles.progressFillWarning);
+    expect(progress.className).not.toContain(styles.progressFillDanger);
+  });
+
+  it('applies the warning fill class at 75% usage and above', () => {
+    render(
+      <LimitsTab
+        limits={{
+          rows: [{ label: 'Cost per day', used: 75, total: 100 }],
+        }}
+      />,
+    );
+
+    const progress = screen.getByRole('progressbar', { name: 'Cost per day' });
+    expect(progress.className).toContain(styles.progressFillWarning);
+    expect(progress.className).not.toContain(styles.progressFillDanger);
+  });
+
+  it('applies the danger fill class once the limit is reached', () => {
+    render(
+      <LimitsTab
+        limits={{
+          rows: [{ label: 'Cost per day', used: 100, total: 100 }],
+        }}
+      />,
+    );
+
+    const progress = screen.getByRole('progressbar', { name: 'Cost per day' });
+    expect(progress.className).toContain(styles.progressFillDanger);
+    expect(progress.className).not.toContain(styles.progressFillWarning);
+  });
+
+  it('renders the limit figure with heavier emphasis than the used figure', () => {
+    render(
+      <LimitsTab
+        limits={{
+          rows: [
+            {
+              label: 'Cost per day',
+              used: 0,
+              total: 100,
+              usedLabel: '$0.00',
+              totalLabel: '$100.00',
+            },
+          ],
+        }}
+        valueClassName="dial-small-text"
+        limitClassName="dial-small-semi-text"
+      />,
+    );
+
+    const usedText = screen.getByText('$0.00');
+    const limitText = screen.getByText('$100.00');
+    expect(usedText.className).toContain('dial-small-text');
+    expect(limitText.className).toContain('dial-small-semi-text');
   });
 });

--- a/libs/catalog/src/models/item-details-data.ts
+++ b/libs/catalog/src/models/item-details-data.ts
@@ -72,9 +72,13 @@ export interface UsageLimitProgressRow {
   total: number;
   /** Whether the backend reports this row as effectively unlimited. */
   isUnlimited?: boolean;
-  /** Preformatted visible value, e.g. "1,200 / 5,000". */
+  /** Preformatted visible value, e.g. "1,200 / 5,000". Used as-is when `usedLabel`/`totalLabel` are absent. */
   valueLabel?: string;
-  /** Accessible label for the progress bar. */
+  /** Preformatted consumed amount, e.g. "$0.00", rendered with the row's normal value weight. Enables rendering `usedLabel` and `totalLabel` with different emphasis instead of the single `valueLabel` string. */
+  usedLabel?: string;
+  /** Preformatted limit amount, e.g. "$100.00", rendered with heavier emphasis than `usedLabel`. */
+  totalLabel?: string;
+  /** Accessible value text for the progress bar (`aria-valuetext`), overriding the default `used / total` reading. */
   ariaLabel?: string;
 }
 

--- a/libs/catalog/src/models/item-details-props.ts
+++ b/libs/catalog/src/models/item-details-props.ts
@@ -91,6 +91,10 @@ export interface ItemDetailsTexts {
   pricingPricesSectionLabel?: string;
   /** "Usage limits" section heading in the Pricing tab. Default: `'Usage limits'`. */
   pricingLimitsSectionLabel?: string;
+  /** "Cost caps" section heading in the Limits tab. Default: `'Cost caps'`. */
+  limitsCostCapsSectionLabel?: string;
+  /** "Unlimited" section heading in the Limits tab. Default: `'Unlimited'`. */
+  limitsUnlimitedSectionLabel?: string;
   /** Accessible label for the loading placeholder shown next to the tab row while structured details are being fetched. Default: `'Loading details'`. */
   detailsLoadingAriaLabel?: string;
   /** "Log in" action button label, shown when the item's credentials are not signed in. Default: `'Log in'`. */


### PR DESCRIPTION
**Description:**

Redesigns the catalog item details Limits tab:

- Splits usage-limit rows into a "Cost caps" progress-bar section and an "Unlimited" section (rows with a real total vs. rows the backend reports as effectively unlimited).
- Formats cost-denominated stats (`minuteCostStats`/`dayCostStats`/`weekCostStats`/`monthCostStats`) as USD currency instead of bare numbers.
- Colors each capped row's progress bar by usage ratio: default (blue-300, `#5976E9`) below 75%, warning (yellow, `#EEC840`) from 75–99%, danger (red-600, `#CC4545`) at 100%+.
- Renders the limit ("total") figure with heavier emphasis than the used figure.
- "Unlimited" section rows use tiny text, a taller row height, and no divider/zebra styling, matching the smaller-footprint design requested.

**UI changes**

Screenshots were captured during development (progress bar states at various usage levels, color iterations) but aren't attached here — happy to add them if useful for review.

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `feat(<scope>):`
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs