### PR TITLE
fix: Custom application configuration toggle is reset after the first message, Issue #8385

### DIFF
--- a/apps/chat/src/hooks/conversation/tests/useToolsMenu.spec.ts
+++ b/apps/chat/src/hooks/conversation/tests/useToolsMenu.spec.ts
@@ -263,4 +263,62 @@ describe('useToolsMenu', () => {
 
     expect(result.current.onToolToggle).toBe(first);
   });
+
+  it('restoreToolConfiguration sets isSelected from a persisted configuration value', () => {
+    mockUseAppConfig.mockReturnValue(makeAppConfig('deep_research') as never);
+    mockUseDeployments.mockReturnValue(
+      makeDeployments('deploy-1', {
+        deep_research: { type: 'boolean', default: false },
+      }) as never,
+    );
+
+    const { result } = renderHook(() => useToolsMenu());
+
+    act(() => {
+      result.current.restoreToolConfiguration({ deep_research: true });
+    });
+
+    expect(result.current.toolsMenuItems[0].isSelected).toBe(true);
+    expect(result.current.toolConfigurationValue).toEqual({
+      deep_research: true,
+    });
+  });
+
+  it('restoreToolConfiguration ignores a non-boolean or missing value', () => {
+    mockUseAppConfig.mockReturnValue(makeAppConfig('deep_research') as never);
+    mockUseDeployments.mockReturnValue(
+      makeDeployments('deploy-1', {
+        deep_research: { type: 'boolean', default: false },
+      }) as never,
+    );
+
+    const { result } = renderHook(() => useToolsMenu());
+
+    act(() => {
+      result.current.restoreToolConfiguration({ other_tool: true });
+    });
+    expect(result.current.toolsMenuItems[0].isSelected).toBe(false);
+
+    act(() => {
+      result.current.restoreToolConfiguration(undefined);
+    });
+    expect(result.current.toolsMenuItems[0].isSelected).toBe(false);
+  });
+
+  it('restoreToolConfiguration is a no-op when deepResearchToolId is null', () => {
+    mockUseAppConfig.mockReturnValue(makeAppConfig(null) as never);
+    mockUseDeployments.mockReturnValue(
+      makeDeployments('deploy-1', {
+        deep_research: { type: 'boolean', default: false },
+      }) as never,
+    );
+
+    const { result } = renderHook(() => useToolsMenu());
+
+    act(() => {
+      result.current.restoreToolConfiguration({ deep_research: true });
+    });
+
+    expect(result.current.toolConfigurationValue).toEqual({});
+  });
 });

--- a/apps/chat/src/hooks/conversation/useToolsMenu.tsx
+++ b/apps/chat/src/hooks/conversation/useToolsMenu.tsx
@@ -58,6 +58,17 @@ export const useToolsMenu = () => {
     [deepResearchToolId],
   );
 
+  const restoreToolConfiguration = useCallback(
+    (configurationValue: Record<string, unknown> | undefined) => {
+      if (deepResearchToolId == null) return;
+      const value = configurationValue?.[deepResearchToolId];
+      if (typeof value === 'boolean') {
+        setIsSelected(value);
+      }
+    },
+    [deepResearchToolId],
+  );
+
   const toolsMenuItems: ToolMenuItem[] = useMemo(() => {
     if (schemaProperty == null || deepResearchToolId == null) return [];
 
@@ -80,5 +91,10 @@ export const useToolsMenu = () => {
     return { [deepResearchToolId]: isSelected };
   }, [deepResearchToolId, schemaProperty, isSelected]);
 
-  return { toolsMenuItems, onToolToggle, toolConfigurationValue };
+  return {
+    toolsMenuItems,
+    onToolToggle,
+    toolConfigurationValue,
+    restoreToolConfiguration,
+  };
 };

--- a/apps/chat/src/pages/Conversation/Conversation.tsx
+++ b/apps/chat/src/pages/Conversation/Conversation.tsx
@@ -53,7 +53,10 @@ import { buildNetworkUploadErrorNotification } from '../../utils/attachment-netw
 import { getConversationPath } from '../../utils/conversation-path';
 import { shouldWatchForDisplayNameUpdate } from '../../utils/display-name-watch';
 import { isAwaitingGenerationResume } from '../../utils/generation-resume';
