### PR TITLE
fix: stop streaming does not interrupt generation during tool calls (#8479)

### DIFF
--- a/apps/chat-api/src/conversations/generation/chat-completions.adapter.ts
+++ b/apps/chat-api/src/conversations/generation/chat-completions.adapter.ts
@@ -111,6 +111,9 @@ export class ChatCompletionsAdapter {
   ): AsyncGenerator<Uint8Array, GenerationRelayOutcome, void> {
     let assembledMessage = initialAssembledMessage;
     let upstreamReader: ReadableStreamDefaultReader<Uint8Array> | null = null;
+    const cancelUpstreamOnAbort = (): void => {
+      void upstreamReader?.cancel().catch(() => undefined);
+    };
 
     try {
       const dialResult =
@@ -165,6 +168,8 @@ export class ChatCompletionsAdapter {
       }
 
       upstreamReader = dialResult.response.body.getReader();
+      signal.addEventListener('abort', cancelUpstreamOnAbort, { once: true });
+      if (signal.aborted) cancelUpstreamOnAbort();
       const decoder = new TextDecoder();
       let sseBuffer = '';
       let receivedDone = false;
@@ -172,6 +177,9 @@ export class ChatCompletionsAdapter {
 
       while (true) {
         const { done, value } = await upstreamReader.read();
+        if (signal.aborted) {
+          return { outcome: 'aborted', assembledMessage };
+        }
         if (done) {
           this.logger.debug(
             `relayModelCompletion upstream socket closed without [DONE] — model: ${model}`,
@@ -267,8 +275,9 @@ export class ChatCompletionsAdapter {
       return { outcome: 'completed', assembledMessage };
     } catch (err) {
       const isAbort =
-        err instanceof Error &&
-        (err.name === 'AbortError' || err.name === 'DOMException');
+        signal.aborted ||
+        (err instanceof Error &&
+          (err.name === 'AbortError' || err.name === 'DOMException'));
       this.logger.debug(
         `relayModelCompletion outcome: ${isAbort ? 'aborted' : 'error'} — model: ${model}: ${err instanceof Error ? err.message : String(err)}`,
       );
@@ -276,6 +285,7 @@ export class ChatCompletionsAdapter {
         ? { outcome: 'aborted', assembledMessage }
         : { outcome: 'error', error: err, assembledMessage };
     } finally {
+      signal.removeEventListener('abort', cancelUpstreamOnAbort);
       if (upstreamReader) {
         try {
           /*

--- a/apps/chat-api/src/conversations/generation/responses.adapter.spec.ts
+++ b/apps/chat-api/src/conversations/generation/responses.adapter.spec.ts
@@ -901,6 +901,43 @@ describe('ResponsesAdapter', () => {
       expect(result.outcome).toBe('aborted');
     });
 
+    it('cancels a pending upstream read when the signal aborts during a tool call', async () => {
+      const { adapter, mockDialClient } = makeAdapter();
+      const encoder = new TextEncoder();
+      const cancel = vi.fn();
+      const pendingToolCallStream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(
+            encoder.encode(
+              'data: {"type":"response.created","response":{"id":"resp-tool"}}\n\n',
+            ),
+          );
+        },
+        cancel,
+      });
+      vi.spyOn(mockDialClient.client, 'createResponse').mockResolvedValue({
+        response: new Response(pendingToolCallStream, { status: 200 }),
+      } as never);
+      const abortController = new AbortController();
+      const res = makeMockRes();
+
+      const relayPromise = adapter.relay(
+        { model: 'gpt-4o', input: [], stream: true, store: false },
+        'test-token',
+        abortController.signal,
+        res as never,
+        { role: ConversationMessageRole.Assistant, content: '' } as never,
+      );
+      await vi.waitFor(() => expect(res.write).toHaveBeenCalled());
+
+      abortController.abort();
+
+      await expect(relayPromise).resolves.toMatchObject({
+        outcome: 'aborted',
+      });
+      expect(cancel).toHaveBeenCalledTimes(1);
+    });
+
     it('does not forward response.reasoning_text.delta to the browser stream', async () => {
       const { adapter, mockDialClient } = makeAdapter();
       const { result, res } = await relay(adapter, mockDialClient, [

--- a/apps/chat-api/src/conversations/generation/responses.adapter.ts
+++ b/apps/chat-api/src/conversations/generation/responses.adapter.ts
@@ -184,6 +184,9 @@ export class ResponsesAdapter {
   ): AsyncGenerator<string, GenerationRelayOutcome, void> {
     let assembledMessage = initialAssembledMessage;
     let upstreamReader: ReadableStreamDefaultReader<Uint8Array> | null = null;
+    const cancelUpstreamOnAbort = (): void => {
+      void upstreamReader?.cancel().catch(() => undefined);
+    };
 
     try {
       const dialResult = (await this.dialClient.client.createResponse({
@@ -248,6 +251,8 @@ export class ResponsesAdapter {
       }
 
       upstreamReader = dialResult.response.body.getReader();
+      signal.addEventListener('abort', cancelUpstreamOnAbort, { once: true });
+      if (signal.aborted) cancelUpstreamOnAbort();
       const decoder = new TextDecoder();
       let sseBuffer = '';
       /*
@@ -378,6 +383,9 @@ export class ResponsesAdapter {
 
       while (true) {
         const { done, value } = await upstreamReader.read();
+        if (signal.aborted) {
+          return { outcome: 'aborted', assembledMessage };
+        }
         if (done) break;
 
         sseBuffer += decoder.decode(value, { stream: true });
@@ -449,12 +457,14 @@ export class ResponsesAdapter {
       };
     } catch (err) {
       const isAbort =
-        err instanceof Error &&
-        (err.name === 'AbortError' || err.name === 'DOMException');
+        signal.aborted ||
+        (err instanceof Error &&
+          (err.name === 'AbortError' || err.name === 'DOMException'));
       return isAbort
         ? { outcome: 'aborted', assembledMessage }
         : { outcome: 'error', error: err, assembledMessage };
     } finally {
+      signal.removeEventListener('abort', cancelUpstreamOnAbort);
       if (upstreamReader) {
         try {
           await upstreamReader.cancel();

--- a/apps/chat-api/src/conversations/streaming/conversation-streaming.service.ts
+++ b/apps/chat-api/src/conversations/streaming/conversation-streaming.service.ts
@@ -202,6 +202,9 @@ export class ConversationStreamingService {
   ): AsyncGenerator<Uint8Array, RelayOutcome, void> {
     let assembledMessage = initialAssembledMessage;
     let upstreamReader: ReadableStreamDefaultReader<Uint8Array> | null = null;
+    const cancelUpstreamOnAbort = (): void => {
+      void upstreamReader?.cancel().catch(() => undefined);
+    };
 
     try {
       const dialResult =
@@ -257,6 +260,8 @@ export class ConversationStreamingService {
       }
 
       upstreamReader = dialResult.response.body.getReader();
+      signal.addEventListener('abort', cancelUpstreamOnAbort, { once: true });
+      if (signal.aborted) cancelUpstreamOnAbort();
       const decoder = new TextDecoder();
       let sseBuffer = '';
       let receivedDone = false;
@@ -264,6 +269,9 @@ export class ConversationStreamingService {
 
       while (true) {
         const { done, value } = await upstreamReader.read();
+        if (signal.aborted) {
+          return { outcome: 'aborted', assembledMessage };
+        }
         if (done) {
           this.logger.debug(
             `relayModelCompletion upstream socket closed without [DONE] — model: ${model}`,
@@ -359,8 +367,9 @@ export class ConversationStreamingService {
       return { outcome: 'completed', assembledMessage };
     } catch (err) {
       const isAbort =
-        err instanceof Error &&
-        (err.name === 'AbortError' || err.name === 'DOMException');
+        signal.aborted ||
+        (err instanceof Error &&
+          (err.name === 'AbortError' || err.name === 'DOMException'));
       this.logger.debug(
         `relayModelCompletion outcome: ${isAbort ? 'aborted' : 'error'} — model: ${model}: ${err instanceof Error ? err.message : String(err)}`,
       );
@@ -368,6 +377,7 @@ export class ConversationStreamingService {
         ? { outcome: 'aborted', assembledMessage }
         : { outcome: 'error', error: err, assembledMessage };
     } finally {
+      signal.removeEventListener('abort', cancelUpstreamOnAbort);
       if (upstreamReader) {
         try {
           /*

--- a/apps/chat-api/src/conversations/streaming/tests/conversation-streaming.service.spec.ts
+++ b/apps/chat-api/src/conversations/streaming/tests/conversation-streaming.service.spec.ts
@@ -1303,5 +1303,75 @@ describe('ConversationStreamingService', () => {
       );
       expect(mockGenerationService.error).not.toHaveBeenCalled();
     });
+
+    it('stops and saves a pending tool-call stream without waiting for another upstream event', async () => {
+      vi.spyOn(
+        service['dialClient'].client,
+        'getConversation',
+      ).mockResolvedValue({
+        data: TEST_CONVERSATION,
+      } as never);
+      const saveConversationSpy = vi
+        .spyOn(service['dialClient'].client, 'saveConversation')
+        .mockResolvedValue({ data: {} } as never);
+      const generationAbortController = new AbortController();
+      vi.mocked(mockGenerationService.register).mockReturnValue(
+        generationAbortController,
+      );
+      vi.mocked(mockGenerationService.getStatus).mockReturnValue(
+        GenerationStatus.Stopped,
+      );
+
+      const encoder = new TextEncoder();
+      const cancel = vi.fn();
+      const pendingToolCallStream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(
+            encoder.encode(
+              'data: {"choices":[{"delta":{"custom_content":{"stages":[{"index":0,"name":"Calling tool","status":"in_progress"}]}}}]}\n\n',
+            ),
+          );
+        },
+        cancel,
+      });
+      vi.spyOn(
+        service['dialClient'].client,
+        'sendChatCompletionRequest',
+      ).mockResolvedValue({
+        response: new Response(pendingToolCallStream, { status: 200 }),
+      } as never);
+
+      const res = makeMockRes();
+      const streamPromise = runStreamCompletion(
+        'gpt-4o__Test__11111111-1111-1111-1111-111111111111',
+        'test-token',
+        'test-bucket',
+        'test-gen-id',
+        CompletionMode.Append,
+        'Use a tool',
+        undefined,
+        'gpt-4o',
+        undefined,
+        'test-session-id',
+        res as never,
+      );
+      await vi.waitFor(() => expect(res.write).toHaveBeenCalled());
+
+      generationAbortController.abort();
+      await streamPromise;
+
+      expect(cancel).toHaveBeenCalledTimes(1);
+      expect(saveConversationSpy).toHaveBeenCalledTimes(2);
+      const stoppedSave = saveConversationSpy.mock.calls[1][2].body as {
+        messages: { wasStoppedByUser?: boolean }[];
+      };
+      expect(stoppedSave.messages.at(-1)?.wasStoppedByUser).toBe(true);
+      expect(mockGenerationService.complete).not.toHaveBeenCalled();
+      expect(mockGenerationService.error).toHaveBeenCalledWith(
+        'test-session-id',
+        'gpt-4o__Test__11111111-1111-1111-1111-111111111111',
+        'test-gen-id',
+      );
+    });
   });
 });


### PR DESCRIPTION
**Description:**

Updated the Chat Completions and Responses API streaming flows to actively cancel the pending upstream stream read when an abort signal is received. The interrupted generation is finalized as user-stopped, and its partial response is preserved.
Added regression tests covering cancellation while a tool-call stream is waiting for another upstream event.

Issues:

- https://github.com/epam/ai-dial-chat/issues/8479

**Checklist:**

- [X] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [X] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [X] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
