### PR TITLE
fix(chat): fix unnecessary toast (#6261)

### DIFF
--- a/apps/chat/src/store/application/application.epics.ts
+++ b/apps/chat/src/store/application/application.epics.ts
@@ -1006,6 +1006,14 @@ const enterEditModeEpic: AppEpic = (action$, state$, { router }) =>
 const exitEditModeEpic: AppEpic = (action$, state$, { router }) =>
   action$.pipe(
     ofType(ApplicationActions.exitEditor.type),
+    tap(() => {
+      const conversationSignal =
+        ConversationsSelectors.selectConversationSignal(state$.value);
+
+      if (!conversationSignal.signal.aborted) {
+        conversationSignal.abort();
+      }
+    }),
     switchMap(({ payload }) => {
       const returnConversationIds =
         ApplicationSelectors.selectReturnConversationIds(state$.value);

--- a/apps/chat/src/store/conversations/conversations.epics.ts
+++ b/apps/chat/src/store/conversations/conversations.epics.ts
@@ -2016,15 +2016,23 @@ const streamMessageEpic: AppEpic = (action$, state$) =>
             .some((c) => c.isMessageStreaming);
 
           if (error.name === 'AbortError') {
+            const conversationExists =
+              !!ConversationsSelectors.selectConversation(
+                state$.value,
+                payload.conversation.id,
+              );
+
             return concat(
-              of(
-                ConversationsActions.updateConversation({
-                  id: payload.conversation.id,
-                  values: {
-                    isMessageStreaming: false,
-                  },
-                }),
-              ),
+              conversationExists
+                ? of(
+                    ConversationsActions.updateConversation({
+                      id: payload.conversation.id,
+                      values: {
+                        isMessageStreaming: false,
+                      },
+                    }),
+                  )
+                : EMPTY,
               iif(
                 () => !areOtherConversationsStreaming,
                 of(ChatEventsActions.unsubscribe()),


### PR DESCRIPTION
**Description:**

Unnessessary toast message when click Save and Exit before response on preview part complete generating

Issues:

- Issue #6261

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
