### PR TITLE
feat(catalog): replace logged-out badge with warning icon on avatar

### DIFF
--- a/apps/chat/src/i18n/locales/en.json
+++ b/apps/chat/src/i18n/locales/en.json
@@ -169,7 +169,7 @@
         "personalDescription": "These credentials apply only to your account.",
         "organizationLabel": "Organization credentials",
         "organizationDescription": "Once added, these credentials will grant all users in your organization access to this toolset.",
-        "badgeLoggedOut": "LOGGED OUT",
+        "badgeLoggedOut": "Authorize to use this toolset.",
         "loginSuccessTitle": "Successful login",
         "loginSuccessOrg": "You have successfully logged into the \"{{name}}\" version {{version}} with credentials to entire organization.",
         "loginSuccessGlobal": "You have successfully logged into the \"{{name}}\" version {{version}}.",

--- a/libs/catalog/src/components/AppIdentity/AppIdentity.tsx
+++ b/libs/catalog/src/components/AppIdentity/AppIdentity.tsx
@@ -38,6 +38,8 @@ export interface AppIdentityProps {
   lastUsedTrailing?: ReactNode;
   /** Additional CSS class applied to the icon wrapper div (e.g. for hover-scale animations). */
   iconClassName?: string;
+  /** Element anchored to the icon's bottom-end corner, overlapping its edge (e.g. a status badge). */
+  iconOverlay?: ReactNode;
 }
 
 /** Shared identity block: logo + type + name + version + optional last-used row. */
