### PR TITLE
fix(chat-api): reject double-encoded toolset traversal (Issue #7925)

### DIFF
--- a/apps/chat-api/src/common/validators/safe-toolset-name.validator.spec.ts
+++ b/apps/chat-api/src/common/validators/safe-toolset-name.validator.spec.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { isSafeToolsetName } from './safe-toolset-name.validator';
+
+describe('isSafeToolsetName', () => {
+  it.each([
+    'my-toolset',
+    'folder.toolset-v1',
+    '@org/toolset:tag',
+    'toolsets/bucket/folder/toolset-name',
+    'toolsets/bucket/My%20Tool',
+    'toolsets%2Fbucket%2Ffolder%2Ftoolset-name',
+  ])('accepts the safe toolset name %s', (value) => {
+    expect(isSafeToolsetName(value)).toBe(true);
+  });
+
+  it.each([
+    '',
+    '.',
+    '..',
+    '../etc/passwd',
+    'toolsets//toolset-name',
+    'toolsets/./toolset-name',
+    'toolsets/../toolset-name',
+    '..%2Fetc%2Fpasswd',
+    '%2E%2E%2Fetc%2Fpasswd',
+    'toolsets%2Fbucket%2F..%2Fsecret',
+    'bad;toolset',
+    'bad toolset',
+    String.raw`..\etc\passwd`,
+    'bad%GGtoolset',
+  ])('rejects the unsafe toolset name %s', (value) => {
+    expect(isSafeToolsetName(value)).toBe(false);
+  });
+
+  it.each([null, undefined, 42, {}])(
+    'rejects the non-string value %s',
+    (value) => {
+      expect(isSafeToolsetName(value)).toBe(false);
+    },
+  );
+});

--- a/apps/chat-api/src/common/validators/safe-toolset-name.validator.ts
+++ b/apps/chat-api/src/common/validators/safe-toolset-name.validator.ts
@@ -1,4 +1,5 @@
 import { registerDecorator, type ValidationOptions } from 'class-validator';
+import { safeDecodeURIComponent } from '../utils/uri';
 import { DEPLOYMENT_ID_PATTERN } from './deployment-id.pattern';
 
 /*
@@ -7,12 +8,19 @@ import { DEPLOYMENT_ID_PATTERN } from './deployment-id.pattern';
  * passes it — see GitHub #7925. Toolset names legitimately need `/` for
  * custom toolset paths (`toolsets/{bucket}/{path}`, see
  * ToolsetsService.parseDialToolsetResource), so the fix adds a
- * segment-level check instead of dropping `/` from the allowlist.
+ * segment-level check instead of dropping `/` from the allowlist. Decoding
+ * each segment once more prevents a double-encoded slash from hiding a
+ * traversal segment from that check.
  */
-const hasTraversalSegment = (value: string): boolean =>
+const getDecodedSegments = (value: string): string[] =>
   value
     .split('/')
-    .some((segment) => segment === '' || segment === '.' || segment === '..');
+    .flatMap((segment) => safeDecodeURIComponent(segment).split('/'));
+
+const hasTraversalSegment = (value: string): boolean =>
+  getDecodedSegments(value).some(
+    (segment) => segment === '' || segment === '.' || segment === '..',
+  );
 
 export const isSafeToolsetName = (value: unknown): value is string => {
   if (typeof value !== 'string' || value.length === 0) return false;
@@ -33,7 +41,7 @@ export const IsSafeToolsetName = (validationOptions?: ValidationOptions) => {
           return (
             'Toolset name must contain only supported characters or valid ' +
             'percent-encoded bytes, and must not contain empty, dot, or ' +
-            'dot-dot path segments'
+            'dot-dot path segments, including when encoded'
           );
         },
       },

--- a/apps/chat-api/src/toolsets/dto/get-toolset.dto.ts
+++ b/apps/chat-api/src/toolsets/dto/get-toolset.dto.ts
@@ -1,14 +1,12 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsString } from 'class-validator';
-import { DEPLOYMENT_ID_PATTERN } from '../../common/validators/deployment-id.pattern';
 import { IsSafeToolsetName } from '../../common/validators/safe-toolset-name.validator';
 
 export class GetToolsetDto {
   @ApiProperty({
     description:
-      'Toolset identifier. Slash-separated names must be percent-encoded in the URL (%2F).',
+      'Toolset identifier. Slash-separated names must be percent-encoded in the URL (%2F). Empty, dot, and dot-dot path segments are rejected, including when encoded.',
     example: 'my-toolset',
-    pattern: DEPLOYMENT_ID_PATTERN.source,
   })
   @IsString()
   @IsSafeToolsetName()

--- a/apps/chat-api/src/toolsets/tests/toolsets.controller.spec.ts
+++ b/apps/chat-api/src/toolsets/tests/toolsets.controller.spec.ts
@@ -144,6 +144,13 @@ describe('ToolsetsController (integration)', () => {
       expect(service.getToolset).not.toHaveBeenCalled();
     });
 
+    it('returns 400 for a double-encoded path-traversal payload, without calling the service', async () => {
+      await request(app.getHttpServer())
+        .get('/api/v1/toolsets/..%252Fetc%252Fpasswd')
+        .expect(400);
+      expect(service.getToolset).not.toHaveBeenCalled();
+    });
+
     it('returns 404 when service throws NotFoundException', async () => {
       service.getToolset.mockRejectedValue(
         new NotFoundException('Toolset not found'),

--- a/libs/chat-api-client/openapi.json
+++ b/libs/chat-api-client/openapi.json
@@ -1232,9 +1232,8 @@
             "name": "toolsetName",
             "required": true,
             "in": "path",
-            "description": "Toolset identifier. Slash-separated names must be percent-encoded in the URL (%2F).",
+            "description": "Toolset identifier. Slash-separated names must be percent-encoded in the URL (%2F). Empty, dot, and dot-dot path segments are rejected, including when encoded.",
             "schema": {
-              "pattern": "^(?:[\\w.\\-:@/()]|%[\\dA-Fa-f]{2})+$",
               "example": "my-toolset",
               "type": "string"
             }
@@ -1289,9 +1288,8 @@
             "name": "toolsetName",
             "required": true,
             "in": "path",
-            "description": "Toolset identifier. Slash-separated names must be percent-encoded in the URL (%2F).",
+            "description": "Toolset identifier. Slash-separated names must be percent-encoded in the URL (%2F). Empty, dot, and dot-dot path segments are rejected, including when encoded.",
             "schema": {
-              "pattern": "^(?:[\\w.\\-:@/()]|%[\\dA-Fa-f]{2})+$",
               "example": "my-toolset",
               "type": "string"
             }
@@ -1353,9 +1351,8 @@
             "name": "toolsetName",
             "required": true,
             "in": "path",
-            "description": "Toolset identifier. Slash-separated names must be percent-encoded in the URL (%2F).",
+            "description": "Toolset identifier. Slash-separated names must be percent-encoded in the URL (%2F). Empty, dot, and dot-dot path segments are rejected, including when encoded.",
             "schema": {
-              "pattern": "^(?:[\\w.\\-:@/()]|%[\\dA-Fa-f]{2})+$",
               "example": "my-toolset",
               "type": "string"
             }
@@ -1402,9 +1399,8 @@
             "name": "toolsetName",
             "required": true,
             "in": "path",
-            "description": "Toolset identifier. Slash-separated names must be percent-encoded in the URL (%2F).",
+            "description": "Toolset identifier. Slash-separated names must be percent-encoded in the URL (%2F). Empty, dot, and dot-dot path segments are rejected, including when encoded.",
             "schema": {
-              "pattern": "^(?:[\\w.\\-:@/()]|%[\\dA-Fa-f]{2})+$",
               "example": "my-toolset",
               "type": "string"
             }
@@ -1465,9 +1461,8 @@
             "name": "toolsetName",
             "required": true,
             "in": "path",
-            "description": "Toolset identifier. Slash-separated names must be percent-encoded in the URL (%2F).",
+            "description": "Toolset identifier. Slash-separated names must be percent-encoded in the URL (%2F). Empty, dot, and dot-dot path segments are rejected, including when encoded.",
             "schema": {
-              "pattern": "^(?:[\\w.\\-:@/()]|%[\\dA-Fa-f]{2})+$",
               "example": "my-toolset",
               "type": "string"
             }

--- a/openspec/specs/toolset-lookup/spec.md
+++ b/openspec/specs/toolset-lookup/spec.md
@@ -95,7 +95,7 @@ The endpoint:
 
 The `:toolsetName` path parameter MUST be validated to prevent path-traversal and injection, while still accepting the `/`-separated custom-toolset path format (`toolsets/{bucket}/{path}`).
 
-Validation MUST be applied to the value after route-parameter URL-decoding (the framework decodes `%XX` sequences before the DTO validator runs), so a percent-encoded traversal payload decodes to its literal form before the checks below run.
+Validation MUST be applied to the value after route-parameter URL-decoding (the framework decodes `%XX` sequences before the DTO validator runs). Any valid percent-encoded bytes that remain in that value MUST also be decoded for the path-segment safety check. This ensures that both single-encoded and double-encoded traversal payloads are evaluated as path segments before upstream proxying.
 
 Allowed characters: word characters, `. - : @ / ( )`, or a valid percent-encoded byte (`%XX`). In addition, no `/`-delimited path segment of the (decoded) value MAY be empty, `.`, or `..`.
 
@@ -115,6 +115,11 @@ Any value that fails either check SHALL cause the BFF to return `400 Bad Request
 
 - **WHEN** the path param is `..%2Fetc%2Fpasswd`, which decodes to the path segments `..`, `etc`, `passwd`
 - **THEN** the BFF returns `400 Bad Request` without calling DIAL Core, because the `..` segment is disallowed even though `/` itself is an allowed character
+
+#### Scenario: Double-encoded traversal payload is rejected
+
+- **WHEN** the path param is `..%252Fetc%252Fpasswd`, which the framework decodes to `..%2Fetc%2Fpasswd` and the path-segment safety check decodes to `../etc/passwd`
+- **THEN** the BFF returns `400 Bad Request` without calling DIAL Core
 
 ---
 


### PR DESCRIPTION
**Description:**

Harden toolset path-parameter validation so double-encoded traversal payloads are rejected with 400 before reaching DIAL Core. Add direct and controller regression coverage, clarify the OpenSpec requirement, and regenerate the OpenAPI contract so Swagger accurately describes encoded segment validation.

Verification: all 2,593 chat-api tests pass; chat-api lint, OpenAPI drift check, and chat-api-client build/lint pass.

Issues:

- Issue #7925

**UI changes**

No UI changes

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with fix(chat-api):
- [x] the pull request name ends with (Issue #7925)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs