### PR TITLE
fix(chat-api): share conversation attachments (Issue #7729)

### DIFF
--- a/apps/chat-api/src/share/share.service.ts
+++ b/apps/chat-api/src/share/share.service.ts
@@ -9,15 +9,18 @@ import {
 import { ConfigService } from '@nestjs/config';
 import {
   handleDialFetchError,
+  handleDialSdkError,
   mapDialHttpStatus,
 } from '../common/dial/dial-error.mapper';
 import { getBearerAuthHeaders } from '../common/utils/auth-header';
+import { encodeDialResourcePath } from '../common/utils/encode-dial-path';
 import {
   countRecipientsByUrl,
   resolveRecipientsCount,
 } from '../common/utils/resource-ownership';
 import { safeDecodeURIComponent } from '../common/utils/uri';
 import { EnvironmentVariables } from '../config/environment.config';
+import { resolveConversationLocation } from '../conversations/utils/conversation.utils';
 import { DeploymentsService } from '../deployments/deployments.service';
 import { DialClientService } from '../dial/dial-client.service';
 import {
@@ -90,6 +93,75 @@ const CONVERSATION_SHARE_INVITATION_ROUTE_PATH = '/conversations/shared';
 
 /** DIAL Core conversation resource paths always start with this prefix. */
 const CONVERSATION_RESOURCE_PREFIX = 'conversations/';
+const FILE_RESOURCE_PREFIX = 'files/';
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null;
+
+const collectAttachmentResourceUrls = (
+  attachments: unknown,
+  resourceUrls: Set<string>,
+): void => {
+  if (!Array.isArray(attachments)) return;
+
+  for (const attachment of attachments) {
+    if (!isRecord(attachment)) continue;
+
+    for (const field of ['url', 'reference_url'] as const) {
+      const url = attachment[field];
+      if (typeof url !== 'string') continue;
+
+      const resourceUrl = url.split('#', 1)[0];
+      if (resourceUrl.startsWith(FILE_RESOURCE_PREFIX)) {
+        resourceUrls.add(resourceUrl);
+      }
+    }
+  }
+};
+
+/** Collects unique DIAL file resources referenced by messages, stages, and citations. */
+const collectConversationResourceUrls = (conversation: unknown): string[] => {
+  if (!isRecord(conversation) || !Array.isArray(conversation.messages)) {
+    return [];
+  }
+
+  const resourceUrls = new Set<string>();
+  for (const message of conversation.messages) {
+    if (!isRecord(message) || !isRecord(message.custom_content)) continue;
+
+    collectAttachmentResourceUrls(
+      message.custom_content.attachments,
+      resourceUrls,
+    );
+
+    const stages = message.custom_content.stages;
+    if (Array.isArray(stages)) {
+      for (const stage of stages) {
+        if (isRecord(stage)) {
+          collectAttachmentResourceUrls(stage.attachments, resourceUrls);
+        }
+      }
+    }
+
+    const annotations = message.custom_content.annotations;
+    if (!Array.isArray(annotations)) continue;
+    for (const annotation of annotations) {
+      if (
+        isRecord(annotation) &&
+        isRecord(annotation.body) &&
+        isRecord(annotation.body.source) &&
+        isRecord(annotation.body.source.attachment)
+      ) {
+        collectAttachmentResourceUrls(
+          [annotation.body.source.attachment],
+          resourceUrls,
+        );
+      }
+    }
+  }
+
+  return [...resourceUrls];
+};
 
 const getInvitationRoutePath = (itemId: string): string =>
   itemId.startsWith(CONVERSATION_RESOURCE_PREFIX)
@@ -147,6 +219,54 @@ export class ShareService {
     return `${this.appOrigin}${getInvitationRoutePath(itemId)}/${invitationId}`;
   }
 
+  private async getRelatedResourceUrls(
+    accessToken: string,
+    sessionBucket: string,
+    resourceUrl: string,
+  ): Promise<string[]> {
+    if (!resourceUrl.startsWith(CONVERSATION_RESOURCE_PREFIX)) return [];
+
+    const conversationPath = resourceUrl.slice(
+      CONVERSATION_RESOURCE_PREFIX.length,
+    );
+    const { bucket, subPath } = resolveConversationLocation(
+      conversationPath,
+      sessionBucket,
+    );
+
+    let result;
+    try {
+      result = await this.dialClient.client.getConversation(
+        bucket,
+        encodeDialResourcePath(subPath),
+        { headers: getBearerAuthHeaders(accessToken) },
+      );
+    } catch (err) {
+      return handleDialSdkError(
+        err,
+        'load conversation resources before sharing',
+        this.logger,
+      );
+    }
+
+    if (result.error != null) {
+      return handleDialSdkError(
+        result.error,
+        'load conversation resources before sharing',
+        this.logger,
+        result.response,
+      );
+    }
+    if (result.data == null) {
+      this.logger.error(
+        `DIAL Core returned an empty conversation for resourceUrl=${resourceUrl}`,
+      );
+      throw new BadGatewayException('DIAL Core returned an empty conversation');
+    }
+
+    return collectConversationResourceUrls(result.data);
+  }
+
   /**
    * Creates a share link for a DIAL Core resource (catalog entity, prompt, or conversation).
    *
@@ -165,9 +285,17 @@ export class ShareService {
     const permissions = Array.from(
       new Set(access.flatMap((level) => ACCESS_PERMISSIONS[level])),
     );
+    const relatedResourceUrls = await this.getRelatedResourceUrls(
+      accessToken,
+      bucket,
+      resourceUrl,
+    );
     const requestBody = {
       invitationType: 'LINK' as const,
-      resources: [{ url: resourceUrl, permissions }],
+      resources: [resourceUrl, ...relatedResourceUrls].map((url) => ({
+        url,
+        permissions,
+      })),
     };
     this.logger.debug(
       `Requesting share link from DIAL Core: ${JSON.stringify(requestBody)}`,

--- a/apps/chat-api/src/share/share.service.ts
+++ b/apps/chat-api/src/share/share.service.ts
@@ -95,6 +95,14 @@ const CONVERSATION_SHARE_INVITATION_ROUTE_PATH = '/conversations/shared';
 const CONVERSATION_RESOURCE_PREFIX = 'conversations/';
 const FILE_RESOURCE_PREFIX = 'files/';
 
+interface AnnotationWithAttachment {
+  body?: {
+    source?: {
+      attachment?: unknown;
+    };
+  };
+}
+
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null;
 
@@ -146,17 +154,9 @@ const collectConversationResourceUrls = (conversation: unknown): string[] => {
     const annotations = message.custom_content.annotations;
     if (!Array.isArray(annotations)) continue;
     for (const annotation of annotations) {
-      if (
-        isRecord(annotation) &&
-        isRecord(annotation.body) &&
-        isRecord(annotation.body.source) &&
-        isRecord(annotation.body.source.attachment)
-      ) {
-        collectAttachmentResourceUrls(
-          [annotation.body.source.attachment],
-          resourceUrls,
-        );
-      }
+      const attachment = (annotation as AnnotationWithAttachment)?.body?.source
+        ?.attachment;
+      collectAttachmentResourceUrls([attachment], resourceUrls);
     }
   }
 

--- a/apps/chat-api/src/share/tests/share.service.spec.ts
+++ b/apps/chat-api/src/share/tests/share.service.spec.ts
@@ -239,6 +239,54 @@ describe('ShareService', () => {
       });
     });
 
+    it('does not share partial resources when the conversation lookup rejects', async () => {
+      const { service, dialClient } = makeService();
+      vi.spyOn(dialClient.client, 'getConversation').mockRejectedValue(
+        new TypeError('fetch failed'),
+      );
+      const shareSpy = vi.spyOn(dialClient.client, 'shareResource');
+
+      await expect(
+        service.createShareLink('token-abc', 'session-bucket', {
+          itemId: 'conversations/owner-bucket/my-chat.json',
+          access: [ShareAccess.View],
+        }),
+      ).rejects.toThrow(ServiceUnavailableException);
+      expect(shareSpy).not.toHaveBeenCalled();
+    });
+
+    it('does not share partial resources when the conversation lookup returns an upstream error', async () => {
+      const { service, dialClient } = makeService();
+      vi.spyOn(dialClient.client, 'getConversation').mockResolvedValue(
+        errResponse(HttpStatus.NOT_FOUND),
+      );
+      const shareSpy = vi.spyOn(dialClient.client, 'shareResource');
+
+      await expect(
+        service.createShareLink('token-abc', 'session-bucket', {
+          itemId: 'conversations/owner-bucket/my-chat.json',
+          access: [ShareAccess.View],
+        }),
+      ).rejects.toThrow(NotFoundException);
+      expect(shareSpy).not.toHaveBeenCalled();
+    });
+
+    it('does not share partial resources when the conversation lookup returns no data', async () => {
+      const { service, dialClient } = makeService();
+      vi.spyOn(dialClient.client, 'getConversation').mockResolvedValue(
+        okResponse(null),
+      );
+      const shareSpy = vi.spyOn(dialClient.client, 'shareResource');
+
+      await expect(
+        service.createShareLink('token-abc', 'session-bucket', {
+          itemId: 'conversations/owner-bucket/my-chat.json',
+          access: [ShareAccess.View],
+        }),
+      ).rejects.toThrow(BadGatewayException);
+      expect(shareSpy).not.toHaveBeenCalled();
+    });
+
     it('does not load related resources for a non-conversation item', async () => {
       const { service, dialClient } = makeService();
       vi.spyOn(dialClient.client, 'shareResource').mockResolvedValue(
@@ -282,7 +330,7 @@ describe('ShareService', () => {
     });
 
     it("qualifies a prompt itemId with the caller's bucket", async () => {
-      const { service } = makeService();
+      const { service, dialClient } = makeService();
       const spy = vi
         .spyOn(service['dialClient'].client, 'shareResource')
         .mockResolvedValue(okResponse({ invitationLink: '/invite/p1' }));
@@ -307,6 +355,7 @@ describe('ShareService', () => {
       });
       /* Prompts live in the catalog, so they use the catalog accept route. */
       expect(result.url).toBe('https://example.com/catalog/shared/p1');
+      expect(dialClient.client.getConversation).not.toHaveBeenCalled();
     });
 
     it('percent-encodes a prompt itemId nested inside a folder with a space in its name', async () => {

--- a/apps/chat-api/src/share/tests/share.service.spec.ts
+++ b/apps/chat-api/src/share/tests/share.service.spec.ts
@@ -27,6 +27,7 @@ function makeService(callbackBaseUrl = 'https://example.com/callback') {
   const dialClient = {
     client: {
       shareResource: vi.fn(),
+      getConversation: vi.fn().mockResolvedValue(okResponse({ messages: [] })),
       getInvitation: vi.fn(),
       discardSharedResources: vi.fn(),
       revokeSharedResources: vi.fn(),
@@ -131,7 +132,7 @@ describe('ShareService', () => {
     });
 
     it('routes conversation itemIds to the conversation accept-invitation path', async () => {
-      const { service } = makeService();
+      const { service, dialClient } = makeService();
       vi.spyOn(service['dialClient'].client, 'shareResource').mockResolvedValue(
         okResponse({ invitationLink: '/v1/invitations/conv-abc' }),
       );
@@ -144,6 +145,112 @@ describe('ShareService', () => {
       expect(result.url).toBe(
         'https://example.com/conversations/shared/conv-abc',
       );
+      expect(dialClient.client.getConversation).toHaveBeenCalledWith(
+        'bucket',
+        'my-chat.json',
+        { headers: { Authorization: 'Bearer token-abc' } },
+      );
+    });
+
+    it('shares unique DIAL file attachments referenced by a conversation', async () => {
+      const { service, dialClient } = makeService();
+      vi.spyOn(dialClient.client, 'getConversation').mockResolvedValue(
+        okResponse({
+          messages: [
+            {
+              custom_content: {
+                attachments: [
+                  { url: 'files/owner-bucket/report.pdf' },
+                  { url: 'https://example.com/public.pdf' },
+                  { data: 'aW5saW5l' },
+                ],
+                annotations: [
+                  {
+                    body: {
+                      source: {
+                        attachment: {
+                          url: 'files/owner-bucket/citation.pdf',
+                        },
+                      },
+                    },
+                  },
+                ],
+              },
+            },
+            {
+              custom_content: {
+                attachments: [
+                  { url: 'files/owner-bucket/report.pdf' },
+                  {
+                    reference_url: 'files/owner-bucket/source.pdf#page=2',
+                  },
+                ],
+                stages: [
+                  {
+                    attachments: [{ url: 'files/owner-bucket/generated.csv' }],
+                  },
+                ],
+              },
+            },
+          ],
+        }),
+      );
+      const shareSpy = vi
+        .spyOn(dialClient.client, 'shareResource')
+        .mockResolvedValue(okResponse({ invitationLink: '/invite/conv' }));
+
+      await service.createShareLink('token-abc', 'session-bucket', {
+        itemId: 'conversations/owner-bucket/Planning/My%20conversation.json',
+        access: [ShareAccess.View, ShareAccess.Edit],
+      });
+
+      expect(dialClient.client.getConversation).toHaveBeenCalledWith(
+        'owner-bucket',
+        'Planning/My%20conversation.json',
+        { headers: { Authorization: 'Bearer token-abc' } },
+      );
+      expect(shareSpy).toHaveBeenCalledWith({
+        headers: { Authorization: 'Bearer token-abc' },
+        body: {
+          invitationType: 'LINK',
+          resources: [
+            {
+              url: 'conversations/owner-bucket/Planning/My%20conversation.json',
+              permissions: ['READ', 'WRITE'],
+            },
+            {
+              url: 'files/owner-bucket/report.pdf',
+              permissions: ['READ', 'WRITE'],
+            },
+            {
+              url: 'files/owner-bucket/citation.pdf',
+              permissions: ['READ', 'WRITE'],
+            },
+            {
+              url: 'files/owner-bucket/source.pdf',
+              permissions: ['READ', 'WRITE'],
+            },
+            {
+              url: 'files/owner-bucket/generated.csv',
+              permissions: ['READ', 'WRITE'],
+            },
+          ],
+        },
+      });
+    });
+
+    it('does not load related resources for a non-conversation item', async () => {
+      const { service, dialClient } = makeService();
+      vi.spyOn(dialClient.client, 'shareResource').mockResolvedValue(
+        okResponse({ invitationLink: '/invite/app' }),
+      );
+
+      await service.createShareLink('token-abc', 'my-bucket', {
+        itemId: 'applications/my-bucket/my-app',
+        access: [ShareAccess.View],
+      });
+
+      expect(dialClient.client.getConversation).not.toHaveBeenCalled();
     });
 
     it('creates a share link for a skills/{bucket}/{path} itemId', async () => {

--- a/openspec/specs/conversation-share/spec.md
+++ b/openspec/specs/conversation-share/spec.md
@@ -50,17 +50,67 @@ The container SHALL:
 
 No new backend endpoint is introduced. `ShareConversationPopoverContainer` SHALL call the existing `getShareLink(itemId, access)` utility (`apps/chat/src/utils/share-link.ts`), which POSTs to `POST /api/v1/share` via `createShareLink` (`apps/chat/src/server-api/share.api.ts`), passing the conversation's DIAL Core resource path as `itemId` and `access: [ShareLinkAccess.View]`.
 
-The backend `POST /api/v1/share` (`apps/chat-api/src/share/share.controller.ts`) `@ApiOperation.description` SHALL be updated to state it creates a share link "for a DIAL Core resource (catalog entity or conversation)", replacing the catalog-only wording. `CreateShareLinkDto`, response DTOs, status codes (201/400/401/429/502/503), and the `@Throttle({ limit: 20, ttl: 60000 })` rate limit are unchanged.
+The backend `POST /api/v1/share` (`apps/chat-api/src/share/share.controller.ts`) `@ApiOperation.description` SHALL be updated to state it creates a share link "for a DIAL Core resource (catalog entity or conversation)", replacing the catalog-only wording. `CreateShareLinkDto`, response DTOs, and the `@Throttle({ limit: 20, ttl: 60000 })` rate limit are unchanged. Conversation-specific related-resource resolution is defined below; non-conversation resources continue to be proxied directly without an additional lookup.
 
 #### Scenario: Conversation itemId is accepted by the existing endpoint
 
 - **WHEN** `POST /api/v1/share` is called with `{ itemId: '<owned-conversation-path>', access: ['view'] }`
-- **THEN** the request is validated and proxied to DIAL Core exactly as any other `itemId`, with no conversation-specific validation branch
+- **THEN** the request is validated, the conversation and its related DIAL file resources are resolved server-side, and all resolved resources are included in the request proxied to DIAL Core
+
+#### Scenario: Non-conversation itemId requires no related-resource lookup
+
+- **WHEN** `POST /api/v1/share` is called with an application, toolset, skill, model, or prompt `itemId`
+- **THEN** the backend does not call DIAL Core's conversation-read API and proxies the resolved `itemId` directly to the sharing API
 
 #### Scenario: Swagger description reflects conversation support
 
 - **WHEN** the OpenAPI spec is generated (`npm run openapi`)
 - **THEN** the `createShareLink` operation description mentions conversations as a valid shareable resource
+
+### Requirement: Sharing a conversation includes its related DIAL file resources
+
+Before calling DIAL Core's `shareResource`, `ShareService.createShareLink` SHALL load a conversation whose resolved resource URL starts with `conversations/`. The read SHALL use the owning bucket and encoded bucket-relative path derived from the conversation resource URL, and SHALL forward the caller's bearer token.
+
+The service SHALL collect unique DIAL file resource URLs from:
+
+- message-level `custom_content.attachments`;
+- `custom_content.stages[].attachments`;
+- citation attachments at `custom_content.annotations[].body.source.attachment`.
+
+Both `url` and `reference_url` fields SHALL be considered. Only URLs starting with `files/` are shareable DIAL resources; public/external URLs and inline `data` attachments SHALL NOT be added to the sharing request. A URL fragment such as `#page=2` identifies a view within a file rather than a distinct resource and SHALL be removed before deduplication and sharing.
+
+The conversation resource SHALL remain the first item in `shareResource.resources`, followed by each unique related file resource in first-seen order. Every related resource SHALL receive the same resolved permissions as the conversation (`READ` for view access, `READ` and `WRITE` for edit access).
+
+If the conversation read throws, returns an upstream error, or returns no conversation data, link creation SHALL fail through the existing DIAL error-mapping behavior and `shareResource` SHALL NOT be called with an incomplete resource set.
+
+#### Scenario: Message attachments are shared with the conversation
+
+- **GIVEN** an owned conversation references `files/owner-bucket/report.pdf` in a message attachment
+- **WHEN** a view-only share link is created for that conversation
+- **THEN** `shareResource.resources` contains the conversation first and `files/owner-bucket/report.pdf` second, both with `permissions: ['READ']`
+
+#### Scenario: Duplicate references are shared once
+
+- **GIVEN** the same DIAL file URL appears in multiple messages, stages, or citations
+- **WHEN** a share link is created
+- **THEN** the file URL appears exactly once in `shareResource.resources`
+
+#### Scenario: Reference fragment is removed
+
+- **GIVEN** an attachment has `reference_url: 'files/owner-bucket/source.pdf#page=2'`
+- **WHEN** a share link is created
+- **THEN** the related resource is shared as `files/owner-bucket/source.pdf`
+
+#### Scenario: Non-DIAL and inline attachments do not become shared resources
+
+- **GIVEN** a conversation contains an HTTPS attachment URL and an inline `data` attachment
+- **WHEN** a share link is created
+- **THEN** neither attachment is added to `shareResource.resources`
+
+#### Scenario: Conversation lookup failure prevents a partial invitation
+
+- **WHEN** DIAL Core rejects or fails the conversation read performed before sharing
+- **THEN** link creation fails through the existing DIAL error mapper and `shareResource` is not called
 
 ### Requirement: Accepting a conversation share invitation redirects into the conversation, not the catalog
 
@@ -327,4 +377,3 @@ This change requires regenerating the OpenAPI spec (`npm run openapi`, `npm run 
 
 - **WHEN** `mergeSharedItem` is called while a `refetchDeployments()`/`refetchToolsets()` call is in flight
 - **THEN** the in-flight refetch's eventual result is still applied or discarded solely based on `deploymentsRequestIdRef`/`toolsetsRequestIdRef`, unaffected by the merge
-


### PR DESCRIPTION
**Description:**

Fix conversation share links so DIAL file resources referenced by message attachments, stage attachments, and citations are shared together with the conversation. Related resources are deduplicated, URL fragments are removed, and external or inline attachments are excluded. The conversation-share OpenSpec and backend tests now cover the behavior.

Validation:

- `npm exec nx run @epam/chat-api:test-ci--src/share/tests/share.service.spec.ts` — 56 tests passed
- `npm exec nx run @epam/chat-api:lint` — passed with pre-existing warnings
- `openspec validate conversation-share --type spec --strict --no-interactive` — passed
- `git diff --check` — passed
- `npm exec nx run @epam/chat-api:typecheck` — blocked by pre-existing workspace type errors unrelated to this change

Issues:

- Issue #7729

**UI changes**

No UI changes

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(chat-api):`
- [x] the pull request name ends with `(Issue #7729)`
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs