### PR TITLE
fix(usage-dashboard): filter empty model usage by period (Issue #8379)

### DIFF
--- a/.claude/skills/git-ship/areas.md
+++ b/.claude/skills/git-ship/areas.md
@@ -48,6 +48,7 @@ Apply in order, stop at the first match:
 | `skill-editor`          | Skill editor UI and authoring components                      |
 | `source-panel`          | Sources panel                                                 |
 | `starter-buttons`       | Starter prompt buttons                                        |
+| `usage-dashboard`       | Usage limits cards and per-model usage dashboard              |
 
 > `chat-api-client` changes are almost always the result of regenerating from OpenAPI sources. Do not
 > hand-edit it; if you must scope a regeneration commit, use `chore(chat-api-client): regenerate client`.

--- a/apps/chat/src/pages/SettingsPage/UsageTab/UsageTab.tsx
+++ b/apps/chat/src/pages/SettingsPage/UsageTab/UsageTab.tsx
@@ -83,6 +83,7 @@ const UsageTab: FC = () => {
       limitReachedBadgeLabel: t(UsageI18nKeys.LimitReachedBadgeLabel),
       noLimitBadgeLabel: t(UsageI18nKeys.NoLimitLabel),
       unavailableBadgeLabel: t(UsageI18nKeys.UnavailableBadgeLabel),
+      emptyStateLabel: t(UsageI18nKeys.ModelLimitsEmptyState),
     }),
     [t],
   );
@@ -117,18 +118,12 @@ const UsageTab: FC = () => {
         ) : (
           <>
             <UsageLimitCardGroup cards={cards} labels={labels} />
-            {modelLimitRows.length > 0 ? (
-              <ModelLimitsSection
-                rows={modelLimitRows}
-                period={period}
-                onPeriodChange={setPeriod}
-                labels={modelLimitsLabels}
-              />
-            ) : (
-              <p className="dial-small-text text-secondary">
-                {t(UsageI18nKeys.ModelLimitsEmptyState)}
-              </p>
-            )}
+            <ModelLimitsSection
+              rows={modelLimitRows}
+              period={period}
+              onPeriodChange={setPeriod}
+              labels={modelLimitsLabels}
+            />
           </>
         )}
       </div>

--- a/apps/chat/src/pages/SettingsPage/UsageTab/tests/UsageTab.spec.tsx
+++ b/apps/chat/src/pages/SettingsPage/UsageTab/tests/UsageTab.spec.tsx
@@ -41,13 +41,17 @@ vi.mock('@epam/ai-dial-usage-dashboard', async (importOriginal) => {
     ),
     ModelLimitsSection: ({
       rows,
+      labels,
     }: {
       rows: { id: string; name: string }[];
+      labels: { emptyStateLabel: string };
     }) => (
       <div>
-        {rows.map((row) => (
-          <span key={row.id}>{row.name}</span>
-        ))}
+        {rows.length === 0 ? (
+          <span>{labels.emptyStateLabel}</span>
+        ) : (
+          rows.map((row) => <span key={row.id}>{row.name}</span>)
+        )}
       </div>
     ),
   };
@@ -226,6 +230,36 @@ describe('UsageTab', () => {
 
       render(<UsageTab />);
 
+      expect(
+        screen.getByText(UsageI18nKeys.ModelLimitsEmptyState),
+      ).toBeTruthy();
+    });
+
+    it('shows the same empty state when every deployment has no usage in the selected period', () => {
+      mockUseDeployments.mockReturnValue(
+        createDeploymentsContextValue({
+          items: [
+            {
+              id: 'gpt-4o',
+              displayName: 'GPT-4o',
+              type: DeploymentItemDtoTypeEnum.Model,
+            },
+          ],
+        }),
+      );
+      mockUseUsageData.mockReturnValue({
+        usage: {
+          deployments: {
+            'gpt-4o': { dayTokenStats: { used: 0, total: 10 } },
+          },
+        },
+        isLoading: false,
+        usageError: undefined,
+      });
+
+      render(<UsageTab />);
+
+      expect(screen.queryByText('GPT-4o')).toBeNull();
       expect(
         screen.getByText(UsageI18nKeys.ModelLimitsEmptyState),
       ).toBeTruthy();

--- a/apps/chat/src/utils/map-user-usage-to-model-limits.ts
+++ b/apps/chat/src/utils/map-user-usage-to-model-limits.ts
@@ -176,13 +176,24 @@ const getRowStatus = (cells: ModelLimitMetricCell[]): ModelLimitStatus => {
 };
 
 /**
+ * Whether at least one of a row's period-mapped raw stats is usable and has nonzero `used` — the
+ * signal that the deployment actually has usage in the selected period, as opposed to merely
+ * having an entry in `usage.deployments` (which may reflect usage in a different period only).
+ */
+const hasUsageInPeriod = (stats: (LimitStatsDto | undefined)[]): boolean =>
+  stats.some((stat) => isUsableStats(stat) && stat.used > 0);
+
+/**
  * Maps `usage.deployments` (already fetched by `useUsageData`) into `ModelLimitsSection`'s `rows`
  * prop, joined with model identity from `useDeployments().items`. Never calls a new endpoint —
- * everything here is derived from data already in memory. The table shows exactly the entries
- * present in `usage.deployments` — never more (no accessible-but-unused models added from `items`)
- * and never fewer — in `Object.keys(deployments)` order, so row set and order depend only on the
- * `usage` fetch and stay stable regardless of whether/when `items` has loaded. `items` is used
- * solely to enrich a row with display name/version/avatar when a match exists.
+ * everything here is derived from data already in memory. Candidate rows come from exactly the
+ * entries present in `usage.deployments` (no accessible-but-unused models added from `items`), but
+ * the returned rows are further scoped to the selected period: a candidate is dropped unless at
+ * least one of its Cost/Tokens/Requests stats mapped for that period is usable and has `used > 0`.
+ * Among rows that pass this filter, order follows `Object.keys(deployments)` order, so row set and
+ * order depend only on the `usage` fetch and the selected period, and stay stable regardless of
+ * whether/when `items` has loaded. `items` is used solely to enrich a row with display
+ * name/version/avatar when a match exists.
  */
 export const mapUserUsageToModelLimits = (
   usage: UserLimitStatsResponseDto | undefined,
@@ -203,37 +214,56 @@ export const mapUserUsageToModelLimits = (
   );
   const fieldMapping = PERIOD_FIELD_MAPPINGS[period];
 
-  return Object.keys(deployments).map((id) => {
-    const item = modelItemById.get(id);
-    const name =
-      item != null
-        ? resolveLocalizedText(item.displayName, activeLocale) || item.id
-        : id;
-    const deploymentStats = deployments[id];
-    const avatarSrc = resolveCatalogIconUrl(item?.iconUrl);
+  return Object.keys(deployments)
+    .map((id) => {
+      const item = modelItemById.get(id);
+      const name =
+        item != null
+          ? resolveLocalizedText(item.displayName, activeLocale) || item.id
+          : id;
+      const deploymentStats = deployments[id];
+      const avatarSrc = resolveCatalogIconUrl(item?.iconUrl);
 
-    const cost =
-      fieldMapping.cost != null
-        ? buildCostMetricCell(deploymentStats[fieldMapping.cost], t)
-        : buildUnavailableCell(t);
-    const tokens =
-      fieldMapping.tokens != null
-        ? buildFiniteMetricCell(deploymentStats[fieldMapping.tokens], t)
-        : buildUnavailableCell(t);
-    const requests =
-      fieldMapping.requests != null
-        ? buildFiniteMetricCell(deploymentStats[fieldMapping.requests], t)
-        : buildUnavailableCell(t);
+      const costStats =
+        fieldMapping.cost != null
+          ? deploymentStats[fieldMapping.cost]
+          : undefined;
+      const tokenStats =
+        fieldMapping.tokens != null
+          ? deploymentStats[fieldMapping.tokens]
+          : undefined;
+      const requestStats =
+        fieldMapping.requests != null
+          ? deploymentStats[fieldMapping.requests]
+          : undefined;
 
-    return {
-      id,
-      name,
-      version: item?.displayVersion,
-      avatarSrc,
-      cost,
-      tokens,
-      requests,
-      status: getRowStatus([cost, tokens, requests]),
-    };
-  });
+      const cost =
+        fieldMapping.cost != null
+          ? buildCostMetricCell(costStats, t)
+          : buildUnavailableCell(t);
+      const tokens =
+        fieldMapping.tokens != null
+          ? buildFiniteMetricCell(tokenStats, t)
+          : buildUnavailableCell(t);
+      const requests =
+        fieldMapping.requests != null
+          ? buildFiniteMetricCell(requestStats, t)
+          : buildUnavailableCell(t);
+
+      return {
+        row: {
+          id,
+          name,
+          version: item?.displayVersion,
+          avatarSrc,
+          cost,
+          tokens,
+          requests,
+          status: getRowStatus([cost, tokens, requests]),
+        },
+        hasUsage: hasUsageInPeriod([costStats, tokenStats, requestStats]),
+      };
+    })
+    .filter(({ hasUsage }) => hasUsage)
+    .map(({ row }) => row);
 };

--- a/apps/chat/src/utils/tests/map-user-usage-to-model-limits.spec.ts
+++ b/apps/chat/src/utils/tests/map-user-usage-to-model-limits.spec.ts
@@ -86,7 +86,7 @@ describe('mapUserUsageToModelLimits', () => {
     ).toEqual([]);
   });
 
-  it('still produces a row for a deployment with all-zero usage', () => {
+  it('excludes a deployment with all-zero usage for the selected period', () => {
     const usage = withUsage({
       'gpt-4o': {
         dayCostStats: { used: 0, total: 2 ** 53 },
@@ -103,8 +103,7 @@ describe('mapUserUsageToModelLimits', () => {
       t,
     );
 
-    expect(rows).toHaveLength(1);
-    expect(rows[0].tokens.usedLabel).toBe('0');
+    expect(rows).toHaveLength(0);
   });
 
   it('falls back to the deployment ID and no avatar when the ID has no matching item', () => {
@@ -355,7 +354,9 @@ describe('mapUserUsageToModelLimits', () => {
     });
 
     it('classifies cost as unavailable when the stat entry is missing', () => {
-      const usage = withUsage({ 'gpt-4o': {} });
+      const usage = withUsage({
+        'gpt-4o': { dayTokenStats: { used: 1, total: 10 } },
+      });
 
       const [row] = mapUserUsageToModelLimits(
         usage,
@@ -387,7 +388,9 @@ describe('mapUserUsageToModelLimits', () => {
     });
 
     it('treats a missing token stat as unavailable, not zero', () => {
-      const usage = withUsage({ 'gpt-4o': {} });
+      const usage = withUsage({
+        'gpt-4o': { dayCostStats: { used: 1, total: 2 ** 53 } },
+      });
 
       const [row] = mapUserUsageToModelLimits(
         usage,
@@ -474,10 +477,13 @@ describe('mapUserUsageToModelLimits', () => {
       expect(row.status).toBe(ModelLimitStatus.NoLimit);
     });
 
-    it('is Unavailable when no metric is usable at all', () => {
+    it('produces no row (rather than an Unavailable one) when no metric is usable at all', () => {
+      // A row with no usable metric also has no evidence of usage in the selected period, so
+      // the period-scoped usage filter excludes it before `ModelLimitStatus.Unavailable` would
+      // ever reach the UI — see the "period-scoped usage filtering" describe block below.
       const usage = withUsage({ 'gpt-4o': {} });
 
-      const [row] = mapUserUsageToModelLimits(
+      const rows = mapUserUsageToModelLimits(
         usage,
         [modelItem()],
         ModelLimitsPeriod.Last24Hours,
@@ -485,7 +491,7 @@ describe('mapUserUsageToModelLimits', () => {
         t,
       );
 
-      expect(row.status).toBe(ModelLimitStatus.Unavailable);
+      expect(rows).toHaveLength(0);
     });
 
     it('derives status from the one finite metric among unlimited/unavailable ones', () => {
@@ -505,6 +511,91 @@ describe('mapUserUsageToModelLimits', () => {
       );
 
       expect(row.status).toBe(ModelLimitStatus.RunningLow);
+    });
+  });
+
+  describe('period-scoped usage filtering', () => {
+    it('keeps a row when only one of cost/tokens/requests has usage in the period', () => {
+      const usage = withUsage({
+        'gpt-4o': {
+          dayCostStats: { used: 0, total: 2 ** 53 },
+          dayTokenStats: { used: 250, total: 10000 },
+        },
+      });
+
+      const rows = mapUserUsageToModelLimits(
+        usage,
+        [modelItem()],
+        ModelLimitsPeriod.Last24Hours,
+        'en',
+        t,
+      );
+
+      expect(rows).toHaveLength(1);
+    });
+
+    it('excludes a row whose only mapped entry for the period is unavailable', () => {
+      const usage = withUsage({
+        'gpt-4o': {},
+      });
+
+      const rows = mapUserUsageToModelLimits(
+        usage,
+        [modelItem()],
+        ModelLimitsPeriod.LastHour,
+        'en',
+        t,
+      );
+
+      expect(rows).toHaveLength(0);
+    });
+
+    it('shows the same deployment for one period and hides it for another', () => {
+      const usage = withUsage({
+        'gpt-4o': {
+          monthTokenStats: { used: 100, total: 1000 },
+          dayTokenStats: { used: 0, total: 1000 },
+        },
+      });
+
+      const monthRows = mapUserUsageToModelLimits(
+        usage,
+        [modelItem()],
+        ModelLimitsPeriod.Last30Days,
+        'en',
+        t,
+      );
+      const dayRows = mapUserUsageToModelLimits(
+        usage,
+        [modelItem()],
+        ModelLimitsPeriod.Last24Hours,
+        'en',
+        t,
+      );
+
+      expect(monthRows).toHaveLength(1);
+      expect(dayRows).toHaveLength(0);
+    });
+
+    it('does not change an included row cell classification or formatting', () => {
+      const usage = withUsage({
+        'gpt-4o': {
+          dayCostStats: { used: 4.2, total: 2 ** 53 },
+          dayTokenStats: { used: 250, total: 10000 },
+        },
+      });
+
+      const [row] = mapUserUsageToModelLimits(
+        usage,
+        [modelItem()],
+        ModelLimitsPeriod.Last24Hours,
+        'en',
+        t,
+      );
+
+      expect(row.cost.kind).toBe(ModelLimitMetricKind.Unlimited);
+      expect(row.tokens.kind).toBe(ModelLimitMetricKind.Finite);
+      expect(row.tokens.usedPercent).toBe(2.5);
     });
   });
 

--- a/libs/usage-dashboard/README.md
+++ b/libs/usage-dashboard/README.md
@@ -27,6 +27,7 @@ single-card use case.
 - `react` ^19.2.7
 - `@epam/ai-dial-ui-kit`
 - `@epam/ai-dial-chat-shared`
+- `@tabler/icons-react`
 
 ## Components
 
@@ -191,6 +192,7 @@ const [period, setPeriod] = useState(ModelLimitsPeriod.Last24Hours);
     limitReachedBadgeLabel: 'Limit reached',
     noLimitBadgeLabel: 'No limit',
     unavailableBadgeLabel: 'Unavailable',
+    emptyStateLabel: 'No models to show yet.',
   }}
 />;
 ```
@@ -198,6 +200,11 @@ const [period, setPeriod] = useState(ModelLimitsPeriod.Last24Hours);
 `ModelLimitsSection` is fully controlled: it never manages the selected period itself, never
 refetches anything, and never infers the unlimited sentinel or a metric's status — the host derives
 `kind`, `usedPercent`, and `status` for every cell and `status` for the row.
+
+The heading and period selector always render, even when `rows` is empty — only the table body
+switches to an empty-state message (`labels.emptyStateLabel`), so the host can still change the
+selected period from an empty result. Pass `emptyStateIconSize` (default `48`) to resize the
+empty-state icon.
 
 ## Types
 
@@ -214,8 +221,8 @@ refetches anything, and never infers the unlimited sentinel or a metric's status
 - `ModelLimitMetricKind` — `Finite | Unlimited | Unavailable`
 - `ModelLimitMetricCell` — `{ kind, usedLabel?, totalLabel?, usedPercent?, status?, ariaLabel }`
 - `ModelLimitRow` — `{ id, name, version?, avatarSrc?, cost, tokens, requests, status }`
-- `ModelLimitsLabels` — `{ headingLabel, periodLabels, periodSelectorAriaLabel, itemColumnLabel, costColumnLabel, tokensColumnLabel, requestsColumnLabel, statusColumnLabel, modelTypeLabel, noLimitLabel, unavailableLabel, withinLimitsBadgeLabel, runningLowBadgeLabel, limitReachedBadgeLabel, noLimitBadgeLabel, unavailableBadgeLabel }`
-- `ModelLimitsSectionProps` — `{ rows, period, onPeriodChange, labels, styles? }`
+- `ModelLimitsLabels` — `{ headingLabel, periodLabels, periodSelectorAriaLabel, itemColumnLabel, costColumnLabel, tokensColumnLabel, requestsColumnLabel, statusColumnLabel, modelTypeLabel, noLimitLabel, unavailableLabel, withinLimitsBadgeLabel, runningLowBadgeLabel, limitReachedBadgeLabel, noLimitBadgeLabel, unavailableBadgeLabel, emptyStateLabel }`
+- `ModelLimitsSectionProps` — `{ rows, period, onPeriodChange, labels, styles?, emptyStateIconSize? }`
 - `ModelLimitsStyles` — `{ colors?, typography? }`
 - `ModelLimitsColors` — CSS-custom-property color overrides
 - `ModelLimitsTypography` — typography class overrides

--- a/libs/usage-dashboard/package.json
+++ b/libs/usage-dashboard/package.json
@@ -20,6 +20,7 @@
   "peerDependencies": {
     "@epam/ai-dial-chat-shared": "*",
     "@epam/ai-dial-ui-kit": "^0.14.0-dev.4",
+    "@tabler/icons-react": "^3.44.0",
     "react": "^19.2.7"
   },
   "nx": {

--- a/libs/usage-dashboard/src/components/ModelLimitsSection/ModelLimitsSection.tsx
+++ b/libs/usage-dashboard/src/components/ModelLimitsSection/ModelLimitsSection.tsx
@@ -1,5 +1,10 @@
-import { buildCssVars, mergeClasses } from '@epam/ai-dial-chat-shared';
+import {
+  buildCssVars,
+  mergeClasses,
+  PanelEmptyState,
+} from '@epam/ai-dial-chat-shared';
 import { SegmentedControl } from '@epam/ai-dial-ui-kit';
+import { IconChartBar } from '@tabler/icons-react';
 import { FC } from 'react';
 import {
   ModelLimitsPeriod,
@@ -36,6 +41,7 @@ export const ModelLimitsSection: FC<ModelLimitsSectionProps> = ({
   onPeriodChange,
   labels,
   styles: stylesProp,
+  emptyStateIconSize = 48,
 }) => {
   const { colors, typography = {} } = stylesProp ?? {};
   const {
@@ -106,47 +112,64 @@ export const ModelLimitsSection: FC<ModelLimitsSectionProps> = ({
           styles.container,
         )}
       >
-        <div
-          role="row"
-          className={mergeClasses(
-            'hidden gap-4 px-6 py-3 desktop:grid',
-            MODEL_LIMITS_GRID_COLUMNS,
-            styles.headerRow,
-          )}
-        >
-          {(
-            [
-              labels.itemColumnLabel,
-              labels.costColumnLabel,
-              labels.tokensColumnLabel,
-              labels.requestsColumnLabel,
-              labels.statusColumnLabel,
-            ] as const
-          ).map((columnLabel) => (
-            <span
-              key={columnLabel}
-              role="columnheader"
+        {rows.length === 0 ? (
+          <div className="flex items-center justify-center px-6 py-10">
+            <PanelEmptyState
+              icon={
+                <IconChartBar
+                  aria-hidden
+                  size={emptyStateIconSize}
+                  stroke={1}
+                />
+              }
+              label={labels.emptyStateLabel}
+            />
+          </div>
+        ) : (
+          <>
+            <div
+              role="row"
               className={mergeClasses(
-                columnHeaderClassName,
-                styles.columnHeader,
+                'hidden gap-4 px-6 py-3 desktop:grid',
+                MODEL_LIMITS_GRID_COLUMNS,
+                styles.headerRow,
               )}
             >
-              {columnLabel}
-            </span>
-          ))}
-        </div>
+              {(
+                [
+                  labels.itemColumnLabel,
+                  labels.costColumnLabel,
+                  labels.tokensColumnLabel,
+                  labels.requestsColumnLabel,
+                  labels.statusColumnLabel,
+                ] as const
+              ).map((columnLabel) => (
+                <span
+                  key={columnLabel}
+                  role="columnheader"
+                  className={mergeClasses(
+                    columnHeaderClassName,
+                    styles.columnHeader,
+                  )}
+                >
+                  {columnLabel}
+                </span>
+              ))}
+            </div>
 
-        <div role="rowgroup">
-          {rows.map((row) => (
-            <ModelLimitsRow
-              key={row.id}
-              row={row}
-              labels={labels}
-              typography={typography}
-              avatarSize={AVATAR_SIZE}
-            />
-          ))}
-        </div>
+            <div role="rowgroup">
+              {rows.map((row) => (
+                <ModelLimitsRow
+                  key={row.id}
+                  row={row}
+                  labels={labels}
+                  typography={typography}
+                  avatarSize={AVATAR_SIZE}
+                />
+              ))}
+            </div>
+          </>
+        )}
       </div>
     </div>
   );

--- a/libs/usage-dashboard/src/components/ModelLimitsSection/tests/ModelLimitsSection.spec.tsx
+++ b/libs/usage-dashboard/src/components/ModelLimitsSection/tests/ModelLimitsSection.spec.tsx
@@ -63,6 +63,7 @@ const labels: ModelLimitsLabels = {
   limitReachedBadgeLabel: 'Limit reached',
   noLimitBadgeLabel: 'No limit',
   unavailableBadgeLabel: 'Unavailable',
+  emptyStateLabel: 'No models to show yet.',
 };
 
 const unlimitedCostCell: ModelLimitMetricCell = {
@@ -117,7 +118,7 @@ describe('ModelLimitsSection', () => {
     ).toBeTruthy();
   });
 
-  it('renders nothing in the row group when rows is empty, but keeps the heading and selector', () => {
+  it('renders the empty state when rows is empty, but keeps the heading and period selector', () => {
     renderSection({ rows: [] });
 
     expect(
@@ -125,6 +126,16 @@ describe('ModelLimitsSection', () => {
     ).toBeTruthy();
     expect(screen.getByText('Last 24 hours')).toBeTruthy();
     expect(screen.queryAllByRole('cell')).toHaveLength(0);
+    expect(screen.getByText('No models to show yet.')).toBeTruthy();
+  });
+
+  it('lets the user change the period from the empty state', async () => {
+    const onPeriodChange = vi.fn();
+    renderSection({ rows: [], onPeriodChange });
+
+    await userEvent.click(screen.getByText('Last 7 days'));
+
+    expect(onPeriodChange).toHaveBeenCalledWith(ModelLimitsPeriod.Last7Days);
   });
 
   it('renders one row per entry with model name and version', () => {

--- a/libs/usage-dashboard/src/models/model-limits-props.ts
+++ b/libs/usage-dashboard/src/models/model-limits-props.ts
@@ -106,6 +106,8 @@ export interface ModelLimitsLabels {
   noLimitBadgeLabel: string;
   /** Status badge text for `ModelLimitStatus.Unavailable`. */
   unavailableBadgeLabel: string;
+  /** Message shown in place of the table when `rows` is empty, e.g. `'No models to show yet.'`. */
+  emptyStateLabel: string;
 }
 
 /** Color overrides for `ModelLimitsSection`, applied as CSS custom properties. */
@@ -196,4 +198,6 @@ export interface ModelLimitsSectionProps {
   labels: ModelLimitsLabels;
   /** Style overrides applied as CSS custom properties and typography class overrides. */
   styles?: ModelLimitsStyles;
+  /** Size (px) of the empty-state icon, shown when `rows` is empty. Defaults to `48`. */
+  emptyStateIconSize?: number;
 }

--- a/openspec/changes/archive/2026-08-24-settings-usage-filter-empty-deployments/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-24-settings-usage-filter-empty-deployments/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-24

--- a/openspec/changes/archive/2026-08-24-settings-usage-filter-empty-deployments/design.md
+++ b/openspec/changes/archive/2026-08-24-settings-usage-filter-empty-deployments/design.md
@@ -1,0 +1,133 @@
+## Context
+
+`mapUserUsageToModelLimits` (`apps/chat/src/utils/map-user-usage-to-model-limits.ts`) currently
+produces one `ModelLimitRow` per key in `usage.deployments`, unconditionally, and `UsageTab.tsx`
+falls back to a plain `<p>` when that array is empty. The existing `usage-model-limits` spec
+explicitly protects "a deployment with all-zero used values for the selected period still
+appears" (it was written to distinguish "no data" from "zero usage") — this change deliberately
+narrows that: a deployment must have nonzero usage *in the selected period* to be shown, because
+in practice every deployment the org has ever configured shows up as a permanent zero row once the
+period no longer covers its last request, which was the reported UX problem.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Hide rows with no cost/token/request usage in the currently selected period, recomputed on every
+  period change (no refetch).
+- Replace the plain-text empty-state fallback with the established `PanelEmptyState` component so
+  the page matches the visual language used by `ScheduledTasks` and sidebar panels.
+- Keep all DTO interpretation inside the app-level adapter; `libs/usage-dashboard` keeps rendering
+  exactly the rows and count it is given, unchanged.
+
+**Non-Goals:**
+
+- No change to `useUsageData`, `useDeployments`, or any network call — filtering is purely a
+  client-side derivation over already-fetched data.
+- No change to per-metric classification (finite/unlimited/unavailable), status derivation, or
+  formatting — only which *rows* are included.
+- No new i18n key is introduced unless product wants period-specific empty-state copy (see Open
+  Questions); the existing `ModelLimitsEmptyState` string is reused by default.
+- No persistence of the selected period across reload — unchanged from today.
+
+## Decisions
+
+### Decision: Filter on raw `used` values, not on formatted cell output
+
+`mapUserUsageToModelLimits` already reads the raw `LimitStatsDto` for each of
+cost/tokens/requests before formatting it into a `ModelLimitMetricCell`. The filter reuses those
+same raw stats (`isUsableStats(stats) && stats.used > 0`) rather than re-parsing the formatted
+`usedLabel` string. A row is kept when **any** of its three raw stats is usable and has `used > 0`;
+it is dropped when all three are either unusable (`unavailable`) or usable with `used <= 0`.
+
+Alternative considered: filtering on the built `ModelLimitMetricCell`s (e.g. `kind === Finite &&
+usedPercent > 0`). Rejected because `Unlimited` cost cells never carry `usedPercent`, and parsing
+`usedLabel` back into a number would be locale-format-dependent and fragile — the raw DTO value is
+already in hand at the point cells are built.
+
+### Decision: Filtering happens in the existing adapter, after row construction
+
+Add the filter as a final `.filter(...)` step inside `mapUserUsageToModelLimits`, keyed off the
+same three `deploymentStats[fieldMapping.*]` lookups already used to build the row's cells. This
+keeps the "which rows exist" decision in one place (the adapter), consistent with the existing
+`usage-model-limits` spec's requirement that row set/order derives only from `usage.deployments`
+plus this one new period-scoped condition — no change to `ModelLimitsSection`'s contract (it still
+just renders `rows`).
+
+Alternative considered: filtering inside `UsageTab` after calling the adapter. Rejected — it would
+split "what counts as usage" logic across two files for no benefit, and the adapter already has
+the raw stats in scope.
+
+### Decision (revised): `ModelLimitsSection` renders its own empty state internally, keeping the period selector always visible
+
+**This supersedes the original plan below.** The first implementation had `UsageTab` branch on
+`modelLimitRows.length > 0` between `ModelLimitsSection` and a `PanelEmptyState` shown in its
+place. That reproduced the original bug in a new component: whenever the filtered rows were empty,
+`ModelLimitsSection` — and with it the period `SegmentedControl` — disappeared entirely, so a user
+who landed on an empty period had no control to switch to a period that *does* have data. It also
+put the empty state outside the section's heading/selector chrome, which read as a stray message on
+the page rather than a state of the Model limits table.
+
+`ModelLimitsSection` now always renders its heading and period selector; only the table body swaps
+between the row list and `PanelEmptyState` (imported from `@epam/ai-dial-chat-shared`, matching the
+`ScheduledTasks` pattern where the lib owns an internal empty-state icon and takes only the label
+via props). This requires `ModelLimitsLabels.emptyStateLabel: string` (new, required) and an
+optional `emptyStateIconSize?: number` on `ModelLimitsSectionProps` (default `48`), plus
+`@tabler/icons-react` as a new peer dependency of `usage-dashboard` for the icon — the same peer
+already required by `scheduled-tasks` for its own empty state. `UsageTab` now renders
+`ModelLimitsSection` unconditionally and passes `emptyStateLabel` through its existing
+`modelLimitsLabels` object; it no longer branches on row count at all.
+
+This keeps the lib's isolation intact: the icon is a generic, host-agnostic glyph chosen by the lib
+itself (not passed in as an app-specific asset), and the label is an English-default, host-supplied
+string like every other `ModelLimitsLabels` field — no host/API knowledge crosses the boundary.
+
+#### Decision as originally written (superseded)
+
+`UsageTab` already branches on `modelLimitRows.length > 0` to choose between `ModelLimitsSection`
+and the plain-text fallback. Swap the fallback branch for `PanelEmptyState` (already used by
+`ScheduledTasks` and sidebar panels), passing the existing `ModelLimitsEmptyState` translation as
+`label`. This is an app-level change only: `PanelEmptyState` lives in `libs/chat-shared`, which
+`apps/chat` already depends on, so no new library dependency or boundary exception is needed.
+`libs/usage-dashboard` is a `type:ui` lib and could import `chat-shared` too, but keeping the
+empty-state decision in `UsageTab` matches where the `rows.length` gate already lives and avoids
+teaching the lib a new "empty" rendering mode for a case it doesn't otherwise need to know about
+(zero rows vs. loading vs. error are already all app-level branches in `UsageTab`).
+
+Alternative considered: adding an internal empty state to `ModelLimitsSection` itself (rendered
+when `rows` is empty). Rejected — it would require threading label/icon props through the lib for
+a state the app can already fully handle at its existing branch point, and `ModelLimitsSection`'s
+existing contract ("renders exactly the rows it's given") stays simplest if it never special-cases
+an empty array. **(Rejected in error — see the revised decision above: this is exactly what
+trapped users on an empty period with no way to change it.)**
+
+### Decision: One empty-state message for both "no deployments at all" and "all filtered out"
+
+Both cases — `usage.deployments` empty, and every entry filtered out for zero usage in the
+selected period — render the same `PanelEmptyState`. Distinguishing the two with different copy
+would require the adapter to return not just `ModelLimitRow[]` but also a reason code, adding
+surface area for a distinction users are unlikely to care about (either way, the table has nothing
+to show for the selected period).
+
+## Risks / Trade-offs
+
+- [Hiding the period selector whenever the filtered result is empty traps the user on that period,
+  since there is no visible control left to try a different one] → Mitigated by the revised
+  decision above: `ModelLimitsSection` always renders its heading and period selector; only the
+  table body swaps to the empty state.
+- [Users lose visibility into deployments they used outside the selected period, even though the
+  data still exists in `usage.deployments`] → Acceptable per proposal: the period selector's whole
+  purpose is period-scoped visibility; a user who wants historical models picks "Last 30 days".
+- [Switching periods can now change the row *count*, not just the metric values, which existing
+  tests/snapshots may assume is stable] → Task list includes updating
+  `map-user-usage-to-model-limits` unit tests and any `ModelLimitsSection`/`UsageTab` tests that
+  assert row count independent of period.
+- [The reused `ModelLimitsEmptyState` copy was written for "no deployments at all" and may read
+  oddly for "you have deployments, just none used in this period"] → Flagged as an Open Question;
+  default is to ship with the existing copy and revisit wording with product if needed.
+
+## Open Questions
+
+- Should the empty-state copy differ between "no deployments at all" vs. "no usage in this
+  period"? Defaulting to the same message (see Decision above) unless product asks for a
+  period-aware variant.

--- a/openspec/changes/archive/2026-08-24-settings-usage-filter-empty-deployments/proposal.md
+++ b/openspec/changes/archive/2026-08-24-settings-usage-filter-empty-deployments/proposal.md
@@ -1,0 +1,66 @@
+## Why
+
+The Settings → Usage "Model limits" table currently lists every deployment present in
+`usage.deployments` regardless of whether it has any usage in the selected time period, so
+switching to "Last 24 hours" (for example) still shows models that were only used a week or a
+month ago, with every metric reading zero. This makes the table noisy and the period selector feel
+ineffective. When the filtered result is empty, the page falls back to a plain, unstyled paragraph
+instead of a real empty state, which is inconsistent with the empty-state pattern used elsewhere in
+the app (`PanelEmptyState`).
+
+## What Changes
+
+- **BREAKING** (behavior, not API): rows whose Cost, Tokens, and Requests metrics are all zero (or
+  all `unavailable`) for the *currently selected period* are no longer included in the Model
+  limits table — a deployment must have nonzero usage in the selected period to appear. This
+  reverses the previously specified "zero-usage deployment still appears" behavior for the selected
+  period (a deployment with usage in a *different* period but none in the current one now drops
+  out when that period is selected).
+- Add a real empty-state UI, rendered by `ModelLimitsSection` itself (reusing the existing
+  `PanelEmptyState` component from `@epam/ai-dial-chat-shared`, the same pattern used by
+  `ScheduledTasks` and sidebar panels) whenever the Model limits table would render zero rows for
+  the selected period — whether because `usage.deployments` itself is empty, or because every
+  deployment was filtered out for having no usage in that period. The section's heading and period
+  selector always stay visible and interactive, even when the table body is empty, so the user can
+  still switch to a different period instead of being stuck with no way back to a period that has
+  data. Replaces the current plain `<p>` fallback text in `UsageTab`, which previously hid the
+  period selector along with the table whenever the row set was empty.
+- The heading row count (`Model limits <N>`) reflects the post-filter row count, not the total
+  number of deployments in `usage.deployments`.
+
+## Capabilities
+
+### New Capabilities
+
+_None._
+
+### Modified Capabilities
+
+- `usage-model-limits`: the adapter (`mapUserUsageToModelLimits`) additionally filters out rows
+  with no usage in the selected period, and `UsageTab` renders `ModelLimitsSection`
+  unconditionally, no longer branching on row count itself.
+- `usage-dashboard-lib`: `ModelLimitsSection` renders its own empty state (with a new required
+  `ModelLimitsLabels.emptyStateLabel` and optional `emptyStateIconSize` prop) in place of the table
+  body when `rows` is empty, while keeping its heading and period selector rendered and
+  interactive; the library gains `@tabler/icons-react` as a peer dependency for the empty-state
+  icon.
+
+## Impact
+
+- `apps/chat/src/utils/map-user-usage-to-model-limits.ts` — add per-period zero-usage filtering
+  after row construction.
+- `apps/chat/src/pages/SettingsPage/UsageTab/UsageTab.tsx` — render `ModelLimitsSection`
+  unconditionally (remove the `modelLimitRows.length > 0` branch and the plain-text/`PanelEmptyState`
+  fallback previously rendered in its place), passing `emptyStateLabel` through the existing
+  `modelLimitsLabels` object.
+- `apps/chat/src/constants/translation-keys.ts` and `apps/chat/src/i18n/locales/en.json` — the
+  existing `ModelLimitsEmptyState` key is reused as `emptyStateLabel` (no new key required unless
+  copy needs to change per empty-state cause).
+- `libs/usage-dashboard/src/components/ModelLimitsSection/ModelLimitsSection.tsx` and
+  `libs/usage-dashboard/src/models/model-limits-props.ts` — render `PanelEmptyState` (from
+  `@epam/ai-dial-chat-shared`) in place of the column-header row and row group when `rows` is
+  empty; add `ModelLimitsLabels.emptyStateLabel` (required) and
+  `ModelLimitsSectionProps.emptyStateIconSize` (optional, default `48`).
+- `libs/usage-dashboard/package.json` and `libs/usage-dashboard/README.md` — add
+  `@tabler/icons-react` as a peer dependency and document the new prop/label.
+- No changes to `libs/chat-api-client` / backend DTOs.

--- a/openspec/changes/archive/2026-08-24-settings-usage-filter-empty-deployments/specs/usage-dashboard-lib/spec.md
+++ b/openspec/changes/archive/2026-08-24-settings-usage-filter-empty-deployments/specs/usage-dashboard-lib/spec.md
@@ -1,0 +1,83 @@
+## MODIFIED Requirements
+
+### Requirement: Host-agnostic usage-dashboard library
+
+The system SHALL provide a buildable React library `libs/usage-dashboard`
+(package `@epam/ai-dial-usage-dashboard`, Nx tag `type:ui`), scaffolded via an Nx generator and
+matching the inferred-target structure used by `libs/settings-panel` (no hand-written
+`project.json`; `package.json` carries `"nx": { "tags": ["type:ui"] }`; build/test come from the
+`@nx/vite` and `@nx/vitest` inferred plugins via `vite.config.mts`). The library SHALL import only
+`react`, `react-dom`, `@epam/ai-dial-ui-kit`, `@epam/ai-dial-chat-shared`, and
+`@tabler/icons-react` as peer/runtime dependencies — the last for its own internal empty-state icon
+(a generic, host-agnostic glyph chosen by the library itself, not supplied by the host), matching
+the same peer already declared by `@epam/ai-dial-scheduled-tasks` for its equivalent empty state. It
+SHALL NOT import `@epam/ai-dial-chat-api-client`, any `server-api/*` wrapper, any app
+context/hook/feature-flag/env/routing/storage/analytics module, or `react-i18next`.
+
+#### Scenario: Module boundary lint passes
+- **WHEN** `npm exec nx lint usage-dashboard` runs
+- **THEN** `@nx/enforce-module-boundaries` reports no violations, confirming the library depends
+  only on `chat-shared`-tier, UI-kit, and `@tabler/icons-react` packages
+
+#### Scenario: No generated-client or i18n imports
+- **WHEN** the library's source is inspected
+- **THEN** no file imports `@epam/ai-dial-chat-api-client`, `apps/chat/src/server-api/*`, or
+  `react-i18next`/`i18next`
+
+---
+
+### Requirement: ModelLimitsSection public API
+
+The library SHALL export from `src/index.ts`, in addition to its existing `UsageLimitCardGroup`/
+`UsageLimitCard` surface: the component `ModelLimitsSection`; the string enums `ModelLimitStatus`
+(`WithinLimits = 'within-limits'`, `RunningLow = 'running-low'`, `LimitReached = 'limit-reached'`,
+`NoLimit = 'no-limit'`, `Unavailable = 'unavailable'`), `ModelLimitsPeriod`
+(`LastMinute = 'last-minute'`, `LastHour = 'last-hour'`, `Last24Hours = 'last-24-hours'`,
+`Last7Days = 'last-7-days'`, `Last30Days = 'last-30-days'`), and
+`ModelLimitMetricKind` (`Finite = 'finite'`, `Unlimited = 'unlimited'`, `Unavailable = 'unavailable'`);
+and the types `ModelLimitMetricCell`, `ModelLimitRow`, `ModelLimitsLabels`, `ModelLimitsColors`,
+`ModelLimitsTypography`, `ModelLimitsStyles`, `ModelLimitsSectionProps`.
+
+`ModelLimitMetricCell` SHALL carry a `kind: ModelLimitMetricKind` discriminant
+plus already-formatted, normalized fields: `usedLabel?: string` (finite/unlimited), `totalLabel?:
+string` (finite only), `usedPercent?: number` (finite only, not pre-clamped), `status?:
+ModelLimitStatus` (finite only — `WithinLimits`/`RunningLow`/`LimitReached`), and `ariaLabel: string`
+(always present, describing the cell's full accessible text regardless of kind). The library SHALL
+treat `usedPercent` as opaque, used only to drive the progress bar's `value`/`aria-valuetext`, and
+SHALL NOT recompute it, detect the unlimited sentinel, or derive `status` itself.
+
+`ModelLimitRow` SHALL carry: `id: string`, `name: string`, `version?: string`, `avatarSrc?: string`,
+`cost: ModelLimitMetricCell`, `tokens: ModelLimitMetricCell`, `requests: ModelLimitMetricCell`, and
+`status: ModelLimitStatus` (the host-derived overall row status, including `NoLimit`/`Unavailable`).
+
+`ModelLimitsLabels` SHALL additionally carry `emptyStateLabel: string` — the message rendered in
+place of the table body when `rows` is empty.
+
+`ModelLimitsSectionProps` SHALL accept: `rows: ModelLimitRow[]` (in display order), `period:
+ModelLimitsPeriod`, `onPeriodChange: (period: ModelLimitsPeriod) => void`, `labels:
+ModelLimitsLabels`, an optional `styles?: ModelLimitsStyles`, and an optional
+`emptyStateIconSize?: number` (pixel size of the internal empty-state icon; defaults to `48`).
+
+#### Scenario: Section exports are available
+- **WHEN** a consumer imports from `@epam/ai-dial-usage-dashboard`
+- **THEN** `ModelLimitsSection`, `ModelLimitStatus`, `ModelLimitsPeriod`, `ModelLimitMetricKind`,
+  `ModelLimitMetricCell`, `ModelLimitRow`, `ModelLimitsLabels`, `ModelLimitsColors`,
+  `ModelLimitsTypography`, `ModelLimitsStyles`, and `ModelLimitsSectionProps` are all importable
+
+#### Scenario: Multiple rows rendered in order
+- **WHEN** `ModelLimitsSection` is rendered with a `rows` array of two or more entries
+- **THEN** it renders one row per entry, in array order, each showing its own avatar, name,
+  version, and Cost/Tokens/Requests/Status cells
+
+#### Scenario: Empty rows renders the section shell with a visible empty-state message, selector still usable
+- **WHEN** `ModelLimitsSection` is rendered with an empty `rows` array
+- **THEN** it still renders the heading (with a count of `0`) and the period selector — fully
+  interactive, so the user can pick a different period — and renders `labels.emptyStateLabel` with
+  an icon in place of the column headers and data rows, rather than rendering blank space or
+  omitting the section
+
+#### Scenario: Changing the period from an empty result still calls back
+- **WHEN** `ModelLimitsSection` is rendered with an empty `rows` array and the user selects a
+  different period from the still-visible selector
+- **THEN** `onPeriodChange` is called with the newly selected `ModelLimitsPeriod`, exactly as it
+  would be if `rows` were non-empty

--- a/openspec/changes/archive/2026-08-24-settings-usage-filter-empty-deployments/specs/usage-model-limits/spec.md
+++ b/openspec/changes/archive/2026-08-24-settings-usage-filter-empty-deployments/specs/usage-model-limits/spec.md
@@ -1,0 +1,146 @@
+## MODIFIED Requirements
+
+### Requirement: UsageTab renders Model limits below the aggregate cards
+
+The `Usage` tab SHALL render `@epam/ai-dial-usage-dashboard`'s `ModelLimitsSection` below
+`UsageLimitCardGroup`, sourced from `useUsageData()`'s already-fetched `usage.deployments` (no
+additional API call), unconditionally passing whatever rows the adapter produces (including zero
+rows) — the `Usage` tab SHALL NOT branch on row count itself. The section SHALL be omitted (not
+rendered) while `isLoading` is `true`, matching the existing cards' loading behavior. Whenever,
+after loading completes, the adapter produces zero rows for the currently selected period —
+whether because `usage` is `undefined`, `usage.deployments` is absent/empty, or every entry in
+`usage.deployments` was filtered out for having no usage in that period (see "Rows with no usage in
+the selected period are excluded" below) — `ModelLimitsSection` itself SHALL render its shared
+empty state in place of the table body, while still rendering its heading and period selector (see
+`ModelLimitsSectionProps.emptyStateLabel` in the "usage-dashboard-lib" spec), so the period
+selector remains available for the user to pick a different period from an empty result.
+
+#### Scenario: Model limits section renders alongside the cards
+- **WHEN** the Usage tab finishes loading and `usage.deployments` contains at least one model with
+  usage in the selected period
+- **THEN** `ModelLimitsSection` renders below `UsageLimitCardGroup` with one row per such model
+
+#### Scenario: Empty deployments map renders the section's own empty state, with the selector still usable
+- **WHEN** the Usage tab finishes loading and `usage.deployments` is an empty object
+- **THEN** `ModelLimitsSection` still renders (with its heading, row count of `0`, and period
+  selector), showing its internal empty state in place of the row table, rather than the `Usage`
+  tab omitting the section or rendering a separate empty-state element outside it
+
+#### Scenario: All deployments filtered out for the selected period renders the same empty state, with the selector still usable
+- **WHEN** the Usage tab finishes loading, `usage.deployments` is non-empty, but every entry has no
+  usage in the currently selected period
+- **THEN** `ModelLimitsSection` still renders (with its heading, row count of `0`, and period
+  selector) showing the same internal empty state as the empty-deployments-map case, and the user
+  can select a different period from the still-visible selector to see whether that period has data
+
+#### Scenario: Usage fetch failure leaves the rest of the page visible
+- **WHEN** `useUsageData()` reports a `usageError`
+- **THEN** the Model limits section renders its own unavailable state (no stale/zeroed rows), the
+  aggregate cards region reflects the same existing partial/full failure behavior, and no additional
+  notification is emitted beyond the one already produced by the existing `usage-data-hook`
+  "Deduplicated error notifications" behavior
+
+---
+
+### Requirement: `usage.deployments` join with model metadata
+
+The adapter SHALL build candidate rows from exactly the entries present in `usage.deployments` —
+every entry present, and no entry not present — regardless of what `useDeployments().items`
+contains: an accessible model with no entry in `usage.deployments` SHALL NOT produce a row, and
+every entry in `usage.deployments` SHALL produce a candidate row even if no matching `items` entry
+exists. Candidate rows are then subject to the period-scoped usage filter defined in "Rows with no
+usage in the selected period are excluded" before being returned. Among the rows that survive that
+filter, order SHALL follow `Object.keys(usage.deployments)` order (the order the API returns),
+independent of `items`' content, order, or load state — `items` is consulted only to enrich a
+matched row's display name/version/avatar, never to determine which rows exist or their order. The
+join against `items` SHALL be filtered to `type === DeploymentItemDtoTypeEnum.Model`.
+
+When a deployment ID has no matching entry in `items`, the adapter SHALL still produce a candidate
+row for it, using the deployment ID as the display name and no `avatarSrc` (so `ModelLimitsSection`
+falls back to its initials avatar), rather than omitting the row outright (it is still subject to
+the usage filter like any other row).
+
+#### Scenario: Row count matches the number of deployments with usage in the selected period
+- **WHEN** `usage.deployments` has 12 entries, all resolvable against `items`, and 9 of them have
+  nonzero usage for the currently selected period
+- **THEN** `ModelLimitsSection` receives exactly 9 rows and its heading reports a count of 9
+
+#### Scenario: A deployment with all-zero used values for the selected period does not appear
+- **WHEN** a deployment in `usage.deployments` has all-zero (or unusable) `used` values across
+  every stat field mapped for the selected period, even though it has nonzero usage recorded under
+  a different period's fields
+- **THEN** it does not produce a row while that period is selected (see "Rows with no usage in the
+  selected period are excluded"); selecting the period under which it has usage makes it reappear
+
+#### Scenario: A model never used in the trailing 30 days does not appear at all
+- **WHEN** an accessible model has no entry in `usage.deployments` at all (never used in the
+  trailing 30 days, per `openspec/specs/user-usage-limits-api/spec.md:80`)
+- **THEN** the adapter produces no row for it — this is the accepted trade-off of reading
+  `usage.deployments` instead of `limits.deployments` (see design.md's data-source correction), not
+  a defect
+
+#### Scenario: Unresolvable deployment ID still renders a fallback row when it has usage
+- **WHEN** a deployment ID in `usage.deployments` has no matching entry in
+  `useDeployments().items`, and it has nonzero usage in the selected period
+- **THEN** the adapter produces a row for it with `name` equal to the deployment ID and
+  `avatarSrc: undefined`, and this row does not cause other rows to be dropped
+
+#### Scenario: Non-model deployment items are never joined in
+- **WHEN** `useDeployments().items` contains an application or toolset whose `id` happens to match a
+  key in `usage.deployments`
+- **THEN** the adapter does not use that non-model item's metadata for the row (join is restricted
+  to `type === DeploymentItemDtoTypeEnum.Model`)
+
+#### Scenario: Row order follows `usage.deployments` key order, not `items`' order
+- **WHEN** `items` lists models in one order (e.g. `['b', 'a']`) but `usage.deployments` has keys
+  in a different order (e.g. `{ a: ..., b: ... }`), and both have usage in the selected period
+- **THEN** the resulting rows are ordered `['a', 'b']` — `Object.keys(usage.deployments)` order —
+  regardless of `items`' order
+
+#### Scenario: Row order does not depend on whether `items` has finished loading
+- **WHEN** `useDeployments().items` is still empty (not yet loaded) while `usage.deployments`
+  already has data with usage in the selected period
+- **THEN** the rows render immediately in `usage.deployments` key order, with the deployment ID as
+  each row's name; once `items` loads, matched rows are enriched with name/version/avatar but the
+  row set and order do not change or re-shuffle
+
+## ADDED Requirements
+
+### Requirement: Rows with no usage in the selected period are excluded
+
+For each candidate row, the adapter SHALL inspect the raw `LimitStatsDto` entries backing that
+row's Cost, Tokens, and Requests cells for the currently selected period (per the existing
+period-to-field mapping) and SHALL include the row in the returned `ModelLimitRow[]` only if at
+least one of those entries is usable (`Number.isFinite(total)` and `Number.isFinite(used)`) and has
+`used > 0`. A row whose every mapped entry for the selected period is either absent/unusable or has
+`used <= 0` SHALL be excluded from the result. This filter SHALL be re-evaluated from the
+already-fetched `usage` value whenever the selected period changes, without an additional API call,
+and SHALL NOT alter the per-metric `finite`/`unlimited`/`unavailable` classification, status
+derivation, or formatting of any row that is included.
+
+#### Scenario: Row with nonzero tokens but zero cost and unavailable requests is kept
+- **WHEN** the selected period is `Last24Hours` and a deployment's `dayTokenStats` is `{ total:
+  10000, used: 250 }`, `dayCostStats.used` is `0`, and `dayRequestStats` is absent
+- **THEN** the row is included, because at least one mapped entry (`dayTokenStats`) has `used > 0`
+
+#### Scenario: Row with all-zero mapped entries for the period is excluded
+- **WHEN** the selected period is `Last7Days` and a deployment's `weekCostStats.used` and
+  `weekTokenStats.used` are both `0` (Requests is unavailable for `Last7Days`)
+- **THEN** the row is excluded from the returned rows for that period
+
+#### Scenario: Row with only unavailable mapped entries for the period is excluded
+- **WHEN** the selected period is `LastHour` and a deployment's `hourRequestStats` is missing from
+  the DTO entirely (Cost and Tokens are always unavailable for `LastHour`)
+- **THEN** the row is excluded — an unusable entry never counts as "has usage"
+
+#### Scenario: Switching periods changes which rows are included
+- **WHEN** a deployment has `used > 0` in `monthTokenStats` but `used === 0` in every field mapped
+  for `Last24Hours`
+- **THEN** the row appears while `Last30Days` is selected and disappears while `Last24Hours` is
+  selected, with no refetch triggered by the period change
+
+#### Scenario: Filtering does not change included rows' metric classification or formatting
+- **WHEN** a row is included because `dayTokenStats.used > 0`, and that same row's `dayCostStats`
+  is a well-formed unlimited-sentinel entry
+- **THEN** the row's Cost cell is still classified `kind: ModelLimitMetricKind.Unlimited` exactly
+  as it would be without this filter — the filter only affects row inclusion, never cell content

--- a/openspec/changes/archive/2026-08-24-settings-usage-filter-empty-deployments/tasks.md
+++ b/openspec/changes/archive/2026-08-24-settings-usage-filter-empty-deployments/tasks.md
@@ -1,0 +1,82 @@
+## 1. Adapter: filter rows with no usage in the selected period
+
+- [x] 1.1 In `apps/chat/src/utils/map-user-usage-to-model-limits.ts`, inside
+      `mapUserUsageToModelLimits`, capture the three raw `LimitStatsDto | undefined` values
+      already looked up for `fieldMapping.cost` / `.tokens` / `.requests` before they're passed to
+      `buildCostMetricCell` / `buildFiniteMetricCell`, so the filter can reuse them without
+      re-fetching or re-deriving anything.
+- [x] 1.2 Add a `hasUsageInPeriod` check per candidate row: `true` if any of those three raw stats
+      is usable (`Number.isFinite(total) && Number.isFinite(used)`, i.e. `isUsableStats`) and has
+      `used > 0`; `false` otherwise.
+- [x] 1.3 Filter the mapped array to rows where `hasUsageInPeriod` is `true` before returning, so
+      row set and order still follow `Object.keys(deployments)` order among the surviving rows.
+- [x] 1.4 Update the function's JSDoc to state that the returned rows are additionally scoped to
+      the selected period's usage (per `specs/usage-model-limits/spec.md`'s new "Rows with no usage
+      in the selected period are excluded" requirement).
+
+## 2. ModelLimitsSection: internal empty state, selector always visible
+
+Superseded plan: the original task 2 had `UsageTab` swap `ModelLimitsSection` for a standalone
+`PanelEmptyState` whenever rows were empty. That hid the period `SegmentedControl` along with the
+table, trapping the user on an empty period with no control to pick a different one, and rendered
+the empty state outside the section's own heading/selector chrome. Fixed by moving the empty state
+inside `ModelLimitsSection` itself, per the revised design.md decision.
+
+- [x] 2.1 In `libs/usage-dashboard/src/models/model-limits-props.ts`, add
+      `emptyStateLabel: string` to `ModelLimitsLabels` and optional
+      `emptyStateIconSize?: number` to `ModelLimitsSectionProps` (JSDoc'd, default documented as
+      `48`).
+- [x] 2.2 In `libs/usage-dashboard/src/components/ModelLimitsSection/ModelLimitsSection.tsx`,
+      import `PanelEmptyState` from `@epam/ai-dial-chat-shared` and `IconChartBar` from
+      `@tabler/icons-react`; destructure `emptyStateIconSize = 48`; when `rows.length === 0`,
+      render `<PanelEmptyState icon={<IconChartBar aria-hidden size={emptyStateIconSize}
+      stroke={1} />} label={labels.emptyStateLabel} />` in place of the column-header row and
+      `rowgroup`, while the heading and `SegmentedControl` continue to render unconditionally
+      above it.
+- [x] 2.3 Add `@tabler/icons-react` (`^3.44.0`, matching `libs/scheduled-tasks/package.json`) as a
+      peer dependency in `libs/usage-dashboard/package.json`.
+- [x] 2.4 In `apps/chat/src/pages/SettingsPage/UsageTab/UsageTab.tsx`, remove the
+      `modelLimitRows.length > 0 ? <ModelLimitsSection ... /> : <PanelEmptyState ... />` branch —
+      render `<ModelLimitsSection rows={modelLimitRows} ... />` unconditionally — and add
+      `emptyStateLabel: t(UsageI18nKeys.ModelLimitsEmptyState)` to the existing
+      `modelLimitsLabels` object. Remove the now-unused `PanelEmptyState`/`IconChartBar` imports
+      from `UsageTab.tsx`.
+- [x] 2.5 Update `libs/usage-dashboard/README.md`: document `emptyStateLabel` in the
+      `ModelLimitsLabels` example and type list, document `emptyStateIconSize` in
+      `ModelLimitsSectionProps`, add `@tabler/icons-react` to Peer Dependencies, and note that the
+      heading/selector stay visible when `rows` is empty. Run `npm run validate:docs`.
+
+## 3. Tests
+
+- [x] 3.1 Update/add unit tests for `mapUserUsageToModelLimits` covering the new spec scenarios:
+      row kept when only one of cost/tokens/requests has `used > 0`; row excluded when all mapped
+      entries are zero or unavailable for the period; switching `period` changes which rows are
+      included (same deployment, different periods) without any new fetch; classification/format
+      of an included row's cells is unchanged by the filter.
+- [x] 3.2 Update any existing `UsageTab` / `ModelLimitsSection` integration test that currently
+      asserts a fixed row count independent of period, to account for period-scoped filtering.
+      (No such test existed — the one row-rendering test already used `used: 1` fixtures, which
+      remain included under the new filter.)
+- [x] 3.3 Add a `UsageTab` test asserting the empty-state label renders (via the mocked
+      `ModelLimitsSection`) when `modelLimitRows` is empty, for both the empty-`usage.deployments`
+      and all-filtered-out-by-period cases.
+- [x] 3.4 Update `libs/usage-dashboard/src/components/ModelLimitsSection/tests/ModelLimitsSection.spec.tsx`:
+      add `emptyStateLabel` to the test `labels` fixture; update the empty-rows test to assert the
+      empty-state label renders alongside the still-present heading and period selector; add a
+      test that selecting a period from the empty state still calls `onPeriodChange`.
+
+## 4. Verification
+
+- [x] 4.1 `npm exec nx test chat` — 212 test files, 3061 passed, 2 skipped.
+- [x] 4.2 `npm exec nx lint chat` — 0 errors, 40 pre-existing warnings unrelated to this change.
+- [x] 4.3 `npm exec nx typecheck chat` (or the project's equivalent typecheck target) — passes.
+- [x] 4.5 `npm exec nx test usage-dashboard` — 33 tests passed (18 in `ModelLimitsSection.spec.tsx`).
+- [x] 4.6 `npm exec nx lint usage-dashboard` and `npm exec nx typecheck usage-dashboard` — both pass.
+- [x] 4.7 `npm run validate:docs` — passes (42 markdown files checked) after the
+      `libs/usage-dashboard/README.md` and `package.json` updates.
+- [x] 4.4 Manually verify in the browser: open Settings → Usage, switch between Last minute/Last
+      hour/Last 24 hours/Last 7 days/Last 30 days, confirm rows with no usage in the selected
+      period disappear while the heading count matches the visible rows, confirm the empty state
+      renders (with the expected label and icon) when a period has no usage across all
+      deployments, and confirm the period selector stays visible and clickable from that empty
+      state so a different period can be picked without leaving the page.

--- a/openspec/specs/usage-dashboard-lib/spec.md
+++ b/openspec/specs/usage-dashboard-lib/spec.md
@@ -19,14 +19,17 @@ The system SHALL provide a buildable React library `libs/usage-dashboard`
 matching the inferred-target structure used by `libs/settings-panel` (no hand-written
 `project.json`; `package.json` carries `"nx": { "tags": ["type:ui"] }`; build/test come from the
 `@nx/vite` and `@nx/vitest` inferred plugins via `vite.config.mts`). The library SHALL import only
-`react`, `react-dom`, `@epam/ai-dial-ui-kit`, and `@epam/ai-dial-chat-shared` as peer/runtime
-dependencies. It SHALL NOT import `@epam/ai-dial-chat-api-client`, any `server-api/*` wrapper, any
-app context/hook/feature-flag/env/routing/storage/analytics module, or `react-i18next`.
+`react`, `react-dom`, `@epam/ai-dial-ui-kit`, `@epam/ai-dial-chat-shared`, and
+`@tabler/icons-react` as peer/runtime dependencies — the last for its own internal empty-state icon
+(a generic, host-agnostic glyph chosen by the library itself, not supplied by the host), matching
+the same peer already declared by `@epam/ai-dial-scheduled-tasks` for its equivalent empty state. It
+SHALL NOT import `@epam/ai-dial-chat-api-client`, any `server-api/*` wrapper, any app
+context/hook/feature-flag/env/routing/storage/analytics module, or `react-i18next`.
 
 #### Scenario: Module boundary lint passes
 - **WHEN** `npm exec nx lint usage-dashboard` runs
 - **THEN** `@nx/enforce-module-boundaries` reports no violations, confirming the library depends
-  only on `chat-shared`-tier and UI-kit packages
+  only on `chat-shared`-tier, UI-kit, and `@tabler/icons-react` packages
 
 #### Scenario: No generated-client or i18n imports
 - **WHEN** the library's source is inspected
@@ -199,9 +202,13 @@ SHALL NOT recompute it, detect the unlimited sentinel, or derive `status` itself
 `cost: ModelLimitMetricCell`, `tokens: ModelLimitMetricCell`, `requests: ModelLimitMetricCell`, and
 `status: ModelLimitStatus` (the host-derived overall row status, including `NoLimit`/`Unavailable`).
 
+`ModelLimitsLabels` SHALL additionally carry `emptyStateLabel: string` — the message rendered in
+place of the table body when `rows` is empty.
+
 `ModelLimitsSectionProps` SHALL accept: `rows: ModelLimitRow[]` (in display order), `period:
 ModelLimitsPeriod`, `onPeriodChange: (period: ModelLimitsPeriod) => void`, `labels:
-ModelLimitsLabels`, and an optional `styles?: ModelLimitsStyles`.
+ModelLimitsLabels`, an optional `styles?: ModelLimitsStyles`, and an optional
+`emptyStateIconSize?: number` (pixel size of the internal empty-state icon; defaults to `48`).
 
 #### Scenario: Section exports are available
 - **WHEN** a consumer imports from `@epam/ai-dial-usage-dashboard`
@@ -214,10 +221,18 @@ ModelLimitsLabels`, and an optional `styles?: ModelLimitsStyles`.
 - **THEN** it renders one row per entry, in array order, each showing its own avatar, name,
   version, and Cost/Tokens/Requests/Status cells
 
-#### Scenario: Empty rows renders the section shell without a table body
+#### Scenario: Empty rows renders the section shell with a visible empty-state message, selector still usable
 - **WHEN** `ModelLimitsSection` is rendered with an empty `rows` array
-- **THEN** it still renders the heading (with a count of `0`) and the period selector, but renders
-  no data rows
+- **THEN** it still renders the heading (with a count of `0`) and the period selector — fully
+  interactive, so the user can pick a different period — and renders `labels.emptyStateLabel` with
+  an icon in place of the column headers and data rows, rather than rendering blank space or
+  omitting the section
+
+#### Scenario: Changing the period from an empty result still calls back
+- **WHEN** `ModelLimitsSection` is rendered with an empty `rows` array and the user selects a
+  different period from the still-visible selector
+- **THEN** `onPeriodChange` is called with the newly selected `ModelLimitsPeriod`, exactly as it
+  would be if `rows` were non-empty
 
 ---
 

--- a/openspec/specs/usage-model-limits/spec.md
+++ b/openspec/specs/usage-model-limits/spec.md
@@ -15,18 +15,34 @@ finite/unlimited/unavailable detection, status derivation, formatting, and the j
 
 The `Usage` tab SHALL render `@epam/ai-dial-usage-dashboard`'s `ModelLimitsSection` below
 `UsageLimitCardGroup`, sourced from `useUsageData()`'s already-fetched `usage.deployments` (no
-additional API call). The section SHALL be omitted (not rendered) while `isLoading` is `true`,
-matching the existing cards' loading behavior, and SHALL render nothing (or an explicit empty state)
-when `usage` is `undefined` or `usage.deployments` is absent/empty after loading completes.
+additional API call), unconditionally passing whatever rows the adapter produces (including zero
+rows) — the `Usage` tab SHALL NOT branch on row count itself. The section SHALL be omitted (not
+rendered) while `isLoading` is `true`, matching the existing cards' loading behavior. Whenever,
+after loading completes, the adapter produces zero rows for the currently selected period —
+whether because `usage` is `undefined`, `usage.deployments` is absent/empty, or every entry in
+`usage.deployments` was filtered out for having no usage in that period (see "Rows with no usage in
+the selected period are excluded" below) — `ModelLimitsSection` itself SHALL render its shared
+empty state in place of the table body, while still rendering its heading and period selector (see
+`ModelLimitsSectionProps.emptyStateLabel` in the "usage-dashboard-lib" spec), so the period
+selector remains available for the user to pick a different period from an empty result.
 
 #### Scenario: Model limits section renders alongside the cards
-- **WHEN** the Usage tab finishes loading and `usage.deployments` contains at least one model
-- **THEN** `ModelLimitsSection` renders below `UsageLimitCardGroup` with one row per accessible model
+- **WHEN** the Usage tab finishes loading and `usage.deployments` contains at least one model with
+  usage in the selected period
+- **THEN** `ModelLimitsSection` renders below `UsageLimitCardGroup` with one row per such model
 
-#### Scenario: Empty deployments map renders an explicit empty state
+#### Scenario: Empty deployments map renders the section's own empty state, with the selector still usable
 - **WHEN** the Usage tab finishes loading and `usage.deployments` is an empty object
-- **THEN** the page renders a localized empty-state message in place of the table, and does not
-  render `ModelLimitsSection` with zero rows silently
+- **THEN** `ModelLimitsSection` still renders (with its heading, row count of `0`, and period
+  selector), showing its internal empty state in place of the row table, rather than the `Usage`
+  tab omitting the section or rendering a separate empty-state element outside it
+
+#### Scenario: All deployments filtered out for the selected period renders the same empty state, with the selector still usable
+- **WHEN** the Usage tab finishes loading, `usage.deployments` is non-empty, but every entry has no
+  usage in the currently selected period
+- **THEN** `ModelLimitsSection` still renders (with its heading, row count of `0`, and period
+  selector) showing the same internal empty state as the empty-deployments-map case, and the user
+  can select a different period from the still-visible selector to see whether that period has data
 
 #### Scenario: Usage fetch failure leaves the rest of the page visible
 - **WHEN** `useUsageData()` reports a `usageError`
@@ -104,27 +120,33 @@ SHALL NOT substitute a different period's field, or a different metric's field, 
 
 ### Requirement: `usage.deployments` join with model metadata
 
-The adapter SHALL build rows from exactly the entries present in `usage.deployments` — every entry
-present, and no entry not present — regardless of what `useDeployments().items` contains: an
-accessible model with no entry in `usage.deployments` SHALL NOT produce a row, and every entry in
-`usage.deployments` SHALL produce a row even if no matching `items` entry exists. Row order SHALL
-follow `Object.keys(usage.deployments)` order (the order the API returns), independent of `items`'
-content, order, or load state — `items` is consulted only to enrich a matched row's display
-name/version/avatar, never to determine which rows exist or their order. The join against `items`
-SHALL be filtered to `type === DeploymentItemDtoTypeEnum.Model`.
+The adapter SHALL build candidate rows from exactly the entries present in `usage.deployments` —
+every entry present, and no entry not present — regardless of what `useDeployments().items`
+contains: an accessible model with no entry in `usage.deployments` SHALL NOT produce a row, and
+every entry in `usage.deployments` SHALL produce a candidate row even if no matching `items` entry
+exists. Candidate rows are then subject to the period-scoped usage filter defined in "Rows with no
+usage in the selected period are excluded" before being returned. Among the rows that survive that
+filter, order SHALL follow `Object.keys(usage.deployments)` order (the order the API returns),
+independent of `items`' content, order, or load state — `items` is consulted only to enrich a
+matched row's display name/version/avatar, never to determine which rows exist or their order. The
+join against `items` SHALL be filtered to `type === DeploymentItemDtoTypeEnum.Model`.
 
-When a deployment ID has no matching entry in `items`, the adapter SHALL still render a row for it,
-using the deployment ID as the display name and no `avatarSrc` (so `ModelLimitsSection` falls back
-to its initials avatar), rather than omitting the row.
+When a deployment ID has no matching entry in `items`, the adapter SHALL still produce a candidate
+row for it, using the deployment ID as the display name and no `avatarSrc` (so `ModelLimitsSection`
+falls back to its initials avatar), rather than omitting the row outright (it is still subject to
+the usage filter like any other row).
 
-#### Scenario: Row count matches the deployments map
-- **WHEN** `usage.deployments` has 12 entries, all resolvable against `items`
-- **THEN** `ModelLimitsSection` receives exactly 12 rows and its heading reports a count of 12
+#### Scenario: Row count matches the number of deployments with usage in the selected period
+- **WHEN** `usage.deployments` has 12 entries, all resolvable against `items`, and 9 of them have
+  nonzero usage for the currently selected period
+- **THEN** `ModelLimitsSection` receives exactly 9 rows and its heading reports a count of 9
 
-#### Scenario: A deployment present in `usage.deployments` with all-zero used values still appears
-- **WHEN** a deployment in `usage.deployments` has all-zero `used` values across every stat field
-  for the selected period (but the entry itself is present, e.g. it had usage in a different period)
-- **THEN** it still produces a row (zero usage for the selected period is not treated as "no data")
+#### Scenario: A deployment with all-zero used values for the selected period does not appear
+- **WHEN** a deployment in `usage.deployments` has all-zero (or unusable) `used` values across
+  every stat field mapped for the selected period, even though it has nonzero usage recorded under
+  a different period's fields
+- **THEN** it does not produce a row while that period is selected (see "Rows with no usage in the
+  selected period are excluded"); selecting the period under which it has usage makes it reappear
 
 #### Scenario: A model never used in the trailing 30 days does not appear at all
 - **WHEN** an accessible model has no entry in `usage.deployments` at all (never used in the
@@ -133,9 +155,9 @@ to its initials avatar), rather than omitting the row.
   `usage.deployments` instead of `limits.deployments` (see design.md's data-source correction), not
   a defect
 
-#### Scenario: Unresolvable deployment ID still renders a fallback row
+#### Scenario: Unresolvable deployment ID still renders a fallback row when it has usage
 - **WHEN** a deployment ID in `usage.deployments` has no matching entry in
-  `useDeployments().items`
+  `useDeployments().items`, and it has nonzero usage in the selected period
 - **THEN** the adapter produces a row for it with `name` equal to the deployment ID and
   `avatarSrc: undefined`, and this row does not cause other rows to be dropped
 
@@ -147,16 +169,57 @@ to its initials avatar), rather than omitting the row.
 
 #### Scenario: Row order follows `usage.deployments` key order, not `items`' order
 - **WHEN** `items` lists models in one order (e.g. `['b', 'a']`) but `usage.deployments` has keys
-  in a different order (e.g. `{ a: ..., b: ... }`)
+  in a different order (e.g. `{ a: ..., b: ... }`), and both have usage in the selected period
 - **THEN** the resulting rows are ordered `['a', 'b']` — `Object.keys(usage.deployments)` order —
   regardless of `items`' order
 
 #### Scenario: Row order does not depend on whether `items` has finished loading
 - **WHEN** `useDeployments().items` is still empty (not yet loaded) while `usage.deployments`
-  already has data
+  already has data with usage in the selected period
 - **THEN** the rows render immediately in `usage.deployments` key order, with the deployment ID as
   each row's name; once `items` loads, matched rows are enriched with name/version/avatar but the
   row set and order do not change or re-shuffle
+
+---
+
+### Requirement: Rows with no usage in the selected period are excluded
+
+For each candidate row, the adapter SHALL inspect the raw `LimitStatsDto` entries backing that
+row's Cost, Tokens, and Requests cells for the currently selected period (per the existing
+period-to-field mapping) and SHALL include the row in the returned `ModelLimitRow[]` only if at
+least one of those entries is usable (`Number.isFinite(total)` and `Number.isFinite(used)`) and has
+`used > 0`. A row whose every mapped entry for the selected period is either absent/unusable or has
+`used <= 0` SHALL be excluded from the result. This filter SHALL be re-evaluated from the
+already-fetched `usage` value whenever the selected period changes, without an additional API call,
+and SHALL NOT alter the per-metric `finite`/`unlimited`/`unavailable` classification, status
+derivation, or formatting of any row that is included.
+
+#### Scenario: Row with nonzero tokens but zero cost and unavailable requests is kept
+- **WHEN** the selected period is `Last24Hours` and a deployment's `dayTokenStats` is `{ total:
+  10000, used: 250 }`, `dayCostStats.used` is `0`, and `dayRequestStats` is absent
+- **THEN** the row is included, because at least one mapped entry (`dayTokenStats`) has `used > 0`
+
+#### Scenario: Row with all-zero mapped entries for the period is excluded
+- **WHEN** the selected period is `Last7Days` and a deployment's `weekCostStats.used` and
+  `weekTokenStats.used` are both `0` (Requests is unavailable for `Last7Days`)
+- **THEN** the row is excluded from the returned rows for that period
+
+#### Scenario: Row with only unavailable mapped entries for the period is excluded
+- **WHEN** the selected period is `LastHour` and a deployment's `hourRequestStats` is missing from
+  the DTO entirely (Cost and Tokens are always unavailable for `LastHour`)
+- **THEN** the row is excluded — an unusable entry never counts as "has usage"
+
+#### Scenario: Switching periods changes which rows are included
+- **WHEN** a deployment has `used > 0` in `monthTokenStats` but `used === 0` in every field mapped
+  for `Last24Hours`
+- **THEN** the row appears while `Last30Days` is selected and disappears while `Last24Hours` is
+  selected, with no refetch triggered by the period change
+
+#### Scenario: Filtering does not change included rows' metric classification or formatting
+- **WHEN** a row is included because `dayTokenStats.used > 0`, and that same row's `dayCostStats`
+  is a well-formed unlimited-sentinel entry
+- **THEN** the row's Cost cell is still classified `kind: ModelLimitMetricKind.Unlimited` exactly
+  as it would be without this filter — the filter only affects row inclusion, never cell content
 
 ---
 


### PR DESCRIPTION
**Description:**

Filter model-limit rows to deployments with actual usage in the selected period so entries from other periods no longer appear as empty rows. Keep the model-limits heading and period selector available when the result is empty, and render the shared empty state so users can switch periods without losing context. Tests, public library documentation, and the archived OpenSpec change cover the updated behavior.

Issues:

- Issue #8379

**UI changes**

Settings → Usage now shows a centered chart empty state below the model-limits heading and period selector when the selected period has no model usage. No screenshot provided.
<img width="1920" height="1200" alt="image" src="https://github.com/user-attachments/assets/f1ea6148-ad99-4a0d-9481-554dddf89c4e" />
<img width="1920" height="1200" alt="image" src="https://github.com/user-attachments/assets/2e95d63a-fc03-4789-87e9-179fa48f3b53" />


**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(usage-dashboard):`
- [x] the pull request name ends with `(Issue #8379)`
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
