### PR TITLE
fix(chat-api): allow OOXML WebAssembly in CSP (Issue #7617)

### DIFF
--- a/apps/chat-api/README.md
+++ b/apps/chat-api/README.md
@@ -523,7 +523,7 @@ property so a client failure can be correlated with server traces and logs.
 - **Input Validation**: A global `ValidationPipe` (`whitelist`, `forbidNonWhitelisted`, `transform`) plus per-endpoint DTOs with validation decorators
 - **Path Traversal Protection**: Any string reaching a path, URL, or log line is constrained by an allowlist regex
 - **Session Security**: Encrypted session cookie, `HttpOnly` + `Secure` + `SameSite=Lax`, `__Host-` prefixed when host-scoped, with CSRF protection on state-changing requests
-- **Security Headers**: Helmet middleware with CSP, HSTS, and other security headers; `frame-ancestors` driven by `ALLOWED_IFRAME_ORIGINS`. Local HTTP smoke mode (`AUTH_COOKIE_SECURE=false`) disables HSTS and CSP `upgrade-insecure-requests`
+- **Security Headers**: Helmet middleware with CSP, HSTS, and other security headers; `script-src` permits WebAssembly compilation for the OOXML attachment viewer without permitting JavaScript `eval`, and `frame-ancestors` is driven by `ALLOWED_IFRAME_ORIGINS`. Local HTTP smoke mode (`AUTH_COOKIE_SECURE=false`) disables HSTS and CSP `upgrade-insecure-requests`
 - **CORS Configuration**: Restricted to configured origin with credentials support
 - **Rate Limiting**: Throttling to prevent abuse (100 req/min default, customizable per endpoint)
 - **Secret Hygiene**: Tokens, refresh tokens, and cookie payloads are never logged

--- a/apps/chat-api/src/config/csp.ts
+++ b/apps/chat-api/src/config/csp.ts
@@ -35,7 +35,12 @@ export const createHelmetOptions = (
       defaultSrc: ["'self'"],
       styleSrc: ["'self'", "'unsafe-inline'", 'https://fonts.googleapis.com'],
       fontSrc: ["'self'", 'https://fonts.gstatic.com'],
-      scriptSrc: ["'self'"],
+      scriptSrc: [
+        "'self'",
+        /* Allows the attachment canvas to compile its same-origin OOXML WASM
+         * parsers without enabling arbitrary JavaScript evaluation. */
+        "'wasm-unsafe-eval'",
+      ],
       workerSrc: ["'self'", 'blob:'],
       imgSrc: ["'self'", 'data:', 'blob:', 'https:'],
       mediaSrc: ["'self'", 'blob:'],

--- a/apps/chat-api/src/config/tests/csp.spec.ts
+++ b/apps/chat-api/src/config/tests/csp.spec.ts
@@ -75,6 +75,20 @@ describe('Helmet security headers', () => {
     );
   });
 
+  it('allows OOXML WebAssembly parsers without enabling JavaScript eval', async () => {
+    app = await createTestApp([]);
+    const response = await request(app.getHttpServer())
+      .get('/ping')
+      .expect(200);
+
+    expect(response.headers['content-security-policy']).toContain(
+      "script-src 'self' 'wasm-unsafe-eval'",
+    );
+    expect(response.headers['content-security-policy']).not.toContain(
+      "'unsafe-eval'",
+    );
+  });
+
   it("sends frame-ancestors 'none' and keeps X-Frame-Options when the allowlist is empty", async () => {
     app = await createTestApp([]);
     const response = await request(app.getHttpServer())

--- a/docs/technical-requirements.md
+++ b/docs/technical-requirements.md
@@ -141,6 +141,7 @@ ring and percentage use the theme error color.
 | NFR-2.3 | `helmet` enforces CSP, HSTS, and standard security headers by default; local HTTP smoke mode disables HSTS and CSP `upgrade-insecure-requests`                 |
 | NFR-2.4 | No auth tokens or user credentials are ever passed to or stored by UI libraries                                                                                |
 | NFR-2.5 | Conversation completions endpoint is rate-limited to 10 req/min per session                                                                                    |
+| NFR-2.6 | CSP permits OOXML WebAssembly compilation without permitting JavaScript `eval`                                                                                 |
 
 ### NFR-3 — Accessibility
 


### PR DESCRIPTION
**Description:**

Allow Attachment Canvas OOXML viewers to compile their bundled WebAssembly parsers under the production Helmet CSP. The policy uses the narrow wasm-unsafe-eval permission instead of unsafe-eval, so JavaScript eval remains blocked while DOCX, XLSX, and PPTX previews work on deployed environments. Regression coverage and security documentation are included.

Issues:

- Issue #7617

**UI changes**

No UI changes

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with fix(chat-api):
- [x] the pull request name ends with (Issue #7617)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs