### PR TITLE
fix(chat): revert Unpublish to Publish once a removal is approved (#8445)

### DIFF
--- a/apps/chat-api/src/conversations/constants/conversation.constants.ts
+++ b/apps/chat-api/src/conversations/constants/conversation.constants.ts
@@ -1,5 +1,8 @@
 export const PUBLIC_BUCKET = 'public';
 export const COMPOUND_TOKEN_PREFIX = 'ct1.';
 
-/** Max owned list items enriched with stored display names per list response. */
+/**
+ * Max list items enriched with stored display names per list response, applied
+ * per source group (owned items, and read-only ones — published or shared).
+ */
 export const MAX_LIST_DISPLAY_NAME_ENRICHMENTS = 20;

--- a/apps/chat-api/src/conversations/listing/conversation-listing.service.ts
+++ b/apps/chat-api/src/conversations/listing/conversation-listing.service.ts
@@ -27,10 +27,24 @@ import {
   encodeCompoundToken,
   getConversationTitleFromName,
   isApplicationDeploymentPath,
-  qualifySessionConversationPath,
   resolveListDisplayTitle,
 } from '../utils/conversation.utils';
 import { parseScheduledTaskConversationPath } from '../utils/parse-scheduled-task-conversation-path';
+
+/** Leading segment of every DIAL Core conversation resource id. */
+const CONVERSATION_RESOURCE_TYPE = 'conversations';
+
+/** True for a writable list item in the caller's own bucket. */
+const isOwned = (item: ConversationListItemDto): boolean =>
+  !item.isReadonly && !item.sharedWithMe && !item.publishedWithMe;
+
+/** The most recently updated slice of one source group's items. */
+const pickMostRecent = (
+  group: ConversationListItemDto[],
+): ConversationListItemDto[] =>
+  [...group]
+    .sort((left, right) => right.updatedAt - left.updatedAt)
+    .slice(0, MAX_LIST_DISPLAY_NAME_ENRICHMENTS);
 
 @Injectable()
 export class ConversationListingService {
@@ -299,33 +313,47 @@ export class ConversationListingService {
     }
   }
 
-  private getListItemRelativePath(itemId: string): string {
-    const decodedId = safeDecodeURIComponent(itemId);
-    const parts = decodedId.split('/');
-    if (parts.length >= 3 && parts[0] === 'conversations') {
-      return parts.slice(2).join('/');
+  /*
+   * Resolves the `{bucket}/{subPath}` storage path of a list item so its body
+   * is read from the bucket the item actually lives in: the caller's own
+   * bucket for owned items, `public` for published copies, another user's
+   * bucket for shared ones. DIAL Core returns ids as
+   * `conversations/{bucket}/{subPath}`; dropping only the resource-type
+   * segment keeps the bucket, which `resolveConversationLocation` (inside
+   * `getStoredConversation`) reads back off the path. An id that carries no
+   * bucket falls back to the session bucket there.
+   */
+  private getListItemStoragePath(itemId: string): string {
+    const segments = safeDecodeURIComponent(itemId).split('/').filter(Boolean);
+    if (segments[0] === CONVERSATION_RESOURCE_TYPE) {
+      segments.shift();
     }
-    if (parts.length >= 2) {
-      return parts.slice(1).join('/');
-    }
-    return decodedId;
+    return segments.join('/');
   }
 
+  /*
+   * A manual rename (and LLM naming) writes the new title into the
+   * conversation body's `name` at the unchanged storage path, so a
+   * filename-derived title can be stale for any item — including a published
+   * copy, whose public-bucket filename is taken from the source filename at
+   * publish time and never follows a later rename. Reading the body back is
+   * the only way to recover the authoritative name, so it is budgeted: the
+   * most recently updated items of each source group (owned, and read-only
+   * ones — published or shared) are enriched per group, so a long list of one
+   * kind cannot starve the other.
+   */
   private async enrichListItemsWithStoredDisplayNames(
     items: ConversationListItemDto[],
     token: string,
     bucket: string,
   ): Promise<ConversationListItemDto[]> {
-    const enrichable = items.filter(
-      (item) => !item.isReadonly && !item.sharedWithMe && !item.publishedWithMe,
-    );
-    if (enrichable.length === 0) {
+    const candidates = [
+      ...pickMostRecent(items.filter(isOwned)),
+      ...pickMostRecent(items.filter((item) => !isOwned(item))),
+    ];
+    if (candidates.length === 0) {
       return items;
     }
-
-    const candidates = [...enrichable]
-      .sort((left, right) => right.updatedAt - left.updatedAt)
-      .slice(0, MAX_LIST_DISPLAY_NAME_ENRICHMENTS);
 
     const displayNameById = new Map<string, string>();
     const batchSize = 25;
@@ -337,10 +365,7 @@ export class ConversationListingService {
           try {
             const conversation =
               await this.persistenceService.getStoredConversation(
-                qualifySessionConversationPath(
-                  this.getListItemRelativePath(item.id),
-                  bucket,
-                ),
+                this.getListItemStoragePath(item.id),
                 token,
                 bucket,
               );

--- a/apps/chat-api/src/conversations/listing/tests/conversation-listing.service.spec.ts
+++ b/apps/chat-api/src/conversations/listing/tests/conversation-listing.service.spec.ts
@@ -169,6 +169,129 @@ describe('ConversationListingService', () => {
       expect(getConversationSpy).toHaveBeenCalledTimes(20);
     });
 
+    it('enriches display names per source group so published copies do not starve owned items', async () => {
+      const buildItems = (bucket: string, count: number) =>
+        Array.from({ length: count }, (_, index) => ({
+          url: `conversations/${bucket}/conv-${index}`,
+          nodeType: 'FILE' as const,
+          updatedAt: index,
+          permissions: ['READ', 'WRITE'],
+        }));
+      mockMetadata(buildItems('test-bucket', 25), buildItems('public', 25));
+      const getConversationSpy = vi
+        .spyOn(service['dialClient'].client, 'getConversation')
+        .mockResolvedValue({
+          data: { name: 'Stored display title' },
+        } as never);
+
+      await service.listConversations('test-token', 'test-bucket');
+
+      expect(getConversationSpy).toHaveBeenCalledTimes(40);
+      expect(getConversationSpy).toHaveBeenCalledWith(
+        'test-bucket',
+        'conv-24',
+        expect.anything(),
+      );
+      expect(getConversationSpy).toHaveBeenCalledWith(
+        'public',
+        'conv-24',
+        expect.anything(),
+      );
+    });
+
+    it("shows a published copy's renamed title, not the filename it was published under", async () => {
+      mockMetadata(
+        [],
+        [
+          {
+            url: 'conversations/public/folder/gpt-4o__Original name',
+            nodeType: 'FILE',
+            name: 'gpt-4o__Original name',
+            parentPath: 'folder',
+            updatedAt: 1000,
+          },
+        ],
+      );
+      const getConversationSpy = vi
+        .spyOn(service['dialClient'].client, 'getConversation')
+        .mockResolvedValue({
+          data: { name: 'Renamed by the author', llmNamingDone: true },
+        } as never);
+
+      const result = await service.listConversations(
+        'test-token',
+        'test-bucket',
+      );
+
+      expect(result.items[0].title).toBe('Renamed by the author');
+      /* Read from the public bucket the copy lives in, not the session bucket. */
+      expect(getConversationSpy).toHaveBeenCalledWith(
+        'public',
+        'folder/gpt-4o__Original%20name',
+        expect.anything(),
+      );
+    });
+
+    it("reads a shared conversation's stored display name from the owner's bucket", async () => {
+      mockMetadata([]);
+      vi.spyOn(
+        service['dialClient'].client,
+        'getSharedResources',
+      ).mockResolvedValue({
+        data: {
+          resources: [
+            {
+              url: 'conversations/other-bucket/gpt-4o__Original name',
+              nodeType: 'FILE',
+              name: 'gpt-4o__Original name',
+            },
+          ],
+        },
+      } as never);
+      const getConversationSpy = vi
+        .spyOn(service['dialClient'].client, 'getConversation')
+        .mockResolvedValue({
+          data: { name: 'Renamed by the owner', llmNamingDone: true },
+        } as never);
+
+      const result = await service.listConversations(
+        'test-token',
+        'test-bucket',
+      );
+
+      expect(result.items[0].title).toBe('Renamed by the owner');
+      expect(getConversationSpy).toHaveBeenCalledWith(
+        'other-bucket',
+        'gpt-4o__Original%20name',
+        expect.anything(),
+      );
+    });
+
+    it('keeps the filename-derived title of a published copy whose body cannot be read', async () => {
+      mockMetadata(
+        [],
+        [
+          {
+            url: 'conversations/public/gpt-4o__Original name',
+            nodeType: 'FILE',
+            name: 'gpt-4o__Original name',
+            updatedAt: 1000,
+          },
+        ],
+      );
+      vi.spyOn(
+        service['dialClient'].client,
+        'getConversation',
+      ).mockRejectedValue({ error: { status: 403 } } as never);
+
+      const result = await service.listConversations(
+        'test-token',
+        'test-bucket',
+      );
+
+      expect(result.items[0].title).toBe('Original name');
+    });
+
     it('does not mistake a bare-numeric title for a version suffix on a plain model deployment', async () => {
       mockMetadata([
         {

--- a/apps/chat-api/src/conversations/tests/conversation-unpublish.service.spec.ts
+++ b/apps/chat-api/src/conversations/tests/conversation-unpublish.service.spec.ts
@@ -264,3 +264,60 @@ describe('ConversationPublishService.getPublishHistory with pending removals', (
     ).resolves.toEqual([]);
   });
 });
+
+/*
+ * GH #8445. Core keeps the original ADD publication as APPROVED forever, so
+ * after an administrator approved an unpublish request the conversation's row
+ * menu went on offering Unpublish for a copy Core had already deleted.
+ */
+describe('ConversationPublishService.getPublishHistory with approved removals', () => {
+  const FOLDER = 'public/Organization/Shared chats/';
+
+  const publication = (action: string, createdAt: number) => ({
+    targetFolder: FOLDER,
+    createdAt,
+    status: 'APPROVED',
+    author: 'Test User',
+    resources: [{ action, sourceUrl: SOURCE_URL }],
+  });
+
+  const getHistory = async (publications: unknown[]) => {
+    const { service, dialClient, cacheManager } = makeService();
+    cacheManager.get.mockResolvedValue(undefined);
+    vi.spyOn(dialClient.client, 'getPublications').mockResolvedValue(
+      okResponse(publications),
+    );
+    return service.getPublishHistory(
+      'token-abc',
+      'bucket-123',
+      CONVERSATION_PATH,
+    );
+  };
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('drops the folder once the removal is APPROVED, so the menu offers Publish again', async () => {
+    await expect(
+      getHistory([
+        publication('ADD', 1_700_000_000_000),
+        publication('DELETE', 1_700_000_100_000),
+      ]),
+    ).resolves.toEqual([]);
+  });
+
+  it('lists the folder again after a re-publish that followed the approved removal', async () => {
+    const result = await getHistory([
+      publication('ADD', 1_700_000_000_000),
+      publication('DELETE', 1_700_000_100_000),
+      publication('ADD', 1_700_000_200_000),
+    ]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].folderPath).toBe('Organization/Shared chats');
+    expect(result[0].publishedAt).toBe(
+      new Date(1_700_000_200_000).toISOString(),
+    );
+  });
+});

--- a/apps/chat-api/src/publish/publication.util.ts
+++ b/apps/chat-api/src/publish/publication.util.ts
@@ -308,6 +308,17 @@ export const resolvePublicationsForSource = async <T extends PublicationLike>(
    * removal Core reports as approved is the more recent statement of what
    * exists, and offering Unpublish for a copy Core has deleted is the failure
    * this cancellation exists to prevent.
+   *
+   * The trade-off this makes deliberately: `+Infinity` also cancels an `ADD`
+   * created *after* the removal, so an undateable removal hides Unpublish for
+   * a genuine re-publish and offers a Publish that Core rejects because the
+   * target already exists. Both outcomes are one wrong menu entry, and this
+   * one is recoverable (the panel lists the folder, the error names the
+   * conflict) while the other leaves a request that can never succeed. Core
+   * stamps every publication, so the fallback only fires on a response that
+   * omitted `createdAt` — logged below rather than applied silently, and
+   * pinned by "cancels a later ADD when the approved removal cannot be dated"
+   * in `publication.util.spec.ts`.
    */
   const removedAtByFolder = new Map<string, number>();
   for (const publication of referencing) {
@@ -322,6 +333,13 @@ export const resolvePublicationsForSource = async <T extends PublicationLike>(
       publication.createdAt,
       Number.POSITIVE_INFINITY,
     );
+    if (!Number.isFinite(removedAt)) {
+      logger?.warn(
+        `Approved removal "${publication.url ?? '(no url)'}" carries no usable createdAt${
+          context ? ` for ${context}` : ''
+        } — cancelling every ADD in "${folderKey}", a re-publish included`,
+      );
+    }
     removedAtByFolder.set(
       folderKey,
       Math.max(

--- a/apps/chat-api/src/publish/publication.util.ts
+++ b/apps/chat-api/src/publish/publication.util.ts
@@ -65,6 +65,8 @@ interface PublicationResourceLike {
 export interface PublicationLike {
   url?: string;
   status?: string;
+  targetFolder?: string;
+  createdAt?: number | string;
   resources?: PublicationResourceLike[];
 }
 
@@ -98,28 +100,120 @@ const isSameResourceUrl = (
 };
 
 /**
+ * The action a publication applies to `sourceUrl`, or `null` when the
+ * publication does not reference it at all.
+ *
+ * A resource with no `action` reads as `ADD` — Core's own default, and a
+ * publication that lists a resource without one is publishing it. A
+ * publication that both adds and removes the same source (Core has no such
+ * flow, but the shape allows it) reports the publishing action, preserving
+ * `publishesSource`'s original behaviour of matching *any* non-`DELETE`
+ * resource.
+ */
+export const getPublicationSourceAction = (
+  publication: PublicationLike,
+  sourceUrl: string,
+): PublicationResourceAction | null => {
+  const resources =
+    publication.resources?.filter((resource) =>
+      isSameResourceUrl(resource.sourceUrl, sourceUrl),
+    ) ?? [];
+  if (resources.length === 0) {
+    return null;
+  }
+  const publishing = resources.find(
+    (resource) => resource.action !== PublicationResourceAction.Delete,
+  );
+  return publishing
+    ? ((publishing.action as PublicationResourceAction | undefined) ??
+        PublicationResourceAction.Add)
+    : PublicationResourceAction.Delete;
+};
+
+/**
  * Whether `publication` publishes `sourceUrl`.
  *
- * A `DELETE` resource is a pending removal request submitted by an unpublish
- * endpoint, not a publication of the resource: counting it would list the
- * folder twice — once for the original `ADD`, once for the pending `DELETE` —
- * and would read as a second publish. Until an administrator approves the
- * removal the resource genuinely is still published there, so the folder stays,
- * sourced from its `ADD` publication.
+ * A `DELETE` resource is a removal request submitted by an unpublish endpoint,
+ * not a publication of the resource: counting it would list the folder twice —
+ * once for the original `ADD`, once for the `DELETE` — and would read as a
+ * second publish. While the removal is still `PENDING` the resource genuinely
+ * is published there, so the folder stays, sourced from its `ADD` publication.
+ * Once the removal is `APPROVED` that `ADD` is cancelled out too — see
+ * `resolvePublicationsForSource`.
  */
 export const publishesSource = (
   publication: PublicationLike,
   sourceUrl: string,
-): boolean =>
-  publication.resources?.some(
-    (resource) =>
-      isSameResourceUrl(resource.sourceUrl, sourceUrl) &&
-      resource.action !== PublicationResourceAction.Delete,
-  ) ?? false;
+): boolean => {
+  const action = getPublicationSourceAction(publication, sourceUrl);
+  return action != null && action !== PublicationResourceAction.Delete;
+};
 
 /**
- * Narrows a bucket-wide publication list to the publications that publish
- * `sourceUrl`, re-fetching each candidate's full record.
+ * Whether `publication` requests the removal of `sourceUrl`.
+ *
+ * Says nothing about whether the removal has happened — that is `status`.
+ */
+export const removesSource = (
+  publication: PublicationLike,
+  sourceUrl: string,
+): boolean =>
+  getPublicationSourceAction(publication, sourceUrl) ===
+  PublicationResourceAction.Delete;
+
+/*
+ * Whether a publication is worth a detail lookup. A missing `status` counts
+ * as a candidate: the only publications that must be skipped are the ones
+ * Core positively reports as `PENDING` or `REJECTED`.
+ */
+const isDetailCandidate = (status: string | undefined): boolean =>
+  status == null || status === PublicationStatus.Approved;
+
+/*
+ * Whether a removal has actually taken effect, which requires Core to say so
+ * outright — deliberately stricter than `isDetailCandidate`. Cancelling an
+ * `ADD` on an *assumed* approval is the more expensive mistake: it would hide
+ * Unpublish for a copy that is still live, and offer a Publish that Core then
+ * rejects because the target already exists.
+ */
+const isApprovedRemoval = (status: string | undefined): boolean =>
+  status === PublicationStatus.Approved;
+
+/*
+ * `Publication.createdAt` is epoch milliseconds in Core's schema, but the SDK
+ * types it loosely and both publish services already tolerate a date string,
+ * so both are accepted. An undateable publication falls back to the caller's
+ * value, which is what decides which side of an ambiguity wins — see the
+ * ordering comment in `resolvePublicationsForSource`.
+ */
+const toPublicationTime = (
+  createdAt: number | string | undefined,
+  fallback: number,
+): number => {
+  if (typeof createdAt === 'number') {
+    return Number.isNaN(createdAt) ? fallback : createdAt;
+  }
+  if (typeof createdAt === 'string') {
+    const parsed = Date.parse(createdAt);
+    return Number.isNaN(parsed) ? fallback : parsed;
+  }
+  return fallback;
+};
+
+/**
+ * Normalizes `Publication.targetFolder` into a comparable identity for the
+ * published copy's folder: Core echoes it percent-encoded and always
+ * trailing-slashed (`public/New%20Folder/`), and an `ADD` whose folder was
+ * built from plain text must compare equal to the `DELETE` that removes it.
+ */
+const toTargetFolderKey = (targetFolder: string | undefined): string => {
+  const decoded = safeDecodeURIComponent(targetFolder ?? '');
+  return decoded.endsWith('/') ? decoded.slice(0, -1) : decoded;
+};
+
+/**
+ * Narrows a bucket-wide publication list to the publications the resource is
+ * *currently* published by, re-fetching each candidate's full record.
  *
  * `getPublications` returns publication **metadata** only — `url`, `status`,
  * `targetFolder`, `createdAt`, `author` — and no `resources` array. Filtering
@@ -135,6 +229,21 @@ export const publishesSource = (
  * describes a folder the resource is published to — and skipping them is what
  * keeps the number of detail lookups proportional to real publications.
  *
+ * **An approved removal cancels the publication it removed.** Core keeps the
+ * original `ADD` publication in the bucket as `APPROVED` forever — it is an
+ * audit record, not live state — so the `ADD` on its own kept claiming the
+ * folder was published after an administrator had approved the unpublish
+ * request. That is
+ * [GH #8445](https://github.com/epam/ai-dial-chat/issues/8445): the action menu
+ * went on offering Unpublish for a copy Core had already deleted, and acting on
+ * it failed with "Target resource does not exists". So an `APPROVED` `DELETE`
+ * drops every `ADD` for the same target folder created at or before it, while
+ * an `ADD` created *after* it survives — that is the publish → unpublish →
+ * publish-again sequence, and comparing `createdAt` is what keeps the
+ * re-publish visible. Only a removal Core labels `APPROVED` outright cancels
+ * anything — a `PENDING` one changes nothing, because the copy is live until it
+ * is approved, and neither does one whose status Core did not report.
+ *
  * A publication that already carries `resources` is matched without a round
  * trip, so a Core (or SDK mock) that does embed them costs nothing extra.
  *
@@ -149,20 +258,15 @@ export const resolvePublicationsForSource = async <T extends PublicationLike>(
   logger?: Logger,
   context?: string,
 ): Promise<T[]> => {
-  const matched: (T | null)[] = publications.map(() => null);
+  const resolved: (T | null)[] = publications.map(() => null);
   const candidates: { index: number; url: string }[] = [];
 
   publications.forEach((publication, index) => {
     if (publication.resources != null) {
-      matched[index] = publishesSource(publication, sourceUrl)
-        ? publication
-        : null;
+      resolved[index] = publication;
       return;
     }
-    if (
-      publication.status != null &&
-      publication.status !== PublicationStatus.Approved
-    ) {
+    if (!isDetailCandidate(publication.status)) {
       return;
     }
     if (!publication.url) {
@@ -188,11 +292,61 @@ export const resolvePublicationsForSource = async <T extends PublicationLike>(
       batch.map((candidate) => fetchPublication(candidate.url)),
     );
     details.forEach((detail, offset) => {
-      if (detail != null && publishesSource(detail, sourceUrl)) {
-        matched[batch[offset].index] = detail;
+      if (detail != null) {
+        resolved[batch[offset].index] = detail;
       }
     });
   }
 
-  return matched.filter((publication): publication is T => publication != null);
+  const referencing = resolved.filter(
+    (publication): publication is T => publication != null,
+  );
+
+  /*
+   * An undateable approved removal wins over everything in its folder
+   * (`+Infinity`) and an undateable `ADD` loses to any removal (`0`): a
+   * removal Core reports as approved is the more recent statement of what
+   * exists, and offering Unpublish for a copy Core has deleted is the failure
+   * this cancellation exists to prevent.
+   */
+  const removedAtByFolder = new Map<string, number>();
+  for (const publication of referencing) {
+    if (
+      !removesSource(publication, sourceUrl) ||
+      !isApprovedRemoval(publication.status)
+    ) {
+      continue;
+    }
+    const folderKey = toTargetFolderKey(publication.targetFolder);
+    const removedAt = toPublicationTime(
+      publication.createdAt,
+      Number.POSITIVE_INFINITY,
+    );
+    removedAtByFolder.set(
+      folderKey,
+      Math.max(
+        removedAtByFolder.get(folderKey) ?? Number.NEGATIVE_INFINITY,
+        removedAt,
+      ),
+    );
+  }
+
+  if (removedAtByFolder.size > 0) {
+    logger?.debug(
+      `Applying ${removedAtByFolder.size} approved removal folder(s)${context ? ` for ${context}` : ''}`,
+    );
+  }
+
+  return referencing.filter((publication) => {
+    if (!publishesSource(publication, sourceUrl)) {
+      return false;
+    }
+    const removedAt = removedAtByFolder.get(
+      toTargetFolderKey(publication.targetFolder),
+    );
+    if (removedAt == null) {
+      return true;
+    }
+    return toPublicationTime(publication.createdAt, 0) > removedAt;
+  });
 };

--- a/apps/chat-api/src/publish/tests/publication.util.spec.ts
+++ b/apps/chat-api/src/publish/tests/publication.util.spec.ts
@@ -1,9 +1,11 @@
 import { Logger } from '@nestjs/common';
 import { describe, expect, it, vi } from 'vitest';
 import {
+  getPublicationSourceAction,
   PublicationResourceAction,
   PublicationStatus,
   publishesSource,
+  removesSource,
   resolvePublicationsForSource,
   toPublicationList,
 } from '../publication.util';
@@ -65,6 +67,7 @@ interface ListedPublication {
   url?: string;
   status?: string;
   targetFolder?: string;
+  createdAt?: number | string;
   resources?: { action?: string; sourceUrl?: string }[];
 }
 
@@ -129,6 +132,97 @@ describe('publishesSource', () => {
 
   it('does not match a publication with no resources', () => {
     expect(publishesSource(listed('publications/b/1'), SOURCE_URL)).toBe(false);
+  });
+});
+
+describe('getPublicationSourceAction', () => {
+  it('returns null when the publication does not reference the source', () => {
+    expect(
+      getPublicationSourceAction(listed('publications/b/1'), SOURCE_URL),
+    ).toBeNull();
+  });
+
+  it('reports ADD and DELETE for the referenced source', () => {
+    expect(
+      getPublicationSourceAction(
+        detailed('publications/b/1', SOURCE_URL),
+        SOURCE_URL,
+      ),
+    ).toBe(PublicationResourceAction.Add);
+    expect(
+      getPublicationSourceAction(
+        detailed(
+          'publications/b/1',
+          SOURCE_URL,
+          PublicationResourceAction.Delete,
+        ),
+        SOURCE_URL,
+      ),
+    ).toBe(PublicationResourceAction.Delete);
+  });
+
+  /* Core's own default, so a resource that omits `action` is publishing. */
+  it('treats a resource with no action as ADD', () => {
+    expect(
+      getPublicationSourceAction(
+        {
+          ...listed('publications/b/1'),
+          resources: [{ sourceUrl: SOURCE_URL }],
+        },
+        SOURCE_URL,
+      ),
+    ).toBe(PublicationResourceAction.Add);
+  });
+
+  it('reports ADD_IF_ABSENT as itself, and as publishing', () => {
+    const publication = detailed(
+      'publications/b/1',
+      SOURCE_URL,
+      PublicationResourceAction.AddIfAbsent,
+    );
+
+    expect(getPublicationSourceAction(publication, SOURCE_URL)).toBe(
+      PublicationResourceAction.AddIfAbsent,
+    );
+    expect(publishesSource(publication, SOURCE_URL)).toBe(true);
+    expect(removesSource(publication, SOURCE_URL)).toBe(false);
+  });
+});
+
+describe('removesSource', () => {
+  it('matches only a DELETE resource for the source url', () => {
+    expect(
+      removesSource(
+        detailed(
+          'publications/b/1',
+          SOURCE_URL,
+          PublicationResourceAction.Delete,
+        ),
+        SOURCE_URL,
+      ),
+    ).toBe(true);
+    expect(
+      removesSource(detailed('publications/b/1', SOURCE_URL), SOURCE_URL),
+    ).toBe(false);
+    expect(removesSource(listed('publications/b/1'), SOURCE_URL)).toBe(false);
+  });
+
+  /* Whether the removal has happened is `status`, not the action. */
+  it('matches a DELETE regardless of status', () => {
+    expect(
+      removesSource(
+        {
+          ...listed('publications/b/1', PublicationStatus.Pending),
+          resources: [
+            {
+              action: PublicationResourceAction.Delete,
+              sourceUrl: SOURCE_URL,
+            },
+          ],
+        },
+        SOURCE_URL,
+      ),
+    ).toBe(true);
   });
 });
 
@@ -256,5 +350,237 @@ describe('resolvePublicationsForSource', () => {
 
     expect(matched).toEqual([detailed('publications/b/42', SOURCE_URL)]);
     expect(peakInFlight).toBeLessThanOrEqual(8);
+  });
+});
+
+const FOLDER = 'public/folder/';
+
+/** An `APPROVED` publication carrying one resource for `SOURCE_URL`. */
+const approved = (
+  url: string,
+  action: PublicationResourceAction,
+  createdAt: number | string | undefined,
+  targetFolder = FOLDER,
+): ListedPublication => ({
+  url,
+  status: PublicationStatus.Approved,
+  targetFolder,
+  createdAt,
+  resources: [{ action, sourceUrl: SOURCE_URL }],
+});
+
+/*
+ * GH #8445. Core never retracts the original `ADD` publication — it stays
+ * `APPROVED` as an audit record — so once an administrator approved an
+ * unpublish request the folder still looked published, the action menu went on
+ * offering Unpublish, and acting on it failed with "Target resource does not
+ * exists".
+ */
+describe('resolvePublicationsForSource, approved removals', () => {
+  const resolve = (publications: ListedPublication[]) =>
+    resolvePublicationsForSource(
+      publications,
+      SOURCE_URL,
+      async () => null,
+      undefined,
+      'ctx',
+    );
+
+  it('drops the ADD once its removal is APPROVED', async () => {
+    expect(
+      await resolve([
+        approved('publications/b/1', PublicationResourceAction.Add, 1000),
+        approved('publications/b/2', PublicationResourceAction.Delete, 2000),
+      ]),
+    ).toEqual([]);
+  });
+
+  /* Until an admin approves, the published copy is still live. */
+  it('keeps the ADD while the removal is only PENDING', async () => {
+    const add = approved(
+      'publications/b/1',
+      PublicationResourceAction.Add,
+      1000,
+    );
+
+    expect(
+      await resolve([
+        add,
+        {
+          ...approved(
+            'publications/b/2',
+            PublicationResourceAction.Delete,
+            2000,
+          ),
+          status: PublicationStatus.Pending,
+        },
+      ]),
+    ).toEqual([add]);
+  });
+
+  /*
+   * Cancelling on an assumed approval is the more expensive mistake: it hides
+   * Unpublish for a copy that is still live and offers a Publish that Core
+   * rejects because the target already exists.
+   */
+  it('keeps the ADD when Core reported no status on the removal', async () => {
+    const add = approved(
+      'publications/b/1',
+      PublicationResourceAction.Add,
+      1000,
+    );
+    const removal = approved(
+      'publications/b/2',
+      PublicationResourceAction.Delete,
+      2000,
+    );
+    delete removal.status;
+
+    expect(await resolve([add, removal])).toEqual([add]);
+  });
+
+  it('keeps the ADD when the removal was REJECTED', async () => {
+    const add = approved(
+      'publications/b/1',
+      PublicationResourceAction.Add,
+      1000,
+    );
+
+    expect(
+      await resolve([
+        add,
+        {
+          ...approved(
+            'publications/b/2',
+            PublicationResourceAction.Delete,
+            2000,
+          ),
+          status: PublicationStatus.Rejected,
+        },
+      ]),
+    ).toEqual([add]);
+  });
+
+  /* publish → unpublish (approved) → publish again: the folder is published. */
+  it('keeps an ADD created after the approved removal', async () => {
+    const republished = approved(
+      'publications/b/3',
+      PublicationResourceAction.Add,
+      3000,
+    );
+
+    expect(
+      await resolve([
+        approved('publications/b/1', PublicationResourceAction.Add, 1000),
+        approved('publications/b/2', PublicationResourceAction.Delete, 2000),
+        republished,
+      ]),
+    ).toEqual([republished]);
+  });
+
+  it('cancels only the folder the removal targeted', async () => {
+    const otherFolder = approved(
+      'publications/b/3',
+      PublicationResourceAction.Add,
+      1000,
+      'public/reports/',
+    );
+
+    expect(
+      await resolve([
+        approved('publications/b/1', PublicationResourceAction.Add, 1000),
+        approved('publications/b/2', PublicationResourceAction.Delete, 2000),
+        otherFolder,
+      ]),
+    ).toEqual([otherFolder]);
+  });
+
+  /* Core echoes `targetFolder` percent-encoded; the ADD was built from plain text. */
+  it('matches the removal across a percent-encoding difference', async () => {
+    expect(
+      await resolve([
+        approved(
+          'publications/b/1',
+          PublicationResourceAction.Add,
+          1000,
+          'public/New Folder/',
+        ),
+        approved(
+          'publications/b/2',
+          PublicationResourceAction.Delete,
+          2000,
+          'public/New%20Folder/',
+        ),
+      ]),
+    ).toEqual([]);
+  });
+
+  it('accepts an ISO createdAt as well as epoch milliseconds', async () => {
+    expect(
+      await resolve([
+        approved(
+          'publications/b/1',
+          PublicationResourceAction.Add,
+          '2026-08-01T00:00:00.000Z',
+        ),
+        approved(
+          'publications/b/2',
+          PublicationResourceAction.Delete,
+          '2026-08-02T00:00:00.000Z',
+        ),
+      ]),
+    ).toEqual([]);
+  });
+
+  /*
+   * An approved removal that cannot be dated is the more recent statement of
+   * what exists: showing Unpublish for a copy Core has deleted is the failure
+   * being prevented.
+   */
+  it('lets an undateable approved removal cancel its folder', async () => {
+    expect(
+      await resolve([
+        approved('publications/b/1', PublicationResourceAction.Add, 1000),
+        approved(
+          'publications/b/2',
+          PublicationResourceAction.Delete,
+          undefined,
+        ),
+      ]),
+    ).toEqual([]);
+  });
+
+  it('never reports the removal publication itself as published', async () => {
+    expect(
+      await resolve([
+        approved('publications/b/2', PublicationResourceAction.Delete, 2000),
+      ]),
+    ).toEqual([]);
+  });
+
+  /* The real path: the list carries metadata only, details come from lookups. */
+  it('cancels across separately fetched detail records', async () => {
+    const details: Record<string, ListedPublication> = {
+      'publications/b/1': approved(
+        'publications/b/1',
+        PublicationResourceAction.Add,
+        1000,
+      ),
+      'publications/b/2': approved(
+        'publications/b/2',
+        PublicationResourceAction.Delete,
+        2000,
+      ),
+    };
+    const fetchPublication = vi.fn(async (url: string) => details[url] ?? null);
+
+    const matched = await resolvePublicationsForSource(
+      [listed('publications/b/1'), listed('publications/b/2')],
+      SOURCE_URL,
+      fetchPublication,
+    );
+
+    expect(fetchPublication).toHaveBeenCalledTimes(2);
+    expect(matched).toEqual([]);
   });
 });

--- a/apps/chat-api/src/publish/tests/publication.util.spec.ts
+++ b/apps/chat-api/src/publish/tests/publication.util.spec.ts
@@ -550,6 +550,50 @@ describe('resolvePublicationsForSource, approved removals', () => {
     ).toEqual([]);
   });
 
+  /*
+   * The trade-off the `+Infinity` fallback makes on purpose: with no date on
+   * the removal there is nothing to order it against, so it cancels the whole
+   * folder — a later re-publish included. Pinned because the alternative
+   * (letting the dateable ADD win) would offer Unpublish for a copy Core may
+   * already have deleted, the failure GH #8445 is about.
+   */
+  it('cancels a later ADD when the approved removal cannot be dated', async () => {
+    expect(
+      await resolve([
+        approved('publications/b/1', PublicationResourceAction.Add, 1000),
+        approved(
+          'publications/b/2',
+          PublicationResourceAction.Delete,
+          undefined,
+        ),
+        approved('publications/b/3', PublicationResourceAction.Add, 3000),
+      ]),
+    ).toEqual([]);
+  });
+
+  it('warns instead of silently cancelling when a removal cannot be dated', async () => {
+    const logger = { debug: vi.fn(), warn: vi.fn() };
+
+    await resolvePublicationsForSource(
+      [
+        approved('publications/b/1', PublicationResourceAction.Add, 1000),
+        approved(
+          'publications/b/2',
+          PublicationResourceAction.Delete,
+          undefined,
+        ),
+      ],
+      SOURCE_URL,
+      async () => null,
+      logger as never,
+      'ctx',
+    );
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('no usable createdAt'),
+    );
+  });
+
   it('never reports the removal publication itself as published', async () => {
     expect(
       await resolve([

--- a/apps/chat-api/src/publish/tests/unpublish.service.spec.ts
+++ b/apps/chat-api/src/publish/tests/unpublish.service.spec.ts
@@ -338,6 +338,103 @@ describe('PublishService.getPublishHistory with pending removals', () => {
   });
 });
 
+/*
+ * GH #8445. Core keeps the original ADD publication as APPROVED forever — it is
+ * an audit record, not live state — so after an administrator approved an
+ * unpublish request the folder still came back as published. The details panel
+ * derives Publish-vs-Unpublish from exactly this history, so the action menu
+ * went on offering Unpublish for a copy Core had already deleted, and acting on
+ * it failed with "Target resource does not exists".
+ */
+describe('PublishService.getPublishHistory with approved removals', () => {
+  const FOLDER = 'public/Organization/Data Science/';
+
+  const addPublication = (createdAt: number, targetFolder = FOLDER) => ({
+    targetFolder,
+    createdAt,
+    status: 'APPROVED',
+    author: 'user@example.com',
+    resources: [{ action: 'ADD', sourceUrl: TOOLSET_ID }],
+  });
+
+  const deletePublication = (createdAt: number, targetFolder = FOLDER) => ({
+    targetFolder,
+    createdAt,
+    status: 'APPROVED',
+    author: 'user@example.com',
+    resources: [{ action: 'DELETE', sourceUrl: TOOLSET_ID }],
+  });
+
+  const getHistory = async (publications: unknown[]) => {
+    const { service, dialClient, cacheManager } = makeService();
+    cacheManager.get.mockResolvedValue(undefined);
+    vi.spyOn(dialClient.client, 'getPublications').mockResolvedValue(
+      okResponse(publications),
+    );
+    return service.getPublishHistory(
+      'token-abc',
+      TEST_BUCKET,
+      CatalogEntityType.Toolset,
+      TOOLSET_ID,
+    );
+  };
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('drops the folder once the removal is APPROVED, so the menu offers Publish again', async () => {
+    await expect(
+      getHistory([
+        addPublication(1_700_000_000_000),
+        deletePublication(1_700_000_100_000),
+      ]),
+    ).resolves.toEqual([]);
+  });
+
+  it('lists the folder again after a re-publish that followed the approved removal', async () => {
+    const result = await getHistory([
+      addPublication(1_700_000_000_000),
+      deletePublication(1_700_000_100_000),
+      addPublication(1_700_000_200_000),
+    ]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].folderPath).toBe('Organization/Data Science');
+    expect(result[0].publishedAt).toBe(
+      new Date(1_700_000_200_000).toISOString(),
+    );
+  });
+
+  it('keeps the folders the removal did not target', async () => {
+    const result = await getHistory([
+      addPublication(1_700_000_000_000),
+      addPublication(1_700_000_000_000, 'public/Organization/Reports/'),
+      deletePublication(1_700_000_100_000),
+    ]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].folderPath).toBe('Organization/Reports');
+  });
+
+  /*
+   * The ADD's `targetFolder` was built from plain text, while Core echoes the
+   * removal's back percent-encoded — a strict comparison would leave the
+   * folder listed.
+   */
+  it('matches the removal across a percent-encoding difference', async () => {
+    await expect(
+      getHistory([
+        addPublication(1_700_000_000_000, 'public/Organization/Data Science/'),
+        deletePublication(
+          1_700_000_100_000,
+          'public/Organization/Data%20Science/',
+        ),
+      ]),
+    ).resolves.toEqual([]);
+  });
+});
+
 describe('PublishService.getPublishHistory list scope', () => {
   beforeEach(() => {
     vi.restoreAllMocks();

--- a/apps/chat/src/components/CatalogView/CatalogView.tsx
+++ b/apps/chat/src/components/CatalogView/CatalogView.tsx
@@ -1219,7 +1219,7 @@ const CatalogView: FC<Props> = ({
       } catch (error) {
         /* Notified here, then rethrown so the panel's own rejection path runs
          * — matching `handlePublish`, which lets the error reach the lib. */
-        showPublishError(error);
+        showPublishError(error, EntityOperation.UnpublishRequested);
         throw error;
       }
       notifyOperationSuccess(

--- a/apps/chat/src/components/ConversationPanel/ConversationPanelView.tsx
+++ b/apps/chat/src/components/ConversationPanel/ConversationPanelView.tsx
@@ -1005,7 +1005,7 @@ const ConversationPanelView: FC<ConversationPanelViewProps> = ({
     try {
       await unpublishConversation(path, folderPath.join('/'));
     } catch (error) {
-      showPublishError(error);
+      showPublishError(error, EntityOperation.UnpublishRequested);
       setIsUnpublishing(false);
       setPendingUnpublishConversation(null);
       setSelectedUnpublishFolder(null);

--- a/apps/chat/src/constants/translation-keys.ts
+++ b/apps/chat/src/constants/translation-keys.ts
@@ -677,6 +677,9 @@ export enum PublishI18nKeys {
   FailedTitle = 'publish.failedTitle',
   FailedMessage = 'publish.failedMessage',
   NetworkErrorMessage = 'publish.networkErrorMessage',
+  UnpublishFailedTitle = 'publish.unpublishFailedTitle',
+  UnpublishFailedMessage = 'publish.unpublishFailedMessage',
+  UnpublishNetworkErrorMessage = 'publish.unpublishNetworkErrorMessage',
   SubmitErrorCallout = 'publish.submitErrorCallout',
 }
 

--- a/apps/chat/src/hooks/publish/tests/usePublishErrorNotification.spec.ts
+++ b/apps/chat/src/hooks/publish/tests/usePublishErrorNotification.spec.ts
@@ -3,6 +3,7 @@ import { renderHook, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useNotification } from '../../../context/NotificationContext';
 import { createNotificationContextValue } from '../../../context/tests/notification-context-mock';
+import { EntityOperation } from '../../../types/entity-notification';
 import { usePublishErrorNotification } from '../usePublishErrorNotification';
 
 vi.mock('../../../context/NotificationContext');
@@ -113,5 +114,86 @@ describe('usePublishErrorNotification', () => {
     result.current(error);
 
     expect(console.error).toHaveBeenCalledWith('Publish request failed', error);
+  });
+
+  /*
+   * GH #8445: a failed Unpublish was reported as "Publish failed", which is
+   * what the user saw in the notification after clicking Unpublish.
+   */
+  describe('for an unpublish request', () => {
+    it('titles the notification after the operation that failed', async () => {
+      const { result } = renderHook(() => usePublishErrorNotification());
+
+      result.current(new Error('boom'), EntityOperation.UnpublishRequested);
+
+      await waitFor(() =>
+        expect(mockShowNotification).toHaveBeenCalledWith({
+          variant: NotificationVariant.Error,
+          title: 'publish.unpublishFailedTitle',
+          message: 'boom',
+          requestId: undefined,
+        }),
+      );
+    });
+
+    it('falls back to the unpublish-specific generic message', async () => {
+      const { result } = renderHook(() => usePublishErrorNotification());
+
+      result.current({}, EntityOperation.UnpublishRequested);
+
+      await waitFor(() =>
+        expect(mockShowNotification).toHaveBeenCalledWith({
+          variant: NotificationVariant.Error,
+          title: 'publish.unpublishFailedTitle',
+          message: 'publish.unpublishFailedMessage',
+          requestId: undefined,
+        }),
+      );
+    });
+
+    it('shows the unpublish-specific connection message while offline', async () => {
+      setOnLine(false);
+      const { result } = renderHook(() => usePublishErrorNotification());
+
+      result.current(
+        new TypeError('Failed to fetch'),
+        EntityOperation.UnpublishRequested,
+      );
+
+      await waitFor(() =>
+        expect(mockShowNotification).toHaveBeenCalledWith({
+          variant: NotificationVariant.Error,
+          title: 'publish.unpublishFailedTitle',
+          message: 'publish.unpublishNetworkErrorMessage',
+        }),
+      );
+    });
+
+    it('logs the operation that failed', () => {
+      const { result } = renderHook(() => usePublishErrorNotification());
+      const error = new Error('boom');
+
+      result.current(error, EntityOperation.UnpublishRequested);
+
+      expect(console.error).toHaveBeenCalledWith(
+        'Unpublish request failed',
+        error,
+      );
+    });
+  });
+
+  it('keeps the publish copy for any other operation', async () => {
+    const { result } = renderHook(() => usePublishErrorNotification());
+
+    result.current(new Error('boom'), EntityOperation.PublishRequested);
+
+    await waitFor(() =>
+      expect(mockShowNotification).toHaveBeenCalledWith({
+        variant: NotificationVariant.Error,
+        title: 'publish.failedTitle',
+        message: 'boom',
+        requestId: undefined,
+      }),
+    );
   });
 });

--- a/apps/chat/src/hooks/publish/usePublishErrorNotification.ts
+++ b/apps/chat/src/hooks/publish/usePublishErrorNotification.ts
@@ -3,21 +3,60 @@ import { useTranslation } from 'react-i18next';
 import { PublishI18nKeys } from '../../constants/translation-keys';
 import { useNotification } from '../../context/NotificationContext';
 import { getApiErrorDetails } from '../../server-api/api-error';
+import { EntityOperation } from '../../types/entity-notification';
+
+/** Copy for the operation whose request failed. */
+interface PublishErrorCopy {
+  titleKey: PublishI18nKeys;
+  messageKey: PublishI18nKeys;
+  networkMessageKey: PublishI18nKeys;
+}
+
+const PUBLISH_COPY: PublishErrorCopy = {
+  titleKey: PublishI18nKeys.FailedTitle,
+  messageKey: PublishI18nKeys.FailedMessage,
+  networkMessageKey: PublishI18nKeys.NetworkErrorMessage,
+};
+
+const UNPUBLISH_COPY: PublishErrorCopy = {
+  titleKey: PublishI18nKeys.UnpublishFailedTitle,
+  messageKey: PublishI18nKeys.UnpublishFailedMessage,
+  networkMessageKey: PublishI18nKeys.UnpublishNetworkErrorMessage,
+};
 
 /**
- * Returns a handler that surfaces a failed publish request as an error
- * notification. Wire it to `usePublishFlow`'s `onPublishError` so a rejected
- * publish is reported outside the panel too, not only through the panel's
- * inline callout. Shows the server-provided error message when the response
- * carries one, falling back to a generic message otherwise.
+ * Returns a handler that surfaces a failed publish or unpublish request as an
+ * error notification. Wire it to `usePublishFlow`'s `onPublishError` so a
+ * rejected publish is reported outside the panel too, not only through the
+ * panel's inline callout. Shows the server-provided error message when the
+ * response carries one, falling back to a generic message otherwise.
+ *
+ * `operation` picks the copy. It defaults to publish, but an unpublish caller
+ * must pass `EntityOperation.UnpublishRequested`: a failed unpublish used to be
+ * reported as "Publish failed", which is what the user saw in
+ * [GH #8445](https://github.com/epam/ai-dial-chat/issues/8445) after clicking
+ * Unpublish.
  */
-export const usePublishErrorNotification = (): ((error: unknown) => void) => {
+export const usePublishErrorNotification = (): ((
+  error: unknown,
+  operation?: EntityOperation,
+) => void) => {
   const { t } = useTranslation();
   const { showErrorNotification } = useNotification();
 
   return useCallback(
-    (error: unknown) => {
-      console.error('Publish request failed', error);
+    (error: unknown, operation?: EntityOperation) => {
+      const copy =
+        operation === EntityOperation.UnpublishRequested
+          ? UNPUBLISH_COPY
+          : PUBLISH_COPY;
+
+      console.error(
+        operation === EntityOperation.UnpublishRequested
+          ? 'Unpublish request failed'
+          : 'Publish request failed',
+        error,
+      );
 
       /*
        * An offline failure never reaches the backend, so it has no trace ID and
@@ -26,8 +65,8 @@ export const usePublishErrorNotification = (): ((error: unknown) => void) => {
        */
       if (!navigator.onLine) {
         showErrorNotification({
-          title: t(PublishI18nKeys.FailedTitle),
-          message: t(PublishI18nKeys.NetworkErrorMessage),
+          title: t(copy.titleKey),
+          message: t(copy.networkMessageKey),
         });
         return;
       }
@@ -35,8 +74,8 @@ export const usePublishErrorNotification = (): ((error: unknown) => void) => {
       const notify = async () => {
         const { message, traceId } = await getApiErrorDetails(error);
         showErrorNotification({
-          title: t(PublishI18nKeys.FailedTitle),
-          message: message ?? t(PublishI18nKeys.FailedMessage),
+          title: t(copy.titleKey),
+          message: message ?? t(copy.messageKey),
           requestId: traceId,
         });
       };

--- a/apps/chat/src/hooks/useConversationPublishHistory/tests/useConversationPublishHistory.spec.ts
+++ b/apps/chat/src/hooks/useConversationPublishHistory/tests/useConversationPublishHistory.spec.ts
@@ -121,6 +121,58 @@ describe('useConversationPublishHistory', () => {
     expect(result.current.getPublishHistory(PATH).entries).toHaveLength(1);
   });
 
+  /*
+   * The TTL alone stops a repeat inside the window, not one just outside it: a
+   * request still running when the window closes would otherwise be joined by
+   * a second, and the slower response could land last and overwrite the newer
+   * folders.
+   */
+  it('issues no second request while one is still in flight past the TTL', async () => {
+    let settleFirst: (value: never[]) => void = () => undefined;
+    vi.mocked(getConversationPublishHistory).mockReturnValueOnce(
+      new Promise((resolve) => {
+        settleFirst = resolve;
+      }),
+    );
+    const { result } = renderHook(() => useConversationPublishHistory());
+
+    act(() => result.current.requestPublishHistory(PATH));
+    act(() => {
+      vi.advanceTimersByTime(60 * 1000 + 1);
+    });
+    act(() => result.current.requestPublishHistory(PATH));
+
+    expect(getConversationPublishHistory).toHaveBeenCalledOnce();
+
+    await act(async () => {
+      settleFirst([]);
+    });
+
+    /* Once it settles the next open revalidates as usual. */
+    act(() => result.current.requestPublishHistory(PATH));
+    await waitFor(() =>
+      expect(getConversationPublishHistory).toHaveBeenCalledTimes(2),
+    );
+  });
+
+  it('releases the in-flight lock when the lookup fails', async () => {
+    vi.mocked(getConversationPublishHistory).mockRejectedValue(
+      new Error('boom'),
+    );
+    const { result } = renderHook(() => useConversationPublishHistory());
+
+    act(() => result.current.requestPublishHistory(PATH));
+    await waitFor(() =>
+      expect(result.current.getPublishHistory(PATH).status).toBe(
+        PublishHistoryStatus.Failed,
+      ),
+    );
+
+    act(() => result.current.requestPublishHistory(PATH));
+
+    expect(getConversationPublishHistory).toHaveBeenCalledTimes(2);
+  });
+
   it('marks the lookup Failed and retries on the next request', async () => {
     vi.mocked(getConversationPublishHistory).mockRejectedValue(
       new Error('boom'),

--- a/apps/chat/src/hooks/useConversationPublishHistory/tests/useConversationPublishHistory.spec.ts
+++ b/apps/chat/src/hooks/useConversationPublishHistory/tests/useConversationPublishHistory.spec.ts
@@ -1,0 +1,164 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { getConversationPublishHistory } from '../../../server-api/conversation-publish.api';
+import { PublishHistoryStatus } from '../../../types/publish-history';
+import { useConversationPublishHistory } from '../useConversationPublishHistory';
+
+vi.mock('../../../server-api/conversation-publish.api', () => ({
+  getConversationPublishHistory: vi.fn(),
+}));
+
+const PATH = 'my-conversation-abc';
+
+const historyEntry = (folderPath: string) => ({
+  path: `conversations/bucket-123/${PATH}`,
+  folderPath,
+  publishedAt: '2026-08-01T00:00:00.000Z',
+  publishedBy: 'user@example.com',
+});
+
+describe('useConversationPublishHistory', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.mocked(getConversationPublishHistory).mockResolvedValue([
+      historyEntry('Organization/Shared chats'),
+    ]);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('reports Idle until a lookup is requested', () => {
+    const { result } = renderHook(() => useConversationPublishHistory());
+
+    expect(result.current.getPublishHistory(PATH).status).toBe(
+      PublishHistoryStatus.Idle,
+    );
+    expect(getConversationPublishHistory).not.toHaveBeenCalled();
+  });
+
+  it('resolves the published folders for the requested conversation', async () => {
+    const { result } = renderHook(() => useConversationPublishHistory());
+
+    act(() => result.current.requestPublishHistory(PATH));
+
+    await waitFor(() =>
+      expect(result.current.getPublishHistory(PATH).status).toBe(
+        PublishHistoryStatus.Resolved,
+      ),
+    );
+    expect(result.current.getPublishHistory(PATH).entries).toEqual([
+      {
+        publishedAt: Date.parse('2026-08-01T00:00:00.000Z'),
+        folderPath: ['Organization', 'Shared chats'],
+      },
+    ]);
+    expect(getConversationPublishHistory).toHaveBeenCalledOnce();
+  });
+
+  it('reuses a fresh result, so reopening the same menu issues no second request', async () => {
+    const { result } = renderHook(() => useConversationPublishHistory());
+
+    act(() => result.current.requestPublishHistory(PATH));
+    await waitFor(() =>
+      expect(result.current.getPublishHistory(PATH).status).toBe(
+        PublishHistoryStatus.Resolved,
+      ),
+    );
+    act(() => result.current.requestPublishHistory(PATH));
+
+    expect(getConversationPublishHistory).toHaveBeenCalledOnce();
+  });
+
+  /*
+   * GH #8445: whether a conversation is published changes outside this tab —
+   * an administrator approving an unpublish request removes the folder
+   * server-side. A cache with no expiry went on offering Unpublish for a copy
+   * Core had already deleted.
+   */
+  it('revalidates once the cached result goes stale', async () => {
+    const { result } = renderHook(() => useConversationPublishHistory());
+
+    act(() => result.current.requestPublishHistory(PATH));
+    await waitFor(() =>
+      expect(result.current.getPublishHistory(PATH).entries).toHaveLength(1),
+    );
+
+    vi.mocked(getConversationPublishHistory).mockResolvedValue([]);
+    act(() => {
+      vi.advanceTimersByTime(60 * 1000 + 1);
+    });
+    act(() => result.current.requestPublishHistory(PATH));
+
+    await waitFor(() =>
+      expect(result.current.getPublishHistory(PATH).entries).toEqual([]),
+    );
+    expect(getConversationPublishHistory).toHaveBeenCalledTimes(2);
+  });
+
+  /* Blanking the folders mid-revalidation would blink Unpublish out of an open menu. */
+  it('keeps the previous folders on screen while revalidating', async () => {
+    const { result } = renderHook(() => useConversationPublishHistory());
+
+    act(() => result.current.requestPublishHistory(PATH));
+    await waitFor(() =>
+      expect(result.current.getPublishHistory(PATH).entries).toHaveLength(1),
+    );
+
+    vi.mocked(getConversationPublishHistory).mockReturnValue(
+      new Promise(() => undefined),
+    );
+    act(() => {
+      vi.advanceTimersByTime(60 * 1000 + 1);
+    });
+    act(() => result.current.requestPublishHistory(PATH));
+
+    expect(result.current.getPublishHistory(PATH).status).toBe(
+      PublishHistoryStatus.Resolved,
+    );
+    expect(result.current.getPublishHistory(PATH).entries).toHaveLength(1);
+  });
+
+  it('marks the lookup Failed and retries on the next request', async () => {
+    vi.mocked(getConversationPublishHistory).mockRejectedValue(
+      new Error('boom'),
+    );
+    const { result } = renderHook(() => useConversationPublishHistory());
+
+    act(() => result.current.requestPublishHistory(PATH));
+    await waitFor(() =>
+      expect(result.current.getPublishHistory(PATH).status).toBe(
+        PublishHistoryStatus.Failed,
+      ),
+    );
+
+    vi.mocked(getConversationPublishHistory).mockResolvedValue([
+      historyEntry('Organization/Reports'),
+    ]);
+    act(() => result.current.requestPublishHistory(PATH));
+
+    await waitFor(() =>
+      expect(result.current.getPublishHistory(PATH).status).toBe(
+        PublishHistoryStatus.Resolved,
+      ),
+    );
+    expect(getConversationPublishHistory).toHaveBeenCalledTimes(2);
+  });
+
+  it('tracks each conversation separately', async () => {
+    const { result } = renderHook(() => useConversationPublishHistory());
+
+    act(() => result.current.requestPublishHistory(PATH));
+    await waitFor(() =>
+      expect(result.current.getPublishHistory(PATH).status).toBe(
+        PublishHistoryStatus.Resolved,
+      ),
+    );
+
+    expect(result.current.getPublishHistory('other-conversation').status).toBe(
+      PublishHistoryStatus.Idle,
+    );
+  });
+});

--- a/apps/chat/src/hooks/useConversationPublishHistory/useConversationPublishHistory.ts
+++ b/apps/chat/src/hooks/useConversationPublishHistory/useConversationPublishHistory.ts
@@ -52,7 +52,8 @@ const PUBLISH_HISTORY_TTL_MS = 60 * 1000;
  *
  * A resolved result is reused for `PUBLISH_HISTORY_TTL_MS` and revalidated
  * after that, so a row menu opened later in a long-lived session reflects
- * approvals that happened meanwhile rather than a first-open snapshot.
+ * approvals that happened meanwhile rather than a first-open snapshot. At most
+ * one request per conversation is ever in flight.
  */
 export const useConversationPublishHistory =
   (): UseConversationPublishHistoryResult => {
@@ -62,8 +63,17 @@ export const useConversationPublishHistory =
     /* When each path's in-flight-or-resolved lookup started, so reopening the
      * same menu does not re-issue the request until the result goes stale. */
     const requestedAtRef = useRef(new Map<string, number>());
+    /* Paths with a lookup in flight. The timestamp alone stops a repeat inside
+     * the TTL but not one just outside it, and a request that outlives the
+     * window would otherwise be joined by a second — which is both a wasted
+     * scan and a chance for the slower response to land last and overwrite the
+     * newer folders. One request per path at a time removes both. */
+    const inFlightRef = useRef(new Set<string>());
 
     const requestPublishHistory = useCallback((path: string) => {
+      if (inFlightRef.current.has(path)) {
+        return;
+      }
       const requestedAt = requestedAtRef.current.get(path);
       if (
         requestedAt != null &&
@@ -72,6 +82,7 @@ export const useConversationPublishHistory =
         return;
       }
       requestedAtRef.current.set(path, Date.now());
+      inFlightRef.current.add(path);
       /* A revalidation keeps the folders already on screen: replacing them with
        * `Loading` would blink the open menu's Unpublish entry out and back. */
       setEntries((prev) => ({
@@ -97,13 +108,16 @@ export const useConversationPublishHistory =
            * that cannot do anything, and raises no notification — the user
            * opened a menu, they did not ask for history. The timestamp is
            * dropped so the next menu open retries immediately instead of
-           * waiting out the TTL.
+           * waiting out the TTL: a failure is forgotten, while a request still
+           * in flight is remembered until it settles.
            */
           requestedAtRef.current.delete(path);
           setEntries((prev) => ({
             ...prev,
             [path]: { status: PublishHistoryStatus.Failed },
           }));
+        } finally {
+          inFlightRef.current.delete(path);
         }
       };
       void resolve();

--- a/apps/chat/src/hooks/useConversationPublishHistory/useConversationPublishHistory.ts
+++ b/apps/chat/src/hooks/useConversationPublishHistory/useConversationPublishHistory.ts
@@ -14,7 +14,7 @@ export interface PublishHistoryEntryState {
 
 /** Per-conversation publish-history lookups resolved on demand. */
 export interface UseConversationPublishHistoryResult {
-  /** Starts a lookup for the conversation unless one already ran for it. */
+  /** Starts a lookup for the conversation unless a fresh one already ran for it. */
   requestPublishHistory: (path: string) => void;
   /** Current lookup state for the conversation. */
   getPublishHistory: (path: string) => PublishHistoryEntryState;
@@ -23,6 +23,21 @@ export interface UseConversationPublishHistoryResult {
 const IDLE_ENTRY: PublishHistoryEntryState = {
   status: PublishHistoryStatus.Idle,
 };
+
+/*
+ * How long a resolved lookup is reused before the next menu open re-issues it.
+ * Matches the server-side publish-history cache in
+ * `conversation-publish.service.ts`, so a revalidation inside the window is
+ * answered from that cache and costs no `getPublications` scan.
+ *
+ * Deliberately not "once per session": whether a conversation is published
+ * changes outside this tab. An administrator approving an unpublish request is
+ * exactly that — the folder disappears from history server-side while a cache
+ * with no expiry keeps offering Unpublish for a copy Core has deleted, which
+ * then fails with "Target resource does not exists"
+ * ([GH #8445](https://github.com/epam/ai-dial-chat/issues/8445)).
+ */
+const PUBLISH_HISTORY_TTL_MS = 60 * 1000;
 
 /**
  * Resolves which folders a conversation is published to, one conversation at a
@@ -34,22 +49,36 @@ const IDLE_ENTRY: PublishHistoryEntryState = {
  * result gates the row's Unpublish entry — which cannot build a request
  * without a folder — and is handed to the publish panel for the same
  * conversation, so opening both issues one request.
+ *
+ * A resolved result is reused for `PUBLISH_HISTORY_TTL_MS` and revalidated
+ * after that, so a row menu opened later in a long-lived session reflects
+ * approvals that happened meanwhile rather than a first-open snapshot.
  */
 export const useConversationPublishHistory =
   (): UseConversationPublishHistoryResult => {
     const [entries, setEntries] = useState<
       Record<string, PublishHistoryEntryState | undefined>
     >({});
-    /* Paths whose lookup has already started, so reopening the same menu does
-     * not re-issue the request. */
-    const requestedPathsRef = useRef(new Set<string>());
+    /* When each path's in-flight-or-resolved lookup started, so reopening the
+     * same menu does not re-issue the request until the result goes stale. */
+    const requestedAtRef = useRef(new Map<string, number>());
 
     const requestPublishHistory = useCallback((path: string) => {
-      if (requestedPathsRef.current.has(path)) return;
-      requestedPathsRef.current.add(path);
+      const requestedAt = requestedAtRef.current.get(path);
+      if (
+        requestedAt != null &&
+        Date.now() - requestedAt < PUBLISH_HISTORY_TTL_MS
+      ) {
+        return;
+      }
+      requestedAtRef.current.set(path, Date.now());
+      /* A revalidation keeps the folders already on screen: replacing them with
+       * `Loading` would blink the open menu's Unpublish entry out and back. */
       setEntries((prev) => ({
         ...prev,
-        [path]: { status: PublishHistoryStatus.Loading },
+        [path]: prev[path]?.entries
+          ? prev[path]
+          : { status: PublishHistoryStatus.Loading },
       }));
 
       const resolve = async () => {
@@ -66,10 +95,11 @@ export const useConversationPublishHistory =
           /*
            * A failed lookup hides the Unpublish entry rather than showing one
            * that cannot do anything, and raises no notification — the user
-           * opened a menu, they did not ask for history. Cleared from the
-           * started set so the next menu open retries.
+           * opened a menu, they did not ask for history. The timestamp is
+           * dropped so the next menu open retries immediately instead of
+           * waiting out the TTL.
            */
-          requestedPathsRef.current.delete(path);
+          requestedAtRef.current.delete(path);
           setEntries((prev) => ({
             ...prev,
             [path]: { status: PublishHistoryStatus.Failed },

--- a/apps/chat/src/i18n/locales/en.json
+++ b/apps/chat/src/i18n/locales/en.json
@@ -469,6 +469,9 @@
     "failedTitle": "Publish failed",
     "failedMessage": "The publish request was not submitted. Please try again.",
     "networkErrorMessage": "The publish request was not submitted because your internet connection was lost. Please check your connection and try again.",
+    "unpublishFailedTitle": "Unpublish failed",
+    "unpublishFailedMessage": "The unpublish request was not submitted. Please try again.",
+    "unpublishNetworkErrorMessage": "The unpublish request was not submitted because your internet connection was lost. Please check your connection and try again.",
     "submitErrorCallout": "Publishing failed. Please try again."
   },
   "publishAccessRules": {

--- a/openspec/specs/conversation-unpublish-flow/spec.md
+++ b/openspec/specs/conversation-unpublish-flow/spec.md
@@ -9,6 +9,8 @@ TBD - created by archiving change add-unpublish-my-resources. Update Purpose aft
 
 `Publish` and `Unpublish` SHALL be mutually exclusive, matching the catalog details menu (`catalog-unpublish-flow`): the row menu SHALL carry exactly one of the two. A conversation with no published copy offers `Publish`; once history resolves to at least one published folder, `Unpublish` takes its place. Republishing an already-published conversation therefore means unpublishing it first.
 
+The swap SHALL reverse once an administrator approves a removal: history then resolves to zero folders for that folder and the entry returns to `Publish`. Only a published folder that is still live yields `Unpublish` — see the history requirement below for what "still live" means when Core keeps the original `ADD` as an audit record.
+
 The entry SHALL be gated by the same conditions that gate `Publish`, plus one more:
 
 - `OverlayFeature.ConversationsPublishing` is enabled — an app whose publish action is hidden must not offer to reverse it.
@@ -38,6 +40,35 @@ The entry SHALL be gated by the same conditions that gate `Publish`, plus one mo
 The conversation panel SHALL call `getConversationPublishHistory(path)` when a row's action menu is opened or its trigger is focused, once per conversation, and hold the result keyed by conversation. It SHALL NOT fetch history while rendering the conversation list: the list can hold hundreds of rows, and history is a bucket-wide `getPublications` scan on the server.
 
 The resolution states and their effect on the `Unpublish` entry are identical to the catalog flow (see `catalog-unpublish-flow`): withheld while unresolved, shown with ≥ 1 folder, hidden on zero folders, hidden on failure. A failure SHALL NOT raise a notification — the user did not ask for history, they opened a menu.
+
+Resolved history SHALL exclude folders whose removal Core has approved. Core never retracts the original `ADD` publication — it stays `APPROVED` as an audit record — so `resolvePublicationsForSource` in `apps/chat-api/src/publish/publication.util.ts` SHALL treat an `APPROVED` `DELETE` as cancelling every `ADD` for the same target folder created at or before it. A `PENDING` removal SHALL cancel nothing: the copy is live until it is approved. An `ADD` created *after* an approved removal SHALL survive, so publish → unpublish → publish-again lists the folder again. When Core reports an approved removal with no usable `createdAt` there is nothing to order it against, and it SHALL cancel the whole folder — a re-publish included — because offering `Unpublish` for a copy Core has deleted is the failure being prevented ([GH #8445](https://github.com/epam/ai-dial-chat/issues/8445)).
+
+A resolved result SHALL be reused for a bounded window (`PUBLISH_HISTORY_TTL_MS`, matching the server-side history cache) and revalidated after it, so a menu opened later in a long-lived session reflects an approval that happened meanwhile rather than a first-open snapshot. A revalidation SHALL keep the folders already on screen rather than reverting to a loading state, and at most one request per conversation SHALL be in flight at a time.
+
+#### Scenario: An approved removal returns the entry to Publish
+- **GIVEN** the conversation was published to one folder and an administrator approved its removal
+- **WHEN** the row's action menu is opened and history resolves
+- **THEN** history reports zero folders, `Publish` renders, and `Unpublish` is not rendered
+
+#### Scenario: A re-publish after an approved removal offers Unpublish again
+- **GIVEN** the conversation was published, removed with approval, and published to that folder again
+- **WHEN** history resolves
+- **THEN** the folder is listed and `Unpublish` renders
+
+#### Scenario: A pending removal still offers Unpublish
+- **GIVEN** an unpublish request for the folder is `PENDING`
+- **WHEN** history resolves
+- **THEN** the folder is still listed, because the published copy is live until an admin approves
+
+#### Scenario: A stale result is revalidated on the next open
+- **GIVEN** a resolved result older than the reuse window
+- **WHEN** the menu is opened again
+- **THEN** one further request is issued while the folders already resolved stay on screen
+
+#### Scenario: A request still in flight is not duplicated
+- **GIVEN** a request for the conversation has not settled
+- **WHEN** the menu is opened again, even past the reuse window
+- **THEN** no second request is issued
 
 The same fetched history SHALL be handed to `PublishConversationPanelContainer` when the publish panel opens for that conversation, so opening Publish after opening the menu issues no second request.
 


### PR DESCRIPTION
…

DIAL Core models an unpublish as a publication whose resource carries `action: 'DELETE'`, but it keeps the original `ADD` publication as `APPROVED` forever — an audit record, not live state. Publish history is derived from those `ADD` publications and is the sole input to the Publish-vs-Unpublish decision in both the catalog details panel and the conversation row menu, so an approved removal left the folder reading as published: the menu went on offering Unpublish for a copy Core had already deleted, and acting on it failed with "Target resource does not exists".

`resolvePublicationsForSource` now returns the publications a resource is *currently* published by. An `APPROVED` `DELETE` cancels every `ADD` for the same target folder created at or before it, while a later `ADD` survives so publish -> unpublish -> publish-again still lists the folder. Folder identity is compared decoded, since Core echoes `targetFolder` percent-encoded. Only a removal Core labels `APPROVED` cancels anything: wrongly cancelling would hide Unpublish for a live copy and offer a Publish that Core then rejects.

Two supporting fixes:

- `useConversationPublishHistory` cached history once per session with no expiry, so a row menu kept serving its first-open snapshot and the backend fix would not reach a user who stayed on the page. It now revalidates after 60s — matching the server's own publish-history cache window — holding the resolved folders on screen meanwhile so an open menu does not blink.
- A failed unpublish was reported as "Publish failed". `usePublishErrorNotification` now takes the operation and uses unpublish-specific title, message and offline copy.

**Description:**

<SHORT_DESCRIPTION>

Issues:

- Issue #<TICKET_ID>

**UI changes**

<Please, provide Screenshots or Figma links>

**Checklist:**

- [ ] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [ ] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
