### PR TITLE
feat(chat-api): forward client metadata to DIAL Core (Issue #8442)

### DIFF
--- a/apps/chat-api/README.md
+++ b/apps/chat-api/README.md
@@ -193,6 +193,21 @@ setting is read at Core startup, so restart DIAL Core after changing it.
 | `ANNOUNCEMENT_DESCRIPTION`              | —                              | Supporting copy shown after the banner title. Sanitized server-side (allowlist: `a b strong em br span`); non-hash anchors are forced to `target="_blank" rel="noopener noreferrer"`. Text that overruns the banner width is silently truncated with an ellipsis, so keep it short. Blank, or markup that sanitizes away entirely, is treated as unset.                                                                                                                                                                                                                              |
 | `ANNOUNCEMENTS`                         | `[]`                           | JSON array feeding the `+N announcements` popover: `[{ "title": "…", "description": "…", "link": { "label": "…", "href": "https://…" } }]`. `description` and `link` are optional; an entry with no link renders without a call to action. Max 10 entries. Validation is drop-and-log and never fatal — an entry is dropped if its title is blank, or if its link is present but has a blank label or an `href` that is not an absolute `http`/`https` URL (relative paths are rejected). Malformed JSON resolves to `[]`. Rejected entries appear only in the server log.           |
 
+#### Outbound DIAL Core client identity
+
+Every request from Chat API to DIAL Core carries
+`User-Agent: ai-dial-chat/<normalized-version>`. This applies to requests made
+through the shared DIAL SDK client and to the raw Core transports used for
+rating, scheduled tasks, and streaming archive uploads. Requests to non-Core
+services, such as the theme service, keep their own transport and identity.
+
+The version is resolved from `CHAT_VERSION`; blank or unset values fall back to
+the app's `package.json` version. For the header only, runs of characters outside
+`A-Z`, `a-z`, `0-9`, `.`, `_`, and `-` become `-`, leading and trailing `-` are
+removed, and an empty normalized value becomes `unknown`. The header is intended
+only for operational diagnostics and client-version attribution. It contains no
+user, tenant, authentication, conversation, or other runtime request data.
+
 Banner dismissal is content-keyed and persists in the browser's `localStorage`: a user who closes the banner keeps it hidden across restarts, and it reappears automatically for everyone once an operator changes the title or the description — no version counter or manual reset. Note that dismissing the banner also hides the announcements popover, since the pill lives inside the banner.
 
 | Variable                    | Default | Description                                                                                                                                                                                                                                                      |

--- a/apps/chat-api/src/config/environment.config.ts
+++ b/apps/chat-api/src/config/environment.config.ts
@@ -577,9 +577,9 @@ export class EnvironmentVariables {
   @IsString()
   FOOTER_HTML_MESSAGE?: string;
 
-  /* Deliberately unconstrained: this is an opaque display string that never
-   * reaches a filesystem path, an outbound URL, or a log line, and CI stamps
-   * take many shapes (0.45.0, 0.45.0-rc.3, 2026.08.10+a1b2c3d). */
+  /* Deliberately unconstrained: this is an opaque display string, and CI
+   * stamps take many shapes (0.45.0, 0.45.0-rc.3, 2026.08.10+a1b2c3d).
+   * Outbound HTTP metadata uses a separately normalized representation. */
   @IsOptional()
   @IsString()
   CHAT_VERSION?: string;

--- a/apps/chat-api/src/conversations/conversation.controller.ts
+++ b/apps/chat-api/src/conversations/conversation.controller.ts
@@ -3,6 +3,7 @@ import {
   Controller,
   Delete,
   Get,
+  Headers,
   HttpCode,
   Logger,
   NotFoundException,
@@ -13,7 +14,7 @@ import {
   Req,
   Res,
 } from '@nestjs/common';
-import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { ApiHeader, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { Throttle } from '@nestjs/throttler';
 import type { Request, Response } from 'express';
 import type { SessionUser } from '../auth/session/session.types';
@@ -44,6 +45,11 @@ import {
 import { SendCompletionDto } from './dto/send-completion.dto';
 import { StopCompletionDto } from './dto/stop-completion.dto';
 import { WatchConversationBodyDto } from './dto/watch-conversation.dto';
+import {
+  assertValidOptionalTimezone,
+  TIMEZONE_HEADER,
+  TIMEZONE_MAX_LENGTH,
+} from './utils/timezone-header';
 
 const SSE_KEEPALIVE_INTERVAL_MS = 15_000;
 const SSE_KEEPALIVE_PAYLOAD = ': keepalive\n\n';
@@ -195,8 +201,23 @@ export class ConversationController {
     description:
       'Appends the user message to the conversation history, streams a completion from DIAL Core as SSE, persists the result, and returns the raw event stream. Backend owns persistence.',
   })
+  @ApiHeader({
+    name: TIMEZONE_HEADER,
+    required: false,
+    description:
+      'Current browser IANA timezone forwarded to DIAL Core for date- and time-sensitive tools.',
+    schema: {
+      type: 'string',
+      maxLength: TIMEZONE_MAX_LENGTH,
+      pattern: '^[A-Za-z0-9._+-]+(?:/[A-Za-z0-9._+-]+)*$',
+      example: 'Europe/Warsaw',
+    },
+  })
   @ApiResponse({ status: 200, description: 'SSE stream of completion chunks' })
-  @ApiResponse({ status: 400, description: 'Invalid request body' })
+  @ApiResponse({
+    status: 400,
+    description: 'Invalid request body or X-Timezone header',
+  })
   @ApiResponse({ status: 401, description: 'Not authenticated' })
   @ApiResponse({
     status: 403,
@@ -214,8 +235,10 @@ export class ConversationController {
     @Req() req: Request,
     @Res() res: Response,
     @Body() dto: SendCompletionDto,
+    @Headers(TIMEZONE_HEADER) timezoneHeader: string | string[] | undefined,
   ): Promise<void> {
     const { at, bucket, sid, sub } = req.user as SessionUser;
+    const timezone = assertValidOptionalTimezone(timezoneHeader);
     const stream = this.conversationService.streamCompletion(
       dto.path,
       at,
@@ -235,6 +258,7 @@ export class ConversationController {
       },
       sub,
       dto.clientChannelId,
+      timezone,
     );
 
     for await (const chunk of stream) {

--- a/apps/chat-api/src/conversations/generation/responses.adapter.spec.ts
+++ b/apps/chat-api/src/conversations/generation/responses.adapter.spec.ts
@@ -291,6 +291,7 @@ describe('ResponsesAdapter', () => {
       mockDialClient: DialClientService,
       streamChunks: string[],
       status = 200,
+      timezone?: string,
     ) => {
       vi.spyOn(mockDialClient.client, 'createResponse').mockResolvedValue({
         response: new Response(textToStream(streamChunks), {
@@ -305,9 +306,45 @@ describe('ResponsesAdapter', () => {
         new AbortController().signal,
         res as never,
         { role: ConversationMessageRole.Assistant, content: '' } as never,
+        undefined,
+        timezone,
       );
       return { result, res };
     };
+
+    it('forwards X-Timezone to DIAL Core when provided', async () => {
+      const { adapter, mockDialClient } = makeAdapter();
+
+      await relay(
+        adapter,
+        mockDialClient,
+        [
+          'data: {"type":"response.completed","response":{"status":"completed"}}\n\n',
+        ],
+        200,
+        'Europe/Warsaw',
+      );
+
+      expect(mockDialClient.client.createResponse).toHaveBeenCalledWith(
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            'X-Timezone': 'Europe/Warsaw',
+          }),
+        }),
+      );
+    });
+
+    it('omits X-Timezone when it is not provided', async () => {
+      const { adapter, mockDialClient } = makeAdapter();
+
+      await relay(adapter, mockDialClient, [
+        'data: {"type":"response.completed","response":{"status":"completed"}}\n\n',
+      ]);
+
+      const request = vi.mocked(mockDialClient.client.createResponse).mock
+        .calls[0][0];
+      expect(request.headers).not.toHaveProperty('X-Timezone');
+    });
 
     it('assembles text deltas into the assistant message and sets responseId on completion', async () => {
       const { adapter, mockDialClient } = makeAdapter();

--- a/apps/chat-api/src/conversations/generation/responses.adapter.ts
+++ b/apps/chat-api/src/conversations/generation/responses.adapter.ts
@@ -10,6 +10,7 @@ import {
   ConversationMessageRole,
 } from '../dto/conversation-message.dto';
 import { applyChunkToMessage } from '../utils/apply-chunk.server';
+import { TIMEZONE_HEADER } from '../utils/timezone-header';
 import { generationUnknownEventsTotal } from './generation-metrics';
 import {
   isValidMaxOutputTokens,
@@ -115,6 +116,7 @@ export class ResponsesAdapter {
     signal: AbortSignal,
     initialAssembledMessage: ConversationMessageDto,
     clientChannelId?: string,
+    timezone?: string,
     timing?: GenerationRelayTiming,
   ): AsyncGenerator<string, GenerationRelayOutcome, void> {
     let assembledMessage = initialAssembledMessage;
@@ -129,6 +131,7 @@ export class ResponsesAdapter {
           ...(clientChannelId
             ? { 'X-DIAL-CLIENT-CHANNEL-ID': clientChannelId }
             : {}),
+          ...(timezone ? { [TIMEZONE_HEADER]: timezone } : {}),
         },
         parseAs: 'stream',
         signal,
@@ -395,6 +398,7 @@ export class ResponsesAdapter {
     res: Response,
     initialAssembledMessage: ConversationMessageDto,
     clientChannelId?: string,
+    timezone?: string,
     timing?: GenerationRelayTiming,
   ): Promise<GenerationRelayOutcome> {
     const iterator = this.stream(
@@ -403,6 +407,7 @@ export class ResponsesAdapter {
       signal,
       initialAssembledMessage,
       clientChannelId,
+      timezone,
       timing,
     );
     let next = await iterator.next();

--- a/apps/chat-api/src/conversations/streaming/conversation-streaming.service.ts
+++ b/apps/chat-api/src/conversations/streaming/conversation-streaming.service.ts
@@ -184,6 +184,7 @@ export class ConversationStreamingService {
     signal: AbortSignal,
     initialAssembledMessage: ConversationMessageDto,
     clientChannelId?: string,
+    timezone?: string,
     timing?: GenerationRelayTiming,
   ): AsyncGenerator<Uint8Array, RelayOutcome, void> {
     let assembledMessage = initialAssembledMessage;
@@ -199,6 +200,7 @@ export class ConversationStreamingService {
             ...(clientChannelId
               ? { 'X-DIAL-CLIENT-CHANNEL-ID': clientChannelId }
               : {}),
+            ...(timezone ? { 'X-Timezone': timezone } : {}),
           },
           params: { query: { 'api-version': this.dialClient.dialApiVersion } },
           parseAs: 'stream',
@@ -388,6 +390,7 @@ export class ConversationStreamingService {
     onReadyToStream: () => void,
     sub: string,
     clientChannelId?: string,
+    timezone?: string,
   ): AsyncGenerator<Uint8Array | string, void, void> {
     this.logger.debug(
       `streamCompletion start — model: ${model}, bucket: ${bucket}, path: ${conversationPath}, mode: ${mode}`,
@@ -562,6 +565,7 @@ export class ConversationStreamingService {
             abortController.signal,
             assembledMessage,
             clientChannelId,
+            timezone,
             timing,
           )
         : this.relayModelCompletion(
@@ -571,6 +575,7 @@ export class ConversationStreamingService {
             abortController.signal,
             assembledMessage,
             clientChannelId,
+            timezone,
             timing,
           );
     let next = await relayIterator.next();

--- a/apps/chat-api/src/conversations/streaming/tests/conversation-streaming.service.spec.ts
+++ b/apps/chat-api/src/conversations/streaming/tests/conversation-streaming.service.spec.ts
@@ -98,6 +98,7 @@ describe('ConversationStreamingService', () => {
     sessionId: string,
     res: ReturnType<typeof makeMockRes>,
     clientChannelId?: string,
+    timezone?: string,
   ) => {
     const stream = service.streamCompletion(
       conversationPath,
@@ -118,6 +119,7 @@ describe('ConversationStreamingService', () => {
       },
       'user1',
       clientChannelId,
+      timezone,
     );
     for await (const chunk of stream) {
       res.write(chunk);
@@ -212,6 +214,7 @@ describe('ConversationStreamingService', () => {
       mode = CompletionMode.Append,
       streamChunks = [': keepalive\n\n'],
       clientChannelId?: string,
+      timezone?: string,
     ) => {
       vi.spyOn(
         service['dialClient'].client,
@@ -248,6 +251,7 @@ describe('ConversationStreamingService', () => {
         'test-session-id',
         res as never,
         clientChannelId,
+        timezone,
       );
       return { sendSpy, res };
     };
@@ -304,6 +308,157 @@ describe('ConversationStreamingService', () => {
       );
     });
 
+    it('forwards the request timezone as X-Timezone when provided', async () => {
+      const conversation = {
+        ...baseConversation,
+        messages: [
+          {
+            id: 'u1',
+            role: ConversationMessageRole.User,
+            content: 'Hello',
+            timestamp: '2024-01-01T00:00:00.000Z',
+          },
+        ],
+      };
+
+      const { sendSpy } = await callStream(
+        conversation,
+        'Next message',
+        'gpt-4o',
+        undefined,
+        CompletionMode.Append,
+        [': keepalive\n\n'],
+        undefined,
+        'Asia/Tokyo',
+      );
+
+      expect(sendSpy.mock.calls[0][1].headers).toMatchObject({
+        'X-Timezone': 'Asia/Tokyo',
+      });
+    });
+
+    it('omits X-Timezone when no request timezone is provided', async () => {
+      const conversation = {
+        ...baseConversation,
+        messages: [
+          {
+            id: 'u1',
+            role: ConversationMessageRole.User,
+            content: 'Hello',
+            timestamp: '2024-01-01T00:00:00.000Z',
+          },
+        ],
+      };
+
+      const { sendSpy } = await callStream(
+        conversation,
+        'Next message',
+        'gpt-4o',
+      );
+
+      expect(sendSpy.mock.calls[0][1].headers).not.toHaveProperty('X-Timezone');
+    });
+
+    it('keeps timezone values isolated across concurrent completion requests', async () => {
+      const conversation = {
+        ...baseConversation,
+        messages: [
+          {
+            id: 'u1',
+            role: ConversationMessageRole.User,
+            content: 'Hello',
+            timestamp: '2024-01-01T00:00:00.000Z',
+          },
+        ],
+      };
+      vi.spyOn(
+        service['dialClient'].client,
+        'getConversation',
+      ).mockResolvedValue({ data: conversation } as never);
+      const sendSpy = vi
+        .spyOn(service['dialClient'].client, 'sendChatCompletionRequest')
+        .mockImplementation(async () => ({
+          response: new Response(textToStream(['data: [DONE]\n\n']), {
+            status: 200,
+          }),
+        })) as ReturnType<typeof vi.fn>;
+
+      await Promise.all([
+        runStreamCompletion(
+          'test-path-a',
+          'test-token',
+          'test-bucket',
+          'test-gen-id-a',
+          CompletionMode.Append,
+          'First',
+          undefined,
+          'gpt-4o',
+          undefined,
+          'test-session-id',
+          makeMockRes(),
+          undefined,
+          'Europe/Warsaw',
+        ),
+        runStreamCompletion(
+          'test-path-b',
+          'test-token',
+          'test-bucket',
+          'test-gen-id-b',
+          CompletionMode.Append,
+          'Second',
+          undefined,
+          'gpt-4o',
+          undefined,
+          'test-session-id',
+          makeMockRes(),
+          undefined,
+          'Asia/Tokyo',
+        ),
+      ]);
+
+      const timezones = sendSpy.mock.calls.map(
+        (call) => (call[1].headers as Record<string, string>)['X-Timezone'],
+      );
+      expect(timezones).toEqual(
+        expect.arrayContaining(['Europe/Warsaw', 'Asia/Tokyo']),
+      );
+    });
+
+    it('does not include the request timezone in service logs', async () => {
+      const conversation = {
+        ...baseConversation,
+        messages: [
+          {
+            id: 'u1',
+            role: ConversationMessageRole.User,
+            content: 'Hello',
+            timestamp: '2024-01-01T00:00:00.000Z',
+          },
+        ],
+      };
+      const debugSpy = vi.spyOn(service['logger'], 'debug');
+      const logSpy = vi.spyOn(service['logger'], 'log');
+      const warnSpy = vi.spyOn(service['logger'], 'warn');
+      const errorSpy = vi.spyOn(service['logger'], 'error');
+
+      await callStream(
+        conversation,
+        'Next message',
+        'gpt-4o',
+        undefined,
+        CompletionMode.Append,
+        [': keepalive\n\n'],
+        undefined,
+        'Pacific/Auckland',
+      );
+
+      const loggedValues = [debugSpy, logSpy, warnSpy, errorSpy]
+        .flatMap((spy) => spy.mock.calls)
+        .flat()
+        .join(' ');
+      expect(loggedValues).not.toContain('Pacific/Auckland');
+    });
+
     it('uses Responses API when the server-resolved deployment supports it', async () => {
       vi.mocked(mockDeploymentsService.getDeploymentDetails).mockResolvedValue({
         id: 'gpt-4o',
@@ -340,6 +495,11 @@ describe('ConversationStreamingService', () => {
         conversation,
         'Next message',
         'gpt-4o',
+        undefined,
+        CompletionMode.Append,
+        [': keepalive\n\n'],
+        undefined,
+        'Europe/Warsaw',
       );
 
       expect(createResponseSpy).toHaveBeenCalledOnce();
@@ -348,6 +508,9 @@ describe('ConversationStreamingService', () => {
         stream: true,
         store: false,
         temperature: 1,
+      });
+      expect(createResponseSpy.mock.calls[0][0].headers).toMatchObject({
+        'X-Timezone': 'Europe/Warsaw',
       });
       expect(sendSpy).not.toHaveBeenCalled();
       expect(res.getWritten()).toContain('Hello');

--- a/apps/chat-api/src/conversations/tests/completions.integration.spec.ts
+++ b/apps/chat-api/src/conversations/tests/completions.integration.spec.ts
@@ -130,6 +130,35 @@ describe('POST /conversations/completions (integration)', () => {
     expect(message).toBe('Hello');
     expect(model).toBe('gpt-4o');
     expect(sid).toBe(TEST_USER.sid);
+    expect(mockService.streamCompletion.mock.calls[0][13]).toBeUndefined();
+  });
+
+  it('passes a valid timezone header to the completion service', async () => {
+    await request(app.getHttpServer())
+      .post('/conversations/completions')
+      .set('X-Timezone', 'Europe/Warsaw')
+      .send(VALID_COMPLETION_BODY)
+      .expect(200);
+
+    expect(mockService.streamCompletion).toHaveBeenCalledOnce();
+    expect(mockService.streamCompletion.mock.calls[0][13]).toBe(
+      'Europe/Warsaw',
+    );
+  });
+
+  it.each([
+    ['malformed', 'Europe Warsaw'],
+    ['unknown', 'Mars/Olympus'],
+    ['oversized', 'A'.repeat(256)],
+    ['multiple', 'Europe/Warsaw, Asia/Tokyo'],
+  ])('returns 400 for a %s timezone header', async (_case, timezone) => {
+    await request(app.getHttpServer())
+      .post('/conversations/completions')
+      .set('X-Timezone', timezone)
+      .send(VALID_COMPLETION_BODY)
+      .expect(400);
+
+    expect(mockService.streamCompletion).not.toHaveBeenCalled();
   });
 
   it('returns 409 when ConversationService throws ConflictException (duplicate active generation)', async () => {

--- a/apps/chat-api/src/conversations/utils/timezone-header.spec.ts
+++ b/apps/chat-api/src/conversations/utils/timezone-header.spec.ts
@@ -1,0 +1,38 @@
+import { BadRequestException } from '@nestjs/common';
+import { describe, expect, it } from 'vitest';
+import {
+  assertValidOptionalTimezone,
+  TIMEZONE_MAX_LENGTH,
+} from './timezone-header';
+
+describe('assertValidOptionalTimezone', () => {
+  it.each(['UTC', 'Europe/Warsaw', 'America/New_York', 'Etc/GMT+5'])(
+    'returns supported timezone %s unchanged',
+    (timezone) => {
+      expect(assertValidOptionalTimezone(timezone)).toBe(timezone);
+    },
+  );
+
+  it('accepts an omitted timezone', () => {
+    expect(assertValidOptionalTimezone(undefined)).toBeUndefined();
+  });
+
+  it.each([
+    '',
+    'Europe Warsaw',
+    'Europe//Warsaw',
+    'Europe/Warsaw\nInjected',
+    'Mars/Olympus',
+    'A'.repeat(TIMEZONE_MAX_LENGTH + 1),
+  ])('rejects invalid timezone %j', (timezone) => {
+    expect(() => assertValidOptionalTimezone(timezone)).toThrow(
+      BadRequestException,
+    );
+  });
+
+  it('rejects multiple timezone header values', () => {
+    expect(() =>
+      assertValidOptionalTimezone(['Europe/Warsaw', 'Asia/Tokyo']),
+    ).toThrow(BadRequestException);
+  });
+});

--- a/apps/chat-api/src/conversations/utils/timezone-header.ts
+++ b/apps/chat-api/src/conversations/utils/timezone-header.ts
@@ -1,0 +1,35 @@
+import { BadRequestException } from '@nestjs/common';
+
+export const TIMEZONE_HEADER = 'X-Timezone';
+export const TIMEZONE_MAX_LENGTH = 255;
+export const TIMEZONE_PATTERN = /^[A-Za-z0-9._+-]+(?:\/[A-Za-z0-9._+-]+)*$/;
+
+const isSupportedTimezone = (timezone: string): boolean => {
+  try {
+    new Intl.DateTimeFormat('en-US', { timeZone: timezone });
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * Validates optional request-scoped timezone context before it can reach an
+ * upstream header. The original value is preserved for DIAL Core forwarding.
+ */
+export const assertValidOptionalTimezone = (
+  timezone: string | string[] | undefined,
+): string | undefined => {
+  if (timezone === undefined) return undefined;
+
+  if (
+    typeof timezone !== 'string' ||
+    timezone.length > TIMEZONE_MAX_LENGTH ||
+    !TIMEZONE_PATTERN.test(timezone) ||
+    !isSupportedTimezone(timezone)
+  ) {
+    throw new BadRequestException(`${TIMEZONE_HEADER} header is invalid`);
+  }
+
+  return timezone;
+};

--- a/apps/chat-api/src/dial/dial-client.service.ts
+++ b/apps/chat-api/src/dial/dial-client.service.ts
@@ -1,7 +1,20 @@
 import { createSDK } from '@epam/ai-dial-typescript-sdk';
 import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
+import { resolveAppVersion } from '../common/utils/app-version';
 import { EnvironmentVariables } from '../config/environment.config';
+
+const USER_AGENT_PRODUCT = 'ai-dial-chat';
+const UNSUPPORTED_USER_AGENT_VERSION_CHARACTERS = /[^A-Za-z0-9._-]+/g;
+const EDGE_USER_AGENT_VERSION_SEPARATORS = /^-+|-+$/g;
+
+const normalizeUserAgentVersion = (version: string): string => {
+  const normalized = version
+    .replace(UNSUPPORTED_USER_AGENT_VERSION_CHARACTERS, '-')
+    .replace(EDGE_USER_AGENT_VERSION_SEPARATORS, '');
+
+  return normalized || 'unknown';
+};
 
 @Injectable()
 export class DialClientService {
@@ -10,6 +23,8 @@ export class DialClientService {
   readonly client: ReturnType<typeof createSDK>;
   readonly baseUrl: string;
   readonly dialApiVersion: string;
+  readonly userAgent: string;
+  readonly fetchCore: typeof fetch;
 
   constructor(configService: ConfigService<EnvironmentVariables>) {
     const baseUrl = configService.get('DIAL_CORE_URL', { infer: true });
@@ -19,11 +34,23 @@ export class DialClientService {
     this.baseUrl = baseUrl;
     this.dialApiVersion =
       configService.get('DIAL_API_VERSION', { infer: true }) ?? '2024-10-21';
+    const appVersion = resolveAppVersion(
+      configService.get('CHAT_VERSION', { infer: true }),
+    );
+    this.userAgent = `${USER_AGENT_PRODUCT}/${normalizeUserAgentVersion(appVersion)}`;
+    this.fetchCore = (input, init) => {
+      const headers = new Headers(
+        init?.headers ?? (input instanceof Request ? input.headers : undefined),
+      );
+      headers.set('User-Agent', this.userAgent);
+
+      return globalThis.fetch(input, { ...init, headers });
+    };
 
     this.logger.debug(
       `Initializing DIAL TypeScript SDK client with baseUrl=${this.baseUrl}`,
     );
-    this.client = createSDK({ baseUrl: this.baseUrl });
+    this.client = createSDK({ baseUrl: this.baseUrl, fetch: this.fetchCore });
     this.logger.debug('DIAL TypeScript SDK client initialized');
   }
 }

--- a/apps/chat-api/src/dial/tests/dial-client.service.spec.ts
+++ b/apps/chat-api/src/dial/tests/dial-client.service.spec.ts
@@ -1,6 +1,7 @@
 import { createSDK } from '@epam/ai-dial-typescript-sdk';
 import { ConfigService } from '@nestjs/config';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { PACKAGE_VERSION } from '../../common/utils/app-version';
 import type { EnvironmentVariables } from '../../config/environment.config';
 import { DialClientService } from '../dial-client.service';
 
@@ -8,11 +9,12 @@ vi.mock('@epam/ai-dial-typescript-sdk', () => ({
   createSDK: vi.fn(() => ({ id: 'sdk-client' })),
 }));
 
-const makeConfigService = () =>
+const makeConfigService = (chatVersion?: string) =>
   ({
     get: vi.fn((key: string) => {
       if (key === 'DIAL_CORE_URL') return 'http://dial-core';
       if (key === 'DIAL_API_VERSION') return '2024-10-21';
+      if (key === 'CHAT_VERSION') return chatVersion;
       return undefined;
     }),
   }) as unknown as ConfigService<EnvironmentVariables>;
@@ -22,21 +24,29 @@ describe('DialClientService', () => {
     vi.clearAllMocks();
   });
 
-  it('creates a single SDK client using DIAL_CORE_URL', () => {
-    const configService = makeConfigService();
-
-    new DialClientService(configService);
-
-    expect(createSDK).toHaveBeenCalledOnce();
-    expect(createSDK).toHaveBeenCalledWith({ baseUrl: 'http://dial-core' });
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
-  it('exposes client, baseUrl, and dialApiVersion', () => {
+  it('creates a single SDK client using DIAL_CORE_URL and the shared Core transport', () => {
+    const configService = makeConfigService();
+
+    const service = new DialClientService(configService);
+
+    expect(createSDK).toHaveBeenCalledOnce();
+    expect(createSDK).toHaveBeenCalledWith({
+      baseUrl: 'http://dial-core',
+      fetch: service.fetchCore,
+    });
+  });
+
+  it('exposes client, baseUrl, dialApiVersion, and the package-based User-Agent', () => {
     const service = new DialClientService(makeConfigService());
 
     expect(service.client).toEqual({ id: 'sdk-client' });
     expect(service.baseUrl).toBe('http://dial-core');
     expect(service.dialApiVersion).toBe('2024-10-21');
+    expect(service.userAgent).toBe(`ai-dial-chat/${PACKAGE_VERSION}`);
   });
 
   it('defaults dialApiVersion when not configured', () => {
@@ -50,5 +60,92 @@ describe('DialClientService', () => {
     const service = new DialClientService(configService);
 
     expect(service.dialApiVersion).toBe('2024-10-21');
+  });
+
+  it('uses CHAT_VERSION in the User-Agent when configured', () => {
+    const service = new DialClientService(
+      makeConfigService('2026.08.25-a1b2c3d'),
+    );
+
+    expect(service.userAgent).toBe('ai-dial-chat/2026.08.25-a1b2c3d');
+  });
+
+  it('uses the package version when CHAT_VERSION is blank', () => {
+    const service = new DialClientService(makeConfigService('   '));
+
+    expect(service.userAgent).toBe(`ai-dial-chat/${PACKAGE_VERSION}`);
+  });
+
+  it('normalizes unsupported User-Agent version characters', () => {
+    const service = new DialClientService(
+      makeConfigService(' release 2026/08 '),
+    );
+
+    expect(service.userAgent).toBe('ai-dial-chat/release-2026-08');
+  });
+
+  it('uses unknown when the version has no supported characters', () => {
+    const service = new DialClientService(makeConfigService('🎉'));
+
+    expect(service.userAgent).toBe('ai-dial-chat/unknown');
+  });
+
+  it('sets the canonical User-Agent while preserving request headers and options', async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(new Response(null, { status: 204 }));
+    const service = new DialClientService(makeConfigService('1.2.3'));
+    const controller = new AbortController();
+
+    await service.fetchCore('http://dial-core/v1/models', {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json',
+        Authorization: 'Bearer token',
+        'user-agent': 'custom-client',
+      },
+      body: '{}',
+      signal: controller.signal,
+    });
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [input, init] = fetchMock.mock.calls[0];
+    const headers = new Headers(init?.headers);
+
+    expect(input).toBe('http://dial-core/v1/models');
+    expect(init).toMatchObject({
+      method: 'POST',
+      body: '{}',
+      signal: controller.signal,
+    });
+    expect(headers.get('Accept')).toBe('application/json');
+    expect(headers.get('Authorization')).toBe('Bearer token');
+    expect(headers.get('User-Agent')).toBe('ai-dial-chat/1.2.3');
+    expect([...headers.keys()].filter((name) => name === 'user-agent')).toEqual(
+      ['user-agent'],
+    );
+  });
+
+  it('preserves authentication headers carried by a Request input', async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(new Response(null, { status: 204 }));
+    const service = new DialClientService(makeConfigService('1.2.3'));
+    const request = new Request('http://dial-core/v1/bucket', {
+      headers: {
+        Accept: 'application/json',
+        Authorization: 'Bearer token',
+      },
+    });
+
+    await service.fetchCore(request);
+
+    const [input, init] = fetchMock.mock.calls[0];
+    const headers = new Headers(init?.headers);
+
+    expect(input).toBe(request);
+    expect(headers.get('Accept')).toBe('application/json');
+    expect(headers.get('Authorization')).toBe('Bearer token');
+    expect(headers.get('User-Agent')).toBe('ai-dial-chat/1.2.3');
   });
 });

--- a/apps/chat-api/src/files/tests/upload/files-upload.service.spec.ts
+++ b/apps/chat-api/src/files/tests/upload/files-upload.service.spec.ts
@@ -35,16 +35,18 @@ function makeService(configOverrides: Record<string, unknown> = {}) {
   const sdkClient: SdkClient = {
     uploadFile: vi.fn(),
   };
+  const fetchCore = vi.fn();
 
   const dialClient = {
     client: sdkClient,
     baseUrl: 'http://dial-core',
     dialApiVersion: '2024-10-21',
+    fetchCore,
   } as unknown as DialClientService;
 
   const service = new FilesUploadService(dialClient, configService);
 
-  return { service, sdkClient };
+  return { service, sdkClient, fetchCore };
 }
 
 const okUpload = (url: string) => ({
@@ -403,10 +405,8 @@ describe('FilesUploadService', () => {
 
   describe('uploadArchive', () => {
     it('uploads all entries successfully', async () => {
-      const { service } = makeService();
-      const fetchSpy = vi
-        .spyOn(globalThis, 'fetch')
-        .mockResolvedValue(okFetchUpload());
+      const { service, fetchCore } = makeService();
+      fetchCore.mockResolvedValue(okFetchUpload());
       const buffer = await buildZipBuffer([
         { name: 'a.txt' },
         { name: 'b.txt' },
@@ -420,9 +420,21 @@ describe('FilesUploadService', () => {
         { path: 'reports/a.txt', success: true },
         { path: 'reports/b.txt', success: true },
       ]);
-      expect(fetchSpy).toHaveBeenCalledTimes(2);
-      expect(fetchSpy.mock.calls[0]?.[0]).toBe(
+      expect(fetchCore).toHaveBeenCalledTimes(2);
+      expect(fetchCore.mock.calls[0]?.[0]).toBe(
         'http://dial-core/v1/files/bucket/reports/a.txt',
+      );
+      const [, init] = fetchCore.mock.calls[0] as [string, RequestInit];
+      expect(init).toMatchObject({
+        method: 'PUT',
+        duplex: 'half',
+      });
+      expect(init.headers).toMatchObject({
+        Authorization: 'Bearer token',
+        'If-None-Match': '*',
+      });
+      expect((init.headers as Record<string, string>)['Content-Type']).toMatch(
+        /^multipart\/form-data; boundary=dial-upload-/,
       );
     });
 
@@ -438,10 +450,8 @@ describe('FilesUploadService', () => {
     });
 
     it('uploads archive entries to the bucket root when destination is empty', async () => {
-      const { service } = makeService();
-      const fetchSpy = vi
-        .spyOn(globalThis, 'fetch')
-        .mockResolvedValue(okFetchUpload());
+      const { service, fetchCore } = makeService();
+      fetchCore.mockResolvedValue(okFetchUpload());
       const buffer = await buildZipBuffer([{ name: 'a.txt' }]);
 
       const result = await withArchiveFixture(buffer, (archiveFile) =>
@@ -449,7 +459,7 @@ describe('FilesUploadService', () => {
       );
 
       expect(result.results).toEqual([{ path: 'a.txt', success: true }]);
-      expect(fetchSpy.mock.calls[0]?.[0]).toBe(
+      expect(fetchCore.mock.calls[0]?.[0]).toBe(
         'http://dial-core/v1/files/bucket/a.txt',
       );
     });
@@ -466,12 +476,10 @@ describe('FilesUploadService', () => {
     });
 
     it('rejects with 422 and zero uploads when the archive exceeds the file-count limit', async () => {
-      const { service } = makeService({
+      const { service, fetchCore } = makeService({
         ARCHIVE_UPLOAD_MAX_FILES: 1,
       });
-      const fetchSpy = vi
-        .spyOn(globalThis, 'fetch')
-        .mockResolvedValue(okFetchUpload());
+      fetchCore.mockResolvedValue(okFetchUpload());
       const buffer = await buildZipBuffer([
         { name: 'a.txt' },
         { name: 'b.txt' },
@@ -482,16 +490,14 @@ describe('FilesUploadService', () => {
           service.uploadArchive('bucket', 'reports', archiveFile, 'token'),
         ).rejects.toThrow(UnprocessableEntityException);
       });
-      expect(fetchSpy).toHaveBeenCalledTimes(0);
+      expect(fetchCore).toHaveBeenCalledTimes(0);
     });
 
     it('aborts mid-extraction once cumulative uncompressed bytes exceed the limit, retaining prior successful uploads', async () => {
-      const { service } = makeService({
+      const { service, fetchCore } = makeService({
         ARCHIVE_UPLOAD_MAX_UNCOMPRESSED_BYTES: 10,
       });
-      const fetchSpy = vi
-        .spyOn(globalThis, 'fetch')
-        .mockResolvedValue(okFetchUpload());
+      fetchCore.mockResolvedValue(okFetchUpload());
       const buffer = await buildZipBuffer([
         { name: 'small.txt', content: 'a'.repeat(5) },
         { name: 'big.txt', content: 'b'.repeat(50) },
@@ -502,16 +508,15 @@ describe('FilesUploadService', () => {
           service.uploadArchive('bucket', 'reports', archiveFile, 'token'),
         ).rejects.toThrow(UnprocessableEntityException);
       });
-      expect(fetchSpy).toHaveBeenCalledTimes(1);
-      expect(fetchSpy.mock.calls[0]?.[0]).toBe(
+      expect(fetchCore).toHaveBeenCalledTimes(1);
+      expect(fetchCore.mock.calls[0]?.[0]).toBe(
         'http://dial-core/v1/files/bucket/reports/small.txt',
       );
     });
 
     it('uploads a conflicting entry with a deduplicated file name', async () => {
-      const { service } = makeService();
-      const fetchSpy = vi
-        .spyOn(globalThis, 'fetch')
+      const { service, fetchCore } = makeService();
+      fetchCore
         .mockResolvedValueOnce(new Response(null, { status: 412 }))
         .mockResolvedValueOnce(okFetchUpload())
         .mockResolvedValueOnce(okFetchUpload());
@@ -528,16 +533,15 @@ describe('FilesUploadService', () => {
         { path: 'reports/a (1).txt', success: true },
         { path: 'reports/b.txt', success: true },
       ]);
-      expect(fetchSpy).toHaveBeenCalledTimes(3);
-      expect(fetchSpy.mock.calls[1]?.[0]).toBe(
+      expect(fetchCore).toHaveBeenCalledTimes(3);
+      expect(fetchCore.mock.calls[1]?.[0]).toBe(
         'http://dial-core/v1/files/bucket/reports/a%20(1).txt',
       );
     });
 
     it('increments the deduplicated file name until upload succeeds', async () => {
-      const { service } = makeService();
-      const fetchSpy = vi
-        .spyOn(globalThis, 'fetch')
+      const { service, fetchCore } = makeService();
+      fetchCore
         .mockResolvedValueOnce(new Response(null, { status: 412 }))
         .mockResolvedValueOnce(new Response(null, { status: 412 }))
         .mockResolvedValueOnce(okFetchUpload());
@@ -550,17 +554,15 @@ describe('FilesUploadService', () => {
       expect(result.results).toEqual([
         { path: 'reports/a (2).txt', success: true },
       ]);
-      expect(fetchSpy).toHaveBeenCalledTimes(3);
-      expect(fetchSpy.mock.calls[2]?.[0]).toBe(
+      expect(fetchCore).toHaveBeenCalledTimes(3);
+      expect(fetchCore.mock.calls[2]?.[0]).toBe(
         'http://dial-core/v1/files/bucket/reports/a%20(2).txt',
       );
     });
 
     it('rejects path-traversal entries without attempting to upload them', async () => {
-      const { service } = makeService();
-      const fetchSpy = vi
-        .spyOn(globalThis, 'fetch')
-        .mockResolvedValue(okFetchUpload());
+      const { service, fetchCore } = makeService();
+      fetchCore.mockResolvedValue(okFetchUpload());
       const buffer = buildRawZipBuffer([
         { name: '../../etc/passwd' },
         { name: 'safe.txt' },
@@ -574,14 +576,14 @@ describe('FilesUploadService', () => {
         { path: '../../etc/passwd', success: false, error: 'Invalid path' },
         { path: 'reports/safe.txt', success: true },
       ]);
-      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      expect(fetchCore).toHaveBeenCalledTimes(1);
     });
 
     it('throws ServiceUnavailableException and stops scheduling uploads when the timeout is exceeded', async () => {
-      const { service } = makeService({
+      const { service, fetchCore } = makeService({
         ARCHIVE_UPLOAD_TIMEOUT_MS: 250,
       });
-      const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(
+      fetchCore.mockImplementation(
         (_input, init) =>
           new Promise<Response>((resolve, reject) => {
             const signal = (init as RequestInit | undefined)?.signal;
@@ -610,14 +612,14 @@ describe('FilesUploadService', () => {
         ).rejects.toThrow(ServiceUnavailableException);
       });
       await new Promise((resolve) => setTimeout(resolve, 30));
-      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      expect(fetchCore).toHaveBeenCalledTimes(1);
     });
 
     it('throws ServiceUnavailableException when the final entry upload times out', async () => {
-      const { service } = makeService({
+      const { service, fetchCore } = makeService({
         ARCHIVE_UPLOAD_TIMEOUT_MS: 250,
       });
-      const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(
+      fetchCore.mockImplementation(
         (_input, init) =>
           new Promise<Response>((resolve, reject) => {
             const signal = (init as RequestInit | undefined)?.signal;
@@ -642,7 +644,7 @@ describe('FilesUploadService', () => {
           service.uploadArchive('bucket', 'reports', archiveFile, 'token'),
         ).rejects.toThrow(ServiceUnavailableException);
       });
-      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      expect(fetchCore).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/apps/chat-api/src/files/upload/files-upload.service.ts
+++ b/apps/chat-api/src/files/upload/files-upload.service.ts
@@ -559,17 +559,20 @@ export class FilesUploadService {
        * The SDK upload helper requires FormData/Blob, which would buffer the
        * staged file again. Raw fetch lets archive uploads stream from disk.
        */
-      const response = await fetch(this.buildDialUploadUrl(bucket, path), {
-        method: 'PUT',
-        headers: {
-          ...getBearerAuthHeaders(token),
-          'If-None-Match': '*',
-          'Content-Type': `multipart/form-data; boundary=${boundary}`,
-        },
-        body: Readable.toWeb(multipartStream) as RequestInit['body'],
-        signal,
-        duplex: 'half',
-      } as RequestInit & { duplex: 'half' });
+      const response = await this.dialClient.fetchCore(
+        this.buildDialUploadUrl(bucket, path),
+        {
+          method: 'PUT',
+          headers: {
+            ...getBearerAuthHeaders(token),
+            'If-None-Match': '*',
+            'Content-Type': `multipart/form-data; boundary=${boundary}`,
+          },
+          body: Readable.toWeb(multipartStream) as RequestInit['body'],
+          signal,
+          duplex: 'half',
+        } as RequestInit & { duplex: 'half' },
+      );
 
       if (response.status === 412) {
         throw new ConflictException('File already exists at this path');

--- a/apps/chat-api/src/rate/rate.service.ts
+++ b/apps/chat-api/src/rate/rate.service.ts
@@ -28,7 +28,7 @@ export class RateService {
         body['comment'] = dto.comment;
       }
 
-      const response = await fetch(url, {
+      const response = await this.dialClient.fetchCore(url, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/apps/chat-api/src/rate/tests/rate.service.spec.ts
+++ b/apps/chat-api/src/rate/tests/rate.service.spec.ts
@@ -10,12 +10,14 @@ import { RateService } from '../rate.service';
 
 const BASE_URL = 'http://dial-core';
 const ACCESS_TOKEN = 'test-token';
+let fetchSpy: ReturnType<typeof vi.fn>;
 
 function makeService() {
   const dialClient = {
     client: {},
     baseUrl: BASE_URL,
     dialApiVersion: '2024-10-21',
+    fetchCore: fetchSpy,
   } as unknown as DialClientService;
 
   return new RateService(dialClient);
@@ -29,10 +31,8 @@ const validDto: RateMessageDto = {
 };
 
 describe('RateService', () => {
-  let fetchSpy: ReturnType<typeof vi.spyOn>;
-
   beforeEach(() => {
-    fetchSpy = vi.spyOn(global, 'fetch');
+    fetchSpy = vi.fn();
   });
 
   afterEach(() => {

--- a/apps/chat-api/src/scheduled-tasks/scheduled-tasks.service.ts
+++ b/apps/chat-api/src/scheduled-tasks/scheduled-tasks.service.ts
@@ -213,7 +213,7 @@ export class ScheduledTasksService {
     this.logger.debug(`Calling DIAL Scheduler: ${method} ${url} (${context})`);
 
     try {
-      const response = await fetch(url, {
+      const response = await this.dialClient.fetchCore(url, {
         method,
         headers: {
           ...getBearerAuthHeaders(accessToken),

--- a/apps/chat-api/src/scheduled-tasks/tests/scheduled-tasks.service.spec.ts
+++ b/apps/chat-api/src/scheduled-tasks/tests/scheduled-tasks.service.spec.ts
@@ -9,6 +9,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { DialClientService } from '../../dial/dial-client.service';
 import { ScheduledTasksService } from '../scheduled-tasks.service';
 
+let fetchMock: ReturnType<typeof vi.fn>;
+
 const makeConfigService = (
   schedulerAppId?: string,
   timeoutMs = 10_000,
@@ -28,6 +30,7 @@ const makeDialClient = (): DialClientService =>
   ({
     baseUrl: 'http://dial-core',
     dialApiVersion: '2025-01-01-preview',
+    fetchCore: fetchMock,
   }) as unknown as DialClientService;
 
 const makeCacheManager = () => {
@@ -46,11 +49,8 @@ const makeCacheManager = () => {
 };
 
 describe('ScheduledTasksService', () => {
-  let fetchMock: ReturnType<typeof vi.fn>;
-
   beforeEach(() => {
     fetchMock = vi.fn();
-    vi.stubGlobal('fetch', fetchMock);
   });
 
   afterEach(() => {

--- a/apps/chat/src/server-api/chat-stream.api.ts
+++ b/apps/chat/src/server-api/chat-stream.api.ts
@@ -1,6 +1,7 @@
 import { SendCompletionDtoModeEnum } from '@epam/ai-dial-chat-api-client';
 import { MessageCustomContent, StreamChunk } from '@epam/ai-dial-chat-shared';
 import { JSON_HEADERS } from '../constants/http';
+import { getBrowserTimezone } from '../utils/browser-timezone';
 import { ApiEndpoints, getCsrfToken, setCsrfToken } from './base';
 
 export { SendCompletionDtoModeEnum as CompletionMode };
@@ -55,6 +56,7 @@ export const streamCompletion = (
   const run = async () => {
     let response: Response;
     try {
+      const timezone = getBrowserTimezone();
       response = await fetch(`${ApiEndpoints.CONVERSATIONS}/completions`, {
         method: 'POST',
         credentials: 'include',
@@ -64,6 +66,7 @@ export const streamCompletion = (
           ...(getCsrfToken() != null
             ? { 'X-CSRF-Token': getCsrfToken() as string }
             : {}),
+          ...(timezone ? { 'X-Timezone': timezone } : {}),
         },
         body: JSON.stringify({
           path,

--- a/apps/chat/src/server-api/tests/chat-stream.api.spec.ts
+++ b/apps/chat/src/server-api/tests/chat-stream.api.spec.ts
@@ -1,6 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { getBrowserTimezone } from '../../utils/browser-timezone';
 import { setCsrfToken } from '../base';
 import { stopCompletion, streamCompletion } from '../chat-stream.api';
+
+vi.mock('../../utils/browser-timezone', () => ({
+  getBrowserTimezone: vi.fn(() => undefined),
+}));
 
 describe('chat-stream api', () => {
   const fetchMock = vi.fn();
@@ -8,6 +13,8 @@ describe('chat-stream api', () => {
   beforeEach(() => {
     vi.stubGlobal('fetch', fetchMock);
     fetchMock.mockReset();
+    vi.mocked(getBrowserTimezone).mockReset();
+    vi.mocked(getBrowserTimezone).mockReturnValue(undefined);
     setCsrfToken(null);
   });
 
@@ -53,6 +60,86 @@ describe('chat-stream api', () => {
         controller.close();
       },
     });
+
+  const completeStreamRequest = (): Promise<void> =>
+    new Promise<void>((resolve) => {
+      streamCompletion('gpt-4o__Hello__uuid', 'hello', 'gpt-4o', {
+        onChunk: vi.fn(),
+        onComplete: resolve,
+        onError: () => resolve(),
+      });
+    });
+
+  it('sends the current browser timezone with each completion request', async () => {
+    fetchMock.mockResolvedValue(
+      new Response(emptyStream(), {
+        status: 200,
+        headers: { 'Content-Type': 'text/event-stream' },
+      }),
+    );
+    vi.mocked(getBrowserTimezone)
+      .mockReturnValueOnce('Europe/Warsaw')
+      .mockReturnValueOnce('Asia/Tokyo');
+
+    await completeStreamRequest();
+    await completeStreamRequest();
+
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      '/api/v1/conversations/completions',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          'X-Timezone': 'Europe/Warsaw',
+        }),
+      }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      '/api/v1/conversations/completions',
+      expect.objectContaining({
+        headers: expect.objectContaining({ 'X-Timezone': 'Asia/Tokyo' }),
+      }),
+    );
+    expect(getBrowserTimezone).toHaveBeenCalledTimes(2);
+  });
+
+  it('omits the timezone header when browser detection has no value', async () => {
+    fetchMock.mockResolvedValue(
+      new Response(emptyStream(), {
+        status: 200,
+        headers: { 'Content-Type': 'text/event-stream' },
+      }),
+    );
+
+    await completeStreamRequest();
+
+    const request = fetchMock.mock.calls[0]?.[1] as RequestInit;
+    expect(new Headers(request.headers).has('X-Timezone')).toBe(false);
+  });
+
+  it('preserves CSRF and request body behavior when adding the timezone', async () => {
+    fetchMock.mockResolvedValue(
+      new Response(emptyStream(), {
+        status: 200,
+        headers: { 'Content-Type': 'text/event-stream' },
+      }),
+    );
+    setCsrfToken('csrf-token');
+    vi.mocked(getBrowserTimezone).mockReturnValue('America/New_York');
+
+    await completeStreamRequest();
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/v1/conversations/completions',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          'X-CSRF-Token': 'csrf-token',
+          'X-Timezone': 'America/New_York',
+        }),
+        body: expect.stringContaining('"model":"gpt-4o"'),
+      }),
+    );
+  });
 
   it('includes clientChannelId in the completion body when provided', async () => {
     fetchMock.mockResolvedValue(

--- a/apps/chat/src/utils/browser-timezone.ts
+++ b/apps/chat/src/utils/browser-timezone.ts
@@ -1,0 +1,12 @@
+/**
+ * Resolves the browser's current IANA timezone for request-scoped downstream
+ * context. Detection is best-effort because embedded or restricted runtimes
+ * may expose an incomplete `Intl` implementation.
+ */
+export const getBrowserTimezone = (): string | undefined => {
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone || undefined;
+  } catch {
+    return undefined;
+  }
+};

--- a/apps/chat/src/utils/tests/browser-timezone.spec.ts
+++ b/apps/chat/src/utils/tests/browser-timezone.spec.ts
@@ -1,0 +1,44 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { getBrowserTimezone } from '../browser-timezone';
+
+describe('getBrowserTimezone', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns the timezone resolved by the browser', () => {
+    vi.spyOn(Intl.DateTimeFormat.prototype, 'resolvedOptions').mockReturnValue({
+      locale: 'en-US',
+      calendar: 'gregory',
+      numberingSystem: 'latn',
+      timeZone: 'Europe/Warsaw',
+      year: 'numeric',
+      month: 'numeric',
+      day: 'numeric',
+    });
+
+    expect(getBrowserTimezone()).toBe('Europe/Warsaw');
+  });
+
+  it('returns undefined when the browser resolves an empty timezone', () => {
+    vi.spyOn(Intl.DateTimeFormat.prototype, 'resolvedOptions').mockReturnValue({
+      locale: 'en-US',
+      calendar: 'gregory',
+      numberingSystem: 'latn',
+      timeZone: '',
+      year: 'numeric',
+      month: 'numeric',
+      day: 'numeric',
+    });
+
+    expect(getBrowserTimezone()).toBeUndefined();
+  });
+
+  it('returns undefined when Intl timezone detection throws', () => {
+    vi.spyOn(Intl, 'DateTimeFormat').mockImplementation(() => {
+      throw new Error('Intl unavailable');
+    });
+
+    expect(getBrowserTimezone()).toBeUndefined();
+  });
+});

--- a/docs/responses-api-integration.md
+++ b/docs/responses-api-integration.md
@@ -52,7 +52,7 @@ resolveGenerationApi()
   |                              |
   | true                         | false / absent
   v                              v
-ResponsesAdapter             ChatCompletionsAdapter
+ResponsesAdapter             ConversationStreamingService
   |                              |
   | POST /openai/v1/responses    | Chat Completions request
   v                              v
@@ -65,7 +65,11 @@ DIAL Core                    DIAL Core
        status, and generation stop handling
 ```
 
-Separating the two modes into adapters preserves the existing external Chat contract and the shared conversation-history logic.
+The Responses mode is isolated in `ResponsesAdapter`. The active Chat Completions
+relay remains in `ConversationStreamingService.relayModelCompletion`; the dormant
+`ChatCompletionsAdapter` refactor is not used for runtime dispatch. Both modes
+preserve the existing external Chat contract and shared conversation-history
+logic.
 
 ## How Responses API Support Is Determined
 
@@ -128,6 +132,42 @@ If the deployment is a toolset, generation is rejected with `400 Bad Request`. I
 
 This lifecycle is the same for Responses and Chat Completions except for upstream request construction and stream parsing.
 
+### Browser timezone context
+
+For each completion request, the frontend resolves the browser's current IANA
+timezone with `Intl.DateTimeFormat().resolvedOptions().timeZone`. Resolution is
+best-effort and happens again for every send, so a changed browser timezone is
+used without reloading the application. When resolution succeeds, the frontend
+adds the optional request header:
+
+```http
+X-Timezone: Europe/Warsaw
+```
+
+The streaming frontend deliberately continues to use raw `fetch` for
+`POST /api/v1/conversations/completions`. Although the generated
+`ConversationsApi.streamCompletion` contract exposes optional
+`xTimezone?: string`, neither that method nor its `Raw` variant exposes the live
+response body needed by the existing SSE reader.
+
+`ConversationController` validates a present header before generation starts.
+It must be a single IANA timezone string, no longer than 255 characters, match
+the safe timezone-segment syntax, and be accepted by `Intl.DateTimeFormat`.
+Malformed, unknown, oversized, or multi-value input returns `400 Bad Request`
+without calling DIAL Core. An absent header is accepted for backward
+compatibility.
+
+The validated value stays request-local. The BFF forwards it unchanged as
+`X-Timezone` through both active upstream paths:
+
+- Chat Completions via
+  `ConversationStreamingService.relayModelCompletion` and
+  `sendChatCompletionRequest`;
+- Responses via `ResponsesAdapter` and `createResponse`.
+
+The timezone is context for DIAL Core only. Chat does not persist it, cache it,
+put it into metrics, or include it in logs.
+
 ## Responses API Request
 
 The Responses adapter calls the SDK's `createResponse` method, which sends a request to:
@@ -165,7 +205,9 @@ Mapping rules:
 - `stream` is always `true`;
 - `store` is always `false`.
 
-The request also includes the user's Bearer token, `Accept: text/event-stream`, an AbortSignal, and `X-DIAL-CLIENT-CHANNEL-ID` when available.
+The request also includes the user's Bearer token, `Accept: text/event-stream`,
+an AbortSignal, `X-DIAL-CLIENT-CHANNEL-ID` when available, and the validated
+`X-Timezone` when supplied by the browser.
 
 ### Why the full history is sent
 
@@ -354,21 +396,23 @@ Possible `generation.api` values:
 
 ## Code Map
 
-| Area                                       | File                                                                                                                                                                              |
-| ------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| API enum and selection                     | `apps/chat-api/src/conversations/generation/generation-api.ts`                                                                                                                    |
-| Shared result types                        | `apps/chat-api/src/conversations/generation/generation.types.ts`                                                                                                                  |
-| Responses request and SSE parser           | `apps/chat-api/src/conversations/generation/responses.adapter.ts`                                                                                                                 |
-| Existing Chat Completions flow             | `apps/chat-api/src/conversations/generation/chat-completions.adapter.ts`                                                                                                          |
-| Metrics                                    | `apps/chat-api/src/conversations/generation/generation-metrics.ts`                                                                                                                |
-| Orchestration and conversation persistence | `apps/chat-api/src/conversations/conversation.service.ts`                                                                                                                         |
-| Deployment-details retrieval and caching   | `apps/chat-api/src/deployments/deployments.service.ts`                                                                                                                            |
-| Deployment-capability DTOs and mapping     | `apps/chat-api/src/deployments/dto/raw-deployment.dto.ts`, `apps/chat-api/src/deployments/dto/deployment-item.dto.ts`, and `apps/chat-api/src/deployments/deployments.service.ts` |
-| Message DTO containing `responseId`        | `apps/chat-api/src/conversations/dto/conversation-message.dto.ts`                                                                                                                 |
-| API-selection unit tests                   | `apps/chat-api/src/conversations/generation/generation-api.spec.ts`                                                                                                               |
-| Responses-adapter unit tests               | `apps/chat-api/src/conversations/generation/responses.adapter.spec.ts`                                                                                                            |
-| Service-level integration                  | `apps/chat-api/src/conversations/tests/conversation.service.spec.ts`                                                                                                              |
-| `features.responsesApiEnabled` flag source | `apps/chat-api/src/app-config/feature-flags/feature-key.enum.ts`, `apps/chat-api/src/app-config/config-registry/config-registry.constants.ts`                                     |
+| Area                                        | File                                                                                                                                                                              |
+| ------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| API enum and selection                      | `apps/chat-api/src/conversations/generation/generation-api.ts`                                                                                                                    |
+| Shared result types                         | `apps/chat-api/src/conversations/generation/generation.types.ts`                                                                                                                  |
+| Responses request and SSE parser            | `apps/chat-api/src/conversations/generation/responses.adapter.ts`                                                                                                                 |
+| Active Chat Completions flow                | `apps/chat-api/src/conversations/streaming/conversation-streaming.service.ts`                                                                                                     |
+| Browser timezone resolution and SSE request | `apps/chat/src/utils/browser-timezone.ts`, `apps/chat/src/server-api/chat-stream.api.ts`                                                                                          |
+| Timezone header validation                  | `apps/chat-api/src/conversations/utils/timezone-header.ts`, `apps/chat-api/src/conversations/conversation.controller.ts`                                                          |
+| Metrics                                     | `apps/chat-api/src/conversations/generation/generation-metrics.ts`                                                                                                                |
+| Orchestration and conversation persistence  | `apps/chat-api/src/conversations/conversation.service.ts`                                                                                                                         |
+| Deployment-details retrieval and caching    | `apps/chat-api/src/deployments/deployments.service.ts`                                                                                                                            |
+| Deployment-capability DTOs and mapping      | `apps/chat-api/src/deployments/dto/raw-deployment.dto.ts`, `apps/chat-api/src/deployments/dto/deployment-item.dto.ts`, and `apps/chat-api/src/deployments/deployments.service.ts` |
+| Message DTO containing `responseId`         | `apps/chat-api/src/conversations/dto/conversation-message.dto.ts`                                                                                                                 |
+| API-selection unit tests                    | `apps/chat-api/src/conversations/generation/generation-api.spec.ts`                                                                                                               |
+| Responses-adapter unit tests                | `apps/chat-api/src/conversations/generation/responses.adapter.spec.ts`                                                                                                            |
+| Service-level integration                   | `apps/chat-api/src/conversations/tests/conversation.service.spec.ts`                                                                                                              |
+| `features.responsesApiEnabled` flag source  | `apps/chat-api/src/app-config/feature-flags/feature-key.enum.ts`, `apps/chat-api/src/app-config/config-registry/config-registry.constants.ts`                                     |
 
 ## DIAL Core Context
 

--- a/libs/chat-api-client/openapi.json
+++ b/libs/chat-api-client/openapi.json
@@ -2248,7 +2248,20 @@
       "post": {
         "description": "Appends the user message to the conversation history, streams a completion from DIAL Core as SSE, persists the result, and returns the raw event stream. Backend owns persistence.",
         "operationId": "streamCompletion",
-        "parameters": [],
+        "parameters": [
+          {
+            "name": "X-Timezone",
+            "in": "header",
+            "description": "Current browser IANA timezone forwarded to DIAL Core for date- and time-sensitive tools.",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "maxLength": 255,
+              "pattern": "^[A-Za-z0-9._+-]+(?:/[A-Za-z0-9._+-]+)*$",
+              "example": "Europe/Warsaw"
+            }
+          }
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -2264,7 +2277,7 @@
             "description": "SSE stream of completion chunks"
           },
           "400": {
-            "description": "Invalid request body"
+            "description": "Invalid request body or X-Timezone header"
           },
           "401": {
             "description": "Not authenticated"

--- a/libs/chat-api-client/src/generated/README.md
+++ b/libs/chat-api-client/src/generated/README.md
@@ -3,27 +3,23 @@
 This generator creates TypeScript/JavaScript client that utilizes [Fetch API](https://fetch.spec.whatwg.org/). The generated Node module can be used in the following environments:
 
 Environment
-
-- Node.js
-- Webpack
-- Browserify
+* Node.js
+* Webpack
+* Browserify
 
 Language level
-
-- ES5 - you must have a Promises/A+ library installed
-- ES6
+* ES5 - you must have a Promises/A+ library installed
+* ES6
 
 Module system
-
-- CommonJS
-- ES6 module system
+* CommonJS
+* ES6 module system
 
 It can be used in both TypeScript and JavaScript. In TypeScript, the definition will be automatically resolved via `package.json`. ([Reference](https://www.typescriptlang.org/docs/handbook/declaration-files/consumption.html))
 
 ### Building
 
 To build and compile the typescript sources to javascript use:
-
 ```
 npm install
 npm run build

--- a/libs/chat-api-client/src/generated/src/apis/ConversationsApi.ts
+++ b/libs/chat-api-client/src/generated/src/apis/ConversationsApi.ts
@@ -102,6 +102,7 @@ export interface StopCompletionRequest {
 
 export interface StreamCompletionRequest {
   sendCompletionDto: SendCompletionDto;
+  xTimezone?: string;
 }
 
 export interface UnpublishConversationRequest {
@@ -937,6 +938,10 @@ export class ConversationsApi extends runtime.BaseAPI {
     const headerParameters: runtime.HTTPHeaders = {};
 
     headerParameters['Content-Type'] = 'application/json';
+
+    if (requestParameters['xTimezone'] != null) {
+      headerParameters['X-Timezone'] = String(requestParameters['xTimezone']);
+    }
 
     let urlPath = `/api/v1/conversations/completions`;
 

--- a/openspec/changes/archive/2026-08-25-forward-browser-timezone-to-dial-core/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-25-forward-browser-timezone-to-dial-core/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-25

--- a/openspec/changes/archive/2026-08-25-forward-browser-timezone-to-dial-core/design.md
+++ b/openspec/changes/archive/2026-08-25-forward-browser-timezone-to-dial-core/design.md
@@ -1,0 +1,111 @@
+## Context
+
+Issue [#8442](https://github.com/epam/ai-dial-chat/issues/8442) requires the browser's timezone to reach DIAL Core so Quick Apps/toolsets/MCP servers can resolve date- and time-sensitive requests in the user's locale. Legacy PR [#8444](https://github.com/epam/ai-dial-chat/pull/8444) established `X-Timezone` and best-effort browser detection as the compatibility contract.
+
+The current application has a host-owned SSE completion adapter in `apps/chat/src/server-api/chat-stream.api.ts`; it is the correct boundary for browser-only data and already owns the exceptional raw `fetch` required to consume the streaming response. The BFF endpoint is `POST /api/v1/conversations/completions`. After resolving the deployment capability, `ConversationStreamingService` currently sends Chat Completions itself and delegates Responses requests to `ResponsesAdapter`. Although `ChatCompletionsAdapter` exists and `docs/responses-api-integration.md` names it, the runtime Chat Completions relay remains `ConversationStreamingService.relayModelCompletion`; this design follows the code that executes today and does not fold an unrelated adapter refactor into the feature.
+
+The feature crosses the browser/BFF/DIAL Core boundary but adds no user-facing UI or persisted data:
+
+```text
+browser Intl API
+  -> X-Timezone on POST /api/v1/conversations/completions
+  -> conversations controller validates header
+  -> ConversationStreamingService carries validated value
+  -> X-Timezone on selected Chat Completions or Responses SDK request
+  -> DIAL Core -> Quick App/toolset -> MCP server
+```
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Send the current browser-resolved IANA timezone with every normal conversation completion when detection succeeds.
+- Treat `X-Timezone` as untrusted input at the BFF boundary and reject invalid values before any DIAL Core call.
+- Forward the validated value through both generation paths so the BFF's internal API selection is transparent to downstream tools.
+- Preserve existing behavior for callers and browsers that omit or cannot resolve a timezone.
+- Keep browser and header knowledge at application edges; do not add it to `libs/chat-hooks` or another hand-authored library.
+
+**Non-Goals:**
+
+- A timezone picker, user preference, React context, hook, Redux-style store, or persistence.
+- Timezone conversion by Chat; downstream consumers interpret the IANA identifier.
+- Adding the header to non-conversation DIAL calls, scheduled-task execution, naming requests, transcription, or `/api/v1/chat/completions`.
+- Refactoring the dormant `ChatCompletionsAdapter` into the active runtime path.
+- Changes to DIAL Core's existing custom `X-*` header forwarding behavior.
+
+## Decisions
+
+### 1. Resolve timezone per send at the frontend server-api boundary
+
+Add a small pure app utility (for example `apps/chat/src/utils/browser-timezone.ts`) that calls `Intl.DateTimeFormat().resolvedOptions().timeZone`, catches runtime failures, and returns `undefined` for an absent/empty result. `apps/chat/src/server-api/chat-stream.api.ts` calls it immediately before `fetch` and conditionally adds `X-Timezone`.
+
+This deliberately introduces no state owner: no context or hook owns the timezone, and there are no memoisation requirements. Resolving per send avoids stale values if a long-lived tab crosses a system-timezone change and makes the same app-owned transport work for the main conversation page and app preview.
+
+Alternatives rejected:
+
+- Resolve once in a top-level provider and store it: unnecessary global state, extra render/synchronisation surface, and potentially stale.
+- Pass timezone through `ConversationStreamTransport`: this would expose browser/integration metadata to `libs/chat-hooks`, contrary to library isolation, even though the lib does not need the value.
+- Add the timezone to the JSON body: diverges from the established DIAL custom-header contract and would make transport context part of the generated conversation DTO.
+
+The direct `fetch` remains confined to `server-api/chat-stream.api.ts`. Neither a component nor a hook gains network code. This is the documented SSE generator gap: the generated operation returns `void` and does not expose the live response body in the shape required by the current decoder.
+
+### 2. Define and validate one optional `X-Timezone` API header
+
+The existing `POST /api/v1/conversations/completions` operation gains an optional Swagger `@ApiHeader` named `X-Timezone`; its body and SSE response stay unchanged. The controller reads the header and delegates validation to a conversations-domain utility modeled on `apps/chat-api/src/client-channel/client-channel.utils.ts:27`.
+
+Validation accepts exactly one non-empty string, at most 255 characters, matching an IANA-name-safe allowlist (`[A-Za-z0-9._+-]+` path segments separated by single `/` characters), and accepted by the server's `Intl.DateTimeFormat` timezone option. The value is forwarded unchanged after validation; it is not trimmed, canonicalized, logged, cached, or stored. An absent header maps to `undefined`. Arrays, malformed syntax, unknown timezones, and oversized values produce `BadRequestException` and the existing documented `400` response.
+
+The endpoint remains authorized for the same authenticated session users through the existing global session guard; no role or feature permission is added. Its existing `100` requests per 60 seconds throttle remains unchanged.
+
+Alternatives rejected:
+
+- Trust the browser-produced value: non-browser clients can call the BFF, so the BFF must enforce the boundary.
+- Syntax-only validation: it blocks header injection but still forwards fabricated timezone names that downstream tools cannot use.
+- Silently drop invalid values: hides client defects and makes behavior difficult to diagnose; explicit `400` matches the backend's validated-input contract.
+
+### 3. Carry the validated value through the existing completion call chain
+
+Append an optional `timezone` argument to the controller-to-service and generation relay calls without restructuring unrelated arguments. At the DIAL SDK call sites, conditionally merge `{ 'X-Timezone': timezone }` alongside bearer auth, `Accept`, and the optional client-channel header:
+
+- `ConversationStreamingService.relayModelCompletion` for the active Chat Completions path;
+- `ResponsesAdapter.stream` for the Responses path.
+
+Both calls continue to use the shared `DialClientService` SDK client. No raw backend `fetch`, new SDK instance, retry, or fallback is introduced. The header is request-local; it is never placed on `DialClientService` or other singleton state, preventing cross-user leakage.
+
+The existing generation API selection, request bodies, response normalization, persistence, abort behavior, and error mapping are unchanged.
+
+### 4. Keep the OpenAPI contract additive and preserve the SSE frontend adapter
+
+Swagger regeneration adds optional `xTimezone?: string` to `StreamCompletionRequest` for operation ID / SDK method `streamCompletion`; `SendCompletionDto` and the `void`/SSE response schema remain unchanged. The generated client is updated only via `npm run openapi` and is not hand-edited.
+
+The frontend continues to call neither the normal nor `Raw` generated method for this endpoint because both abstractions are unsuitable for its live SSE reader; it keeps the existing `server-api/chat-stream.api.ts` raw transport and sends the documented header there. Other generated-client callers remain source-compatible because the new request member is optional.
+
+### 5. Do not add product/UI or operational controls
+
+There are no new user-visible strings or UI states, so i18n keys, loading/empty/error UI, accessibility behavior, RTL/direction handling, and responsive layout are unaffected. The capability is always best-effort and is not gated by `ENABLED_FEATURES` or `ENABLED_FEATURES_ROLES`.
+
+No cache is used (there is no cache key, TTL, or invalidation event). No new metric or analytics event is added; existing generation metrics continue unchanged, and the timezone is not logged because it can reveal coarse user location.
+
+## Risks / Trade-offs
+
+- **[Browser or embedded runtime lacks a usable Intl timezone]** → Catch detection errors and omit the optional header; completion remains functional.
+- **[Client sends a forged or injection-shaped header]** → Enforce single-value, length, syntax, and semantic timezone validation before calling the service or DIAL Core.
+- **[Timezone changes while the tab remains open]** → Resolve on every send instead of storing the first value.
+- **[One generation path misses propagation]** → Exercise Chat Completions and Responses SDK calls independently in adapter/service tests and cover selection in integration tests.
+- **[DIAL Core or a downstream component ignores the custom header]** → Chat cannot enforce behavior beyond its boundary; tests verify the exact outgoing SDK header, and rollout relies on the Core/Quick Apps forwarding mechanism stated in #8442.
+- **[OpenAPI generator changes a request signature]** → Keep the parameter optional, regenerate from Swagger, run OpenAPI checks, and inspect the generated `ConversationsApi` diff.
+- **[Pre-existing docs/runtime adapter mismatch causes implementation in dead code]** → Tasks name `ConversationStreamingService.relayModelCompletion` as the active Chat Completions call site and update the integration document to describe current behavior.
+
+## Migration Plan
+
+1. Add frontend detection/header tests and browser emission.
+2. Add BFF header documentation/validation and controller integration coverage.
+3. Propagate the validated value through both DIAL SDK request paths and verify present/absent cases.
+4. Regenerate and validate OpenAPI artifacts, then update the Responses API integration document.
+5. Deploy frontend and BFF together. Older callers remain compatible because the header is optional; a newer frontend talking to an older BFF also continues to complete because unknown request headers are ignored.
+
+Rollback requires reverting browser emission, BFF validation/plumbing, upstream header merges, generated artifacts, and the documentation update. No data migration, cache invalidation, configuration rollback, or coordinated DIAL Core rollback is required.
+
+## Open Questions
+
+None blocking. The selected header name and best-effort semantics come from #8442/#8444; support for forwarding custom `X-*` headers beyond Chat remains an external DIAL Core/Quick Apps prerequisite.

--- a/openspec/changes/archive/2026-08-25-forward-browser-timezone-to-dial-core/proposal.md
+++ b/openspec/changes/archive/2026-08-25-forward-browser-timezone-to-dial-core/proposal.md
@@ -1,0 +1,61 @@
+## Why
+
+MCP-backed tools that interpret dates and times currently receive no reliable indication of the user's browser timezone, so requests such as calendar lookups can be evaluated in the wrong local time. Issue [#8442](https://github.com/epam/ai-dial-chat/issues/8442) requests forwarding that context through Chat to DIAL Core, and legacy PR [#8444](https://github.com/epam/ai-dial-chat/pull/8444) provides the established `X-Timezone` contract to carry forward into the current architecture.
+
+### Problem
+
+The current browser completion transport sends only JSON/CSRF headers (`apps/chat/src/server-api/chat-stream.api.ts:42`), while the BFF's active Chat Completions relay and Responses adapter construct their upstream headers independently (`apps/chat-api/src/conversations/streaming/conversation-streaming.service.ts:180`, `apps/chat-api/src/conversations/generation/responses.adapter.ts:112`). Consequently, DIAL Core, Quick Apps, toolsets, and MCP servers cannot infer the user's local timezone from a normal conversation completion.
+
+### Solution
+
+Detect the browser's current IANA timezone on each conversation completion request, send it as an optional `X-Timezone` header to the BFF, validate it at the existing completion endpoint, and forward the accepted value to DIAL Core for both supported generation APIs.
+
+### Non-goals
+
+- Add a user-facing timezone selector, persisted timezone preference, or new React context/state.
+- Change scheduled-task timezone conversion or the audio-transcription-only `/api/v1/chat/completions` flow.
+- Configure or modify DIAL Core, Quick Apps, toolsets, or MCP servers beyond emitting the header they already support.
+
+### Acceptance criteria
+
+- A normal browser conversation completion includes `X-Timezone` when `Intl.DateTimeFormat().resolvedOptions().timeZone` returns a non-empty value.
+- The BFF validates the optional header and forwards it unchanged to the selected DIAL Core Chat Completions or Responses request.
+- Missing or unavailable browser timezone remains backward compatible: completion proceeds and the header is omitted.
+- Malformed or oversized timezone headers are rejected with `400 Bad Request` before contacting DIAL Core.
+- Automated frontend, controller/integration, and generation-adapter tests cover present, absent, and invalid timezone behavior.
+
+## What Changes
+
+- Extend the app-owned completion transport pattern (`apps/chat/src/utils/conversation-stream-transport.ts:13`) with best-effort, per-request browser timezone detection at the application edge.
+- Document and validate optional `X-Timezone` input on `POST /api/v1/conversations/completions` (`apps/chat-api/src/conversations/conversation.controller.ts:213`).
+- Thread the validated value through the conversation streaming service and add it to both DIAL Core generation adapter header sets.
+- Regenerate the OpenAPI client so the existing `streamCompletion` operation exposes the optional header while the frontend keeps its raw fetch path for SSE streaming.
+- Update the Responses API integration documentation to describe consistent timezone forwarding across both generation modes.
+- No user-visible strings are introduced; i18n, RTL, accessibility, UI layout, feature flags, caching, rate limits, and telemetry behavior are unchanged.
+
+### Alternatives considered
+
+- **Selected — optional request header, resolved per completion:** matches the legacy/DIAL Core contract, avoids stale state when the system timezone changes, and is omitted safely when browser detection fails.
+- **Persist timezone in React context or user configuration:** rejected because the value is browser runtime context, requires unnecessary ownership/synchronization, and creates migration and stale-value risk.
+- **Add timezone to the JSON completion DTO:** rejected because it diverges from the established custom-header forwarding chain and treats transport metadata as conversation content.
+- **Forward only through Chat Completions:** rejected because the BFF selects Chat Completions or Responses transparently; tool behavior must not depend on that internal choice.
+
+## Capabilities
+
+### New Capabilities
+
+- `browser-timezone-forwarding`: Defines browser timezone detection, the optional BFF header contract and validation, and propagation to every DIAL Core generation path.
+
+### Modified Capabilities
+
+- None.
+
+## Impact
+
+- **Frontend:** `apps/chat/src/server-api/chat-stream.api.ts` and its tests; a small app-owned timezone utility may be added under `apps/chat/src/utils/`. No hand-authored library receives browser, endpoint, or header knowledge.
+- **Backend:** the existing conversations controller, a domain-local header validation primitive, conversation streaming service, Chat Completions adapter, Responses adapter, and their tests.
+- **API/OpenAPI:** `POST /api/v1/conversations/completions` gains one optional `X-Timezone` request header; operation ID, request body, response stream, auth, CSRF, rate limiting, and error mapping remain otherwise unchanged. The generated client changes are additive and generated rather than hand-edited.
+- **Documentation:** `docs/responses-api-integration.md` will state that both generation paths forward the same validated timezone header.
+- **Dependencies and operations:** no new dependency, environment variable, feature flag, cache, metric, or deployment step.
+- **Compatibility and rollback:** additive and non-breaking for callers that omit the header. Rollback is removal of browser emission, controller validation/documentation, and upstream propagation; existing request bodies and completion behavior remain valid throughout.
+- **Scope:** no shared/global provider or hand-authored `libs/*` change. `libs/chat-api-client` changes only through OpenAPI regeneration.

--- a/openspec/changes/archive/2026-08-25-forward-browser-timezone-to-dial-core/specs/browser-timezone-forwarding/spec.md
+++ b/openspec/changes/archive/2026-08-25-forward-browser-timezone-to-dial-core/specs/browser-timezone-forwarding/spec.md
@@ -1,0 +1,131 @@
+## ADDED Requirements
+
+### Requirement: Browser timezone is attached to conversation completion requests
+
+Immediately before starting a normal conversation completion, the Chat frontend SHALL resolve the current browser timezone through `Intl.DateTimeFormat().resolvedOptions().timeZone`. When resolution returns a non-empty string, the app-owned transport SHALL send that value in the `X-Timezone` request header to `POST /api/v1/conversations/completions`. The timezone SHALL be resolved per request and SHALL NOT be stored in a React context, hook, hand-authored library, browser storage, or user configuration.
+
+#### Scenario: Browser supplies a timezone
+
+- **WHEN** the browser resolves the current timezone as `Europe/Warsaw` and a user starts a conversation completion
+- **THEN** the request to `POST /api/v1/conversations/completions` contains `X-Timezone: Europe/Warsaw`
+
+#### Scenario: System timezone changes in a long-lived tab
+
+- **WHEN** two completion requests in the same tab resolve different current timezone values
+- **THEN** each request contains the value resolved immediately before that request, without requiring a reload
+
+#### Scenario: Browser timezone is unavailable
+
+- **WHEN** timezone resolution throws, returns an empty value, or returns no value
+- **THEN** the frontend omits `X-Timezone` and starts the completion normally
+
+#### Scenario: App preview uses the same behavior
+
+- **WHEN** a completion is started from app preview through the shared app-owned conversation stream transport
+- **THEN** timezone detection and conditional header emission match the main conversation flow
+
+### Requirement: Completion endpoint validates the optional timezone header
+
+The existing authenticated business endpoint `POST /api/v1/conversations/completions` SHALL accept one optional `X-Timezone` header. An accepted value MUST be a single string no longer than 255 characters, MUST consist only of IANA-name-safe path segments using ASCII letters, digits, `.`, `_`, `+`, and `-` separated by single `/` characters, and MUST be accepted as a timezone by the backend JavaScript `Intl.DateTimeFormat` implementation. The BFF SHALL pass an accepted value onward unchanged and SHALL NOT trim, canonicalize, persist, cache, or log it. A missing header SHALL remain valid; a present invalid value SHALL return `400 Bad Request` before DIAL Core is called.
+
+The endpoint contract remains:
+
+```http
+POST /api/v1/conversations/completions
+Content-Type: application/json
+X-CSRF-Token: <session-csrf-token>
+X-Timezone: Europe/Warsaw
+
+{
+  "generationId": "cfeaf733-4ecd-4898-ad3b-d6835c0b5fc8",
+  "path": "gpt-4o__Calendar__cfeaf733-4ecd-4898-ad3b-d6835c0b5fc8",
+  "model": "gpt-4o",
+  "mode": "append",
+  "message": "What is on my calendar tomorrow?"
+}
+```
+
+A successful response remains the existing SSE stream, for example:
+
+```text
+data: {"id":"cfeaf733-4ecd-4898-ad3b-d6835c0b5fc8","object":"chat.completion.chunk","choices":[{"delta":{"content":"You have..."}}]}
+
+data: [DONE]
+```
+
+The existing response statuses remain `200` (SSE), `400`, `401`, `403`, `404`, `409`, `429`, `502`, and `503`; this change adds invalid timezone input as another `400` case. Authentication remains the existing session/header-token authentication with no new role requirement, and the existing per-route limit of 100 requests per 60 seconds remains unchanged.
+
+#### Scenario: Valid IANA timezone is accepted
+
+- **WHEN** an authenticated completion request contains `X-Timezone: America/New_York` and a valid existing request body
+- **THEN** the endpoint starts the SSE completion and delegates `America/New_York` as the validated timezone
+
+#### Scenario: Missing timezone remains backward compatible
+
+- **WHEN** an otherwise valid completion request omits `X-Timezone`
+- **THEN** the endpoint starts the SSE completion with no timezone value
+
+#### Scenario: Invalid timezone syntax is rejected
+
+- **WHEN** `X-Timezone` contains whitespace, control characters, repeated separators, or characters outside the allowlist
+- **THEN** the endpoint returns `400 Bad Request` and does not call DIAL Core
+
+#### Scenario: Unknown timezone is rejected
+
+- **WHEN** `X-Timezone` is syntactically safe but is not accepted by the backend `Intl.DateTimeFormat` implementation
+- **THEN** the endpoint returns `400 Bad Request` and does not call DIAL Core
+
+#### Scenario: Oversized timezone is rejected
+
+- **WHEN** `X-Timezone` is longer than 255 characters
+- **THEN** the endpoint returns `400 Bad Request` and does not call DIAL Core
+
+#### Scenario: Multiple timezone header values are rejected
+
+- **WHEN** the request exposes `X-Timezone` as more than one header value
+- **THEN** the endpoint returns `400 Bad Request` and does not select or concatenate a value
+
+### Requirement: Validated timezone is forwarded through every generation API
+
+For a completion carrying a validated timezone, the BFF SHALL add `X-Timezone` with the unchanged value to the authenticated DIAL Core SDK request selected for that generation. This applies both to the active Chat Completions call and to the Responses API call. When the BFF receives no timezone, both upstream requests SHALL omit `X-Timezone`. Generation API selection, request bodies, SSE normalization, persistence, stopping, retries, and error handling SHALL otherwise remain unchanged. The timezone SHALL remain request-local and SHALL NOT be stored on a singleton SDK client or shared across requests.
+
+#### Scenario: Chat Completions request forwards timezone
+
+- **WHEN** the BFF selects Chat Completions for a request carrying validated timezone `Asia/Tokyo`
+- **THEN** `sendChatCompletionRequest` receives `X-Timezone: Asia/Tokyo` alongside the existing auth and stream headers
+
+#### Scenario: Responses request forwards timezone
+
+- **WHEN** the BFF selects Responses API for a request carrying validated timezone `Asia/Tokyo`
+- **THEN** `createResponse` receives `X-Timezone: Asia/Tokyo` alongside the existing auth and stream headers
+
+#### Scenario: Upstream header is omitted when client header is absent
+
+- **WHEN** a valid completion request omits `X-Timezone`
+- **THEN** the selected DIAL Core SDK request contains no `X-Timezone` header
+
+#### Scenario: Concurrent requests do not share timezone
+
+- **WHEN** two concurrent authenticated completions carry different valid timezone values
+- **THEN** each DIAL Core request receives only the timezone from its own BFF request
+
+### Requirement: OpenAPI and cross-cutting behavior remain compatible
+
+Swagger SHALL document `X-Timezone` as an optional header on operation ID / SDK method `streamCompletion`. OpenAPI regeneration SHALL add optional `xTimezone?: string` to `StreamCompletionRequest` while leaving `SendCompletionDto` and the SSE response contract unchanged. The frontend SHALL continue using the existing raw SSE transport rather than the normal or `Raw` generated method because the generated response abstraction does not expose the live stream required by the decoder.
+
+The capability SHALL introduce no user-visible strings, i18n keys, UI surface, keyboard interaction, ARIA contract, RTL/direction behavior, responsive layout, memoisation, `ENABLED_FEATURES` / `ENABLED_FEATURES_ROLES` gate, cache key/TTL/invalidation rule, new rate limit, metric, or analytics event. Existing generation metrics SHALL remain unchanged, and logs SHALL NOT contain the timezone value.
+
+#### Scenario: Generated client remains source compatible
+
+- **WHEN** OpenAPI artifacts are regenerated from the annotated completion endpoint
+- **THEN** `ConversationsApi.streamCompletion` accepts optional `xTimezone`, existing callers that provide only `sendCompletionDto` still type-check, and no generated file is hand-edited
+
+#### Scenario: No UI or product configuration is introduced
+
+- **WHEN** the timezone-forwarding capability is enabled by deploying the change
+- **THEN** users see no new control or text, no feature role is required, and no UI accessibility or direction behavior changes
+
+#### Scenario: Timezone is excluded from observability
+
+- **WHEN** a completion with `X-Timezone` succeeds or fails
+- **THEN** existing completion metrics may record their current generation attributes, but no log, metric, or analytics event records the timezone value

--- a/openspec/changes/archive/2026-08-25-forward-browser-timezone-to-dial-core/tasks.md
+++ b/openspec/changes/archive/2026-08-25-forward-browser-timezone-to-dial-core/tasks.md
@@ -1,0 +1,31 @@
+## 1. Vertical Slice: Browser to DIAL Core Chat Completions
+
+- [x] 1.1 Add a best-effort per-request browser timezone resolver in `apps/chat/src/utils/browser-timezone.ts`, wire conditional `X-Timezone` emission into `apps/chat/src/server-api/chat-stream.api.ts`, and keep the browser/header concern out of `libs/chat-hooks` and every other hand-authored `libs/*` package.
+- [x] 1.2 Add dedicated unit coverage in `apps/chat/src/utils/tests/browser-timezone.spec.ts` and `apps/chat/src/server-api/tests/chat-stream.api.spec.ts` for a resolved timezone, re-resolution on consecutive sends, empty/throwing `Intl` results, header omission, and preservation of the existing completion request body/CSRF behavior.
+- [x] 1.3 Add `apps/chat-api/src/conversations/utils/timezone-header.ts` with optional single-header validation (255-character limit, segment allowlist, and `Intl.DateTimeFormat` semantic validation), document the optional `X-Timezone` header with Swagger in `apps/chat-api/src/conversations/conversation.controller.ts`, and pass only the validated request-local value through `ConversationService` / `ConversationStreamingService` to the active `relayModelCompletion` SDK call in `apps/chat-api/src/conversations/streaming/conversation-streaming.service.ts`.
+- [x] 1.4 Add dedicated backend tests in `apps/chat-api/src/conversations/utils/timezone-header.spec.ts`, `apps/chat-api/src/conversations/tests/completions.integration.spec.ts`, and `apps/chat-api/src/conversations/streaming/tests/conversation-streaming.service.spec.ts` for valid, absent, unknown, malformed, oversized, and multi-value headers; assert invalid requests never reach the service/Core, valid values reach `sendChatCompletionRequest` unchanged, omitted values add no upstream header, concurrent calls do not share values, and logs contain no timezone.
+- [x] 1.5 Verify the completed Chat Completions slice with `npm exec nx test @epam/chat`, `npm exec nx lint @epam/chat`, `npm exec nx typecheck @epam/chat`, `npm exec nx test @epam/chat-api`, `npm exec nx lint @epam/chat-api`, and `npm exec nx typecheck @epam/chat-api`; fix only failures caused by this slice before continuing.
+
+## 2. Vertical Slice: Responses API Parity
+
+- [x] 2.1 Thread the same validated optional timezone into `apps/chat-api/src/conversations/generation/responses.adapter.ts` and conditionally add `X-Timezone` to `DialClientService.client.createResponse` without changing generation selection, request bodies, SSE normalization, persistence, retry, abort, metrics, or error behavior.
+- [x] 2.2 Extend the dedicated adapter coverage in `apps/chat-api/src/conversations/generation/responses.adapter.spec.ts` and the generation-selection coverage in `apps/chat-api/src/conversations/streaming/tests/conversation-streaming.service.spec.ts` to prove present and absent timezone behavior on the Responses request and parity with Chat Completions.
+- [x] 2.3 Verify the Responses slice with `npm exec nx test @epam/chat-api`, `npm exec nx lint @epam/chat-api`, `npm exec nx typecheck @epam/chat-api`, and `npm exec nx build @epam/chat-api`; fix only failures caused by this slice before continuing.
+
+## 3. Generated Contract and Documentation
+
+- [x] 3.1 Regenerate the Swagger/OpenAPI artifacts with `npm run openapi`, then verify `libs/chat-api-client/openapi.json` and the generated `ConversationsApi.streamCompletion` contract expose optional `xTimezone?: string` while `SendCompletionDto` and the SSE response remain unchanged; do not hand-edit any file under `libs/chat-api-client/src/generated/`.
+- [x] 3.2 Confirm the existing generated API singleton in `apps/chat/src/server-api/api-client.ts` remains the owner of `ConversationsApi` and needs no new singleton, while `apps/chat/src/server-api/chat-stream.api.ts` intentionally continues its raw SSE `fetch` path because neither the normal nor `Raw` generated method exposes the required live stream.
+- [x] 3.3 Run `npm run openapi:check`, `npm exec nx build chat-api-client -- --skip-nx-cache`, `npm exec nx lint chat-api-client`, and `npm exec nx typecheck chat-api-client`; verify the generated-client-only library exception contains no hand-authored app behavior or manual generated-file changes.
+- [x] 3.4 Update `docs/responses-api-integration.md` with the browser-to-BFF-to-DIAL-Core timezone header flow for both generation modes and describe the actual runtime Chat Completions relay accurately; do not introduce i18n, UI, RTL, accessibility, feature-flag, cache, rate-limit, or telemetry documentation because those contracts are unchanged.
+- [x] 3.5 Run `npm run validate:docs` after the integration document and generated client public contract changes, and correct only documentation drift introduced by this change.
+
+## 4. Final Verification and Scope Audit
+
+- [x] 4.1 Run `npm exec nx affected --target=test --base=origin/development`, `npm exec nx affected --target=lint --base=origin/development`, `npm exec nx affected --target=typecheck --base=origin/development`, and `npm exec nx affected --target=build --base=origin/development` as the final affected-set verification.
+- [x] 4.2 Review the final diff against `specs/browser-timezone-forwarding/spec.md`: confirm the header is optional and request-local, both upstream generation paths are covered, invalid values fail before Core, timezone values are absent from logs/metrics/storage, no user-visible strings or feature gate were added, TypeScript source imports remain extensionless, and unrelated cleanup (including the dormant Chat Completions adapter refactor) is excluded.
+
+## 5. Temporary Header Diagnostics
+
+- [x] 5.1 Add a temporary debug-level dump of incoming completion request headers for #8442 verification, keeping authentication, cookie, CSRF, token, secret, and API-key values redacted and covering the redaction behavior with an integration test.
+- [x] 5.2 Remove the temporary header dump and its dedicated test after propagation is verified, then repeat the final lint/test checks so the no-timezone-in-logs requirement is restored before archive.

--- a/openspec/changes/archive/2026-08-25-identify-dial-client-user-agent/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-25-identify-dial-client-user-agent/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-25

--- a/openspec/changes/archive/2026-08-25-identify-dial-client-user-agent/design.md
+++ b/openspec/changes/archive/2026-08-25-identify-dial-client-user-agent/design.md
@@ -1,0 +1,82 @@
+## Context
+
+The BFF is the HTTP user agent for all server-to-server calls to DIAL Core. Today, `DialClientService` creates one `@epam/ai-dial-typescript-sdk` client with the runtime's default fetch implementation, so Undici supplies `User-Agent: node`. The SDK accepts a custom `fetch` function, while three current Core integrations use raw fetch because their operations are SDK gaps: rating (`apps/chat-api/src/rate/rate.service.ts:31`), Scheduler routes (`apps/chat-api/src/scheduled-tasks/scheduled-tasks.service.ts:216`), and streaming file upload (`apps/chat-api/src/files/upload/files-upload.service.ts:562`).
+
+The application already has a single version precedence rule in `resolveAppVersion`: a non-blank `CHAT_VERSION` wins, otherwise the bundled `apps/chat-api/package.json` version is used. The displayed and health-check version may contain operator-authored text, but an HTTP product version must be normalized to a conservative token before being placed in a header.
+
+This is outbound operational metadata. There is no new inbound endpoint, authorization rule, rate limit, cache, feature flag, browser state, UI, i18n, RTL, accessibility, or generated-client surface.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Identify every DIAL Core request from this BFF as `ai-dial-chat/<normalized-version>`.
+- Keep SDK-backed and raw Core requests consistent.
+- Preserve every caller-provided header and request option except an attempted per-call User-Agent override.
+- Reuse the deployed application version without restricting the existing display-version configuration.
+- Keep the identification implementation at the `apps/chat-api` integration edge.
+
+**Non-Goals:**
+
+- Identifying the end user's browser, tenant, account, pod, hostname, Node.js runtime, or environment.
+- Creating a machine-enforced client identity or authentication mechanism.
+- Applying the Chat User-Agent to non-Core upstream requests.
+- Removing raw Core fetch escape hatches where the SDK still lacks an operation.
+- Changing any browser-facing API, OpenAPI document, generated client, UI, or library.
+
+## Decisions
+
+### 1. Use the standard product/version User-Agent form
+
+The canonical value is `ai-dial-chat/<normalized-version>`. `User-Agent` already represents the software making an HTTP request, and a product/version token is directly recognizable in access logs. The value will not include comments or secondary products such as the Node.js version because they create high-cardinality noise and disclose unnecessary runtime details.
+
+Alternative: custom `X-DIAL-CLIENT-NAME` and `X-DIAL-CLIENT-VERSION` fields. Those would be appropriate for a future DIAL-wide machine contract, but add a proprietary contract with no current consumer. This proposal is limited to diagnostics.
+
+### 2. Resolve the version once and normalize only the header representation
+
+`DialClientService` resolves the build version once during construction with `resolveAppVersion(configService.get('CHAT_VERSION', { infer: true }))`. For the User-Agent representation, runs of characters outside `A-Z`, `a-z`, `0-9`, `.`, `_`, and `-` are replaced with `-`; leading and trailing separators introduced by normalization are removed; an empty normalized result becomes `unknown`.
+
+The raw `CHAT_VERSION` remains unchanged for the health endpoint, client config, and footer. This avoids a breaking validation change for operators while guaranteeing that arbitrary configured text cannot inject control characters or produce an invalid header.
+
+Alternative: strengthen `CHAT_VERSION` validation globally. Rejected because that setting is also user-visible text and existing deployments may legitimately use characters that are unsuitable for an HTTP product token.
+
+### 3. Own a Core-only fetch transport in DialClientService
+
+`DialClientService` will expose a bound fetch-compatible function for DIAL Core requests. It will construct `Headers` from each request's existing headers, set the canonical `User-Agent` case-insensitively, and delegate to `globalThis.fetch` with every other option unchanged.
+
+The same function will be:
+
+1. passed to `createSDK({ baseUrl, fetch })`, covering all SDK operations; and
+2. called by rating, scheduled-task, and file-upload raw Core integrations.
+
+The wrapper deliberately overrides any caller-supplied User-Agent so all Core traffic has one identity. It does not inject authorization or other request-specific fields; those remain the responsibility of each operation.
+
+Alternative: configure a global Undici dispatcher or replace global fetch. Rejected because theme-service and other unrelated upstream requests would be mislabeled. Alternative: add the header at every call site. Rejected because it duplicates version logic and allows future SDK/raw operations to omit the identity.
+
+### 4. Verify behavior at the transport boundary and raw escape hatches
+
+`dial-client.service.spec.ts` will verify the SDK receives the shared fetch function and that invoking it produces the exact User-Agent for configured, fallback, and normalized versions while preserving existing headers. Existing service tests for rating, scheduled tasks, and file upload will assert that their raw Core request uses the shared transport rather than global fetch and retains operation-specific headers.
+
+No live-network integration test is required: the contract is fully observable at the fetch boundary, and existing domain tests already mock upstream calls.
+
+## Risks / Trade-offs
+
+- **[Risk] Core dashboards group by the full build version and create excess cardinality.** → Keep the value limited to the existing deployment version and do not add pod, tenant, or runtime dimensions; operators can aggregate by the `ai-dial-chat/` prefix.
+- **[Risk] A raw DIAL Core caller added later uses global fetch directly.** → Document `DialClientService` as the required Core transport and cover known escape hatches in the capability spec and code review checklist.
+- **[Risk] Header normalization makes two unusual version strings identical.** → Acceptable because User-Agent is diagnostic rather than a unique build identifier; the original version remains available through health/config endpoints.
+- **[Risk] A downstream intermediary rewrites User-Agent.** → Acceptable for diagnostic metadata. If Core requires reliable machine semantics later, introduce an explicit DIAL client-identity contract instead.
+- **[Trade-off] Passing a custom fetch function slightly expands DialClientService's public surface.** → This centralizes a cross-cutting outbound concern and is narrower than global fetch configuration or repeated headers.
+
+## Migration Plan
+
+1. Add version resolution, normalization, and the Core-only fetch transport to `DialClientService`.
+2. Pass that transport to the SDK and verify SDK behavior.
+3. Migrate each raw Core fetch escape hatch and verify its request headers.
+4. Update backend documentation and run project/documentation checks.
+5. Deploy normally; no data or frontend migration is required. DIAL Core logs begin showing the new value immediately.
+
+Rollback removes the injected transport from SDK construction and restores raw callers to global fetch. Requests then return to the runtime-supplied User-Agent without affecting persistence or public APIs.
+
+## Open Questions
+
+None. If DIAL Core later needs client identity for business logic rather than observability, that must be proposed as a separate cross-service contract instead of extending this User-Agent behavior.

--- a/openspec/changes/archive/2026-08-25-identify-dial-client-user-agent/proposal.md
+++ b/openspec/changes/archive/2026-08-25-identify-dial-client-user-agent/proposal.md
@@ -1,0 +1,63 @@
+## Why
+
+Outbound requests from the new Chat BFF currently inherit Undici's generic `User-Agent: node`, so DIAL Core logs cannot reliably distinguish AI DIAL Chat from other Node.js clients or identify the deployed Chat build. The shared DIAL transport should provide a stable, product-specific identifier without exposing tenant, host, or user information.
+
+## Problem
+
+`DialClientService` currently constructs the shared SDK with only `baseUrl` (`apps/chat-api/src/dial/dial-client.service.ts:26`), leaving the HTTP runtime to choose `User-Agent`. Several DIAL Core integrations also use raw `fetch`, so changing only the SDK headers would leave inconsistent identification across rating, scheduled-task, and file-upload requests.
+
+## Solution
+
+Route both SDK and raw DIAL Core requests through a shared transport owned by `DialClientService`. The transport will set `User-Agent: ai-dial-chat/<version>`, deriving the version through the existing `resolveAppVersion` precedence rule (`apps/chat-api/src/common/utils/app-version.ts:23`) and normalizing it to a safe HTTP product-version token.
+
+## What Changes
+
+- Add a product-specific `User-Agent` to every outbound request that `chat-api` sends to DIAL Core.
+- Reuse `CHAT_VERSION`, falling back to the bundled `apps/chat-api/package.json` version.
+- Normalize unsupported version characters for the header without changing the version displayed by the UI or health endpoint.
+- Use one DIAL Core fetch transport for the SDK and existing raw-fetch escape hatches.
+- Add transport and affected-service tests that verify the exact header while preserving existing request headers.
+- Update backend documentation for the outbound client identity.
+
+## Non-goals
+
+- No browser-to-BFF request or response contract changes.
+- No OpenAPI or generated frontend-client changes.
+- DIAL Core must not use `User-Agent` for authentication, authorization, routing, feature gating, or other business decisions.
+- The header will not include the Node.js version, hostname, environment, tenant, account, or user identifiers.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `dial-core-client`: identify AI DIAL Chat with a stable product/version User-Agent and apply it consistently through the shared SDK and raw DIAL Core transport.
+
+## Alternatives Considered
+
+- Keep Undici's `User-Agent: node`: rejected because it is runtime-dependent and does not identify the calling product.
+- Add custom `X-DIAL-CLIENT-NAME` and `X-DIAL-CLIENT-VERSION` headers: not selected because this change is diagnostic metadata, for which the standard `User-Agent` product/version format is sufficient. A dedicated DIAL contract remains appropriate if Core later needs machine-enforced client semantics.
+- Configure a process-global fetch or Undici dispatcher: rejected because it would also label unrelated upstream calls, such as theme-service requests, as DIAL Chat-to-Core traffic.
+
+## Acceptance Criteria
+
+- SDK-backed Chat-to-Core calls send `User-Agent: ai-dial-chat/<normalized-version>`.
+- Raw DIAL Core calls made by rating, scheduled tasks, and file upload send the identical header.
+- Existing Authorization, content negotiation, correlation, conversation, and client-channel headers remain unchanged.
+- `CHAT_VERSION` is preferred; blank or missing values use the bundled package version.
+- Arbitrary configured version text cannot produce an invalid HTTP header value.
+- Backend unit tests, lint, build, and documentation validation pass for the affected project; typecheck is run and the change introduces no new errors relative to the current branch baseline.
+
+## Compatibility and Rollback
+
+The change is backward-compatible because it only replaces an automatically generated outbound metadata value. Rollback consists of removing the shared User-Agent injection and returning raw DIAL requests to the runtime default; no persisted data, public endpoint, or frontend migration is involved.
+
+## Impact
+
+- Backend: `apps/chat-api/src/dial/dial-client.service.ts`, its tests, and raw DIAL Core callers in rating, scheduled tasks, and file upload.
+- Documentation/OpenSpec: `apps/chat-api/README.md` and the `dial-core-client` capability.
+- External observation: DIAL Core access logs will see `ai-dial-chat/<version>` instead of the Node runtime default.
+- Dependencies, frontend, libraries, OpenAPI, rate limiting, caching, i18n, RTL, and accessibility: no impact.

--- a/openspec/changes/archive/2026-08-25-identify-dial-client-user-agent/specs/dial-core-client/spec.md
+++ b/openspec/changes/archive/2026-08-25-identify-dial-client-user-agent/specs/dial-core-client/spec.md
@@ -1,10 +1,4 @@
-# dial-core-client Specification
-
-## Purpose
-
-A single shared DIAL Core SDK client service used by every chat-api domain.
-
-## Requirements
+## MODIFIED Requirements
 
 ### Requirement: Single shared DIAL Core SDK client
 The system SHALL create exactly one `@epam/ai-dial-typescript-sdk` client instance per process, owned by `DialClientService`, using `createSDK({ baseUrl, fetch })` where `baseUrl` is read from the `DIAL_CORE_URL` environment variable via `ConfigService<EnvironmentVariables>` with `{ infer: true }` and `fetch` is the shared DIAL Core transport owned by `DialClientService`.
@@ -20,6 +14,15 @@ The system SHALL create exactly one `@epam/ai-dial-typescript-sdk` client instan
 #### Scenario: SDK uses the shared Core transport
 - **WHEN** `DialClientService` constructs the SDK client
 - **THEN** it passes the same fetch-compatible transport that raw DIAL Core callers receive, so SDK and raw requests share the client identity behavior
+
+### Requirement: No behavior change to DIAL Core requests
+Except for cross-cutting transport behavior explicitly specified by this capability, replacing inheritance-based client access with injected `DialClientService` access SHALL NOT change the DIAL Core base URL, API version, operation-specific request headers, or any HTTP behavior observed by DIAL Core or by API consumers of `chat-api`.
+
+#### Scenario: Identical operation-specific requests before and after migration
+- **WHEN** any migrated service (e.g. `ModelsService.listModels`) issues the same logical request before and after the `DialClientService` migration
+- **THEN** the resulting DIAL Core HTTP request has the same URL, method, operation-specific headers, and body, while also carrying any shared transport headers required by this capability
+
+## ADDED Requirements
 
 ### Requirement: DIAL Core requests carry the Chat product identity
 Every outbound HTTP request from `chat-api` to DIAL Core SHALL include exactly one `User-Agent` field with the value `ai-dial-chat/<normalized-version>`. The value is diagnostic metadata only and MUST NOT contain a tenant, user, hostname, pod, environment, credential, or Node.js runtime identifier. This behavior SHALL NOT change any browser-facing API, OpenAPI operation, generated client, authorization rule, rate limit, cache, UI, or feature flag.
@@ -67,21 +70,3 @@ Any `chat-api` integration that calls a DIAL Core URL without an SDK operation M
 #### Scenario: Non-Core upstream remains unaffected
 - **WHEN** `ThemeService` fetches theme configuration or an icon from the configured theme service
 - **THEN** it does not use the DIAL Core transport and does not receive `User-Agent: ai-dial-chat/<normalized-version>` from this capability
-
-### Requirement: DialClientService exposes baseUrl and dialApiVersion
-`DialClientService` SHALL expose `baseUrl` (the raw `DIAL_CORE_URL` value) and `dialApiVersion` (the raw `DIAL_API_VERSION` value) as readonly members, in addition to `client`, so that services needing raw HTTP access or the `api-version` query parameter do not need their own `ConfigService` reads for these values.
-
-#### Scenario: Raw fetch escape hatch
-- **WHEN** `ApplicationsService` needs to call a DIAL Core endpoint not covered by the SDK (e.g. `/v1/bucket`)
-- **THEN** it builds the request URL using `dialClient.baseUrl` rather than reading `DIAL_CORE_URL` from `ConfigService` itself
-
-#### Scenario: Chat completion api-version parameter
-- **WHEN** `ChatService`, `TranscriptionService`, or `ConversationNamingService` issue a chat completion request
-- **THEN** they read `dialClient.dialApiVersion` for the `api-version` query parameter rather than reading `DIAL_API_VERSION` from `ConfigService` themselves
-
-### Requirement: No behavior change to DIAL Core requests
-Except for cross-cutting transport behavior explicitly specified by this capability, replacing inheritance-based client access with injected `DialClientService` access SHALL NOT change the DIAL Core base URL, API version, operation-specific request headers, or any HTTP behavior observed by DIAL Core or by API consumers of `chat-api`.
-
-#### Scenario: Identical operation-specific requests before and after migration
-- **WHEN** any migrated service (e.g. `ModelsService.listModels`) issues the same logical request before and after the `DialClientService` migration
-- **THEN** the resulting DIAL Core HTTP request has the same URL, method, operation-specific headers, and body, while also carrying any shared transport headers required by this capability

--- a/openspec/changes/archive/2026-08-25-identify-dial-client-user-agent/tasks.md
+++ b/openspec/changes/archive/2026-08-25-identify-dial-client-user-agent/tasks.md
@@ -1,0 +1,23 @@
+## 1. Shared DIAL Core transport
+
+- [x] 1.1 In `apps/chat-api/src/dial/dial-client.service.ts`, resolve `CHAT_VERSION` through `resolveAppVersion`, normalize it to the specified product-version representation, expose the canonical `ai-dial-chat/<version>` value without changing the existing public health/config version, and keep the `apps/chat-api/src/config/environment.config.ts` comment accurate for the new normalized outbound use.
+- [x] 1.2 In `apps/chat-api/src/dial/dial-client.service.ts`, implement a fetch-compatible Core-only transport that merges existing `HeadersInit`, replaces any User-Agent casing with the canonical value, preserves all other request options, and delegates to `globalThis.fetch`.
+- [x] 1.3 Pass the shared transport to `createSDK({ baseUrl, fetch })` so the single SDK client applies the identity to every SDK-backed DIAL Core request.
+- [x] 1.4 Extend `apps/chat-api/src/dial/tests/dial-client.service.spec.ts` with configured-version, package fallback, normalization, empty-normalization fallback, header preservation, and User-Agent override scenarios; verify the SDK receives the same shared transport.
+- [x] 1.5 Run `npm exec nx test chat-api`, `npm exec nx lint chat-api`, and `npm exec nx build chat-api` after the shared transport slice.
+
+## 2. Raw DIAL Core escape hatches
+
+- [x] 2.1 Replace the global fetch call in `apps/chat-api/src/rate/rate.service.ts` with the shared `DialClientService` transport while preserving the current Authorization and Content-Type headers; the shared transport must also preserve X-CONVERSATION-ID when the separate conversation-header change is present.
+- [x] 2.2 Replace the DIAL Core Scheduler fetch call in `apps/chat-api/src/scheduled-tasks/scheduled-tasks.service.ts` with the shared transport while preserving its authentication, body, cancellation, and error behavior.
+- [x] 2.3 Replace the streaming DIAL Core upload fetch call in `apps/chat-api/src/files/upload/files-upload.service.ts` with the shared transport while preserving duplex/stream, authentication, content, cancellation, and progress behavior.
+- [x] 2.4 Update `apps/chat-api/src/rate/tests/rate.service.spec.ts`, `apps/chat-api/src/scheduled-tasks/tests/scheduled-tasks.service.spec.ts`, and `apps/chat-api/src/files/tests/upload/files-upload.service.spec.ts` to verify each escape hatch uses the shared transport with its existing operation-specific headers and options.
+- [x] 2.5 Search `apps/chat-api/src` for remaining raw fetch calls to DIAL Core; migrate any missed Core caller to `DialClientService` and confirm non-Core callers such as `ThemeService` remain on their own transport.
+- [x] 2.6 Run `npm exec nx test chat-api`, `npm exec nx lint chat-api`, and `npm exec nx build chat-api` after the raw-call migration slice.
+
+## 3. Documentation and final verification
+
+- [x] 3.1 Update `apps/chat-api/README.md` to document the outbound `User-Agent: ai-dial-chat/<normalized-version>`, its `CHAT_VERSION`/package fallback, normalization, diagnostic-only semantics, and coverage of SDK plus raw DIAL Core requests.
+- [x] 3.2 Run `npm run validate:docs` after the README change; no OpenAPI generation is required because no browser-facing endpoint or DTO changes.
+- [x] 3.3 Run final `npm exec nx test chat-api`, `npm exec nx lint chat-api`, `npm exec nx build chat-api`, and `npm exec nx typecheck chat-api`; if the repository baseline still has unrelated typecheck failures, record them and verify no changed file introduces a new error.
+- [x] 3.4 Run `openspec validate identify-dial-client-user-agent --type change --strict --no-interactive` and `git diff --check`, then review the diff for accidental public API, non-Core transport, dependency, library, i18n, UI, or OpenAPI changes.

--- a/openspec/specs/browser-timezone-forwarding/spec.md
+++ b/openspec/specs/browser-timezone-forwarding/spec.md
@@ -1,0 +1,135 @@
+# browser-timezone-forwarding Specification
+
+## Purpose
+Define how the Chat frontend attaches the current browser timezone to completion requests and how the BFF validates and forwards it to DIAL Core without changing existing completion behavior.
+
+## Requirements
+### Requirement: Browser timezone is attached to conversation completion requests
+
+Immediately before starting a normal conversation completion, the Chat frontend SHALL resolve the current browser timezone through `Intl.DateTimeFormat().resolvedOptions().timeZone`. When resolution returns a non-empty string, the app-owned transport SHALL send that value in the `X-Timezone` request header to `POST /api/v1/conversations/completions`. The timezone SHALL be resolved per request and SHALL NOT be stored in a React context, hook, hand-authored library, browser storage, or user configuration.
+
+#### Scenario: Browser supplies a timezone
+
+- **WHEN** the browser resolves the current timezone as `Europe/Warsaw` and a user starts a conversation completion
+- **THEN** the request to `POST /api/v1/conversations/completions` contains `X-Timezone: Europe/Warsaw`
+
+#### Scenario: System timezone changes in a long-lived tab
+
+- **WHEN** two completion requests in the same tab resolve different current timezone values
+- **THEN** each request contains the value resolved immediately before that request, without requiring a reload
+
+#### Scenario: Browser timezone is unavailable
+
+- **WHEN** timezone resolution throws, returns an empty value, or returns no value
+- **THEN** the frontend omits `X-Timezone` and starts the completion normally
+
+#### Scenario: App preview uses the same behavior
+
+- **WHEN** a completion is started from app preview through the shared app-owned conversation stream transport
+- **THEN** timezone detection and conditional header emission match the main conversation flow
+
+### Requirement: Completion endpoint validates the optional timezone header
+
+The existing authenticated business endpoint `POST /api/v1/conversations/completions` SHALL accept one optional `X-Timezone` header. An accepted value MUST be a single string no longer than 255 characters, MUST consist only of IANA-name-safe path segments using ASCII letters, digits, `.`, `_`, `+`, and `-` separated by single `/` characters, and MUST be accepted as a timezone by the backend JavaScript `Intl.DateTimeFormat` implementation. The BFF SHALL pass an accepted value onward unchanged and SHALL NOT trim, canonicalize, persist, cache, or log it. A missing header SHALL remain valid; a present invalid value SHALL return `400 Bad Request` before DIAL Core is called.
+
+The endpoint contract remains:
+
+```http
+POST /api/v1/conversations/completions
+Content-Type: application/json
+X-CSRF-Token: <session-csrf-token>
+X-Timezone: Europe/Warsaw
+
+{
+  "generationId": "cfeaf733-4ecd-4898-ad3b-d6835c0b5fc8",
+  "path": "gpt-4o__Calendar__cfeaf733-4ecd-4898-ad3b-d6835c0b5fc8",
+  "model": "gpt-4o",
+  "mode": "append",
+  "message": "What is on my calendar tomorrow?"
+}
+```
+
+A successful response remains the existing SSE stream, for example:
+
+```text
+data: {"id":"cfeaf733-4ecd-4898-ad3b-d6835c0b5fc8","object":"chat.completion.chunk","choices":[{"delta":{"content":"You have..."}}]}
+
+data: [DONE]
+```
+
+The existing response statuses remain `200` (SSE), `400`, `401`, `403`, `404`, `409`, `429`, `502`, and `503`; this change adds invalid timezone input as another `400` case. Authentication remains the existing session/header-token authentication with no new role requirement, and the existing per-route limit of 100 requests per 60 seconds remains unchanged.
+
+#### Scenario: Valid IANA timezone is accepted
+
+- **WHEN** an authenticated completion request contains `X-Timezone: America/New_York` and a valid existing request body
+- **THEN** the endpoint starts the SSE completion and delegates `America/New_York` as the validated timezone
+
+#### Scenario: Missing timezone remains backward compatible
+
+- **WHEN** an otherwise valid completion request omits `X-Timezone`
+- **THEN** the endpoint starts the SSE completion with no timezone value
+
+#### Scenario: Invalid timezone syntax is rejected
+
+- **WHEN** `X-Timezone` contains whitespace, control characters, repeated separators, or characters outside the allowlist
+- **THEN** the endpoint returns `400 Bad Request` and does not call DIAL Core
+
+#### Scenario: Unknown timezone is rejected
+
+- **WHEN** `X-Timezone` is syntactically safe but is not accepted by the backend `Intl.DateTimeFormat` implementation
+- **THEN** the endpoint returns `400 Bad Request` and does not call DIAL Core
+
+#### Scenario: Oversized timezone is rejected
+
+- **WHEN** `X-Timezone` is longer than 255 characters
+- **THEN** the endpoint returns `400 Bad Request` and does not call DIAL Core
+
+#### Scenario: Multiple timezone header values are rejected
+
+- **WHEN** the request exposes `X-Timezone` as more than one header value
+- **THEN** the endpoint returns `400 Bad Request` and does not select or concatenate a value
+
+### Requirement: Validated timezone is forwarded through every generation API
+
+For a completion carrying a validated timezone, the BFF SHALL add `X-Timezone` with the unchanged value to the authenticated DIAL Core SDK request selected for that generation. This applies both to the active Chat Completions call and to the Responses API call. When the BFF receives no timezone, both upstream requests SHALL omit `X-Timezone`. Generation API selection, request bodies, SSE normalization, persistence, stopping, retries, and error handling SHALL otherwise remain unchanged. The timezone SHALL remain request-local and SHALL NOT be stored on a singleton SDK client or shared across requests.
+
+#### Scenario: Chat Completions request forwards timezone
+
+- **WHEN** the BFF selects Chat Completions for a request carrying validated timezone `Asia/Tokyo`
+- **THEN** `sendChatCompletionRequest` receives `X-Timezone: Asia/Tokyo` alongside the existing auth and stream headers
+
+#### Scenario: Responses request forwards timezone
+
+- **WHEN** the BFF selects Responses API for a request carrying validated timezone `Asia/Tokyo`
+- **THEN** `createResponse` receives `X-Timezone: Asia/Tokyo` alongside the existing auth and stream headers
+
+#### Scenario: Upstream header is omitted when client header is absent
+
+- **WHEN** a valid completion request omits `X-Timezone`
+- **THEN** the selected DIAL Core SDK request contains no `X-Timezone` header
+
+#### Scenario: Concurrent requests do not share timezone
+
+- **WHEN** two concurrent authenticated completions carry different valid timezone values
+- **THEN** each DIAL Core request receives only the timezone from its own BFF request
+
+### Requirement: OpenAPI and cross-cutting behavior remain compatible
+
+Swagger SHALL document `X-Timezone` as an optional header on operation ID / SDK method `streamCompletion`. OpenAPI regeneration SHALL add optional `xTimezone?: string` to `StreamCompletionRequest` while leaving `SendCompletionDto` and the SSE response contract unchanged. The frontend SHALL continue using the existing raw SSE transport rather than the normal or `Raw` generated method because the generated response abstraction does not expose the live stream required by the decoder.
+
+The capability SHALL introduce no user-visible strings, i18n keys, UI surface, keyboard interaction, ARIA contract, RTL/direction behavior, responsive layout, memoisation, `ENABLED_FEATURES` / `ENABLED_FEATURES_ROLES` gate, cache key/TTL/invalidation rule, new rate limit, metric, or analytics event. Existing generation metrics SHALL remain unchanged, and logs SHALL NOT contain the timezone value.
+
+#### Scenario: Generated client remains source compatible
+
+- **WHEN** OpenAPI artifacts are regenerated from the annotated completion endpoint
+- **THEN** `ConversationsApi.streamCompletion` accepts optional `xTimezone`, existing callers that provide only `sendCompletionDto` still type-check, and no generated file is hand-edited
+
+#### Scenario: No UI or product configuration is introduced
+
+- **WHEN** the timezone-forwarding capability is enabled by deploying the change
+- **THEN** users see no new control or text, no feature role is required, and no UI accessibility or direction behavior changes
+
+#### Scenario: Timezone is excluded from observability
+
+- **WHEN** a completion with `X-Timezone` succeeds or fails
+- **THEN** existing completion metrics may record their current generation attributes, but no log, metric, or analytics event records the timezone value


### PR DESCRIPTION
**Description:**

Forward the browser IANA timezone per completion through the BFF to both Chat Completions and Responses API so DIAL Core receives request-local `X-Timezone` metadata. Invalid values are rejected at the boundary, the generated OpenAPI contract is updated, and timezone values remain excluded from logs. The shared DIAL transport also identifies SDK and raw fetch traffic with a normalized `User-Agent: ai-dial-chat/<version>` value.

Issues:

- Issue #8442

**UI changes**

No UI changes.

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `feat(chat-api):`
- [x] the pull request name ends with `(Issue #8442)`
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs