### PR TITLE
fix: Fix how file extension is calculated, #8492

### DIFF
--- a/libs/chat-hooks/src/attachment/useAttachmentAction/useAttachmentAction.ts
+++ b/libs/chat-hooks/src/attachment/useAttachmentAction/useAttachmentAction.ts
@@ -5,6 +5,7 @@ import {
 } from '@epam/ai-dial-attachment-canvas';
 import {
   base64ToBlob,
+  ensureDownloadFilename,
   triggerAnchorDownload,
   triggerBlobDownload,
   MIMEType,
@@ -54,7 +55,10 @@ export const downloadAttachment = (
     const downloadUrl = resolveDownloadUrl(url);
     if (downloadUrl == null) return false;
 
-    triggerAnchorDownload(downloadUrl, name);
+    triggerAnchorDownload(
+      downloadUrl,
+      ensureDownloadFilename(name, url, contentType),
+    );
     return true;
   }
 
@@ -64,7 +68,7 @@ export const downloadAttachment = (
   if (data != null) {
     triggerBlobDownload(
       base64ToBlob(data, contentType || MIMEType.Plain),
-      name,
+      ensureDownloadFilename(name, url, contentType),
     );
     return true;
   }
@@ -83,9 +87,10 @@ const openAnnotationAttachment = (
   if (isDialFileId(fileId)) {
     const downloadUrl = resolveDownloadUrl(fileId);
     if (downloadUrl == null) return;
+    const displayName = attachment.title ?? fileId.split('/').pop() ?? '';
     triggerAnchorDownload(
       downloadUrl,
-      attachment.title ?? fileId.split('/').pop() ?? '',
+      ensureDownloadFilename(displayName, fileId, attachment.type),
     );
   } else {
     window.open(url, '_blank', 'noopener,noreferrer');

--- a/libs/chat-shared/README.md
+++ b/libs/chat-shared/README.md
@@ -293,6 +293,7 @@ import {
   extractInitials,
   pickAvatarColor,
   isAudioTranscriptionSupported,
+  ensureDownloadFilename,
   downloadTextFile,
   triggerBlobDownload,
   getUtf8ByteLength,
@@ -327,6 +328,10 @@ formatUnitPrice('0.000003', 'token'); // '$3/M tokens'
 // Derive an avatar's initials and its deterministic color from a name
 const initials = extractInitials(user.displayName);
 const { background, foreground } = pickAvatarColor(user.displayName);
+
+// Ensure a download filename carries a file extension; derives one from the url path or MIME type when absent
+ensureDownloadFilename('Q3 Summary', 'files/bucket/Q3_2026.xlsx', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'); // 'Q3 Summary.xlsx'
+ensureDownloadFilename('report.pdf', undefined, undefined); // 'report.pdf' — unchanged
 
 // Strip characters DIAL Core rejects in a conversation name (tab, ": ; / \ , = { } % &)
 sanitizeConversationName('bad:name/here'); // 'badnamehere'

--- a/libs/chat-shared/src/utils/file-download.ts
+++ b/libs/chat-shared/src/utils/file-download.ts
@@ -1,3 +1,33 @@
+import { MIME_TYPE_EXT_MAP } from '../constants/mime-types';
+
+/**
+ * Returns `name` with a file extension appended when it lacks one.
+ * Priority: extension already present → extension from the last segment of `url` → extension from `contentType` via `MIME_TYPE_EXT_MAP`.
+ */
+export const ensureDownloadFilename = (
+  name: string,
+  url: string | undefined,
+  contentType: string | undefined,
+): string => {
+  const dot = name.lastIndexOf('.');
+  if (dot > 0 && dot < name.length - 1) return name;
+
+  if (url != null) {
+    const segment = url.split(/[?#]/)[0].split('/').pop() ?? '';
+    const segDot = segment.lastIndexOf('.');
+    if (segDot > 0 && segDot < segment.length - 1) {
+      return `${name}.${segment.slice(segDot + 1)}`;
+    }
+  }
+
+  if (contentType != null) {
+    const ext = MIME_TYPE_EXT_MAP[contentType];
+    if (ext != null) return `${name}.${ext}`;
+  }
+
+  return name;
+};
+
 /** Maps a fenced-code-block language identifier to a file extension (without the leading dot). */
 const LANGUAGE_EXTENSIONS: Record<string, string> = {
   typescript: 'ts',

--- a/libs/chat-shared/src/utils/tests/file-download.spec.ts
+++ b/libs/chat-shared/src/utils/tests/file-download.spec.ts
@@ -2,10 +2,55 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   base64ToBlob,
   downloadTextFile,
+  ensureDownloadFilename,
   getFileExtensionForLanguage,
   triggerAnchorDownload,
   tryBase64ToBytes,
 } from '../file-download';
+
+describe('ensureDownloadFilename', () => {
+  it('returns the name unchanged when it already has an extension', () => {
+    expect(ensureDownloadFilename('report.xlsx', undefined, undefined)).toBe(
+      'report.xlsx',
+    );
+  });
+
+  it('appends the extension extracted from the url path segment', () => {
+    expect(
+      ensureDownloadFilename(
+        'Thermo Fisher Scientific - 10-K Risk Factors',
+        'files/bucket/appdata/ThermoFisher_2024.xlsx',
+        'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+      ),
+    ).toBe('Thermo Fisher Scientific - 10-K Risk Factors.xlsx');
+  });
+
+  it('falls back to the MIME type extension when the url has no extension', () => {
+    expect(
+      ensureDownloadFilename(
+        'Q3 Financial Summary',
+        'files/bucket/appdata/document',
+        'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+      ),
+    ).toBe('Q3 Financial Summary.xlsx');
+  });
+
+  it('returns the name unchanged when neither url nor contentType provide an extension', () => {
+    expect(ensureDownloadFilename('unknown file', undefined, undefined)).toBe(
+      'unknown file',
+    );
+  });
+
+  it('strips query string and fragment from the url before extracting the extension', () => {
+    expect(
+      ensureDownloadFilename(
+        'Report',
+        'files/bucket/report.pdf?token=abc#page=2',
+        undefined,
+      ),
+    ).toBe('Report.pdf');
+  });
+});
 
 describe('getFileExtensionForLanguage', () => {
   it('maps known language identifiers to their file extension', () => {

--- a/openspec/specs/attachment-card-click/spec.md
+++ b/openspec/specs/attachment-card-click/spec.md
@@ -93,7 +93,7 @@ The DIAL-file-id-to-URL step is host-owned — it encodes the application's own 
 
 When `handleAttachmentClick` is called with an attachment:
 
-1. If `attachment.url` or inline `attachment.data` is set, delegate to `downloadAttachment`, which downloads a DIAL file id through `resolveDownloadUrl` + `triggerAnchorDownload`, or builds a blob from inline base64 `data` and downloads it through `triggerBlobDownload`. A `url` that is set but is not a DIAL file id, with no `data`, resolves to no download.
+1. If `attachment.url` or inline `attachment.data` is set, delegate to `downloadAttachment`, which downloads a DIAL file id through `resolveDownloadUrl` + `triggerAnchorDownload`, or builds a blob from inline base64 `data` and downloads it through `triggerBlobDownload`. The download filename is produced by `ensureDownloadFilename(name, url, contentType)` — if the attachment's `name` already ends with a file extension, it is used as-is; otherwise the extension is derived first from the last path segment of `url`, then from `MIME_TYPE_EXT_MAP[contentType]`. A `url` that is set but is not a DIAL file id, with no `data`, resolves to no download.
 2. Otherwise, if `attachment.referenceUrl` is set (a reference-only attachment — no `url`, e.g. a RAG/search-grounding chunk):
    - If the reference targets a PDF (optionally with a `#page=N` fragment), open the canvas with the resulting `PdfCanvasContent` via `openCanvas(content, attachment.name)`. A referenced page is expressed as a single transparent, zero-area highlight plus a matching `selectedHighlightId`, so the viewer scrolls to that page without painting anything over it.
    - Otherwise, download DIAL-hosted files through `resolveDownloadUrl` or open external URLs via `window.open(url, '_blank', 'noopener,noreferrer')`.
@@ -108,7 +108,22 @@ The returned callback SHALL be stable across re-renders (wrapped in `useCallback
 #### Scenario: DIAL file attachment triggers a download
 
 - **WHEN** `handleAttachmentClick` is called with an attachment whose `url` is `'files/my-bucket/folder/file.pdf'`
-- **THEN** `triggerAnchorDownload` is called with the URL that `resolveDownloadUrl` returned and the attachment's name
+- **THEN** `triggerAnchorDownload` is called with the URL that `resolveDownloadUrl` returned and the filename produced by `ensureDownloadFilename`
+
+#### Scenario: Download filename preserves an already-present extension
+
+- **WHEN** `handleAttachmentClick` is called with an attachment whose `name` is `'Q3_2026_Financial_Performance.xlsx'`
+- **THEN** `triggerAnchorDownload` is called with the filename `'Q3_2026_Financial_Performance.xlsx'` unchanged
+
+#### Scenario: Download filename gains extension from the URL path when the name has none
+
+- **WHEN** `handleAttachmentClick` is called with an attachment whose `name` is `'Thermo Fisher 10-K Summary'` and whose `url` ends with `'ThermoFisher_2024.xlsx'`
+- **THEN** `triggerAnchorDownload` is called with the filename `'Thermo Fisher 10-K Summary.xlsx'`
+
+#### Scenario: Download filename falls back to MIME type when neither name nor URL carries an extension
+
+- **WHEN** `handleAttachmentClick` is called with an attachment whose `name` has no extension, whose `url` path segment has no extension, and whose `contentType` is `'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'`
+- **THEN** `triggerAnchorDownload` is called with a filename ending in `.xlsx`
 
 #### Scenario: Inline data attachment downloads as a blob
 

--- a/openspec/specs/chat-hooks-attachments/spec.md
+++ b/openspec/specs/chat-hooks-attachments/spec.md
@@ -62,6 +62,13 @@ accept a required `resolveDownloadUrl: (fileId: string) => string | undefined`
 parameter and use it wherever a DIAL file id needs to become a downloadable
 URL.
 
+Before passing the filename to `triggerAnchorDownload` or `triggerBlobDownload`,
+the hook SHALL call `ensureDownloadFilename(name, url, contentType)` to guarantee
+a file extension is present. The function returns `name` unchanged when it already
+ends with an extension; otherwise it appends the extension extracted from the last
+path segment of `url`, then falls back to `MIME_TYPE_EXT_MAP[contentType]`, and
+finally returns `name` as-is when neither source provides an extension.
+
 The hook SHALL return `{ handleAttachmentClick: (attachment: DisplayAttachment)
 => void }`. It SHALL also export the standalone `isDownloadableAttachment:
 (attachment: DisplayAttachment) => boolean` and `downloadAttachment:
@@ -75,7 +82,22 @@ action).
 - **WHEN** a consumer calls `handleAttachmentClick` with a `DisplayAttachment`
   whose `url` is a DIAL file id
 - **THEN** the hook calls the supplied `resolveDownloadUrl` with that file id
-  and triggers a browser download from the resolved URL
+  and triggers a browser download from the resolved URL, using a filename
+  produced by `ensureDownloadFilename`
+
+#### Scenario: Download filename gets extension from the URL when the name has none
+
+- **WHEN** a consumer calls `handleAttachmentClick` with a `DisplayAttachment`
+  whose `name` is `'Thermo Fisher 10-K Summary'` and whose `url` path ends with
+  `'ThermoFisher_2024.xlsx'`
+- **THEN** the triggered download uses the filename `'Thermo Fisher 10-K Summary.xlsx'`
+
+#### Scenario: Download filename falls back to MIME-type extension when the URL has none
+
+- **WHEN** a consumer calls `handleAttachmentClick` with a `DisplayAttachment`
+  whose `name` has no extension, whose `url` path segment has no extension, and
+  whose `contentType` is `'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'`
+- **THEN** the triggered download uses a filename ending in `.xlsx`
 
 #### Scenario: Canvas-previewable reference attachment opens the canvas
 


### PR DESCRIPTION
**Description:**

File was downloaded without extension if it's missing in title - though we can take it from other data.

Issues:

- Issue #8492

**UI changes**

<Please, provide Screenshots or Figma links>

**Checklist:**

- [X] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [X] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [X] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