@@ -53,6 +55,7 @@ export const AppIdentity: FC<AppIdentityProps> = ({
   styles: appIdentityStyles,
   lastUsedTrailing,
   iconClassName,
+  iconOverlay,
 }) => {
   const colors = appIdentityStyles?.colors;
   const typography = appIdentityStyles?.typography ?? {};
@@ -75,21 +78,24 @@ export const AppIdentity: FC<AppIdentityProps> = ({
     >
       <div
         className={mergeClasses(
-          'flex-shrink-0 overflow-hidden',
+          'relative flex-shrink-0',
           logoClass,
           iconClassName,
         )}
       >
-        <DeploymentIcon
-          src={icon ?? undefined}
-          size={logoSize}
-          initialsName={name}
-          styles={{
-            badgeClassName: mergeClasses(
-              isLg ? 'rounded-[14px]' : 'rounded-[12px]',
-            ),
-          }}
-        />
+        <div className="size-full overflow-hidden rounded-[inherit]">
+          <DeploymentIcon
+            src={icon ?? undefined}
+            size={logoSize}
+            initialsName={name}
+            styles={{
+              badgeClassName: mergeClasses(
+                isLg ? 'rounded-[14px]' : 'rounded-[12px]',
+              ),
+            }}
+          />
+        </div>
+        {iconOverlay}
       </div>
 
       <div className="flex min-w-0 flex-1 flex-col gap-1">

--- a/libs/catalog/src/components/CardGrid/Card.tsx
+++ b/libs/catalog/src/components/CardGrid/Card.tsx
@@ -143,6 +143,12 @@ export const Card: FC<CardProps> = ({
         size={DeploymentSize.SM}
         query={query}
         iconClassName={styles.cardIcon}
+        iconOverlay={
+          <CredentialsBadge
+            credentials={item.credentials}
+            loggedOutLabel={credentialsBadgeLoggedOutLabel}
+          />
+        }
       />
 
       <p
@@ -164,12 +170,8 @@ export const Card: FC<CardProps> = ({
 
       {/* `mt-auto` pins the topics row and footer to the card bottom — the job
        * `flex-1` on the description used to do before it broke the clamp. */}
-      <div className="mt-auto flex items-center justify-between gap-2">
+      <div className="mt-auto flex items-center gap-2">
         <TopicsLine topics={item.topics} />
-        <CredentialsBadge
-          credentials={item.credentials}
-          loggedOutLabel={credentialsBadgeLoggedOutLabel}
-        />
       </div>
 
       <div className={mergeClasses('border-t pt-3', styles.footer)}>

--- a/libs/catalog/src/components/CardGrid/CardGrid.tsx
+++ b/libs/catalog/src/components/CardGrid/CardGrid.tsx
@@ -32,7 +32,8 @@ export const CardGrid: FC<CardGridProps> = memo(
     const removeFromFavoritesAriaLabel =
       titles?.removeFromFavoritesAriaLabel ?? 'Remove from favorites';
     const credentialsBadgeLoggedOutLabel =
-      titles?.credentialsBadgeLoggedOutLabel ?? 'LOGGED OUT';
+      titles?.credentialsBadgeLoggedOutLabel ??
+      'Authorize to use this toolset.';
 
     const { containerRef, startRow, endRow, columnCount, totalHeight } =
       useScrollVirtualizer(items.length);

--- a/libs/catalog/src/components/CardGrid/tests/Card.spec.tsx
+++ b/libs/catalog/src/components/CardGrid/tests/Card.spec.tsx
@@ -94,7 +94,7 @@ describe('Card — favorite revert', () => {
 });
 
 describe('Card — credentials badge', () => {
-  it('shows the LOGGED OUT badge for a signed-out toolset, for both API_KEY and OAUTH', () => {
+  it('shows the logged-out warning icon for a signed-out toolset, for both API_KEY and OAUTH', () => {
     for (const authenticationType of [
       ToolsetAuthenticationType.ApiKey,
       ToolsetAuthenticationType.OAuth,
@@ -108,15 +108,17 @@ describe('Card — credentials badge', () => {
               globalStatus: CredentialStatus.SignedOut,
             },
           })}
-          credentialsBadgeLoggedOutLabel="LOGGED OUT"
+          credentialsBadgeLoggedOutLabel="Authorize to use this toolset."
         />,
       );
-      expect(screen.getByText('LOGGED OUT')).toBeTruthy();
+      expect(
+        screen.getByRole('img', { name: 'Authorize to use this toolset.' }),
+      ).toBeTruthy();
       unmount();
     }
   });
 
-  it('shows no badge when signed in or when authenticationType is NONE', () => {
+  it('shows no warning icon when signed in or when authenticationType is NONE', () => {
     const { unmount } = render(
       <Card
         item={makeItem({
@@ -125,10 +127,12 @@ describe('Card — credentials badge', () => {
             userStatus: CredentialStatus.SignedIn,
           },
         })}
-        credentialsBadgeLoggedOutLabel="LOGGED OUT"
+        credentialsBadgeLoggedOutLabel="Authorize to use this toolset."
       />,
     );
-    expect(screen.queryByText('LOGGED OUT')).toBeNull();
+    expect(
+      screen.queryByRole('img', { name: 'Authorize to use this toolset.' }),
+    ).toBeNull();
     unmount();
 
     render(
@@ -136,9 +140,11 @@ describe('Card — credentials badge', () => {
         item={makeItem({
           credentials: { authenticationType: ToolsetAuthenticationType.None },
         })}
-        credentialsBadgeLoggedOutLabel="LOGGED OUT"
+        credentialsBadgeLoggedOutLabel="Authorize to use this toolset."
       />,
     );
-    expect(screen.queryByText('LOGGED OUT')).toBeNull();
+    expect(
+      screen.queryByRole('img', { name: 'Authorize to use this toolset.' }),
+    ).toBeNull();
   });
 });

--- a/libs/catalog/src/components/CredentialsBadge/CredentialsBadge.module.scss
+++ b/libs/catalog/src/components/CredentialsBadge/CredentialsBadge.module.scss
@@ -1,6 +1,12 @@
-/* Re-points `CardTag`'s color variables at the error palette. */
-.badge {
-  --cat-card-tag-bg: var(--bg-error, #f3d6d8);
-  --cat-card-tag-text: var(--text-error, #ae2f2f);
-  --cat-card-tag-border: transparent;
+.icon {
+  color: var(--cat-cred-badge-icon, var(--text-warning-icon, #eec840));
+  stroke: var(--cat-cred-badge-halo, var(--bg-layer-raised, #fcfcfc));
+  stroke-width: 6px;
+  /* Default miter join spikes past the stroke width at the triangle's sharp
+     apex angle; round avoids that artifact. */
+  stroke-linejoin: round;
+  paint-order: stroke;
+  /* The icon's viewBox clips anything drawn outside its bounds by default;
+     a stroke this thick bleeds past it, so let it render unclipped. */
+  overflow: visible;
 }

--- a/libs/catalog/src/components/CredentialsBadge/CredentialsBadge.tsx
+++ b/libs/catalog/src/components/CredentialsBadge/CredentialsBadge.tsx
@@ -1,38 +1,36 @@
-import { mergeClasses } from '@epam/ai-dial-chat-shared';
+import { buildCssVars, mergeClasses } from '@epam/ai-dial-chat-shared';
+import { DIAL_ICON_SIZE, DialTooltip } from '@epam/ai-dial-ui-kit';
+import { IconAlertTriangleFilled } from '@tabler/icons-react';
 import { FC } from 'react';
 import type { CatalogItemCredentials } from '../../models/catalog-item-credentials';
 import { getCredentialsBadgeState } from '../../utils/toolset-credentials';
-import { CardTag } from '../CardTag/CardTag';
 import styles from './CredentialsBadge.module.scss';
 
 /** Props for `CredentialsBadge`. */
 export interface CredentialsBadgeProps {
   /** Credential status to render a badge for. Renders nothing when absent, when authentication is `NONE`, or when signed in at any level. */
   credentials?: CatalogItemCredentials;
-  /** Badge label shown when signed out. Default: `'LOGGED OUT'`. */
+  /** Accessible label for the icon and the text shown in its hover tooltip. Default: `'Authorize to use this toolset.'`. */
   loggedOutLabel?: string;
-  /** Additional CSS class applied for layout/spacing (e.g. margins). */
+  /** Additional CSS class applied to the badge's root element (e.g. to override its corner position). */
   className?: string;
-  /** Typography class for the badge itself. Default: `'dial-caption-lead-semi-text'`. Colors come from the module stylesheet. */
-  badgeClassName?: string;
   /** Color overrides applied as CSS custom properties. */
   colors?: CredentialsBadgeColors;
 }
 
 /** Color overrides for `CredentialsBadge`, applied as CSS custom properties. */
 export interface CredentialsBadgeColors {
-  /** Badge background color. Fallback: `--bg-error`. */
-  background?: string;
-  /** Badge text color. Fallback: `--text-error`. */
-  text?: string;
+  /** Color of the stroke drawn around the icon's outline, separating it from the avatar. Fallback: `--bg-layer-raised`. */
+  halo?: string;
+  /** Icon fill color. Fallback: `--text-warning-icon`. */
+  icon?: string;
 }
 
-/** Credential-status badge shown on toolset cards — only rendered when signed out. */
+/** Warning icon anchored to the entity avatar's bottom-end corner — only rendered when signed out. */
 export const CredentialsBadge: FC<CredentialsBadgeProps> = ({
   credentials,
-  loggedOutLabel = 'Logged Out',
+  loggedOutLabel = 'Authorize to use this toolset.',
   className,
-  badgeClassName = 'dial-caption-lead-semi-text',
   colors,
 }) => {
   if (credentials == null) return null;
@@ -40,12 +38,28 @@ export const CredentialsBadge: FC<CredentialsBadgeProps> = ({
   const state = getCredentialsBadgeState(credentials);
   if (state == null) return null;
 
+  const cssVars = buildCssVars({
+    '--cat-cred-badge-halo': colors?.halo,
+    '--cat-cred-badge-icon': colors?.icon,
+  });
+
   return (
-    <CardTag
-      label={loggedOutLabel}
-      className={mergeClasses(styles.badge, className)}
-      badgeClassName={badgeClassName}
-      colors={colors}
-    />
+    <DialTooltip tooltip={loggedOutLabel}>
+      <span
+        role="img"
+        aria-label={loggedOutLabel}
+        style={cssVars}
+        className={mergeClasses(
+          'absolute -bottom-1 -end-1 shrink-0',
+          className,
+        )}
+      >
+        <IconAlertTriangleFilled
+          size={DIAL_ICON_SIZE.SM}
+          className={styles.icon}
+          aria-hidden
+        />
+      </span>
+    </DialTooltip>
   );
 };

--- a/libs/catalog/src/components/Favorites/FavoriteCard.tsx
+++ b/libs/catalog/src/components/Favorites/FavoriteCard.tsx
@@ -36,7 +36,7 @@ export interface FavoriteCardProps {
   removeFromFavoritesAriaLabel?: string;
   /** Whether this card represents the currently selected item — shows an accent border, tinted background, and a checkmark. Default: false. */
   isSelected?: boolean;
-  /** Credentials-status badge label shown when signed out. Default: `'LOGGED OUT'`. */
+  /** Accessible label for the logged-out warning icon on the entity avatar, and the text shown in its hover tooltip. Default: `'Authorize to use this toolset.'`. */
   credentialsBadgeLoggedOutLabel?: string;
 }
 
@@ -133,10 +133,12 @@ export const FavoriteCard: FC<FavoriteCardProps> = ({
               lastUsedClassName,
             },
           }}
-        />
-        <CredentialsBadge
-          credentials={item.credentials}
-          loggedOutLabel={credentialsBadgeLoggedOutLabel}
+          iconOverlay={
+            <CredentialsBadge
+              credentials={item.credentials}
+              loggedOutLabel={credentialsBadgeLoggedOutLabel}
+            />
+          }
         />
       </div>
       <StarToggleButton

--- a/libs/catalog/src/components/Favorites/tests/FavoriteCard.spec.tsx
+++ b/libs/catalog/src/components/Favorites/tests/FavoriteCard.spec.tsx
@@ -43,7 +43,7 @@ describe('FavoriteCard — selected state', () => {
 });
 
 describe('FavoriteCard — credentials badge', () => {
-  it('shows the LOGGED OUT badge for a signed-out API_KEY toolset', () => {
+  it('shows the logged-out warning icon for a signed-out API_KEY toolset', () => {
     render(
       <FavoriteCard
         item={makeItem({
@@ -53,14 +53,16 @@ describe('FavoriteCard — credentials badge', () => {
             globalStatus: CredentialStatus.SignedOut,
           },
         })}
-        credentialsBadgeLoggedOutLabel="LOGGED OUT"
+        credentialsBadgeLoggedOutLabel="Authorize to use this toolset."
       />,
     );
 
-    expect(screen.getByText('LOGGED OUT')).toBeTruthy();
+    expect(
+      screen.getByRole('img', { name: 'Authorize to use this toolset.' }),
+    ).toBeTruthy();
   });
 
-  it('shows the LOGGED OUT badge for a signed-out OAUTH toolset', () => {
+  it('shows the logged-out warning icon for a signed-out OAUTH toolset', () => {
     render(
       <FavoriteCard
         item={makeItem({
@@ -70,14 +72,16 @@ describe('FavoriteCard — credentials badge', () => {
             globalStatus: CredentialStatus.SignedOut,
           },
         })}
-        credentialsBadgeLoggedOutLabel="LOGGED OUT"
+        credentialsBadgeLoggedOutLabel="Authorize to use this toolset."
       />,
     );
 
-    expect(screen.getByText('LOGGED OUT')).toBeTruthy();
+    expect(
+      screen.getByRole('img', { name: 'Authorize to use this toolset.' }),
+    ).toBeTruthy();
   });
 
-  it('shows no badge when signed in', () => {
+  it('shows no warning icon when signed in', () => {
     render(
       <FavoriteCard
         item={makeItem({
@@ -87,14 +91,16 @@ describe('FavoriteCard — credentials badge', () => {
             globalStatus: CredentialStatus.SignedOut,
           },
         })}
-        credentialsBadgeLoggedOutLabel="LOGGED OUT"
+        credentialsBadgeLoggedOutLabel="Authorize to use this toolset."
       />,
     );
 
-    expect(screen.queryByText('LOGGED OUT')).toBeNull();
+    expect(
+      screen.queryByRole('img', { name: 'Authorize to use this toolset.' }),
+    ).toBeNull();
   });
 
-  it('shows no badge for authenticationType NONE', () => {
+  it('shows no warning icon for authenticationType NONE', () => {
     render(
       <FavoriteCard
         item={makeItem({
@@ -102,10 +108,12 @@ describe('FavoriteCard — credentials badge', () => {
             authenticationType: ToolsetAuthenticationType.None,
           },
         })}
-        credentialsBadgeLoggedOutLabel="LOGGED OUT"
+        credentialsBadgeLoggedOutLabel="Authorize to use this toolset."
       />,
     );
 
-    expect(screen.queryByText('LOGGED OUT')).toBeNull();
+    expect(
+      screen.queryByRole('img', { name: 'Authorize to use this toolset.' }),
+    ).toBeNull();
   });
 });

--- a/libs/catalog/src/components/ListView/Renders/NameCellRenderer.tsx
+++ b/libs/catalog/src/components/ListView/Renders/NameCellRenderer.tsx
@@ -25,12 +25,18 @@ export const NameCellRenderer: FC<
   if (!data) return null;
   return (
     <div className="flex h-full min-w-0 items-center gap-2.5">
-      <DeploymentIcon
-        src={data.iconUrl}
-        size={36}
-        initialsName={data.name}
-        styles={{ badgeClassName: 'rounded-[10px]' }}
-      />
+      <div className="relative shrink-0">
+        <DeploymentIcon
+          src={data.iconUrl}
+          size={36}
+          initialsName={data.name}
+          styles={{ badgeClassName: 'rounded-[10px]' }}
+        />
+        <CredentialsBadge
+          credentials={data.credentials}
+          loggedOutLabel={context?.credentialsBadgeLoggedOutLabel}
+        />
+      </div>
       <ItemHeader
         title={data.name}
         postfix={data.version}
@@ -47,11 +53,6 @@ export const NameCellRenderer: FC<
             />
           ) : undefined
         }
-      />
-      <CredentialsBadge
-        credentials={data.credentials}
-        loggedOutLabel={context?.credentialsBadgeLoggedOutLabel}
-        className="ms-2 shrink-0"
       />
     </div>
   );

--- a/libs/catalog/src/index.ts
+++ b/libs/catalog/src/index.ts
@@ -136,7 +136,10 @@ export { InfoCard } from './components/InfoCard/InfoCard';
 export type { InfoCardProps } from './components/InfoCard/InfoCard';
 
 export { CredentialsBadge } from './components/CredentialsBadge/CredentialsBadge';
-export type { CredentialsBadgeProps } from './components/CredentialsBadge/CredentialsBadge';
+export type {
+  CredentialsBadgeColors,
+  CredentialsBadgeProps,
+} from './components/CredentialsBadge/CredentialsBadge';
 
 export { ContentTab } from './components/Details/TabsContent/Content';
 export type { ContentTabProps } from './components/Details/TabsContent/Content';

--- a/libs/catalog/src/models/card-props.ts
+++ b/libs/catalog/src/models/card-props.ts
@@ -68,6 +68,6 @@ export interface CardProps {
   removeFromFavoritesAriaLabel?: string;
   /** Whether this card represents the currently selected item — shows an accent border, tinted background, and a checkmark. Default: false. */
   isSelected?: boolean;
-  /** Credentials-status badge label shown when signed out. Default: `'LOGGED OUT'`. */
+  /** Accessible label for the logged-out warning icon on the entity avatar, and the text shown in its hover tooltip. Default: `'Authorize to use this toolset.'`. */
   credentialsBadgeLoggedOutLabel?: string;
 }

--- a/libs/catalog/src/models/card-row-data.ts
+++ b/libs/catalog/src/models/card-row-data.ts
@@ -20,6 +20,6 @@ export interface CardRowData {
   removeFromFavoritesAriaLabel: string;
   /** ID of an item to visually mark as selected (border, tint, and checkmark). */
   selectedItemId?: string;
-  /** Credentials-status badge label shown when signed out. */
+  /** Accessible label for the logged-out warning icon on the entity avatar, and the text shown in its hover tooltip. */
   credentialsBadgeLoggedOutLabel: string;
 }

--- a/libs/catalog/src/models/favorites.ts
+++ b/libs/catalog/src/models/favorites.ts
@@ -62,6 +62,6 @@ export interface FavoritesProps {
   removeFromFavoritesAriaLabel?: string;
   /** ID of an item to visually mark as selected (border, tint, and checkmark). */
   selectedItemId?: string;
-  /** Credentials-status badge label shown when a favorited item is signed out. Default: `'LOGGED OUT'`. */
+  /** Accessible label for the logged-out warning icon on a favorited item's avatar, and the text shown in its hover tooltip. Default: `'Authorize to use this toolset.'`. */
   credentialsBadgeLoggedOutLabel?: string;
 }

--- a/libs/catalog/src/models/grid-context.ts
+++ b/libs/catalog/src/models/grid-context.ts
@@ -10,6 +10,6 @@ export interface GridContext {
   onToggleFavorite?: (id: string, isStarred: boolean) => void;
   /** ID of an item to visually mark as selected (border, tint, and checkmark). */
   selectedItemId?: string;
-  /** Credentials-status badge label shown when signed out. */
+  /** Accessible label for the logged-out warning icon on the entity avatar, and the text shown in its hover tooltip. */
   credentialsBadgeLoggedOutLabel?: string;
 }

--- a/libs/catalog/src/models/grid-props.ts
+++ b/libs/catalog/src/models/grid-props.ts
@@ -10,7 +10,7 @@ export interface CardGridTitles {
   addToFavoritesAriaLabel?: string;
   /** Accessible label for the star button when the item is already starred. Default: `'Remove from favorites'`. */
   removeFromFavoritesAriaLabel?: string;
-  /** Credentials-status badge label shown on cards when signed out. Default: `'LOGGED OUT'`. */
+  /** Accessible label for the logged-out warning icon on card avatars, and the text shown in its hover tooltip. Default: `'Authorize to use this toolset.'`. */
   credentialsBadgeLoggedOutLabel?: string;
 }
 

--- a/libs/catalog/src/models/item-details-props.ts
+++ b/libs/catalog/src/models/item-details-props.ts
@@ -127,7 +127,7 @@ export interface ItemDetailsTexts {
   apiKeyFieldLabel?: string;
   /** Validation error shown under the API key input when "Add" is submitted with an empty value. Default: `'API key is required.'`. */
   apiKeyRequiredErrorMessage?: string;
-  /** Credentials-status badge label shown on catalog cards when signed out. Default: `'LOGGED OUT'`. */
+  /** Accessible label for the logged-out warning icon on catalog card avatars, and the text shown in its hover tooltip. Default: `'Authorize to use this toolset.'`. */
   credentialsBadgeLoggedOutLabel?: string;
   /**
    * Top action button label when the item requires an API key and the

--- a/libs/catalog/src/models/list-props.ts
+++ b/libs/catalog/src/models/list-props.ts
@@ -69,6 +69,6 @@ export interface ListViewProps {
   stickyHeaderTop?: number;
   /** ID of an item to visually mark as selected (border, tint, and checkmark). */
   selectedItemId?: string;
-  /** Credentials-status badge label shown when signed out. Default: `'LOGGED OUT'`. */
+  /** Accessible label for the logged-out warning icon on the entity avatar, and the text shown in its hover tooltip. Default: `'Authorize to use this toolset.'`. */
   credentialsBadgeLoggedOutLabel?: string;
 }

--- a/openspec/specs/catalog-toolset-credentials/spec.md
+++ b/openspec/specs/catalog-toolset-credentials/spec.md
@@ -8,7 +8,7 @@ TBD - created by archiving change catalog-toolset-credentials-login. Update Purp
 ### Requirement: Credentials action visibility and label resolution
 The Catalog Details Panel SHALL show a credentials action for `Toolset` items whose
 `authenticationType` is not `NONE`, and SHALL show no credentials action (button, section, or
-badge) for toolsets whose `authenticationType` is `NONE`. The action label and behavior SHALL be
+logged-out warning icon) for toolsets whose `authenticationType` is `NONE`. The action label and behavior SHALL be
 resolved from four states, matching the legacy Marketplace decision tree:
 - **Manage credentials**: the current user is an admin and the toolset is public.
 - **Login with my creds**: the user is not an admin, the toolset is public, and the user is not
@@ -23,8 +23,8 @@ English text.
 
 #### Scenario: No auth toolset shows no credentials UI
 - **WHEN** a user opens the Details Panel for a toolset with `authenticationType: NONE`
-- **THEN** no credentials button, section, or badge is rendered anywhere in the panel or on its
-  card/list row
+- **THEN** no credentials button, section, or logged-out warning icon is rendered anywhere in
+  the panel or on its card/list row
 
 #### Scenario: Admin on public toolset sees Manage credentials
 - **WHEN** an admin user opens the Details Panel for a public toolset with `authenticationType`
@@ -65,13 +65,14 @@ with no level chooser.
 
 ### Requirement: Signed-in detection uses either credentials level
 A toolset SHALL be considered signed in if its `USER`-level status **or** its `GLOBAL`-level
-status is `SIGNED_IN`. This applies to the header action label, the card/list badge, and the
-level resolved for a direct "Log out" action.
+status is `SIGNED_IN`. This applies to the header action label, the card/list logged-out
+warning icon, and the level resolved for a direct "Log out" action.
 
 #### Scenario: Signed in via GLOBAL only still shows Log out
 - **WHEN** a toolset's `USER`-level status is `SIGNED_OUT` and its `GLOBAL`-level status is
   `SIGNED_IN`
-- **THEN** the panel shows "Log out" (not "Log in"), and its card badge is not "LOGGED OUT"
+- **THEN** the panel shows "Log out" (not "Log in"), and its card shows no logged-out warning
+  icon
 
 ### Requirement: API key login submission with level and header hint
 For toolsets with `authenticationType: API_KEY`, the active section SHALL present an API key
@@ -194,22 +195,25 @@ and favorite cards reflect the change immediately.
 - **THEN** the Details Panel's credentials status updates to reflect the signed-in state
   without the user reloading the page
 
-#### Scenario: Card badge updates after API-key logout
+#### Scenario: Card warning icon updates after API-key logout
 - **WHEN** an API-key logout succeeds
-- **THEN** the corresponding toolset card's credentials badge updates without a full page reload
+- **THEN** the logged-out warning icon on the corresponding toolset card's avatar appears without
+  a full page reload
 
 #### Scenario: Catalog refreshes after a successful OAuth login
 - **WHEN** the tab that initiated an OAuth login for a Catalog toolset receives a success result
   from the callback popup
 - **THEN** the system refetches the toolset list without a full page reload, the open Details
   Panel (if any) updates its credentials status to signed in, its "Log in" action becomes
-  "Log out", and the toolset's card/row/favorite-card badge is removed
+  "Log out", and the logged-out warning icon is removed from the toolset's card, row, and
+  favorite card
 
 #### Scenario: Catalog shows an error after a failed OAuth login
 - **WHEN** the tab that initiated an OAuth login receives a failure result from the callback
   popup
 - **THEN** the system shows an error notification, shows no success notification, keeps "Log in"
-  available, and the toolset's card/row/favorite-card badge remains "LOGGED OUT"
+  available, and the logged-out warning icon remains on the toolset's card, row, and favorite
+  card
 
 #### Scenario: Toolset Editor reflects a successful OAuth login
 - **WHEN** the Toolset Editor tab that initiated an OAuth login receives a success result from
@@ -229,38 +233,63 @@ and favorite cards reflect the change immediately.
   success notification; when the pending timeout elapses, the system also closes the popup so a
   late callback cannot complete the abandoned login
 
-### Requirement: Toolset card and list credentials badge
-Toolset cards (grid view), rows (list view), and favorite cards in the Catalog SHALL show a
-"LOGGED OUT" credentials badge when `authenticationType` is not `NONE` and the toolset is not
-signed in at `USER` or `GLOBAL` level. No badge is shown when the toolset is signed in at either
-level, or when `authenticationType` is `NONE`. This applies identically to `API_KEY` and `OAUTH`
+### Requirement: Toolset card and list logged-out warning icon
+Toolset cards (grid view), rows (list view), and favorite cards in the Catalog SHALL mark a
+signed-out toolset with a filled warning-triangle icon anchored to the bottom-end corner of the
+entity avatar and overlapping its edge, rather than with a text tag placed in the card body. The
+icon SHALL be shown when `authenticationType` is not `NONE` and the toolset is not signed in at
+`USER` or `GLOBAL` level. No icon is shown when the toolset is signed in at either level, or
+when `authenticationType` is `NONE`. This applies identically to `API_KEY` and `OAUTH`
 toolsets and is deliberately simpler than the legacy Marketplace's `CredentialsStatusIndicator`,
-which also distinguished "MY CREDS"/"ORG CREDS" signed-in states; no positive/signed-in badge is
-introduced.
+which also distinguished "MY CREDS"/"ORG CREDS" signed-in states; no positive/signed-in indicator
+is introduced.
 
-#### Scenario: Logged out badge
+The icon SHALL carry `role="img"` with an accessible label and SHALL show that same text in a
+hover tooltip, so its meaning is available without relying on color or shape alone. The text
+defaults to `'Authorize to use this toolset.'` and is overridable by the host through the
+existing `credentialsBadgeLoggedOutLabel` text prop (`CardGridTitles`, `ListViewProps`,
+`FavoritesProps`, `ItemDetailsTexts`, `GridContext`). The triangle icon itself is decorative
+(`aria-hidden`) inside that labeled wrapper.
+
+The icon SHALL be visually separated from the avatar artwork behind it by a halo stroke drawn in
+the surrounding surface color. Its fill and halo colors SHALL be themable CSS custom properties
+with `--text-warning-icon` and `--bg-layer-raised` fallbacks, overridable through
+`CredentialsBadgeColors` (`icon`, `halo`), which `libs/catalog` exports alongside
+`CredentialsBadgeProps`.
+
+Hosting the icon over the avatar is the responsibility of the avatar block: `AppIdentity` SHALL
+accept an `iconOverlay` node rendered inside a positioned icon wrapper, so the same icon appears
+in the same corner across grid cards, favorite cards, and list rows.
+
+#### Scenario: Logged out warning icon
 - **WHEN** a toolset with auth enabled has no active credentials at any level
-- **THEN** its card and list row show a "LOGGED OUT" badge
+- **THEN** its card and list row show the warning icon on the bottom-end corner of the entity
+  avatar
 
-#### Scenario: No badge when signed in
+#### Scenario: Warning icon exposes its meaning as text
+- **WHEN** a user hovers or focuses the logged-out warning icon
+- **THEN** a tooltip shows the logged-out label, and assistive technology reads the same text as
+  the icon's accessible name
+
+#### Scenario: No icon when signed in
 - **WHEN** a toolset is signed in at `USER` level, at `GLOBAL` level, or both
-- **THEN** its card and list row show no credentials badge
+- **THEN** its card and list row show no credentials warning icon
 
-#### Scenario: No badge for no-auth toolsets
+#### Scenario: No icon for no-auth toolsets
 - **WHEN** a toolset has `authenticationType: NONE`
-- **THEN** its card and list row show no credentials badge
+- **THEN** its card and list row show no credentials warning icon
 
-#### Scenario: Favorite card shows the same logged out badge
+#### Scenario: Favorite card shows the same warning icon
 - **WHEN** a toolset with auth enabled has no active credentials at any level and is displayed as
   a favorite card
-- **THEN** the favorite card shows the same "LOGGED OUT" badge as the toolset's grid card and
-  list row
+- **THEN** the favorite card shows the same avatar-anchored warning icon as the toolset's grid
+  card and list row
 
-#### Scenario: Badge rule is identical for API key and OAuth toolsets
+#### Scenario: Icon rule is identical for API key and OAuth toolsets
 - **WHEN** two toolsets, one with `authenticationType: API_KEY` and one with
   `authenticationType: OAUTH`, are both signed out at every credentials level
-- **THEN** both show the "LOGGED OUT" badge on their card, list row, and favorite card, with no
-  difference in badge treatment based on authentication type
+- **THEN** both show the warning icon on their card, list row, and favorite card, with no
+  difference in treatment based on authentication type
 
 ### Requirement: Library isolation for credentials UI
 `libs/catalog` SHALL expose the credentials UI only through additive props on `CatalogItem`,


### PR DESCRIPTION
**Description:**

Replaces the "LOGGED OUT" text tag on toolset/catalog cards with a warning
icon anchored to the entity avatar's bottom-end corner, matching the Figma
toolset-card design. The icon shows a hover tooltip ("Authorize to use this
toolset.") and carries an accessible label for screen readers; `AppIdentity`
gains an `iconOverlay` slot to anchor it. Applied consistently across the
grid `Card`, `FavoriteCard`, and the list-view name cell renderer. Also
updates the stale `"LOGGED OUT"` English translation string that fed the
old tag to match the new tooltip copy.

Issues:

- No ticket — skipped per explicit request.

**UI changes**

Warning icon (amber filled triangle with a white outline stroke) replaces the
text tag, sitting in the bottom-end corner of the entity avatar on catalog
cards, favorite cards, and list rows; shows a tooltip with the authorization
instructions on hover.

**Checklist:**

- [x] the pull request name complies with Conventional Commits
- [x] the pull request name starts with `feat(catalog):`
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` — no ticket ID was provided for this change
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs