### PR TITLE
feat(chat-e2e): added edit assistant message features tests

### DIFF
--- a/apps/chat-e2e/src/testData/overlay/overlaySandboxUrls.ts
+++ b/apps/chat-e2e/src/testData/overlay/overlaySandboxUrls.ts
@@ -39,4 +39,8 @@ export const OverlaySandboxUrls = {
     '/cases/overlay/enabled-hide-custom-app-creation-sandbox', //sandbox to test 'EPMDIAL-2294'
   skipFocusSetSandboxUrl: '/cases/overlay/skip-focus-set-sandbox', //sandbox to test 'EPMDIAL-2318'
   disabledDefaultButtonsUrl: '/cases/overlay/disabled-default-buttons', //sandbox to test 'EPMDIAL-2319'
+  enableEditAllAssistantContentUrl:
+    '/cases/overlay/enabled-edit-all-assistant-content-sandbox', //sandbox to test 'EPMDIAL-2313'
+  enableEditLastAssistantContentUrl:
+    '/cases/overlay/edit-last-assistant-message', //sandbox to test 'EPMDIAL-2314', 'EPMDIAL-2316'
 };

--- a/apps/chat-e2e/src/tests/overlay/editAllAssistantContentFeature.test.ts
+++ b/apps/chat-e2e/src/tests/overlay/editAllAssistantContentFeature.test.ts
@@ -1,0 +1,179 @@
+import { Conversation } from '@/chat/types/chat';
+import dialOverlayTest from '@/src/core/dialOverlayFixtures';
+import {
+  MockedChatApiResponseBodies,
+  OverlaySandboxUrls,
+} from '@/src/testData';
+import { GeneratorUtil, ModelsUtil } from '@/src/utils';
+import { expect } from '@playwright/test';
+
+const prompt1 = 'prompt1';
+const prompt2 = 'prompt2';
+const prompt3 = 'prompt3';
+const prompt1Index = 1;
+const response1Index = 2;
+const prompt2Index = 3;
+const response2Index = 4;
+
+dialOverlayTest(
+  '[Overlay] enable Feature.EditAllAssistantContent',
+  async ({
+    overlayHomePage,
+    overlayHeader,
+    overlayConversations,
+    overlayChatMessages,
+    overlayChatMessagesAssertion,
+    overlayBaseAssertion,
+    overlayDataInjector,
+    conversationData,
+    setTestIds,
+  }) => {
+    setTestIds('EPMDIAL-2313');
+    let conversation: Conversation;
+    const editedResponse = GeneratorUtil.randomString(10);
+
+    await dialOverlayTest.step(
+      'Prepare a conversation with two prompt-response pairs',
+      async () => {
+        conversation = conversationData.prepareModelConversationBasedOnRequests(
+          [prompt1, prompt2],
+        );
+        await overlayDataInjector.createConversations([conversation]);
+      },
+    );
+
+    await dialOverlayTest.step(
+      'Open sandbox with Feature.EditAllAssistantContent enabled, select the conversation and verify Edit button is available for both responses',
+      async () => {
+        await overlayHomePage.navigateToUrl(
+          OverlaySandboxUrls.enableEditAllAssistantContentUrl,
+        );
+        await overlayHomePage.waitForPageLoaded();
+        await overlayHeader.leftPanelToggle.click();
+        await overlayConversations.selectEntity(conversation.name);
+        await overlayChatMessagesAssertion.assertMessageEditIconState(
+          response1Index,
+          'visible',
+        );
+        await overlayChatMessagesAssertion.assertMessageEditIconState(
+          response2Index,
+          'visible',
+        );
+      },
+    );
+
+    await dialOverlayTest.step(
+      'Edit response1, save changes and verify edit mode is closed, response1 is updated and other messages are not changed',
+      async () => {
+        await overlayChatMessages.openEditMessageMode(response1Index);
+        await overlayChatMessages.fillEditData(response1Index, editedResponse);
+        await overlayChatMessages.saveAndSubmit.click();
+        await overlayBaseAssertion.assertElementState(
+          overlayChatMessages.getChatMessageTextarea(response1Index),
+          'hidden',
+        );
+        await overlayChatMessagesAssertion.assertMessageContent(
+          response1Index,
+          editedResponse,
+        );
+        await overlayChatMessagesAssertion.assertMessageContent(
+          prompt1Index,
+          prompt1,
+        );
+        await overlayChatMessagesAssertion.assertMessageContent(
+          prompt2Index,
+          prompt2,
+        );
+        await overlayChatMessagesAssertion.assertMessageContent(
+          response2Index,
+          `response on ${prompt2}`,
+        );
+      },
+    );
+  },
+);
+
+dialOverlayTest(
+  '[Overlay] enable Feature.EditAllAssistantContent when System message is used',
+  async ({
+    overlayHomePage,
+    overlayActions,
+    overlayChat,
+    overlayChatMessages,
+    overlayChatMessagesAssertion,
+    overlayBaseAssertion,
+    overlayLocalStorageManager,
+    setTestIds,
+  }) => {
+    setTestIds('EPMDIAL-2312');
+    const systemPrompt = `End each word with string "!?!?!"`;
+    const editedResponse = GeneratorUtil.randomString(10);
+    const modelWithSystemPrompt = GeneratorUtil.randomArrayElement(
+      ModelsUtil.getLatestModels().filter((m) =>
+        ModelsUtil.doesModelAllowSystemPrompt(m),
+      ),
+    );
+
+    await dialOverlayTest.step(
+      'Set a model with allowed system prompt to the recent',
+      async () => {
+        await overlayLocalStorageManager.setRecentModelsIdsAndUseLastModel(
+          modelWithSystemPrompt,
+        );
+      },
+    );
+
+    await dialOverlayTest.step(
+      'Open sandbox with Feature.EditAllAssistantContent enabled and click on "Set system prompt"',
+      async () => {
+        await overlayHomePage.navigateToUrl(
+          OverlaySandboxUrls.enableEditAllAssistantContentUrl,
+        );
+        await overlayHomePage.waitForPageLoaded();
+        await overlayActions.setSysPromptButton.click();
+      },
+    );
+
+    await dialOverlayTest.step(
+      'Send 2 requests with system prompt',
+      async () => {
+        await overlayHomePage.mockChatTextResponse(
+          MockedChatApiResponseBodies.simpleTextBody,
+          { isOverlay: true },
+        );
+        for (const prompt of [prompt1, prompt2]) {
+          await overlayChat.sendRequestWithButton(prompt);
+        }
+      },
+    );
+
+    await dialOverlayTest.step(
+      'Edit response2 and verify it is updated',
+      async () => {
+        await overlayChatMessages.openEditMessageMode(response2Index);
+        await overlayChatMessages.fillEditData(response2Index, editedResponse);
+        await overlayChatMessages.saveAndSubmit.click();
+        await overlayBaseAssertion.assertElementState(
+          overlayChatMessages.getChatMessageTextarea(response2Index),
+          'hidden',
+        );
+        await overlayChatMessagesAssertion.assertMessageContent(
+          response2Index,
+          editedResponse,
+        );
+      },
+    );
+
+    await dialOverlayTest.step(
+      'Send a new prompt and verify the system prompt is sent in the completion request',
+      async () => {
+        const requests = await overlayChat.sendRequestWithButton(prompt3);
+        const systemMessage = (
+          requests.completionRequest as Conversation
+        ).messages.find((m) => m.role === 'system');
+        expect.soft(systemMessage).toBeDefined();
+        overlayBaseAssertion.assertValue(systemMessage?.content, systemPrompt);
+      },
+    );
+  },
+);

