### PR TITLE
fix(usage-dashboard, settings-panel): truncate long model versions, pad nav list

### DIFF
--- a/libs/settings-panel/src/components/SettingsPanel/SettingsPanel.tsx
+++ b/libs/settings-panel/src/components/SettingsPanel/SettingsPanel.tsx
@@ -113,7 +113,7 @@ export const SettingsPanel: FC<SettingsPanelProps> = ({
         // a tab stop, but jsx-a11y requires an interactive role to declare
         // its own (non-reachable) focusability.
         tabIndex={-1}
-        className="flex flex-col"
+        className="flex flex-col px-2"
       >
         {items.map((item) => {
           const isActive = item.id === activeId;

--- a/libs/usage-dashboard/src/components/ModelLimitsSection/ModelLimitsRow.tsx
+++ b/libs/usage-dashboard/src/components/ModelLimitsSection/ModelLimitsRow.tsx
@@ -3,6 +3,7 @@ import {
   InitialsAvatar,
   mergeClasses,
 } from '@epam/ai-dial-chat-shared';
+import { EllipsisTooltip } from '@epam/ai-dial-ui-kit';
 import { FC } from 'react';
 import {
   ModelLimitRow as ModelLimitRowData,
@@ -125,15 +126,16 @@ export const ModelLimitsRow: FC<ModelLimitsRowProps> = ({
               {row.name}
             </span>
             {row.version != null && (
-              <span
+              /* Capped at 30% of the row so a long version truncates instead of
+                 squeezing the name out of the cell, matching the Catalog pattern. */
+              <EllipsisTooltip
+                text={row.version}
                 className={mergeClasses(
-                  'shrink-0',
+                  'max-w-[30%] shrink-0',
                   versionClassName,
                   styles.version,
                 )}
-              >
-                {row.version}
-              </span>
+              />
             )}
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Usage → Model limits: long model version strings were hard-clipped mid-character with no ellipsis or tooltip, starving the model name of layout space. Reuses the same `EllipsisTooltip` + `max-w-[30%] shrink-0` pattern already applied in the Catalog (`AppIdentity`/`ItemHeader`) so the version truncates gracefully and remains hoverable.
- Settings panel: added horizontal padding (`px-2`) to the nav button list so items no longer sit flush against the sidebar edges.

## Screenshot
<img width="1920" height="1200" alt="image" src="https://github.com/user-attachments/assets/50557612-9104-45c2-b478-5f30f788a7fe" />

## Test plan
- [x] `nx lint usage-dashboard`
- [x] `nx typecheck usage-dashboard`
- [x] `nx lint ai-dial-settings-panel`
- [ ] Manual check in browser: Settings → Usage with a long model version, and Settings sidebar nav spacing
