### PR TITLE
fix: Fix Attachment type validation in Custom App, #6905

### DIFF
--- a/apps/chat-api/src/applications/dto/update-application.dto.ts
+++ b/apps/chat-api/src/applications/dto/update-application.dto.ts
@@ -78,7 +78,10 @@ export class UpdateApplicationBodyDto {
   @ApiPropertyOptional({ example: ['image/png'], type: [String] })
   @IsArray()
   @IsString({ each: true })
-  @Matches(/^([a-zA-Z0-9!*\-.+]+|\*)\/([a-zA-Z0-9!*\-.+]+|\*)$/, { each: true })
+  @Matches(/^([a-zA-Z0-9!*\-.+]+|\*)\/([a-zA-Z0-9!*\-.+]+|\*)$/, {
+    each: true,
+    message: 'Attachment types must be MIME types, for example image/png',
+  })
   @IsOptional()
   inputAttachmentTypes?: string[];
 

--- a/apps/chat/src/pages/ToolsetEditor/CustomAppEditor.tsx
+++ b/apps/chat/src/pages/ToolsetEditor/CustomAppEditor.tsx
@@ -418,15 +418,21 @@ const CustomAppEditor: FC = () => {
       });
       return;
     }
-    setSettingsErrors({});
-
     const hasMimeError = settingsForm.inputAttachmentTypes.some(
       (tag) => !MIME_TYPE_REGEX.test(tag),
     );
+    if (hasMimeError) {
+      setSettingsErrors({
+        inputAttachmentTypes: t(CustomAppI18nKeys.InvalidMimeType),
+      });
+      return;
+    }
+    setSettingsErrors({});
+
     const hasFeaturesDataError = !isValidFeaturesData(
       settingsForm.featuresData,
     );
-    if (hasMimeError || hasFeaturesDataError) {
+    if (hasFeaturesDataError) {
       setIsConfirmSaveOpen(true);
       return;
     }

--- a/openspec/specs/custom-app-editor/spec.md
+++ b/openspec/specs/custom-app-editor/spec.md
@@ -68,6 +68,17 @@ The Save action on the Settings step SHALL stay disabled until the Chat completi
 - **WHEN** user types a MIME type and confirms
 - **THEN** it is added as a tag in the Attachment types field
 
+### Requirement: Attachment types — invalid MIME type blocks save
+A non-MIME-type entry MAY still be accepted as a tag in the Attachment types `TagInput` (the field shows an inline error as soon as the tag is added), but `CustomAppEditor` SHALL treat that inline error as blocking, the same way it treats the Chat completion URL error: clicking Save while any tag fails MIME-type validation SHALL set the field error and send no request, instead of routing through the "save anyway" confirmation used for other soft warnings (e.g. Features data). This differs from the Features-data-invalid case specifically because letting an invalid tag reach the create/update request has been observed to also silently drop unrelated Settings fields (e.g. Max attachments number) from what gets persisted; blocking the request is the fix, not merely a stricter opinion on tag content.
+
+#### Scenario: Save blocked by an invalid MIME type tag
+- **WHEN** the Attachment types field contains at least one tag that is not a valid MIME type and the user clicks Save
+- **THEN** the Attachment types field shows an "invalid MIME type" error and no create/update request is sent
+
+#### Scenario: Unrelated fields are unaffected by a blocked save
+- **WHEN** a save attempt is blocked by an invalid MIME type tag
+- **THEN** other Settings field values (e.g. Max attachments number) are left exactly as entered, since no request was sent and no reload occurred
+
 ### Requirement: Create — no type sent
 On save in creation mode, `CustomAppEditor` SHALL NOT send `type` in the create payload. Custom apps are plain-endpoint applications with no application-type schema ID; `application_type_schema_id` is omitted from the DIAL Core body.
 


### PR DESCRIPTION
**Description:**

Fix for comment in #6905

Issues:

- Issue #6905

**UI changes**

<img width="1824" height="708" alt="image" src="https://github.com/user-attachments/assets/7c6dd095-fa4f-42ee-b97b-5a965a409e3c" />


**Checklist:**

- [X] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [X] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [X] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
