### PR TITLE
feat(chat): add capability to pass language headers to dial core /completions api (Issue #8442) (#8444)

### DIFF
--- a/apps/chat/src/components/Layout.tsx
+++ b/apps/chat/src/components/Layout.tsx
@@ -100,6 +100,18 @@ export function Layout({
 
     dispatch(UIActions.setLocale(locale));
   }, [dispatch, router.defaultLocale, router.locale]);
+
+  useEffect(() => {
+    try {
+      const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+
+      if (timezone) {
+        dispatch(UIActions.setTimezone(timezone));
+      }
+    } catch {
+      // Timezone detection is best-effort; the header is simply omitted.
+    }
+  }, [dispatch]);
   useEffect(() => {
     setLoading(isApplyingModel);
   }, [isApplyingModel]);

--- a/apps/chat/src/pages/api/chat.ts
+++ b/apps/chat/src/pages/api/chat.ts
@@ -115,6 +115,12 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
       : rawLanguageHeader;
     const language = languageHeaderValue?.trim() || undefined;
 
+    const rawTimezoneHeader = req.headers['x-timezone'];
+    const timezoneHeaderValue = Array.isArray(rawTimezoneHeader)
+      ? rawTimezoneHeader[0]
+      : rawTimezoneHeader;
+    const timezone = timezoneHeaderValue?.trim() || undefined;
+
     const stream = await OpenAIStream({
       model,
       messages: messagesToSend,
@@ -122,6 +128,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
       chatReference: reference ?? id,
       jobTitle: token?.jobTitle,
       language: language,
+      timezone: timezone,
       maxRequestTokens: features?.truncatePrompt
         ? limits?.maxRequestTokens
         : undefined,

--- a/apps/chat/src/store/conversations/conversations.epics.ts
+++ b/apps/chat/src/store/conversations/conversations.epics.ts
@@ -1877,6 +1877,7 @@ const streamMessageEpic: AppEpic = (action$, state$) =>
       const conversationSignal =
         ConversationsSelectors.selectConversationSignal(state$.value);
       const locale = UISelectors.selectLocale(state$.value);
+      const timezone = UISelectors.selectTimezone(state$.value);
       const decoder = new TextDecoder();
       let eventData = '';
       let message = payload.message;
@@ -1888,6 +1889,7 @@ const streamMessageEpic: AppEpic = (action$, state$) =>
           headers: {
             'Content-Type': 'application/json',
             'x-language': locale,
+            ...(timezone && { 'x-timezone': timezone }),
             ...(channelId &&
               isApplication && {
                 [HeadersNames.X_DIAL_CLIENT_CHANNEL_ID]: channelId,

--- a/apps/chat/src/store/ui/ui.reducers.ts
+++ b/apps/chat/src/store/ui/ui.reducers.ts
@@ -28,6 +28,7 @@ const openFoldersInitialState = {
 const initialState: UIState = {
   initialized: false,
   locale: DEFAULT_LOCAL,
+  timezone: '',
   theme: '',
   availableThemes: [],
   themesImages: {},
@@ -79,6 +80,9 @@ export const uiSlice = createSlice({
     },
     setLocale: (state, { payload }: PayloadAction<string>) => {
       state.locale = payload;
+    },
+    setTimezone: (state, { payload }: PayloadAction<string>) => {
+      state.timezone = payload;
     },
     setEnterType: (state, { payload }: PayloadAction<EnterType>) => {
       state.enterType = payload;

--- a/apps/chat/src/store/ui/ui.selectors.ts
+++ b/apps/chat/src/store/ui/ui.selectors.ts
@@ -16,6 +16,8 @@ const rootSelector = (state: RootState) => state.ui;
 
 const selectLocale = (state: RootState) => rootSelector(state).locale;
 
+const selectTimezone = (state: RootState) => rootSelector(state).timezone;
+
 const selectThemeState = (state: RootState) => rootSelector(state).theme;
 
 const selectEnterType = (state: RootState) => rootSelector(state).enterType;
@@ -150,6 +152,7 @@ const selectAllowEnterToSend = createSelector([selectEnterType], (enterType) =>
 
 export const UISelectors = {
   selectLocale,
+  selectTimezone,
   selectThemeState,
   selectEnterType,
   selectShowChatbar,

--- a/apps/chat/src/store/ui/ui.types.ts
+++ b/apps/chat/src/store/ui/ui.types.ts
@@ -6,6 +6,7 @@ import { Theme, ThemesImages } from '@/src/types/themes';
 export interface UIState {
   initialized: boolean;
   locale: string;
+  timezone: string;
   theme: string;
   availableThemes: Theme[];
   themesImages: ThemesImages;

--- a/apps/chat/src/utils/server/get-headers.ts
+++ b/apps/chat/src/utils/server/get-headers.ts
@@ -5,12 +5,14 @@ export const getApiHeaders = ({
   jwt,
   jobTitle,
   language,
+  timezone,
   ifNoneMatch,
 }: {
   jwt?: string;
   chatReference?: string;
   jobTitle?: string;
   language?: string;
+  timezone?: string;
   ifNoneMatch?: string;
 }): Record<string, string> => {
   const headers: Record<string, string> = {
@@ -30,6 +32,10 @@ export const getApiHeaders = ({
     process.env.PROXY_LANGUAGE_HEADER || 'accept-language';
   if (proxyLanguageHeader && language) {
     headers[proxyLanguageHeader] = language;
+  }
+
+  if (timezone) {
+    headers['X-Timezone'] = timezone;
   }
 
   if (jobTitle) {

--- a/apps/chat/src/utils/server/index.ts
+++ b/apps/chat/src/utils/server/index.ts
@@ -61,6 +61,7 @@ export const OpenAIStream = async ({
   userJWT,
   jobTitle,
   language,
+  timezone,
   maxRequestTokens,
   configurationSchemaValue,
   channelId,
@@ -71,6 +72,7 @@ export const OpenAIStream = async ({
   chatReference: string;
   jobTitle: string | undefined;
   language?: string;
+  timezone?: string;
   maxRequestTokens: number | undefined;
   configurationSchemaValue?: MessageFormValue;
   temperature?: number;
@@ -84,6 +86,7 @@ export const OpenAIStream = async ({
     jwt: userJWT,
     jobTitle,
     language,
+    timezone,
   });
 
   if (channelId) {


### PR DESCRIPTION


**Description:**

Add capability to pass timezone header to from user's browser to Dial Core completions api.

Issues:

- Issue #8442 

**UI changes**

<Please, provide Screenshots or Figma links>

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
