### PR TITLE
fix(chat-api): restore conversation id forwarding

### DIFF
--- a/apps/chat-api/src/conversations/generation/chat-completions.adapter.ts
+++ b/apps/chat-api/src/conversations/generation/chat-completions.adapter.ts
@@ -107,6 +107,7 @@ export class ChatCompletionsAdapter {
     initialAssembledMessage: ConversationMessageDto,
     clientChannelId?: string,
     timing?: GenerationRelayTiming,
+    conversationId?: string,
   ): AsyncGenerator<Uint8Array, GenerationRelayOutcome, void> {
     let assembledMessage = initialAssembledMessage;
     let upstreamReader: ReadableStreamDefaultReader<Uint8Array> | null = null;
@@ -121,6 +122,7 @@ export class ChatCompletionsAdapter {
             ...(clientChannelId
               ? { 'X-DIAL-CLIENT-CHANNEL-ID': clientChannelId }
               : {}),
+            ...(conversationId ? { 'X-CONVERSATION-ID': conversationId } : {}),
           },
           params: { query: { 'api-version': this.dialClient.dialApiVersion } },
           parseAs: 'stream',
@@ -297,6 +299,7 @@ export class ChatCompletionsAdapter {
     initialAssembledMessage: ConversationMessageDto,
     clientChannelId?: string,
     timing?: GenerationRelayTiming,
+    conversationId?: string,
   ): Promise<GenerationRelayOutcome> {
     const iterator = this.stream(
       model,
@@ -306,6 +309,7 @@ export class ChatCompletionsAdapter {
       initialAssembledMessage,
       clientChannelId,
       timing,
+      conversationId,
     );
     let next = await iterator.next();
     while (!next.done) {

--- a/apps/chat-api/src/conversations/generation/responses.adapter.ts
+++ b/apps/chat-api/src/conversations/generation/responses.adapter.ts
@@ -116,6 +116,7 @@ export class ResponsesAdapter {
     initialAssembledMessage: ConversationMessageDto,
     clientChannelId?: string,
     timing?: GenerationRelayTiming,
+    conversationId?: string,
   ): AsyncGenerator<string, GenerationRelayOutcome, void> {
     let assembledMessage = initialAssembledMessage;
     let upstreamReader: ReadableStreamDefaultReader<Uint8Array> | null = null;
@@ -129,6 +130,7 @@ export class ResponsesAdapter {
           ...(clientChannelId
             ? { 'X-DIAL-CLIENT-CHANNEL-ID': clientChannelId }
             : {}),
+          ...(conversationId ? { 'X-CONVERSATION-ID': conversationId } : {}),
         },
         parseAs: 'stream',
         signal,
@@ -396,6 +398,7 @@ export class ResponsesAdapter {
     initialAssembledMessage: ConversationMessageDto,
     clientChannelId?: string,
     timing?: GenerationRelayTiming,
+    conversationId?: string,
   ): Promise<GenerationRelayOutcome> {
     const iterator = this.stream(
       requestBody,
@@ -404,6 +407,7 @@ export class ResponsesAdapter {
       initialAssembledMessage,
       clientChannelId,
       timing,
+      conversationId,
     );
     let next = await iterator.next();
     while (!next.done) {

--- a/apps/chat-api/src/conversations/streaming/conversation-streaming.service.ts
+++ b/apps/chat-api/src/conversations/streaming/conversation-streaming.service.ts
@@ -185,6 +185,7 @@ export class ConversationStreamingService {
     initialAssembledMessage: ConversationMessageDto,
     clientChannelId?: string,
     timing?: GenerationRelayTiming,
+    conversationId?: string,
   ): AsyncGenerator<Uint8Array, RelayOutcome, void> {
     let assembledMessage = initialAssembledMessage;
     let upstreamReader: ReadableStreamDefaultReader<Uint8Array> | null = null;
@@ -199,6 +200,7 @@ export class ConversationStreamingService {
             ...(clientChannelId
               ? { 'X-DIAL-CLIENT-CHANNEL-ID': clientChannelId }
               : {}),
+            ...(conversationId ? { 'X-CONVERSATION-ID': conversationId } : {}),
           },
           params: { query: { 'api-version': this.dialClient.dialApiVersion } },
           parseAs: 'stream',
@@ -563,6 +565,7 @@ export class ConversationStreamingService {
             assembledMessage,
             clientChannelId,
             timing,
+            startConversation.id,
           )
         : this.relayModelCompletion(
             model,
@@ -572,6 +575,7 @@ export class ConversationStreamingService {
             assembledMessage,
             clientChannelId,
             timing,
+            startConversation.id,
           );
     let next = await relayIterator.next();
     while (!next.done) {

--- a/apps/chat-api/src/conversations/streaming/tests/conversation-streaming.service.spec.ts
+++ b/apps/chat-api/src/conversations/streaming/tests/conversation-streaming.service.spec.ts
@@ -280,6 +280,30 @@ describe('ConversationStreamingService', () => {
       });
     });
 
+    it('forwards the stable conversation id as X-CONVERSATION-ID for Chat Completions', async () => {
+      const conversation = {
+        ...baseConversation,
+        messages: [
+          {
+            id: 'u1',
+            role: ConversationMessageRole.User,
+            content: 'Hello',
+            timestamp: '2024-01-01T00:00:00.000Z',
+          },
+        ],
+      };
+
+      const { sendSpy } = await callStream(
+        conversation,
+        'Next message',
+        'gpt-4o',
+      );
+
+      expect(sendSpy.mock.calls[0][1].headers).toMatchObject({
+        'X-CONVERSATION-ID': baseConversation.id,
+      });
+    });
+
     it('omits X-DIAL-CLIENT-CHANNEL-ID when no channel id is provided', async () => {
       const conversation = {
         ...baseConversation,
@@ -348,6 +372,9 @@ describe('ConversationStreamingService', () => {
         stream: true,
         store: false,
         temperature: 1,
+      });
+      expect(createResponseSpy.mock.calls[0][0].headers).toMatchObject({
+        'X-CONVERSATION-ID': baseConversation.id,
       });
       expect(sendSpy).not.toHaveBeenCalled();
       expect(res.getWritten()).toContain('Hello');

--- a/apps/chat-api/src/rate/rate.service.ts
+++ b/apps/chat-api/src/rate/rate.service.ts
@@ -33,6 +33,7 @@ export class RateService {
         headers: {
           'Content-Type': 'application/json',
           ...getBearerAuthHeaders(accessToken),
+          'X-CONVERSATION-ID': dto.conversationId,
         },
         body: JSON.stringify(body),
       });

--- a/apps/chat-api/src/rate/tests/rate.service.spec.ts
+++ b/apps/chat-api/src/rate/tests/rate.service.spec.ts
@@ -93,6 +93,17 @@ describe('RateService', () => {
       expect(headers['Authorization']).toBe(`Bearer ${ACCESS_TOKEN}`);
     });
 
+    it('forwards the conversation id in the X-CONVERSATION-ID header', async () => {
+      fetchSpy.mockResolvedValue({ ok: true } as Response);
+      const service = makeService();
+
+      await service.rateMessage(validDto, ACCESS_TOKEN);
+
+      const [, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+      const headers = init.headers as Record<string, string>;
+      expect(headers['X-CONVERSATION-ID']).toBe(validDto.conversationId);
+    });
+
     it('includes optional comment when provided', async () => {
       fetchSpy.mockResolvedValue({ ok: true } as Response);
       const service = makeService();

--- a/docs/responses-api-integration.md
+++ b/docs/responses-api-integration.md
@@ -121,7 +121,7 @@ If the deployment is a toolset, generation is rejected with `400 Bad Request`. I
 2. `ConversationService` registers an active generation, preserving the existing protection against concurrent generations in the same conversation.
 3. The BFF retrieves details for the selected model or application and selects the generation API.
 4. The initial conversation state and assistant placeholder are created and saved before Core is called.
-5. The selected adapter sends the request to DIAL Core and processes the upstream SSE stream.
+5. The selected adapter sends the request to DIAL Core with the stable persisted conversation id in `X-CONVERSATION-ID` and processes the upstream SSE stream.
 6. Response fragments are applied to the assistant message through the shared `applyChunkToMessage` function.
 7. The final text, status, optional error, and `responseId` are saved when generation ends.
 8. The active-generation record is removed regardless of the outcome.
@@ -165,7 +165,7 @@ Mapping rules:
 - `stream` is always `true`;
 - `store` is always `false`.
 
-The request also includes the user's Bearer token, `Accept: text/event-stream`, an AbortSignal, and `X-DIAL-CLIENT-CHANNEL-ID` when available.
+The request also includes the user's Bearer token, `Accept: text/event-stream`, an AbortSignal, the stable persisted conversation id in `X-CONVERSATION-ID`, and `X-DIAL-CLIENT-CHANNEL-ID` when available. The Chat Completions adapter forwards the same conversation header.
 
 ### Why the full history is sent
 

--- a/openspec/changes/archive/2026-08-25-restore-conversation-id-header/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-25-restore-conversation-id-header/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-25

--- a/openspec/changes/archive/2026-08-25-restore-conversation-id-header/design.md
+++ b/openspec/changes/archive/2026-08-25-restore-conversation-id-header/design.md
@@ -1,0 +1,55 @@
+## Context
+
+Legacy Chat generated a stable per-conversation `reference` and forwarded it as `X-CONVERSATION-ID` to DIAL Core from both completion and rating proxies. The current BFF owns generation and persistence, but its outbound Chat Completions, Responses API, and rating calls omit that header. Current conversations already carry a persisted `id`; newly created and duplicated conversations receive a trailing UUID, while rename updates the display name without moving the stored resource. The BFF therefore has an authoritative stable identifier without extending the browser-facing contract.
+
+This change crosses the conversation-generation and rating domains in `apps/chat-api`; implementation follows `apps/chat-api/AGENTS.md`. It changes only the BFF-to-DIAL-Core transport contract.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Restore conversation-level correlation on every outbound generation request, regardless of whether the selected transport is Chat Completions or Responses API.
+- Restore the same correlation on outbound rating requests.
+- Use one authoritative persisted identifier and lock the behavior with transport-level unit tests.
+- Keep public BFF endpoints backward compatible.
+
+**Non-Goals:**
+
+- Adding a new request header or DTO field to the browser-facing API.
+- Restoring the legacy `conversation.reference` field as a separate data-model property.
+- Changing generation selection, SSE normalization, persistence, authentication, rate limiting, caching, or error mapping.
+- Changing frontend state, UI, i18n, accessibility, RTL behavior, feature flags, or any library under `libs/*`.
+
+## Decisions
+
+### Decision 1: Derive the header at the BFF boundary from the authoritative conversation id
+
+`ConversationStreamingService` SHALL pass the loaded `startConversation.id` into the selected generation transport, which SHALL set `X-CONVERSATION-ID` immediately before calling DIAL Core. `RateService` SHALL use the already-required `RateMessageDto.conversationId` for the same header.
+
+Alternative: add a browser-supplied header or a second DTO field mirroring legacy `reference`. Rejected because the BFF already loads the authoritative persisted conversation for generation, and the rating DTO already carries its conversation id. Duplicating transport metadata would expand OpenAPI and allow the client to send a value inconsistent with the resource being processed.
+
+Alternative: extract only the trailing UUID from the current storage path. Rejected because legacy/imported conversations can have unsuffixed paths; the full persisted id works for both formats and remains stable under the current rename behavior.
+
+### Decision 2: Apply the contract to both generation implementations
+
+The live Chat Completions relay in `ConversationStreamingService`, the extracted `ChatCompletionsAdapter` seam, and `ResponsesAdapter` SHALL all support the header. This avoids transport-dependent observability and prevents the dormant/extracted adapter contract from diverging when orchestration is consolidated later.
+
+Alternative: patch only the currently selected Chat Completions call site. Rejected because Responses-capable deployments would still lose correlation and the documented adapter seam would remain inconsistent.
+
+### Decision 3: Preserve public API and generated-client contracts
+
+`POST /api/v1/conversations/completions` and `POST /api/v1/rate` retain their existing bodies, status codes, auth requirements, throttles, and response shapes. The new header exists only on outbound BFF-to-Core requests, so Swagger and `libs/chat-api-client` require no regeneration.
+
+## Risks / Trade-offs
+
+- **[Risk] A transport path omits the header during a later refactor** → Keep assertions for both Chat Completions and Responses calls in `conversation-streaming.service.spec.ts`, plus the rating assertion in `rate.service.spec.ts`.
+- **[Risk] A persisted id differs from a UI route representation because of encoding** → Source the generation value from the conversation loaded by the BFF, not the route string sent by the browser; rating continues to use its canonical DTO field as it already does in the DIAL Core body.
+- **[Trade-off] The full persisted id is more descriptive than legacy's random `reference`** → Accepted because it is already sent as `conversationId` in the rating body and no new logging is added by Chat. Tokens and request bodies remain excluded from logs.
+
+## Migration Plan
+
+Deploy the BFF changes without a frontend or DIAL Core migration. Existing and newly created conversations begin sending the header on their next generation or rating request. Rollback removes the three generation header insertions and the rating header insertion; no stored data or public API needs migration.
+
+## Open Questions
+
+_None._

--- a/openspec/changes/archive/2026-08-25-restore-conversation-id-header/proposal.md
+++ b/openspec/changes/archive/2026-08-25-restore-conversation-id-header/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+Legacy Chat forwarded a stable conversation reference to DIAL Core in `X-CONVERSATION-ID` for generation and rating requests. The backend-owned generation flow on `development` dropped that outbound header, breaking conversation-level correlation in DIAL Core and any downstream observability or application logic that depends on it.
+
+## What Changes
+
+- Forward the persisted `conversation.id` as `X-CONVERSATION-ID` on both Chat Completions and Responses API generation requests from the BFF to DIAL Core.
+- Forward `RateMessageDto.conversationId` as the same header on rating requests.
+- Keep the browser-facing completion and rating endpoints, request DTOs, generated client, authentication, rate limits, and response shapes unchanged.
+- Document and test the restored outbound-header contract.
+- **BREAKING**: none. This restores legacy-compatible upstream behavior; rollback is removal of the outbound header additions and their tests/spec clauses.
+
+## Capabilities
+
+### New Capabilities
+
+_None._
+
+### Modified Capabilities
+
+- `responses-api-generation`: both generation transports forward the stable persisted conversation id to DIAL Core in `X-CONVERSATION-ID`.
+- `message-rating`: the BFF rating proxy forwards the request's `conversationId` to DIAL Core in `X-CONVERSATION-ID`.
+
+## Impact
+
+- Generation transport: `apps/chat-api/src/conversations/streaming/conversation-streaming.service.ts`, `apps/chat-api/src/conversations/generation/chat-completions.adapter.ts`, and `apps/chat-api/src/conversations/generation/responses.adapter.ts`.
+- Rating transport: `apps/chat-api/src/rate/rate.service.ts`.
+- Tests: the existing conversation-streaming and rating service specs assert the outbound header.
+- Documentation: `docs/responses-api-integration.md` records the BFF-to-Core header behavior.
+- No OpenAPI regeneration, frontend change, library change, i18n, RTL, accessibility, cache, feature-flag, or rate-limit impact.
+- Alternative considered: have the browser send a new header or DTO field. Rejected because the BFF already owns and loads the authoritative persisted conversation and should not trust or duplicate client-supplied transport metadata.

--- a/openspec/changes/archive/2026-08-25-restore-conversation-id-header/specs/message-rating/spec.md
+++ b/openspec/changes/archive/2026-08-25-restore-conversation-id-header/specs/message-rating/spec.md
@@ -1,0 +1,32 @@
+## MODIFIED Requirements
+
+### Requirement: BFF rate endpoint
+
+`POST /api/v1/rate` SHALL accept a JSON body with `conversationId`, `responseId`, `modelId`, and `rate` (`1` for like, `-1` for dislike), plus an optional `comment`. It SHALL proxy the rating to the DIAL Core endpoint `POST /v1/{modelId}/rate` using the authenticated session's access token as a Bearer credential and SHALL include `X-CONVERSATION-ID: <conversationId>` in that outbound BFF-to-DIAL-Core request. On success it SHALL return HTTP 204 No Content. Invalid request bodies SHALL return HTTP 400.
+
+The browser-facing request DTO, response, generated `RateApi.rateMessage` method, authentication, authorization, rate limit, cache behavior, and error mapping SHALL remain unchanged. This transport-only change introduces no UI, state, i18n, RTL, accessibility, feature-flag, or telemetry event changes.
+
+#### Scenario: Valid rating returns 204
+
+- **WHEN** an authenticated user sends `POST /api/v1/rate` with a valid body
+- **THEN** the endpoint returns HTTP 204 with an empty body
+
+#### Scenario: Rating forwards the conversation id header
+
+- **WHEN** an authenticated user rates a message with `conversationId: "bucket/gpt-4o__Hello__uuid"`
+- **THEN** the BFF calls `POST /v1/{modelId}/rate` with `X-CONVERSATION-ID: bucket/gpt-4o__Hello__uuid`
+
+#### Scenario: Missing required field returns 400
+
+- **WHEN** `modelId` (or any other required field) is absent from the body
+- **THEN** the endpoint returns HTTP 400
+
+#### Scenario: Invalid rate value returns 400
+
+- **WHEN** `rate` is a value other than `1` or `-1`
+- **THEN** the endpoint returns HTTP 400
+
+#### Scenario: DIAL Core error is propagated
+
+- **WHEN** the DIAL Core rating endpoint returns a non-2xx status
+- **THEN** the BFF returns an appropriate HTTP error (502 or 503)

--- a/openspec/changes/archive/2026-08-25-restore-conversation-id-header/specs/responses-api-generation/spec.md
+++ b/openspec/changes/archive/2026-08-25-restore-conversation-id-header/specs/responses-api-generation/spec.md
@@ -1,0 +1,33 @@
+## ADDED Requirements
+
+### Requirement: Generation requests forward the stable conversation id
+
+After loading the authoritative persisted conversation, `ConversationStreamingService.streamCompletion` SHALL pass `startConversation.id` to the selected generation transport. Both the Chat Completions request issued through `sendChatCompletionRequest` and the Responses request issued through `createResponse` MUST include `X-CONVERSATION-ID: <startConversation.id>` in the outbound BFF-to-DIAL-Core headers. The value SHALL be derived by the BFF and SHALL NOT require a new browser request header or completion DTO field.
+
+This internal transport change SHALL NOT alter `POST /api/v1/conversations/completions`, its request/response DTOs, authentication, rate limit, cache behavior, generated-client surface, feature-flag behavior, or SSE contract. It introduces no UI, state, i18n, RTL, accessibility, or telemetry event changes; it restores the identifier consumed by downstream DIAL Core observability.
+
+#### Scenario: Chat Completions forwards the persisted conversation id
+
+- **WHEN** a completion resolves to `GenerationApi.ChatCompletions` and the loaded conversation has `id: "bucket/gpt-4o__Hello__uuid"`
+- **THEN** the BFF calls DIAL Core's Chat Completions transport with `X-CONVERSATION-ID: bucket/gpt-4o__Hello__uuid`
+
+#### Scenario: Responses API forwards the same persisted conversation id
+
+- **WHEN** a completion resolves to `GenerationApi.Responses` and the loaded conversation has `id: "bucket/gpt-4o__Hello__uuid"`
+- **THEN** the BFF calls DIAL Core's Responses transport with `X-CONVERSATION-ID: bucket/gpt-4o__Hello__uuid`
+
+#### Scenario: Browser completion contract is unchanged
+
+- **WHEN** the frontend starts a completion after this change
+- **THEN** it continues to send the existing completion DTO without a new conversation header or identifier field, and the BFF derives the outbound header from the loaded conversation
+
+## MODIFIED Requirements
+
+### Requirement: SDK createResponse call and cast isolation
+
+`responses.adapter.ts` SHALL call `this.dialClient.client.createResponse({ body: responsesRequest as never, headers: { ...bearer auth headers, Accept: 'text/event-stream', 'X-CONVERSATION-ID': conversationId, ...optional X-DIAL-CLIENT-CHANNEL-ID }, parseAs: 'stream', signal })`. The `as never` cast SHALL be confined to this single call site; the function's return value SHALL be converted immediately to the locally defined types in `generation.types.ts` before being passed to any caller.
+
+#### Scenario: Cast does not leak past the adapter
+
+- **WHEN** `ConversationService` or `apply-chunk.server.ts` consumes output from `responses.adapter.ts`
+- **THEN** the consumed value is typed via `generation.types.ts`, with no `as never`/`any` in the calling code

--- a/openspec/changes/archive/2026-08-25-restore-conversation-id-header/tasks.md
+++ b/openspec/changes/archive/2026-08-25-restore-conversation-id-header/tasks.md
@@ -1,0 +1,17 @@
+## 1. Generation transport
+
+- [x] 1.1 In `apps/chat-api/src/conversations/streaming/conversation-streaming.service.ts`, pass the loaded `startConversation.id` into both generation branches and add `X-CONVERSATION-ID` to the live Chat Completions SDK call; keep the browser completion DTO and endpoint unchanged.
+- [x] 1.2 In `apps/chat-api/src/conversations/generation/chat-completions.adapter.ts` and `apps/chat-api/src/conversations/generation/responses.adapter.ts`, accept the resolved conversation id and add the same outbound header so both adapter contracts remain aligned.
+- [x] 1.3 In `apps/chat-api/src/conversations/streaming/tests/conversation-streaming.service.spec.ts`, assert the exact persisted conversation id is forwarded for both Chat Completions and Responses API requests.
+
+## 2. Rating transport
+
+- [x] 2.1 In `apps/chat-api/src/rate/rate.service.ts`, add `X-CONVERSATION-ID: dto.conversationId` to the existing DIAL Core rating request without changing `RateMessageDto`, Swagger, the generated client, authentication, throttling, caching, or error mapping.
+- [x] 2.2 In `apps/chat-api/src/rate/tests/rate.service.spec.ts`, assert the rating request forwards the exact DTO conversation id in the header.
+
+## 3. Documentation and verification
+
+- [x] 3.1 Update `docs/responses-api-integration.md` to document the restored BFF-to-DIAL-Core header for both generation transports.
+- [x] 3.2 Run focused verification with `npm exec nx test @epam/chat-api -- src/conversations/streaming/tests/conversation-streaming.service.spec.ts src/rate/tests/rate.service.spec.ts` (31/31 tests passed).
+- [x] 3.3 Run project verification with `npm exec nx test @epam/chat-api` (2675/2675 tests passed), `npm exec nx lint @epam/chat-api` (0 errors; 2 unrelated warnings), `npm exec nx build @epam/chat-api`, and `npm run validate:docs`.
+- [x] 3.4 Run `npm exec nx typecheck @epam/chat-api -- --force` and confirm it reports only existing errors outside the files changed by this change; no changed file appears in the error set.

--- a/openspec/specs/message-rating/spec.md
+++ b/openspec/specs/message-rating/spec.md
@@ -3,19 +3,25 @@
 ## Purpose
 
 Rating assistant messages: the BFF endpoint, the optimistic toggle, the negative-feedback modal, and read-only gating.
-
 ## Requirements
 
 ---
 
 ### Requirement: BFF rate endpoint
 
-`POST /api/v1/rate` SHALL accept a JSON body with `conversationId`, `responseId`, `modelId`, and `rate` (`1` for like, `-1` for dislike), plus an optional `comment`. It SHALL proxy the rating to the DIAL Core endpoint `POST /v1/{modelId}/rate` using the authenticated session's access token as a Bearer credential. On success it SHALL return HTTP 204 No Content. Invalid request bodies SHALL return HTTP 400.
+`POST /api/v1/rate` SHALL accept a JSON body with `conversationId`, `responseId`, `modelId`, and `rate` (`1` for like, `-1` for dislike), plus an optional `comment`. It SHALL proxy the rating to the DIAL Core endpoint `POST /v1/{modelId}/rate` using the authenticated session's access token as a Bearer credential and SHALL include `X-CONVERSATION-ID: <conversationId>` in that outbound BFF-to-DIAL-Core request. On success it SHALL return HTTP 204 No Content. Invalid request bodies SHALL return HTTP 400.
+
+The browser-facing request DTO, response, generated `RateApi.rateMessage` method, authentication, authorization, rate limit, cache behavior, and error mapping SHALL remain unchanged. This transport-only change introduces no UI, state, i18n, RTL, accessibility, feature-flag, or telemetry event changes.
 
 #### Scenario: Valid rating returns 204
 
 - **WHEN** an authenticated user sends `POST /api/v1/rate` with a valid body
 - **THEN** the endpoint returns HTTP 204 with an empty body
+
+#### Scenario: Rating forwards the conversation id header
+
+- **WHEN** an authenticated user rates a message with `conversationId: "bucket/gpt-4o__Hello__uuid"`
+- **THEN** the BFF calls `POST /v1/{modelId}/rate` with `X-CONVERSATION-ID: bucket/gpt-4o__Hello__uuid`
 
 #### Scenario: Missing required field returns 400
 
@@ -31,8 +37,6 @@ Rating assistant messages: the BFF endpoint, the optimistic toggle, the negative
 
 - **WHEN** the DIAL Core rating endpoint returns a non-2xx status
 - **THEN** the BFF returns an appropriate HTTP error (502 or 503)
-
----
 
 ### Requirement: Generated rate API client
 

--- a/openspec/specs/responses-api-generation/spec.md
+++ b/openspec/specs/responses-api-generation/spec.md
@@ -3,9 +3,7 @@
 ## Purpose
 
 Generating assistant responses through DIAL's Responses API behind an adapter seam, normalized into the existing stream chunk contract.
-
 ## Requirements
-
 ### Requirement: Generation API resolver
 
 `resolveGenerationApi` (`apps/chat-api/src/conversations/generation/generation-api.ts`) SHALL be a pure function that takes the resolved deployment `features` object (`{ responsesApi?: boolean }`, as produced by `DeploymentsService.getDeploymentDetails`) and returns a `GenerationApi` string enum value: `Responses = 'responses'` when `features.responsesApi === true`, otherwise `ChatCompletions = 'chat_completions'`. A missing `features` object or a missing/`false` `responsesApi` field SHALL resolve to `ChatCompletions`.
@@ -130,14 +128,12 @@ The existing SDK `sendChatCompletionRequest` call, request construction from `bu
 
 ### Requirement: SDK createResponse call and cast isolation
 
-`responses.adapter.ts` SHALL call `this.dialClient.client.createResponse({ body: responsesRequest as never, headers: { ...bearer auth headers, Accept: 'text/event-stream', ...optional X-DIAL-CLIENT-CHANNEL-ID }, parseAs: 'stream', signal })`. The `as never` cast SHALL be confined to this single call site; the function's return value SHALL be converted immediately to the locally defined types in `generation.types.ts` before being passed to any caller.
+`responses.adapter.ts` SHALL call `this.dialClient.client.createResponse({ body: responsesRequest as never, headers: { ...bearer auth headers, Accept: 'text/event-stream', 'X-CONVERSATION-ID': conversationId, ...optional X-DIAL-CLIENT-CHANNEL-ID }, parseAs: 'stream', signal })`. The `as never` cast SHALL be confined to this single call site; the function's return value SHALL be converted immediately to the locally defined types in `generation.types.ts` before being passed to any caller.
 
 #### Scenario: Cast does not leak past the adapter
 
 - **WHEN** `ConversationService` or `apply-chunk.server.ts` consumes output from `responses.adapter.ts`
 - **THEN** the consumed value is typed via `generation.types.ts`, with no `as never`/`any` in the calling code
-
----
 
 ### Requirement: Responses SSE events normalized into the existing StreamChunk contract
 
@@ -388,3 +384,24 @@ A Responses request MAY include both `temperature` and `max_output_tokens` simul
 
 - **WHEN** a Responses request built with either or both new parameters is relayed through `ResponsesAdapter.relay`
 - **THEN** SSE event handling, terminal-state precedence, partial-message persistence on error, and abort/error outcome reporting behave identically to a request built without the new parameters
+
+### Requirement: Generation requests forward the stable conversation id
+
+After loading the authoritative persisted conversation, `ConversationStreamingService.streamCompletion` SHALL pass `startConversation.id` to the selected generation transport. Both the Chat Completions request issued through `sendChatCompletionRequest` and the Responses request issued through `createResponse` MUST include `X-CONVERSATION-ID: <startConversation.id>` in the outbound BFF-to-DIAL-Core headers. The value SHALL be derived by the BFF and SHALL NOT require a new browser request header or completion DTO field.
+
+This internal transport change SHALL NOT alter `POST /api/v1/conversations/completions`, its request/response DTOs, authentication, rate limit, cache behavior, generated-client surface, feature-flag behavior, or SSE contract. It introduces no UI, state, i18n, RTL, accessibility, or telemetry event changes; it restores the identifier consumed by downstream DIAL Core observability.
+
+#### Scenario: Chat Completions forwards the persisted conversation id
+
+- **WHEN** a completion resolves to `GenerationApi.ChatCompletions` and the loaded conversation has `id: "bucket/gpt-4o__Hello__uuid"`
+- **THEN** the BFF calls DIAL Core's Chat Completions transport with `X-CONVERSATION-ID: bucket/gpt-4o__Hello__uuid`
+
+#### Scenario: Responses API forwards the same persisted conversation id
+
+- **WHEN** a completion resolves to `GenerationApi.Responses` and the loaded conversation has `id: "bucket/gpt-4o__Hello__uuid"`
+- **THEN** the BFF calls DIAL Core's Responses transport with `X-CONVERSATION-ID: bucket/gpt-4o__Hello__uuid`
+
+#### Scenario: Browser completion contract is unchanged
+
+- **WHEN** the frontend starts a completion after this change
+- **THEN** it continues to send the existing completion DTO without a new conversation header or identifier field, and the BFF derives the outbound header from the loaded conversation


### PR DESCRIPTION
**Description:**

Restore the stable persisted conversation identifier in outbound BFF requests to DIAL Core. Chat Completions, Responses, and message rating requests now include `X-CONVERSATION-ID`, matching the legacy chat behavior while keeping the browser-facing API unchanged. The affected documentation and OpenSpec capabilities are updated and archived with the implementation.

**UI changes**

No UI changes.

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(chat-api):`
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (no issue is associated with this change)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