--- a/apps/chat-e2e/src/tests/overlay/editLastAssistantContentFeature.test.ts
+++ b/apps/chat-e2e/src/tests/overlay/editLastAssistantContentFeature.test.ts
@@ -1,0 +1,266 @@
+import { Conversation } from '@/chat/types/chat';
+import dialOverlayTest from '@/src/core/dialOverlayFixtures';
+import {
+  API,
+  Attachment,
+  MockedChatApiResponseBodies,
+  OverlaySandboxUrls,
+} from '@/src/testData';
+import { GeneratorUtil, ModelsUtil } from '@/src/utils';
+import { expect } from '@playwright/test';
+
+const prompt1 = 'prompt1';
+const prompt2 = 'prompt2';
+const prompt3 = 'prompt3';
+const response1Index = 2;
+const response2Index = 4;
+
+dialOverlayTest(
+  '[Overlay] enable Feature.EditLastAssistantContent',
+  async ({
+    overlayHomePage,
+    overlayHeader,
+    overlayConversations,
+    overlayChat,
+    overlayChatMessages,
+    overlayChatMessagesAssertion,
+    overlayBaseAssertion,
+    overlayDataInjector,
+    conversationData,
+    setTestIds,
+  }) => {
+    setTestIds('EPMDIAL-2314');
+    let conversation: Conversation;
+    const cancelledText = GeneratorUtil.randomString(10);
+    const editedResponse = GeneratorUtil.randomString(10);
+    const originalResponse2 = `response on ${prompt2}`;
+
+    await dialOverlayTest.step(
+      'Prepare a conversation with two prompt-response pairs',
+      async () => {
+        conversation = conversationData.prepareModelConversationBasedOnRequests(
+          [prompt1, prompt2],
+        );
+        await overlayDataInjector.createConversations([conversation]);
+      },
+    );
+
+    await dialOverlayTest.step(
+      'Open sandbox with Feature.EditLastAssistantContent enabled, select the conversation and verify Edit button is available only for the last response',
+      async () => {
+        await overlayHomePage.navigateToUrl(
+          OverlaySandboxUrls.enableEditLastAssistantContentUrl,
+        );
+        await overlayHomePage.waitForPageLoaded();
+        await overlayHeader.leftPanelToggle.click();
+        await overlayConversations.selectEntity(conversation.name);
+        await overlayChatMessagesAssertion.assertMessageEditIconState(
+          response1Index,
+          'hidden',
+        );
+        await overlayChatMessagesAssertion.assertMessageEditIconState(
+          response2Index,
+          'visible',
+        );
+      },
+    );
+
+    await dialOverlayTest.step(
+      'Edit response2, click Cancel and verify edit mode is closed with no changes applied',
+      async () => {
+        await overlayChatMessages.openEditMessageMode(response2Index);
+        await overlayChatMessages.fillEditData(response2Index, cancelledText);
+        await overlayChatMessages.cancel.click();
+        await overlayBaseAssertion.assertElementState(
+          overlayChatMessages.getChatMessageTextarea(response2Index),
+          'hidden',
+        );
+        await overlayChatMessagesAssertion.assertMessageContent(
+          response2Index,
+          originalResponse2,
+        );
+      },
+    );
+
+    await dialOverlayTest.step(
+      'Edit response2 again, save changes and verify edit mode is closed with changes applied',
+      async () => {
+        await overlayChatMessages.openEditMessageMode(response2Index);
+        await overlayChatMessages.fillEditData(response2Index, editedResponse);
+        await overlayChatMessages.saveAndSubmit.click();
+        await overlayBaseAssertion.assertElementState(
+          overlayChatMessages.getChatMessageTextarea(response2Index),
+          'hidden',
+        );
+        await overlayChatMessagesAssertion.assertMessageContent(
+          response2Index,
+          editedResponse,
+        );
+      },
+    );
+
+    await dialOverlayTest.step(
+      'Send a new message and verify Edit button moved from response2 to the new response3',
+      async () => {
+        await overlayHomePage.mockChatTextResponse(
+          MockedChatApiResponseBodies.simpleTextBody,
+          { isOverlay: true },
+        );
+        await overlayChat.sendRequestWithButton(GeneratorUtil.randomString(5));
+        await overlayChatMessagesAssertion.assertMessageEditIconState(
+          response2Index,
+          'hidden',
+        );
+        await overlayChatMessagesAssertion.assertMessageEditIconState(
+          response2Index + 2,
+          'visible',
+        );
+      },
+    );
+  },
+);
+
+dialOverlayTest(
+  '[Overlay] enable Feature.EditLastAssistantContent: Attachments are available, Clip icon is available when agent-response is opened in edit mode',
+  async ({
+    overlayHomePage,
+    overlayHeader,
+    overlayConversations,
+    overlayChatMessages,
+    overlayBaseAssertion,
+    overlayDataInjector,
+    overlayFileApiHelper,
+    conversationData,
+    setTestIds,
+  }) => {
+    setTestIds('EPMDIAL-2316');
+    let conversation: Conversation;
+    const responseIndex = 2;
+    const modelWithAttachment = GeneratorUtil.randomArrayElement(
+      ModelsUtil.getLatestModelsWithAttachment(),
+    );
+
+    await dialOverlayTest.step(
+      'Prepare a conversation based on a model which returns an attachment in the response',
+      async () => {
+        const attachmentUrl = await overlayFileApiHelper.putFile(
+          Attachment.sunImageName,
+          { parentPath: API.modelFilePath(modelWithAttachment.id) },
+        );
+        conversation =
+          conversationData.prepareConversationWithAttachmentInResponse(
+            attachmentUrl,
+            modelWithAttachment,
+          );
+        await overlayDataInjector.createConversations([conversation]);
+      },
+    );
+
+    await dialOverlayTest.step(
+      'Open the conversation, click on Edit in the response and verify attachment and Clip icon are available in edit mode',
+      async () => {
+        await overlayHomePage.navigateToUrl(
+          OverlaySandboxUrls.enableEditLastAssistantContentUrl,
+        );
+        await overlayHomePage.waitForPageLoaded();
+        await overlayHeader.leftPanelToggle.click();
+        await overlayConversations.selectEntity(conversation.name);
+        await overlayChatMessages.openEditMessageMode(responseIndex);
+        await overlayBaseAssertion.assertElementState(
+          overlayChatMessages.getChatMessageAttachment(responseIndex),
+          'visible',
+        );
+        await overlayBaseAssertion.assertElementState(
+          overlayChatMessages.getChatMessageClipIcon(responseIndex),
+          'visible',
+        );
+      },
+    );
+  },
+);
+
+dialOverlayTest(
+  '[Overlay] enable Feature.EditLastAssistantContent when System message is used',
+  async ({
+    overlayHomePage,
+    overlayActions,
+    overlayChat,
+    overlayChatMessages,
+    overlayChatMessagesAssertion,
+    overlayBaseAssertion,
+    overlayLocalStorageManager,
+    setTestIds,
+  }) => {
+    setTestIds('EPMDIAL-2315');
+    const response2Index = 4;
+    const systemPrompt = `End each word with string "!?!?!"`;
+    const editedResponse = GeneratorUtil.randomString(10);
+    const modelWithSystemPrompt = GeneratorUtil.randomArrayElement(
+      ModelsUtil.getLatestModels().filter((m) =>
+        ModelsUtil.doesModelAllowSystemPrompt(m),
+      ),
+    );
+
+    await dialOverlayTest.step(
+      'Set a model with allowed system prompt to the recent',
+      async () => {
+        await overlayLocalStorageManager.setRecentModelsIdsAndUseLastModel(
+          modelWithSystemPrompt,
+        );
+      },
+    );
+
+    await dialOverlayTest.step(
+      'Open sandbox with Feature.EditLastAssistantContent enabled and click on "Set system prompt"',
+      async () => {
+        await overlayHomePage.navigateToUrl(
+          OverlaySandboxUrls.enableEditLastAssistantContentUrl,
+        );
+        await overlayHomePage.waitForPageLoaded();
+        await overlayActions.setSysPromptButton.click();
+      },
+    );
+
+    await dialOverlayTest.step(
+      'Send 2 requests with system prompt',
+      async () => {
+        await overlayHomePage.mockChatTextResponse(
+          MockedChatApiResponseBodies.simpleTextBody,
+          { isOverlay: true },
+        );
+        for (const prompt of [prompt1, prompt2]) {
+          await overlayChat.sendRequestWithButton(prompt);
+        }
+      },
+    );
+
+    await dialOverlayTest.step(
+      'Edit the last response and verify it is updated',
+      async () => {
+        await overlayChatMessages.openEditMessageMode(response2Index);
+        await overlayChatMessages.fillEditData(response2Index, editedResponse);
+        await overlayChatMessages.saveAndSubmit.click();
+        await overlayBaseAssertion.assertElementState(
+          overlayChatMessages.getChatMessageTextarea(response2Index),
+          'hidden',
+        );
+        await overlayChatMessagesAssertion.assertMessageContent(
+          response2Index,
+          editedResponse,
+        );
+      },
+    );
+
+    await dialOverlayTest.step(
+      'Send a new prompt and verify the system prompt is sent in the completion request',
+      async () => {
+        const requests = await overlayChat.sendRequestWithButton(prompt3);
+        const systemMessage = (
+          requests.completionRequest as Conversation
+        ).messages.find((m) => m.role === 'system');
+        expect.soft(systemMessage).toBeDefined();
+        overlayBaseAssertion.assertValue(systemMessage?.content, systemPrompt);
+      },
+    );
+  },
+);

--- a/apps/chat-e2e/src/ui/webElements/dropdownButtonMenu.ts
+++ b/apps/chat-e2e/src/ui/webElements/dropdownButtonMenu.ts
@@ -4,5 +4,5 @@ import { Menu } from '@/src/ui/webElements/menu';
 export class DropdownButtonMenu extends Menu {
   public menuOptions = () => this.getChildElementBySelector(Tags.button);
   public menuOption = (option: string) =>
-    this.menuOptions().getElementLocatorByText(new RegExp(`^${option}$`));
+    this.menuOptions().getElementLocatorByText(new RegExp(`^${option}\\s*$`));
 }

--- a/apps/chat-e2e/src/ui/webElements/dropdownButtonMenu.ts
+++ b/apps/chat-e2e/src/ui/webElements/dropdownButtonMenu.ts
@@ -4,5 +4,5 @@ import { Menu } from '@/src/ui/webElements/menu';
 export class DropdownButtonMenu extends Menu {
   public menuOptions = () => this.getChildElementBySelector(Tags.button);
   public menuOption = (option: string) =>
-    this.menuOptions().getElementLocatorByText(option);
+    this.menuOptions().getElementLocatorByText(new RegExp(`^${option}$`));
 }

--- a/apps/overlay-sandbox/app/cases/overlay/enabled-edit-all-assistant-content-sandbox/page.tsx
+++ b/apps/overlay-sandbox/app/cases/overlay/enabled-edit-all-assistant-content-sandbox/page.tsx
@@ -8,11 +8,10 @@ import { Feature } from '@epam/ai-dial-shared';
 const overlayOptions = {
   ...commonOverlayProps,
   enabledFeatures: [
-    Feature.EditLastAssistantContent,
+    Feature.EditAllAssistantContent,
     Feature.Header,
     Feature.ConversationsSection,
     Feature.LiveChatInteraction,
-    Feature.InputFiles,
   ],
 };
 


### PR DESCRIPTION
**Description:**

added edit assistant message feature tests

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
