### PR TITLE
fix(chat): fix keyboard shortcuts are not displayed in user's settings for laptop with touchscreen (Issue #8376)

### DIFF
--- a/apps/chat/src/components/Settings/SettingDialog.tsx
+++ b/apps/chat/src/components/Settings/SettingDialog.tsx
@@ -5,7 +5,7 @@ import { useRouter } from 'next/router';
 import { useScreenState } from '@/src/hooks/useScreenState';
 import { useTranslation } from '@/src/hooks/useTranslation';
 
-import { isTouchable } from '@/src/utils/app/mobile';
+import { isDesktopDevice, isTouchable } from '@/src/utils/app/mobile';
 import { navigateToLocale } from '@/src/utils/app/navigateToLocale';
 import { splitEntityId } from '@/src/utils/app/shared-utils';
 
@@ -268,7 +268,7 @@ const view = withRenderWhen((state) => {
             className="mt-1"
           />
         )}
-        {!isTouchable() && (
+        {(!isTouchable() || isDesktopDevice()) && (
           <EnterTypeSelectLabeled
             label={t(SettingsI18nKeys.KeyboardShortcuts)}
             value={enterType}

--- a/apps/chat/src/utils/app/__tests__/keyboard.test.ts
+++ b/apps/chat/src/utils/app/__tests__/keyboard.test.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { allowEnterClick } from '@/src/utils/app/keyboard';
+
+import { EnterType } from '@/src/types/settings';
+
+const mocks = vi.hoisted(() => ({
+  isTouchable: vi.fn(),
+  isDesktopDevice: vi.fn(),
+  isMacOs: vi.fn(),
+}));
+
+vi.mock('@/src/utils/app/mobile', () => mocks);
+
+const enterEvent = (overrides: Partial<KeyboardEvent> = {}) =>
+  ({
+    key: 'Enter',
+    keyCode: 13,
+    isComposing: false,
+    shiftKey: false,
+    altKey: false,
+    metaKey: false,
+    ctrlKey: false,
+    ...overrides,
+  }) as KeyboardEvent;
+
+describe('allowEnterClick', () => {
+  beforeEach(() => {
+    mocks.isTouchable.mockReturnValue(false);
+    mocks.isDesktopDevice.mockReturnValue(true);
+    mocks.isMacOs.mockReturnValue(false);
+  });
+
+  it('sends on Enter on a desktop without a touch screen', () => {
+    expect(allowEnterClick(EnterType.Enter)(enterEvent())).toBe(true);
+  });
+
+  it('sends on Enter on a laptop with a touch screen', () => {
+    mocks.isTouchable.mockReturnValue(true);
+    mocks.isDesktopDevice.mockReturnValue(true);
+
+    expect(allowEnterClick(EnterType.Enter)(enterEvent())).toBe(true);
+  });
+
+  it('does not send on Enter on a touch device that is not a desktop', () => {
+    mocks.isTouchable.mockReturnValue(true);
+    mocks.isDesktopDevice.mockReturnValue(false);
+
+    expect(allowEnterClick(EnterType.Enter)(enterEvent())).toBe(false);
+  });
+
+  it('ignores keys other than Enter', () => {
+    expect(allowEnterClick(EnterType.Enter)(enterEvent({ key: 'a' }))).toBe(
+      false,
+    );
+  });
+
+  it('does not send while an IME composition is active', () => {
+    expect(
+      allowEnterClick(EnterType.Enter)(enterEvent({ isComposing: true })),
+    ).toBe(false);
+    expect(allowEnterClick(EnterType.Enter)(enterEvent({ keyCode: 229 }))).toBe(
+      false,
+    );
+  });
+
+  it('does not send on Shift+Enter or Alt+Enter', () => {
+    expect(
+      allowEnterClick(EnterType.Enter)(enterEvent({ shiftKey: true })),
+    ).toBe(false);
+    expect(allowEnterClick(EnterType.Enter)(enterEvent({ altKey: true }))).toBe(
+      false,
+    );
+  });
+
+  describe('with the Ctrl+Enter shortcut', () => {
+    it('requires Ctrl on a touch laptop', () => {
+      mocks.isTouchable.mockReturnValue(true);
+
+      expect(allowEnterClick(EnterType.CtrlEnter)(enterEvent())).toBe(false);
+      expect(
+        allowEnterClick(EnterType.CtrlEnter)(enterEvent({ ctrlKey: true })),
+      ).toBe(true);
+    });
+
+    it('requires Cmd on a mac', () => {
+      mocks.isMacOs.mockReturnValue(true);
+
+      expect(
+        allowEnterClick(EnterType.CtrlEnter)(enterEvent({ ctrlKey: true })),
+      ).toBe(false);
+      expect(
+        allowEnterClick(EnterType.CtrlEnter)(enterEvent({ metaKey: true })),
+      ).toBe(true);
+    });
+  });
+
+  it('does not send plain Enter with a modifier when Enter is the shortcut', () => {
+    expect(
+      allowEnterClick(EnterType.Enter)(enterEvent({ ctrlKey: true })),
+    ).toBe(false);
+  });
+});

--- a/apps/chat/src/utils/app/__tests__/mobile.test.ts
+++ b/apps/chat/src/utils/app/__tests__/mobile.test.ts
@@ -1,0 +1,176 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { isDesktopDevice, isTouchable } from '@/src/utils/app/mobile';
+
+const USER_AGENTS = {
+  windowsChrome:
+    'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36',
+  macSafari:
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4 Safari/605.1.15',
+  iPhone:
+    'Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4 Mobile/15E148 Safari/604.1',
+  iPad: 'Mozilla/5.0 (iPad; CPU OS 17_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4 Mobile/15E148 Safari/604.1',
+  androidPhone:
+    'Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Mobile Safari/537.36',
+  androidTablet:
+    'Mozilla/5.0 (Linux; Android 14; SM-X710) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36',
+};
+
+interface DeviceStub {
+  userAgent: string;
+  platform: string;
+  maxTouchPoints: number;
+  coarsePointer: boolean;
+}
+
+const stubbedKeys: string[] = [];
+
+const stubDevice = ({
+  userAgent,
+  platform,
+  maxTouchPoints,
+  coarsePointer,
+}: DeviceStub) => {
+  const values = { userAgent, platform, maxTouchPoints };
+
+  (Object.keys(values) as (keyof typeof values)[]).forEach((key) => {
+    stubbedKeys.push(key);
+    Object.defineProperty(navigator, key, {
+      value: values[key],
+      configurable: true,
+    });
+  });
+
+  vi.stubGlobal(
+    'matchMedia',
+    vi.fn((query: string) => ({
+      matches: query === '(pointer: coarse)' && coarsePointer,
+      media: query,
+    })),
+  );
+};
+
+afterEach(() => {
+  // `navigator` properties are inherited from Navigator.prototype in jsdom, so
+  // deleting the own properties added above restores the original getters.
+  stubbedKeys.splice(0).forEach((key) => {
+    delete (navigator as unknown as Record<string, unknown>)[key];
+  });
+  vi.unstubAllGlobals();
+});
+
+describe('isDesktopDevice', () => {
+  const cases: { name: string; device: DeviceStub; expected: boolean }[] = [
+    {
+      name: 'a desktop without a touch screen',
+      device: {
+        userAgent: USER_AGENTS.windowsChrome,
+        platform: 'Win32',
+        maxTouchPoints: 0,
+        coarsePointer: false,
+      },
+      expected: true,
+    },
+    {
+      name: 'a laptop with a touch screen',
+      device: {
+        userAgent: USER_AGENTS.windowsChrome,
+        platform: 'Win32',
+        maxTouchPoints: 5,
+        coarsePointer: false,
+      },
+      expected: true,
+    },
+    {
+      name: 'a mac',
+      device: {
+        userAgent: USER_AGENTS.macSafari,
+        platform: 'MacIntel',
+        maxTouchPoints: 0,
+        coarsePointer: false,
+      },
+      expected: true,
+    },
+    {
+      name: 'an iPhone',
+      device: {
+        userAgent: USER_AGENTS.iPhone,
+        platform: 'iPhone',
+        maxTouchPoints: 5,
+        coarsePointer: true,
+      },
+      expected: false,
+    },
+    {
+      name: 'an android phone',
+      device: {
+        userAgent: USER_AGENTS.androidPhone,
+        platform: 'Linux armv8l',
+        maxTouchPoints: 5,
+        coarsePointer: true,
+      },
+      expected: false,
+    },
+    {
+      name: 'an android tablet',
+      device: {
+        userAgent: USER_AGENTS.androidTablet,
+        platform: 'Linux armv8l',
+        maxTouchPoints: 5,
+        coarsePointer: true,
+      },
+      expected: false,
+    },
+    {
+      name: 'an iPad',
+      device: {
+        userAgent: USER_AGENTS.iPad,
+        platform: 'iPad',
+        maxTouchPoints: 5,
+        coarsePointer: true,
+      },
+      expected: false,
+    },
+    {
+      // the user agent is indistinguishable from a mac here: only
+      // `navigator.platform` + `maxTouchPoints` give the iPad away
+      name: 'an iPad requesting the desktop site',
+      device: {
+        userAgent: USER_AGENTS.macSafari,
+        platform: 'MacIntel',
+        maxTouchPoints: 5,
+        coarsePointer: true,
+      },
+      expected: false,
+    },
+  ];
+
+  it.each(cases)('returns $expected for $name', ({ device, expected }) => {
+    stubDevice(device);
+
+    expect(isDesktopDevice()).toBe(expected);
+  });
+
+  it('returns false when there is no user agent', () => {
+    stubDevice({
+      userAgent: '',
+      platform: '',
+      maxTouchPoints: 0,
+      coarsePointer: false,
+    });
+
+    expect(isDesktopDevice()).toBe(false);
+  });
+
+  it('reports a touch laptop as both touchable and desktop', () => {
+    stubDevice({
+      userAgent: USER_AGENTS.windowsChrome,
+      platform: 'Win32',
+      maxTouchPoints: 5,
+      coarsePointer: false,
+    });
+
+    expect(isTouchable()).toBe(true);
+    expect(isDesktopDevice()).toBe(true);
+  });
+});

--- a/apps/chat/src/utils/app/keyboard.ts
+++ b/apps/chat/src/utils/app/keyboard.ts
@@ -2,7 +2,7 @@ import { KeyboardEvent as ReactKeyboardEvent } from 'react';
 
 import { EnterType } from '@/src/types/settings';
 
-import { isMacOs, isTouchable } from './mobile';
+import { isDesktopDevice, isMacOs, isTouchable } from './mobile';
 
 const isComposing = <T>(e: KeyboardEvent | ReactKeyboardEvent<T>) =>
   // `isComposing`/keyCode 229 signal that the keypress belongs to an active
@@ -17,7 +17,9 @@ export const allowEnterClick =
   <T>(e: KeyboardEvent | ReactKeyboardEvent<T>) => {
     if (
       e.key !== 'Enter' ||
-      isTouchable() ||
+      // touch laptops are touchable but still have a physical keyboard, so the
+      // shortcut must keep working there
+      (isTouchable() && !isDesktopDevice()) ||
       isComposing(e) ||
       e.shiftKey ||
       e.altKey

--- a/apps/chat/src/utils/app/mobile.ts
+++ b/apps/chat/src/utils/app/mobile.ts
@@ -14,6 +14,20 @@ export const isMobile = () => {
   const { isMobileOnly, isTablet } = getDeviceSelectors();
   return isMobileOnly && !isTablet;
 };
+
+// A desktop-class device (Windows/macOS/Linux browser), regardless of whether it
+// also has a touch screen. `isTablet` is excluded on purpose: an iPad asking for
+// the desktop site sends a macOS user agent, and only `getIPad13()` (via
+// `navigator.platform`/`maxTouchPoints`) tells it apart from a real Mac.
+export const isDesktopDevice = () => {
+  if (typeof navigator === 'undefined' || !navigator.userAgent) {
+    return false;
+  }
+
+  const { isDesktop, isTablet } = getDeviceSelectors();
+
+  return isDesktop && !isTablet;
+};
 export const isTouchable = () => {
   if (typeof window !== 'undefined') {
     const hasCoarsePointer =


### PR DESCRIPTION


**Description:**

This is a behavior change, not only a visibility fix: enterType defaults to EnterType.Enter, so on touch-screen laptops **Enter now sends the message where it previously inserted a newline**. `Shift+Enter` still inserts a newline, IME composition is unaffected, and users can switch to Ctrl+Enter in the newly visible setting.

Issues:

- Issue #8376 

**UI changes**

<img width="1333" height="959" alt="image" src="https://github.com/user-attachments/assets/6bfcb70a-19fc-4491-86c9-a4fd991e7aca" />

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
