### PR TITLE
docs(chat-api): document private CA configuration (Issue #8396)

### DIFF
--- a/apps/chat-api/.env.template
+++ b/apps/chat-api/.env.template
@@ -60,6 +60,12 @@ AUTH_AUTH0_HOST=your-tenant.auth0.com
 # AUTH_KEYCLOAK_SECRET=<client-secret>
 # AUTH_KEYCLOAK_HOST=keycloak.example.com/realms/dial
 
+# If an OIDC provider uses a certificate issued by a private CA, mount the
+# PEM-encoded CA bundle into the container and set this path before startup.
+# See README.md "Trusting a private certificate authority". Never disable TLS
+# verification with NODE_TLS_REJECT_UNAUTHORIZED=0.
+# NODE_EXTRA_CA_CERTS=/certificates/company-ca.pem
+
 # PingID
 # AUTH_PING_ID_CLIENT_ID=your-client-id
 # AUTH_PING_ID_SECRET=<client-secret>

--- a/apps/chat-api/README.md
+++ b/apps/chat-api/README.md
@@ -287,6 +287,36 @@ Google has no host variable (issuer is the fixed `https://accounts.google.com`) 
 
 \* Required only if that provider is being configured at all (signaled by its `CLIENT_ID` variable being set); the provider is skipped entirely otherwise.
 
+#### Trusting a private certificate authority
+
+At startup, `chat-api` discovers every configured OIDC provider over HTTPS. If
+an identity provider uses a certificate issued by a private CA, the Node.js
+process must trust that CA before the application starts; otherwise provider
+discovery fails and the application does not boot.
+
+Mount a PEM-encoded CA bundle into the container and point
+[`NODE_EXTRA_CA_CERTS`](https://nodejs.org/api/cli.html#node_extra_ca_certsfile)
+to it. For example, with Docker Compose:
+
+```yaml
+services:
+  chat:
+    environment:
+      NODE_EXTRA_CA_CERTS: /certificates/company-ca.pem
+    volumes:
+      - ./company-ca.pem:/certificates/company-ca.pem:ro
+```
+
+The bundle should contain the issuing root and any required intermediate CA
+certificates. If the server certificate is genuinely self-signed, include that
+certificate itself. The file must exist when the Node.js process starts because
+`NODE_EXTRA_CA_CERTS` is read only at process launch.
+
+`NODE_EXTRA_CA_CERTS` is a Node.js runtime variable, not an application-owned
+variable validated by `chat-api`. Do not use `NODE_TLS_REJECT_UNAUTHORIZED=0`:
+it disables certificate verification for every HTTPS connection made by the
+process.
+
 ### 3. Run the Application
 
 **Development mode:**
@@ -651,6 +681,9 @@ kill -TERM %1                                  # should exit cleanly within a fe
 
 - **Check environment variables**: Ensure all required variables are set
 - **Validation errors**: The application validates environment variables at startup and will fail with clear error messages if configuration is invalid
+- **Self-signed certificate error**: Mount the private CA bundle and configure
+  `NODE_EXTRA_CA_CERTS` as described in
+  [Trusting a private certificate authority](#trusting-a-private-certificate-authority)
 
 ### Theme endpoints returning errors
 

--- a/docs/legacy-chat-migration-guide.md
+++ b/docs/legacy-chat-migration-guide.md
@@ -30,6 +30,8 @@ API, never a rebuild of the frontend image.
 ## Migration checklist
 
 1. Stand up `chat-api` with DIAL Core access and at least one auth provider.
+   If the provider uses a private CA, configure its trust bundle before startup
+   as described in [Private certificate authorities](#private-certificate-authorities).
 2. Port environment variables — see [Environment variables](#environment-variables).
 3. Port UI feature flags — see [UI feature flags](#ui-feature-flags).
 4. Port the themes configuration — see [Themes](#themes).
@@ -115,6 +117,20 @@ Practical consequences for a migration:
   are in `apps/chat-api/README.md` § "Auth provider environment variables".
 - For a cross-site iframe deployment, set `AUTH_COOKIE_SECURE=true` so the
   session cookie is `SameSite=None; Secure`.
+
+### Private certificate authorities
+
+In 1.0, `chat-api` discovers every configured OIDC provider during startup. A
+provider certificate issued by a private CA therefore causes startup to fail
+unless that CA is already trusted by the Node.js process.
+
+Provide the deployment's private CA bundle when migrating. Mount the PEM-encoded
+bundle into the `chat-api` container and set `NODE_EXTRA_CA_CERTS` to its
+in-container path before the process starts. The complete Docker Compose example
+and certificate-chain guidance are in the Chat API README section
+[Trusting a private certificate authority](../apps/chat-api/README.md#trusting-a-private-certificate-authority).
+Do not use `NODE_TLS_REJECT_UNAUTHORIZED=0`, which disables certificate
+verification for every HTTPS connection made by the process.
 
 Design detail — cookie format, refresh, federated logout, `SessionGuard` — is in
 [`docs/auth/`](./auth/).


### PR DESCRIPTION
**Description:**

Document how to trust private or self-signed certificate authorities for OIDC provider discovery so operators can start `chat-api` against privately issued certificates. Add a safe `NODE_EXTRA_CA_CERTS` container example to the Chat API reference, environment template, and legacy migration guide, and explicitly warn against disabling TLS verification globally.

Issues:

- Issue #8396

**UI changes**

No UI changes.

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `docs(chat-api):`
- [x] the pull request name ends with `(Issue #8396)`
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs