### PR TITLE
fix(chat-api): reject double-encoded toolset traversal (Issue #7925)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ After that it is no longer maintained, so plan the move before then.
 [Migrating from the Legacy DIAL Chat](#migrating-from-the-legacy-dial-chat)
 below is the starting point.
 
-
 ## 📚 Table of Contents
 
 - [Overview](#overview)

--- a/apps/chat-api/src/common/validators/safe-toolset-name.validator.spec.ts
+++ b/apps/chat-api/src/common/validators/safe-toolset-name.validator.spec.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { isSafeToolsetName } from './safe-toolset-name.validator';
+
+describe('isSafeToolsetName', () => {
+  it.each([
+    'my-toolset',
+    'folder.toolset-v1',
+    '@org/toolset:tag',
+    'toolsets/bucket/folder/toolset-name',
+    'toolsets/bucket/My%20Tool',
+    'toolsets%2Fbucket%2Ffolder%2Ftoolset-name',
+  ])('accepts the safe toolset name %s', (value) => {
+    expect(isSafeToolsetName(value)).toBe(true);
+  });
+
+  it.each([
+    '',
+    '.',
+    '..',
+    '../etc/passwd',
+    'toolsets//toolset-name',
+    'toolsets/./toolset-name',
+    'toolsets/../toolset-name',
+    '..%2Fetc%2Fpasswd',
+    '%2E%2E%2Fetc%2Fpasswd',
+    'toolsets%2Fbucket%2F..%2Fsecret',
+    'bad;toolset',
+    'bad toolset',
+    String.raw`..\etc\passwd`,
+    'bad%GGtoolset',
+  ])('rejects the unsafe toolset name %s', (value) => {
+    expect(isSafeToolsetName(value)).toBe(false);
+  });
+
+  it.each([null, undefined, 42, {}])(
+    'rejects the non-string value %s',
+    (value) => {
+      expect(isSafeToolsetName(value)).toBe(false);
+    },
+  );
+});

--- a/apps/chat-api/src/common/validators/safe-toolset-name.validator.ts
+++ b/apps/chat-api/src/common/validators/safe-toolset-name.validator.ts
@@ -1,4 +1,5 @@
 import { registerDecorator, type ValidationOptions } from 'class-validator';
+import { safeDecodeURIComponent } from '../utils/uri';
 import { DEPLOYMENT_ID_PATTERN } from './deployment-id.pattern';
 
 /*
@@ -7,12 +8,19 @@ import { DEPLOYMENT_ID_PATTERN } from './deployment-id.pattern';
  * passes it — see GitHub #7925. Toolset names legitimately need `/` for
  * custom toolset paths (`toolsets/{bucket}/{path}`, see
  * ToolsetsService.parseDialToolsetResource), so the fix adds a
- * segment-level check instead of dropping `/` from the allowlist.
+ * segment-level check instead of dropping `/` from the allowlist. Decoding
+ * each segment once more prevents a double-encoded slash from hiding a
+ * traversal segment from that check.
  */
-const hasTraversalSegment = (value: string): boolean =>
+const getDecodedSegments = (value: string): string[] =>
   value
     .split('/')
-    .some((segment) => segment === '' || segment === '.' || segment === '..');
+    .flatMap((segment) => safeDecodeURIComponent(segment).split('/'));
+
+const hasTraversalSegment = (value: string): boolean =>
+  getDecodedSegments(value).some(
+    (segment) => segment === '' || segment === '.' || segment === '..',
+  );
 
 export const isSafeToolsetName = (value: unknown): value is string => {
   if (typeof value !== 'string' || value.length === 0) return false;
@@ -33,7 +41,7 @@ export const IsSafeToolsetName = (validationOptions?: ValidationOptions) => {
           return (
             'Toolset name must contain only supported characters or valid ' +
             'percent-encoded bytes, and must not contain empty, dot, or ' +
-            'dot-dot path segments'
+            'dot-dot path segments, including when encoded'
           );
         },
       },

--- a/apps/chat-api/src/toolsets/dto/get-toolset.dto.ts
+++ b/apps/chat-api/src/toolsets/dto/get-toolset.dto.ts
@@ -1,14 +1,12 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsString } from 'class-validator';
-import { DEPLOYMENT_ID_PATTERN } from '../../common/validators/deployment-id.pattern';
 import { IsSafeToolsetName } from '../../common/validators/safe-toolset-name.validator';
 
 export class GetToolsetDto {
   @ApiProperty({
     description:
-      'Toolset identifier. Slash-separated names must be percent-encoded in the URL (%2F).',
+      'Toolset identifier. Slash-separated names must be percent-encoded in the URL (%2F). Empty, dot, and dot-dot path segments are rejected, including when encoded.',
     example: 'my-toolset',
-    pattern: DEPLOYMENT_ID_PATTERN.source,
   })
   @IsString()
   @IsSafeToolsetName()

--- a/apps/chat-api/src/toolsets/tests/toolsets.controller.spec.ts
+++ b/apps/chat-api/src/toolsets/tests/toolsets.controller.spec.ts
@@ -144,6 +144,13 @@ describe('ToolsetsController (integration)', () => {
       expect(service.getToolset).not.toHaveBeenCalled();
     });
 
+    it('returns 400 for a double-encoded path-traversal payload, without calling the service', async () => {
+      await request(app.getHttpServer())
+        .get('/api/v1/toolsets/..%252Fetc%252Fpasswd')
+        .expect(400);
+      expect(service.getToolset).not.toHaveBeenCalled();
+    });
+
     it('returns 404 when service throws NotFoundException', async () => {
       service.getToolset.mockRejectedValue(
         new NotFoundException('Toolset not found'),

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -109,7 +109,7 @@ All libraries live in `libs/*`, resolve through `tsconfig.base.json` paths plus 
 | `@epam/ai-dial-builder-form`             | `builder-form`             | Presentational builder form for composing and editing DIAL entities          |
 | `@epam/ai-dial-deployment-creation-form` | `deployment-creation-form` | Form for creating and editing a deployment                                   |
 | `@epam/ai-dial-scheduled-tasks`          | `scheduled-tasks`          | Scheduled Tasks page shell — header, toolbar, empty state                    |
-| `@epam/ai-dial-usage-dashboard`          | `usage-dashboard`          | Aggregate daily/monthly cost-limit cards for the Settings Usage tab         |
+| `@epam/ai-dial-usage-dashboard`          | `usage-dashboard`          | Aggregate daily/monthly cost-limit cards for the Settings Usage tab          |
 
 `libs/ai-dial-kit/` is a leftover build-output directory from a removed library — no `package.json`, no sources, no importers. Do not add to it.
 

--- a/docs/technical-requirements.md
+++ b/docs/technical-requirements.md
@@ -138,7 +138,7 @@ ring and percentage use the theme error color.
 | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | NFR-2.1 | All state-changing API calls include a `X-CSRF-Token` header validated against the session                                                                     |
 | NFR-2.2 | Session cookies are `HttpOnly`, `Secure` by default, `SameSite=Lax` normally, and `SameSite=None; Secure` only for overlay embedding that must work cross-site |
-| NFR-2.3 | `helmet` enforces CSP, HSTS, and standard security headers by default; local HTTP smoke mode disables HSTS and CSP `upgrade-insecure-requests`                |
+| NFR-2.3 | `helmet` enforces CSP, HSTS, and standard security headers by default; local HTTP smoke mode disables HSTS and CSP `upgrade-insecure-requests`                 |
 | NFR-2.4 | No auth tokens or user credentials are ever passed to or stored by UI libraries                                                                                |
 | NFR-2.5 | Conversation completions endpoint is rate-limited to 10 req/min per session                                                                                    |
 

--- a/libs/catalog/README.md
+++ b/libs/catalog/README.md
@@ -292,7 +292,11 @@ body is re-fetched.
         content: '# Instructions',
         selectedFileId: 'SKILL.md',
         files: [
-          { type: CatalogContentNodeType.File, id: 'SKILL.md', name: 'SKILL.md' },
+          {
+            type: CatalogContentNodeType.File,
+            id: 'SKILL.md',
+            name: 'SKILL.md',
+          },
           {
             type: CatalogContentNodeType.Folder,
             id: 'scripts',

--- a/libs/chat-api-client/openapi.json
+++ b/libs/chat-api-client/openapi.json
@@ -1232,9 +1232,8 @@
             "name": "toolsetName",
             "required": true,
             "in": "path",
-            "description": "Toolset identifier. Slash-separated names must be percent-encoded in the URL (%2F).",
+            "description": "Toolset identifier. Slash-separated names must be percent-encoded in the URL (%2F). Empty, dot, and dot-dot path segments are rejected, including when encoded.",
             "schema": {
-              "pattern": "^(?:[\\w.\\-:@/()]|%[\\dA-Fa-f]{2})+$",
               "example": "my-toolset",
               "type": "string"
             }
@@ -1289,9 +1288,8 @@
             "name": "toolsetName",
             "required": true,
             "in": "path",
-            "description": "Toolset identifier. Slash-separated names must be percent-encoded in the URL (%2F).",
+            "description": "Toolset identifier. Slash-separated names must be percent-encoded in the URL (%2F). Empty, dot, and dot-dot path segments are rejected, including when encoded.",
             "schema": {
-              "pattern": "^(?:[\\w.\\-:@/()]|%[\\dA-Fa-f]{2})+$",
               "example": "my-toolset",
               "type": "string"
             }
@@ -1353,9 +1351,8 @@
             "name": "toolsetName",
             "required": true,
             "in": "path",
-            "description": "Toolset identifier. Slash-separated names must be percent-encoded in the URL (%2F).",
+            "description": "Toolset identifier. Slash-separated names must be percent-encoded in the URL (%2F). Empty, dot, and dot-dot path segments are rejected, including when encoded.",
             "schema": {
-              "pattern": "^(?:[\\w.\\-:@/()]|%[\\dA-Fa-f]{2})+$",
               "example": "my-toolset",
               "type": "string"
             }
@@ -1402,9 +1399,8 @@
             "name": "toolsetName",
             "required": true,
             "in": "path",
-            "description": "Toolset identifier. Slash-separated names must be percent-encoded in the URL (%2F).",
+            "description": "Toolset identifier. Slash-separated names must be percent-encoded in the URL (%2F). Empty, dot, and dot-dot path segments are rejected, including when encoded.",
             "schema": {
-              "pattern": "^(?:[\\w.\\-:@/()]|%[\\dA-Fa-f]{2})+$",
               "example": "my-toolset",
               "type": "string"
             }
@@ -1465,9 +1461,8 @@
             "name": "toolsetName",
             "required": true,
             "in": "path",
-            "description": "Toolset identifier. Slash-separated names must be percent-encoded in the URL (%2F).",
+            "description": "Toolset identifier. Slash-separated names must be percent-encoded in the URL (%2F). Empty, dot, and dot-dot path segments are rejected, including when encoded.",
             "schema": {
-              "pattern": "^(?:[\\w.\\-:@/()]|%[\\dA-Fa-f]{2})+$",
               "example": "my-toolset",
               "type": "string"
             }

--- a/libs/chat-api-client/src/generated/README.md
+++ b/libs/chat-api-client/src/generated/README.md
@@ -3,23 +3,27 @@
 This generator creates TypeScript/JavaScript client that utilizes [Fetch API](https://fetch.spec.whatwg.org/). The generated Node module can be used in the following environments:
 
 Environment
-* Node.js
-* Webpack
-* Browserify
+
+- Node.js
+- Webpack
+- Browserify
 
 Language level
-* ES5 - you must have a Promises/A+ library installed
-* ES6
+
+- ES5 - you must have a Promises/A+ library installed
+- ES6
 
 Module system
-* CommonJS
-* ES6 module system
+
+- CommonJS
+- ES6 module system
 
 It can be used in both TypeScript and JavaScript. In TypeScript, the definition will be automatically resolved via `package.json`. ([Reference](https://www.typescriptlang.org/docs/handbook/declaration-files/consumption.html))
 
 ### Building
 
 To build and compile the typescript sources to javascript use:
+
 ```
 npm install
 npm run build

--- a/libs/settings-panel/README.md
+++ b/libs/settings-panel/README.md
@@ -43,7 +43,12 @@ import { SettingsPanel } from '@epam/ai-dial-settings-panel';
   activeId="usage"
   onSelect={(id) => setActiveTab(id)}
   items={[
-    { id: 'general', label: 'General', icon: <IconUser size={18} />, disabled: true },
+    {
+      id: 'general',
+      label: 'General',
+      icon: <IconUser size={18} />,
+      disabled: true,
+    },
     { id: 'usage', label: 'Usage', icon: <IconLayoutGrid size={18} /> },
   ]}
 />;
@@ -63,7 +68,7 @@ the row background/text/focus colors (applied as CSS custom properties):
       rowFocusOutline: '#161b2d',
     },
   }}
-/>;
+/>
 ```
 
 ## Types

--- a/openspec/specs/toolset-lookup/spec.md
+++ b/openspec/specs/toolset-lookup/spec.md
@@ -95,7 +95,7 @@ The endpoint:
 
 The `:toolsetName` path parameter MUST be validated to prevent path-traversal and injection, while still accepting the `/`-separated custom-toolset path format (`toolsets/{bucket}/{path}`).
 
-Validation MUST be applied to the value after route-parameter URL-decoding (the framework decodes `%XX` sequences before the DTO validator runs), so a percent-encoded traversal payload decodes to its literal form before the checks below run.
+Validation MUST be applied to the value after route-parameter URL-decoding (the framework decodes `%XX` sequences before the DTO validator runs). Any valid percent-encoded bytes that remain in that value MUST also be decoded for the path-segment safety check. This ensures that both single-encoded and double-encoded traversal payloads are evaluated as path segments before upstream proxying.
 
 Allowed characters: word characters, `. - : @ / ( )`, or a valid percent-encoded byte (`%XX`). In addition, no `/`-delimited path segment of the (decoded) value MAY be empty, `.`, or `..`.
 
@@ -115,6 +115,11 @@ Any value that fails either check SHALL cause the BFF to return `400 Bad Request
 
 - **WHEN** the path param is `..%2Fetc%2Fpasswd`, which decodes to the path segments `..`, `etc`, `passwd`
 - **THEN** the BFF returns `400 Bad Request` without calling DIAL Core, because the `..` segment is disallowed even though `/` itself is an allowed character
+
+#### Scenario: Double-encoded traversal payload is rejected
+
+- **WHEN** the path param is `..%252Fetc%252Fpasswd`, which the framework decodes to `..%2Fetc%2Fpasswd` and the path-segment safety check decodes to `../etc/passwd`
+- **THEN** the BFF returns `400 Bad Request` without calling DIAL Core
 
 ---
 


### PR DESCRIPTION
**Description:**

Harden toolset path-parameter validation so double-encoded traversal payloads are rejected with 400 before reaching DIAL Core. Add direct and controller regression coverage, clarify the OpenSpec requirement, and regenerate the OpenAPI contract so Swagger accurately describes encoded segment validation.

Verification: all 2,593 chat-api tests pass; chat-api lint, OpenAPI drift check, and chat-api-client build/lint pass.

Issues:

- Issue #7925

**UI changes**

No UI changes

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with fix(chat-api):
- [x] the pull request name ends with (Issue #7925)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs