### PR TITLE
docs(docs): document Core OAuth redirect allowlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -594,6 +594,23 @@ Every variable is validated at boot by
 `apps/chat-api/src/config/environment.config.ts`, so a missing or malformed
 value fails the container fast rather than at first request.
 
+### DIAL Core OAuth Redirect Allowlist
+
+Toolset OAuth also requires a setting on the DIAL Core deployment. Add the
+Chat callback URL to Core's
+[`toolsets.security.allowedRedirectUris`](https://github.com/epam/ai-dial-core/blob/development/README.md#static-settings):
+
+```text
+https://your-frontend-domain.com/auth/toolset-signin
+```
+
+Use the public Chat origin (the URL users open), not
+`AUTH_CALLBACK_BASE_URL` when the frontend and API use different origins. Keep
+the redirect URIs for any other clients, such as the Admin panel, in the same
+array. This is a static Core setting, so restart DIAL Core after changing it.
+See the [Chat API deployment setup](apps/chat-api/README.md#dial-core-oauth-redirect-allowlist)
+for a configuration example.
+
 ## Troubleshooting
 
 ### Port Conflicts

--- a/apps/chat-api/README.md
+++ b/apps/chat-api/README.md
@@ -110,6 +110,34 @@ part of the callback is a literal in `src/auth/auth.controller.ts` and does not
 follow `API_PREFIX`, so a deployment that overrides `API_PREFIX` sends the IdP a
 `redirect_uri` that no longer resolves to a route.
 
+#### DIAL Core OAuth redirect allowlist
+
+Toolset OAuth needs the public Chat callback URL to be allowed by DIAL Core.
+Add `<CHAT_PUBLIC_ORIGIN>/auth/toolset-signin` to Core's
+[`toolsets.security.allowedRedirectUris`](https://github.com/epam/ai-dial-core/blob/development/README.md#static-settings).
+For example, the relevant part of `aidial.settings.json` is:
+
+```json
+{
+  "toolsets": {
+    "security": {
+      "allowedRedirectUris": [
+        "https://chat.example.com/auth/toolset-signin"
+      ]
+    }
+  }
+}
+```
+
+Use the public origin from which users open Chat. The SPA builds this URI from
+`window.location.origin`, so it is not necessarily the same as
+`AUTH_CALLBACK_BASE_URL` when the frontend and API are exposed separately. Add
+the Chat URI without removing entries for other clients, such as the Admin
+panel. Core accepts a client-provided OAuth redirect URI only when it is in this
+allowlist or equals the toolset's own `redirect_uri`; the allowlist is therefore
+required when more than one client can start sign-in for the same toolset. The
+setting is read at Core startup, so restart DIAL Core after changing it.
+
 **Optional:**
 
 | Variable                                | Default                        | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |

--- a/docs/legacy-chat-migration-guide.md
+++ b/docs/legacy-chat-migration-guide.md
@@ -36,12 +36,15 @@ API, never a rebuild of the frontend image.
 3. Re-register the OIDC redirect URI and the post-logout redirect URI with every
    identity provider. Both moved in 1.0 — the callback path gained the `/v1` API
    version segment — see [Authentication](#authentication).
-4. Port UI feature flags — see [UI feature flags](#ui-feature-flags).
-5. Port the themes configuration — see [Themes](#themes).
-6. Port any embedded-overlay integration — see [Embedding](#embedding).
-7. Point a non-production deployment at a copy of real storage and verify
+4. If the deployment uses toolset OAuth, add the public Chat callback URI to
+   DIAL Core's redirect allowlist and restart Core — see
+   [Authentication](#authentication).
+5. Port UI feature flags — see [UI feature flags](#ui-feature-flags).
+6. Port the themes configuration — see [Themes](#themes).
+7. Port any embedded-overlay integration — see [Embedding](#embedding).
+8. Point a non-production deployment at a copy of real storage and verify
    existing conversations — see [User data](#user-data).
-8. Review the [capabilities not in 1.0 yet](#capabilities-not-in-10-yet) and
+9. Review the [capabilities not in 1.0 yet](#capabilities-not-in-10-yet) and
    decide what to do about the flows that depend on them.
 
 ## Environment variables
@@ -142,6 +145,21 @@ redirect_uri`.
   browser there through the IdP, so it must be in the client's post-logout
   allow-list (Keycloak: _Valid post logout redirect URIs_). Unlike the callback it
   points at the **application** origin, not the API.
+- **Allow Chat's toolset OAuth callback in DIAL Core.** When toolset OAuth is
+  used and more than one client can start sign-in for the same toolset, add the
+  1.0 callback URI to Core's `toolsets.security.allowedRedirectUris`, preserving
+  the entries for other clients such as the Admin panel:
+
+  ```text
+  <CHAT_PUBLIC_ORIGIN>/auth/toolset-signin
+  ```
+
+  This uses the public origin from which users open Chat, not
+  `AUTH_CALLBACK_BASE_URL` when the frontend and API are exposed separately.
+  The setting is read at Core startup, so restart DIAL Core after changing it.
+  See the
+  [Chat API deployment setup](../apps/chat-api/README.md#dial-core-oauth-redirect-allowlist)
+  for the Core configuration example.
 - Existing sessions do not carry over. Users log in once after the switch.
 - Provider configuration keeps the legacy shape: one set of discrete
   `AUTH_{PROVIDER}_*` variables per provider, registered when its `CLIENT_ID` is


### PR DESCRIPTION
**Description:**

Document the DIAL Core toolset OAuth redirect allowlist requirement for Chat deployments. The setup now identifies the public Chat callback URI, distinguishes it from the API callback base when the UI and API use different origins, and explains the multi-client allowlist and Core restart requirements.

**UI changes**

No UI changes.

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
