### PR TITLE
fix: Fix error when running Dial Chat on HTTP host

### DIFF
--- a/apps/chat-api/src/common/utils/generate-uuid.ts
+++ b/apps/chat-api/src/common/utils/generate-uuid.ts
@@ -1,0 +1,4 @@
+import { randomUUID } from 'node:crypto';
+
+/** Returns a UUID v4 string. */
+export const generateUUID = (): string => randomUUID();

--- a/apps/chat-api/src/conversations/lifecycle/conversation-lifecycle.service.ts
+++ b/apps/chat-api/src/conversations/lifecycle/conversation-lifecycle.service.ts
@@ -6,6 +6,7 @@ import {
   ServiceUnavailableException,
 } from '@nestjs/common';
 import { handleDialSdkError } from '../../common/dial/dial-error.mapper';
+import { generateUUID } from '../../common/utils/generate-uuid';
 import { getBearerAuthHeaders } from '../../common/utils/auth-header';
 import { encodeDialResourcePath } from '../../common/utils/encode-dial-path';
 import { safeDecodeURIComponent } from '../../common/utils/uri';
@@ -60,7 +61,7 @@ export class ConversationLifecycleService {
     customContent?: MessageCustomContentDto,
   ): Promise<ConversationResponseDto> {
     const now = Date.now();
-    const uuid = crypto.randomUUID();
+    const uuid = generateUUID();
     const baseName = getConversationName('New chat', firstMessage);
     const name = baseName;
     const conversationPath = `${deploymentId}__${baseName}__${uuid}`;
@@ -313,7 +314,7 @@ export class ConversationLifecycleService {
       [...decodedFolderSegments, decodedRenamedFilename].join('/'),
     );
     const decodedFinalFilename = pathExists
-      ? `${decodedRenamedFilename}__${crypto.randomUUID()}`
+      ? `${decodedRenamedFilename}__${generateUUID()}`
       : decodedRenamedFilename;
     const decodedDestinationSubPath = [
       ...decodedFolderSegments,

--- a/apps/chat-api/src/conversations/utils/conversation-history-builder.ts
+++ b/apps/chat-api/src/conversations/utils/conversation-history-builder.ts
@@ -1,4 +1,5 @@
 import { BadRequestException } from '@nestjs/common';
+import { generateUUID } from '../../common/utils/generate-uuid';
 import { ConversationResponseDto } from '../../openapi/openapi-response.dto';
 import {
   ConversationMessageDto,
@@ -11,7 +12,7 @@ const makeUserMessage = (
   content: string,
   customContent?: MessageCustomContentDto,
 ): ConversationMessageDto => ({
-  id: crypto.randomUUID(),
+  id: generateUUID(),
   role: ConversationMessageRole.User,
   content,
   timestamp: new Date().toISOString(),
@@ -45,7 +46,7 @@ const clearStateFromMessages = (
 const makeAssistantPlaceholder = (
   deploymentId: string,
 ): ConversationMessageDto => ({
-  id: crypto.randomUUID(),
+  id: generateUUID(),
   role: ConversationMessageRole.Assistant,
   content: '',
   timestamp: new Date().toISOString(),

--- a/apps/chat/src/context/ConversationsContext.tsx
+++ b/apps/chat/src/context/ConversationsContext.tsx
@@ -4,6 +4,7 @@ import type {
   ConversationResponseDto,
 } from '@epam/ai-dial-chat-api-client';
 import { getConversationPath } from '@epam/ai-dial-chat-hooks';
+import { generateUUID } from '@epam/ai-dial-chat-shared';
 import {
   createContext,
   type ReactNode,
@@ -363,7 +364,7 @@ export const ConversationsProvider = ({
   const duplicateConversation = useCallback(
     async (id: string) => {
       const source = conversationsRef.current.find((c) => c.id === id);
-      const tempId = crypto.randomUUID();
+      const tempId = generateUUID();
       setConversations((prev) => [
         {
           id: tempId,

--- a/apps/chat/src/context/NotificationContext.tsx
+++ b/apps/chat/src/context/NotificationContext.tsx
@@ -1,3 +1,4 @@
+import { generateUUID } from '@epam/ai-dial-chat-shared';
 import { NotificationVariant } from '@epam/ai-dial-ui-kit';
 import {
   createContext,
@@ -59,7 +60,7 @@ export const NotificationProvider = ({ children }: { children: ReactNode }) => {
   }, []);
 
   const showNotification = useCallback((options: ShowNotificationOptions) => {
-    const id = crypto.randomUUID();
+    const id = generateUUID();
     setNotifications((prev) => [...prev, { ...options, id }]);
   }, []);
 

--- a/apps/chat/src/pages/AppsEditor/AppPreviewChat.tsx
+++ b/apps/chat/src/pages/AppsEditor/AppPreviewChat.tsx
@@ -7,6 +7,7 @@ import {
 } from '@epam/ai-dial-chat-hooks';
 import {
   MessageRating,
+  generateUUID,
   MessageRole,
   ResponseFormat,
   type Attachment,
@@ -199,7 +200,7 @@ const AppPreviewChat: FC<Props> = ({ appId, appDisplayName, appIconUrl }) => {
         withPlaceholder.messages.length - 1,
         appId,
         attachmentDtos?.length ? { attachments: attachmentDtos } : undefined,
-        crypto.randomUUID(),
+        generateUUID(),
         CompletionMode.ContinueLastUser,
       );
     },

--- a/apps/chat/src/pages/Conversation/Conversation.tsx
+++ b/apps/chat/src/pages/Conversation/Conversation.tsx
@@ -7,6 +7,7 @@ import {
   useToolsMenu,
 } from '@epam/ai-dial-chat-hooks';
 import {
+  generateUUID,
   MessageRating,
   MessageRole,
   type Conversation,
@@ -416,7 +417,7 @@ export const ConversationPage: FC<Props> = ({ onDuplicateReadonly }) => {
               withPlaceholder.messages.length - 1,
               lastDeploymentId ?? result.model.id,
               lastMsg.custom_content,
-              crypto.randomUUID(),
+              generateUUID(),
               CompletionMode.ContinueLastUser,
             );
           }

--- a/apps/chat/src/utils/message-factory.ts
+++ b/apps/chat/src/utils/message-factory.ts
@@ -1,4 +1,5 @@
 import {
+  generateUUID,
   MessageRole,
   StatusEvent,
   StatusMessage,
@@ -19,7 +20,7 @@ export const createDeploymentChangedMessage = (
     new_deployment_id: newDeploymentId,
   };
   return {
-    id: crypto.randomUUID(),
+    id: generateUUID(),
     role: MessageRole.Status,
     content: '',
     timestamp: new Date().toISOString(),

--- a/apps/chat/src/utils/toolsets.ts
+++ b/apps/chat/src/utils/toolsets.ts
@@ -3,6 +3,7 @@ import type {
   ToolsetBodyDto,
 } from '@epam/ai-dial-chat-api-client';
 import { ResponseError } from '@epam/ai-dial-chat-api-client';
+import { generateUUID } from '@epam/ai-dial-chat-shared';
 import { validateDeploymentCreationFields } from '@epam/ai-dial-deployment-creation-form';
 import {
   DEFAULT_TOOLSET_NAME,
@@ -225,7 +226,7 @@ export const navigateToolsetOAuthPopup = (
   resourceKind: OAuthResourceKind = OAuthResourceKind.Toolset,
 ): ToolsetOAuthInitiationResult => {
   const redirectUri = getToolsetRedirectUri();
-  const state = crypto.randomUUID();
+  const state = generateUUID();
   const url = buildToolsetAuthorizeUrl(auth, redirectUri, state);
   if (!url) {
     popup.close();
@@ -260,7 +261,7 @@ export const initiateOAuthLogin = (
   credentialsLevel: ToolsetCredentialsLevel = ToolsetCredentialsLevel.User,
 ): ToolsetOAuthInitiationResult => {
   const redirectUri = getToolsetRedirectUri();
-  const state = crypto.randomUUID();
+  const state = generateUUID();
   const url = buildToolsetAuthorizeUrl(auth, redirectUri, state);
   if (!url) return { type: ToolsetOAuthInitiationResultType.InvalidConfig };
 

--- a/libs/chat-hooks/src/conversation/conversation-transfer/import-conversation.ts
+++ b/libs/chat-hooks/src/conversation/conversation-transfer/import-conversation.ts
@@ -1,3 +1,4 @@
+import { generateUUID } from '@epam/ai-dial-chat-shared';
 import type {
   Conversation,
   ExportFolder,
@@ -130,7 +131,7 @@ export const rebaseConversationId = (
   const oldFileName =
     pathSegmentsAfterFolder.at(-1) ?? idSegments.at(-1) ?? rawId;
 
-  const newFileName = `${stripTrailingUuid(oldFileName)}__${crypto.randomUUID()}`;
+  const newFileName = `${stripTrailingUuid(oldFileName)}__${generateUUID()}`;
   const subPath = [
     ...folderSegments,
     ...deploymentPrefixSegments,

--- a/libs/chat-hooks/src/conversation/conversation-transfer/queue.ts
+++ b/libs/chat-hooks/src/conversation/conversation-transfer/queue.ts
@@ -1,3 +1,4 @@
+import { generateUUID } from '@epam/ai-dial-chat-shared';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import {
   ConversationTransferJobStatus,
@@ -52,7 +53,7 @@ export const useConversationTransferQueue = (): ConversationTransferQueue => {
   );
 
   const addJob = useCallback((subject: ConversationTransferSubject): string => {
-    const jobId = crypto.randomUUID();
+    const jobId = generateUUID();
     setJobs((prev) => [
       ...prev,
       { id: jobId, subject, status: ConversationTransferJobStatus.InProgress },

--- a/libs/chat-hooks/src/conversation/useConversationHandlers/useConversationHandlers.ts
+++ b/libs/chat-hooks/src/conversation/useConversationHandlers/useConversationHandlers.ts
@@ -10,6 +10,7 @@ import {
   type Attachment,
   type Conversation,
   type DisplayAttachment,
+  generateUUID,
   type MessageCustomContent,
   MessageRating,
   MessageRole,
@@ -187,7 +188,7 @@ export const useConversationHandlers = ({
         conversation.messages.length + 1,
         modelId,
         customContent,
-        crypto.randomUUID(),
+        generateUUID(),
         CompletionMode.Append,
       );
     },
@@ -250,7 +251,7 @@ export const useConversationHandlers = ({
         messageIndex,
         modelId,
         userMsg.custom_content,
-        crypto.randomUUID(),
+        generateUUID(),
         CompletionMode.Regenerate,
       );
     },
@@ -453,7 +454,7 @@ export const useConversationHandlers = ({
         conversation.messages.length + 1,
         modelId,
         customContent,
-        crypto.randomUUID(),
+        generateUUID(),
         CompletionMode.Append,
       );
     },
@@ -587,7 +588,7 @@ export const useConversationHandlers = ({
         updatedMessages.length - 1,
         modelId,
         updatedCustomContent,
-        crypto.randomUUID(),
+        generateUUID(),
         CompletionMode.Edit,
       );
 

--- a/libs/chat-hooks/src/conversation/useConversationImport/useConversationImport.ts
+++ b/libs/chat-hooks/src/conversation/useConversationImport/useConversationImport.ts
@@ -3,6 +3,7 @@ import type {
   ConversationsApi,
   FilesApi,
 } from '@epam/ai-dial-chat-api-client';
+import { generateUUID } from '@epam/ai-dial-chat-shared';
 import type { Conversation } from '@epam/ai-dial-chat-shared';
 import { useCallback } from 'react';
 import { runWithConcurrency } from '../conversation-transfer/async';
@@ -460,7 +461,7 @@ export const useConversationImport = ({
          * queue, retry, or dismiss. `jobId` is a transient correlation id
          * only, not a member of `jobs`. */
         onError?.({
-          jobId: crypto.randomUUID(),
+          jobId: generateUUID(),
           code: ConversationTransferErrorCode.UnsupportedFormat,
         });
         if (!(error instanceof UnsupportedImportFormatError)) {

--- a/libs/chat-hooks/src/conversation/useConversationStream/useConversationStream.ts
+++ b/libs/chat-hooks/src/conversation/useConversationStream/useConversationStream.ts
@@ -1,6 +1,7 @@
 import { SendCompletionDtoModeEnum } from '@epam/ai-dial-chat-api-client';
 import {
   type Conversation,
+  generateUUID,
   type MessageCustomContent,
   type StreamChunk,
 } from '@epam/ai-dial-chat-shared';
@@ -205,7 +206,7 @@ export const useConversationStream = ({
       generationId?: string,
       mode: SendCompletionDtoModeEnum = SendCompletionDtoModeEnum.Append,
     ) => {
-      const genId = generationId ?? crypto.randomUUID();
+      const genId = generationId ?? generateUUID();
       const conversationPath = getConversationPath(currentConversationId);
       activeGenerationIdRef.current = genId;
       activeGenerationPathRef.current = conversationPath;

--- a/libs/chat-shared/src/index.ts
+++ b/libs/chat-shared/src/index.ts
@@ -28,6 +28,7 @@ export * from './utils/format-price';
 export * from './utils/file-download';
 export * from './constants/entity-colors';
 export * from './utils/prompt-variables';
+export * from './utils/generate-uuid';
 export * from './constants/mime-types';
 export * from './constants/icon';
 export * from './constants/dial';

--- a/libs/chat-shared/src/utils/generate-uuid.ts
+++ b/libs/chat-shared/src/utils/generate-uuid.ts
@@ -1,0 +1,14 @@
+/** Returns a UUID v4 string, with a fallback for non-secure browser contexts (HTTP deployments). */
+export const generateUUID = (): string => {
+  if (
+    typeof crypto !== 'undefined' &&
+    typeof crypto.randomUUID === 'function'
+  ) {
+    return crypto.randomUUID();
+  }
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
+    const r = (Math.random() * 16) | 0;
+    const v = c === 'x' ? r : (r & 0x3) | 0x8;
+    return v.toString(16);
+  });
+};

--- a/openspec/specs/auto-index-duplicate-names/spec.md
+++ b/openspec/specs/auto-index-duplicate-names/spec.md
@@ -90,7 +90,7 @@ The DIAL Core storage path for a newly **created** conversation SHALL always be:
 {deploymentId}__{baseName}__{uuid}
 ```
 
-where `{baseName}` is the sanitised display name and `{uuid}` is `crypto.randomUUID()` generated at create time. The UUID segment is unconditional — `createConversation` SHALL NOT perform a path-existence check before building the path. `conversation.name` SHALL remain the unsuffixed `{baseName}`.
+where `{baseName}` is the sanitised display name and `{uuid}` is `generateUUID()` generated at create time. The UUID segment is unconditional — `createConversation` SHALL NOT perform a path-existence check before building the path. `conversation.name` SHALL remain the unsuffixed `{baseName}`.
 
 For versioned or multi-segment deployment IDs, the invariant is the fresh trailing UUID rather than a fixed total number of `__`-separated segments.
 
@@ -121,7 +121,7 @@ The DIAL Core storage path for every **duplicated** conversation SHALL be:
 {deploymentId}__{baseName}__{uuid}
 ```
 
-where `{baseName}` is the sanitised display name and `{uuid}` is `crypto.randomUUID()` generated at duplicate time. The UUID segment is unconditional, including when no resource exists at the corresponding unsuffixed path. `conversation.name` SHALL remain the unsuffixed `{baseName}`.
+where `{baseName}` is the sanitised display name and `{uuid}` is `generateUUID()` generated at duplicate time. The UUID segment is unconditional, including when no resource exists at the corresponding unsuffixed path. `conversation.name` SHALL remain the unsuffixed `{baseName}`.
 
 `duplicateConversation` SHALL NOT call `getConversationMetadata` to check whether `{deploymentId}__{baseName}` exists. The destination path SHALL use a fresh UUID rather than reusing a trailing UUID from the source path.
 

--- a/openspec/specs/conversations-api/spec.md
+++ b/openspec/specs/conversations-api/spec.md
@@ -8,7 +8,7 @@ Define the versioned conversation REST API, DIAL Core persistence contract, path
 
 ### Requirement: POST /api/v1/conversations creates and persists a new conversation
 
-The backend SHALL expose `POST /api/v1/conversations` in `apps/chat-api/src/conversations/conversation.controller.ts`. The controller MUST be versioned (`version: '1'`), annotated with `@ApiTags('conversations')`, and delegate all logic to `ConversationService`. The endpoint accepts a JSON body validated by `CreateConversationDto`. On success it returns HTTP 201 with the created `Conversation`. The service generates a UUID via `crypto.randomUUID()`, constructs a `Conversation` object using the provided `deploymentId` for `model.id` and `assistantModelId`, and persists it to DIAL Core via the SDK client.
+The backend SHALL expose `POST /api/v1/conversations` in `apps/chat-api/src/conversations/conversation.controller.ts`. The controller MUST be versioned (`version: '1'`), annotated with `@ApiTags('conversations')`, and delegate all logic to `ConversationService`. The endpoint accepts a JSON body validated by `CreateConversationDto`. On success it returns HTTP 201 with the created `Conversation`. The service generates a UUID via `generateUUID()`, constructs a `Conversation` object using the provided `deploymentId` for `model.id` and `assistantModelId`, and persists it to DIAL Core via the SDK client.
 
 Request body (`CreateConversationDto`):
 

--- a/openspec/specs/duplicate-conversation/spec.md
+++ b/openspec/specs/duplicate-conversation/spec.md
@@ -17,7 +17,7 @@ The system SHALL expose `POST /api/v1/conversations/duplicate?path=<sourcePath>`
 
 The returned `newPath` is the encoded full DIAL Core resource path and SHALL be treated as an opaque conversation identifier by callers.
 
-The duplicated conversation SHALL keep the source conversation's stored display name, sanitised via `prepareEntityName`, without adding a numeric title suffix. Its destination storage path SHALL always end with a fresh `crypto.randomUUID()` segment:
+The duplicated conversation SHALL keep the source conversation's stored display name, sanitised via `prepareEntityName`, without adding a numeric title suffix. Its destination storage path SHALL always end with a fresh `generateUUID()` segment:
 
 ```
 {deploymentId}__{displayName}__{uuid}


### PR DESCRIPTION
**Description:**

If Dial Chat is deployed using http protocol, crypto,randomUUID is not available and chat produce error ("TypeError: crypto.randomUUID is not a function") This PR introduce wrap around this function with fallback for this case.

Issues:

- Issue #<TICKET_ID>

**UI changes**

<Please, provide Screenshots or Figma links>

**Checklist:**

- [X] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [X] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