-import { getLastDeploymentId } from '../../utils/message-utils';
+import {
+  getLastDeploymentId,
+  getLastUserMessageToolConfiguration,
+} from '../../utils/message-utils';
 
 interface Props {
   onDuplicateReadonly?: () => void;
@@ -81,6 +84,12 @@ export const ConversationPage: FC<Props> = ({ onDuplicateReadonly }) => {
     selectedItemId: currentSelectedItemId,
     isLoading: isDeploymentsLoading,
   } = useDeployments();
+  const {
+    toolsMenuItems,
+    onToolToggle,
+    toolConfigurationValue,
+    restoreToolConfiguration,
+  } = useToolsMenu();
   const { handleClose: handleCloseSourcesSidebar, setMessages } =
     useSourcesSidebar();
   const { user } = useUser();
@@ -311,6 +320,9 @@ export const ConversationPage: FC<Props> = ({ onDuplicateReadonly }) => {
         if (modelToSelect) {
           restoreSelectedItemId(modelToSelect);
         }
+        restoreToolConfiguration(
+          getLastUserMessageToolConfiguration(result.messages),
+        );
 
         const lastMsg = result.messages[result.messages.length - 1];
 
@@ -383,6 +395,7 @@ export const ConversationPage: FC<Props> = ({ onDuplicateReadonly }) => {
     [
       navigate,
       restoreSelectedItemId,
+      restoreToolConfiguration,
       startStream,
       resumeIfAwaitingGeneration,
       updateConversationTitle,
@@ -417,9 +430,6 @@ export const ConversationPage: FC<Props> = ({ onDuplicateReadonly }) => {
      */
     navigate(`${pathname}${search}`, { replace: true, state: null });
   }, [conversationId, prefetchedConversation, navigate, pathname, search]);
-
-  const { toolsMenuItems, onToolToggle, toolConfigurationValue } =
-    useToolsMenu();
 
   const {
     handleSend,

--- a/apps/chat/src/pages/Conversation/Conversation.tsx
+++ b/apps/chat/src/pages/Conversation/Conversation.tsx
@@ -77,6 +77,7 @@ export const ConversationPage: FC<Props> = ({ onDuplicateReadonly }) => {
   const displayNameWatchCleanupRef = useRef<(() => void) | null>(null);
   const displayNameWatchKeyRef = useRef<string | null>(null);
   const notificationShownForRef = useRef<string | null>(null);
+  const restoredToolConfigIdRef = useRef<string | null>(null);
   const navigate = useNavigate();
   const { t } = useTranslation();
   const {
@@ -320,9 +321,12 @@ export const ConversationPage: FC<Props> = ({ onDuplicateReadonly }) => {
         if (modelToSelect) {
           restoreSelectedItemId(modelToSelect);
         }
-        restoreToolConfiguration(
-          getLastUserMessageToolConfiguration(result.messages),
-        );
+        if (restoredToolConfigIdRef.current !== id) {
+          restoredToolConfigIdRef.current = id;
+          restoreToolConfiguration(
+            getLastUserMessageToolConfiguration(result.messages),
+          );
+        }
 
         const lastMsg = result.messages[result.messages.length - 1];
 

--- a/apps/chat/src/pages/ConversationRoute/ConversationRoute.integration.spec.tsx
+++ b/apps/chat/src/pages/ConversationRoute/ConversationRoute.integration.spec.tsx
@@ -245,6 +245,7 @@ describe('ConversationRoute — new chat model inheritance (issue #8150 Case 3)'
       toolsMenuItems: [],
       onToolToggle: vi.fn(),
       toolConfigurationValue: {},
+      restoreToolConfiguration: vi.fn(),
     });
     mockCreateConversation.mockResolvedValue({
       id: 'bucket/path__Hello',

--- a/apps/chat/src/pages/ConversationRoute/ConversationRoute.spec.tsx
+++ b/apps/chat/src/pages/ConversationRoute/ConversationRoute.spec.tsx
@@ -295,6 +295,7 @@ describe('ConversationRoute', () => {
       toolsMenuItems: [],
       onToolToggle: vi.fn(),
       toolConfigurationValue: {},
+      restoreToolConfiguration: vi.fn(),
     });
     mockUseNotification.mockReturnValue(
       createNotificationContextValue(mockShowNotification),
@@ -775,6 +776,7 @@ describe('ConversationRoute', () => {
       toolsMenuItems: [],
       onToolToggle: vi.fn(),
       toolConfigurationValue: { starter: true },
+      restoreToolConfiguration: vi.fn(),
     });
     const selectedDeploymentConfiguration: DeploymentConfigurationSchema = {
       type: 'object',

--- a/apps/chat/src/utils/message-utils.ts
+++ b/apps/chat/src/utils/message-utils.ts
@@ -69,6 +69,22 @@ export const hasActiveToolConfig = (
   value: Record<string, boolean> | undefined,
 ): boolean => value != null && Object.keys(value).length > 0;
 
+/**
+ * Returns the `configuration_value` stored on the last user message, or
+ * `undefined` if none exists. Used to restore the tools menu toggle state
+ * when a conversation is (re-)loaded, mirroring `getLastDeploymentId`.
+ */
+export const getLastUserMessageToolConfiguration = (
+  messages: Message[],
+): Record<string, unknown> | undefined => {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (messages[i].role === MessageRole.User) {
+      return messages[i].custom_content?.configuration_value;
+    }
+  }
+  return undefined;
+};
+
 /** Normalises a stored response-format string to the current enum.
  * Legacy data may contain 'Markdown' or 'PlainText' (capital-first) instead
  * of the current enum values 'markdown' / 'plain_text'. */

--- a/apps/chat/src/utils/tests/message-utils.spec.ts
+++ b/apps/chat/src/utils/tests/message-utils.spec.ts
@@ -11,6 +11,7 @@ import {
 import { describe, expect, it } from 'vitest';
 import {
   getLastDeploymentId,
+  getLastUserMessageToolConfiguration,
   isMessageChanged,
   isMessageStreaming,
   messageHasStages,
@@ -121,6 +122,50 @@ describe('getLastDeploymentId', () => {
     expect(
       getLastDeploymentId([userMessage(), statusModelChanged('model-x')]),
     ).toBe('model-x');
+  });
+});
+
+/*
+ * ---------------------------------------------------------------------------
+ * getLastUserMessageToolConfiguration
+ * ---------------------------------------------------------------------------
+ */
+
+describe('getLastUserMessageToolConfiguration', () => {
+  it('returns undefined for an empty list', () => {
+    expect(getLastUserMessageToolConfiguration([])).toBeUndefined();
+  });
+
+  it('returns undefined when the last user message has no configuration_value', () => {
+    expect(
+      getLastUserMessageToolConfiguration([userMessage(), assistantMessage()]),
+    ).toBeUndefined();
+  });
+
+  it('returns the configuration_value from the last user message', () => {
+    const withConfig: Message = {
+      ...userMessage('second'),
+      custom_content: { configuration_value: { deep_research: true } },
+    };
+    const messages: Message[] = [
+      { ...userMessage('first'), custom_content: {} },
+      assistantMessage(),
+      withConfig,
+      assistantMessage(),
+    ];
+    expect(getLastUserMessageToolConfiguration(messages)).toEqual({
+      deep_research: true,
+    });
+  });
+
+  it('reads the configuration from the last user message while awaiting a reply', () => {
+    const withConfig: Message = {
+      ...userMessage('awaiting reply'),
+      custom_content: { configuration_value: { deep_research: true } },
+    };
+    expect(getLastUserMessageToolConfiguration([withConfig])).toEqual({
+      deep_research: true,
+    });
   });
 });
 

--- a/openspec/specs/chat-input-tools-menu/spec.md
+++ b/openspec/specs/chat-input-tools-menu/spec.md
@@ -132,7 +132,9 @@ When the selected deployment changes, all tool toggle states SHALL be reinitiali
 
 ### Requirement: Tool selection restored when a conversation (re)mounts
 
-The tools menu state is owned by a `useToolsMenu` hook instance scoped to the page component it is called from. Creating a conversation from the new-chat screen navigates from that screen's component to a separate conversation-view component, mounting a new `useToolsMenu` instance whose local toggle state starts uninitialized from conversation history. To prevent the just-sent toggle from silently reverting to the schema default on that navigation, the conversation-view component SHALL restore the toggle from the `configuration_value` stored on the conversation's last user message as soon as the conversation is (re)loaded — whether freshly created, opened from the sidebar, or reloaded — using the same value it stores per user message (see "Tool choices persisted in conversation history" below). This restore SHALL NOT be treated as a deployment-driven reset and SHALL NOT be persisted as a new user choice.
+The tools menu state is owned by a `useToolsMenu` hook instance scoped to the page component it is called from. Creating a conversation from the new-chat screen navigates from that screen's component to a separate conversation-view component, mounting a new `useToolsMenu` instance whose local toggle state starts uninitialized from conversation history. To prevent the just-sent toggle from silently reverting to the schema default on that navigation, the conversation-view component SHALL restore the toggle from the `configuration_value` stored on the conversation's last user message the first time a given conversation id is loaded in that component instance — whether freshly created, opened from the sidebar, switched to from another conversation, or reloaded — using the same value it stores per user message (see "Tool choices persisted in conversation history" below). This restore SHALL NOT be treated as a deployment-driven reset and SHALL NOT be persisted as a new user choice.
+
+The restore SHALL run at most once per conversation id per component mount. While that conversation's generation is still in flight, the last user message's `configuration_value` reflects only the turn already sent and does not change until the user sends a new message; re-running the restore on every reload of that same in-flight turn would silently overwrite a toggle change the user made locally after sending it. A conversation id already restored in this component instance SHALL NOT be restored again unless the user navigates away to a different conversation and back.
 
 #### Scenario: First message toggle survives the new-chat-to-conversation navigation
 - **WHEN** the user toggles Deep Research on and sends the first message from the new-chat screen
@@ -147,6 +149,14 @@ The tools menu state is owned by a `useToolsMenu` hook instance scoped to the pa
 #### Scenario: No configuration on the last user message — falls back to schema default
 - **WHEN** the conversation's last user message has no `configuration_value` (or no value for the configured tool id)
 - **THEN** the Tools toggle state is left at the deployment configuration schema's `default` value
+
+#### Scenario: In-flight generation does not re-clobber a local toggle change
+- **WHEN** a conversation's generation is still in flight for its last user message (`configuration_value: { "deep_research": true }`) AND the user locally toggles Deep Research off while waiting AND the component reloads that same conversation id again without the user navigating away
+- **THEN** the Tools toggle stays off — the restore does not re-run for a conversation id already restored in this component instance
+
+#### Scenario: Navigating away and back to an in-flight conversation re-derives from its persisted state
+- **WHEN** the user navigates from a conversation with an in-flight generation to a different conversation and back
+- **THEN** the Tools toggle for the original conversation is re-restored from its last user message's `configuration_value`, since it is a fresh load for that conversation id in this component instance
 
 ---
 

--- a/openspec/specs/chat-input-tools-menu/spec.md
+++ b/openspec/specs/chat-input-tools-menu/spec.md
@@ -130,6 +130,26 @@ When the selected deployment changes, all tool toggle states SHALL be reinitiali
 
 ---
 
+### Requirement: Tool selection restored when a conversation (re)mounts
+
+The tools menu state is owned by a `useToolsMenu` hook instance scoped to the page component it is called from. Creating a conversation from the new-chat screen navigates from that screen's component to a separate conversation-view component, mounting a new `useToolsMenu` instance whose local toggle state starts uninitialized from conversation history. To prevent the just-sent toggle from silently reverting to the schema default on that navigation, the conversation-view component SHALL restore the toggle from the `configuration_value` stored on the conversation's last user message as soon as the conversation is (re)loaded — whether freshly created, opened from the sidebar, or reloaded — using the same value it stores per user message (see "Tool choices persisted in conversation history" below). This restore SHALL NOT be treated as a deployment-driven reset and SHALL NOT be persisted as a new user choice.
+
+#### Scenario: First message toggle survives the new-chat-to-conversation navigation
+- **WHEN** the user toggles Deep Research on and sends the first message from the new-chat screen
+- **THEN** the created conversation's user message is persisted with `configuration_value: { "deep_research": true }`
+- **AND** the conversation view that the app navigates to shows the Tools toggle as selected
+- **AND** the next message the user sends also includes `configuration_value: { "deep_research": true }`
+
+#### Scenario: Opening an existing conversation restores its last toggle state
+- **WHEN** the user opens a conversation whose last user message has `configuration_value: { "deep_research": true }`
+- **THEN** the Tools toggle displays as selected for that conversation
+
+#### Scenario: No configuration on the last user message — falls back to schema default
+- **WHEN** the conversation's last user message has no `configuration_value` (or no value for the configured tool id)
+- **THEN** the Tools toggle state is left at the deployment configuration schema's `default` value
+
+---
+
 ### Requirement: Tool choices sent in completion request
 
 When the user sends a message, the selected tool states SHALL be included in the message's `custom_content.configuration_value` as key-value pairs (e.g. `{ "deep_research": true }`).


### PR DESCRIPTION
## Description of changes

Keep the configuration settings from the last message in the conversation

## Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #8385

## UI changes

<Please, provide Screenshots or Figma links>

## Checklist

- [X] the pull request name ends with `(Issue #<ISSUE_ID>)` (comma-separated list of issues)
- [X] I confirm that I don't share any confidential information like API keys or any other secrets and private URLs

<details>
  <summary>PR title cheatsheet</summary>

`<type>[optional scope]: <description>`

1. type (required)
    - `feat` - A new feature
    - `fix` - A bug fix
    - `docs` - Documentation only changes
    - `test` - Adding missing tests or correcting existing tests
    - `ci` - Changes to our CI configuration files and scripts
    - `chore` - Other changes that are minor and/or not user-facing
2. scope (optional, current repo suggestions below)
    - `chat`
    - `overlay`
    - `shared`
    - `sandbox-overlay`
    - `visualizer-connector`

</details>
