### PR TITLE
chore(chat-overlay): replace ChatOverlay inline styles with an injected stylesheet

### DIFF
--- a/libs/chat-overlay/README.md
+++ b/libs/chat-overlay/README.md
@@ -168,7 +168,7 @@ manager.destroy();
 | ----------------------- | ---------------------------------------------------------- | -------------------------------------------------------------------------------------- |
 | `domain`                | `string`                                                   | Full URL of the chat app instance to embed (origin + optional path).                   |
 | `requestTimeout`        | `number?`                                                  | Milliseconds to wait for a request's response before rejecting. Defaults to `10000`.   |
-| `loaderStyles`          | `Record<string, string>?`                                  | Inline CSS properties applied to the loader element, overriding the injected defaults. |
+| `loaderStyles`          | `Record<string, string>?`                                  | Inline CSS properties applied to the loader element, overriding the injected defaults — except `display`, which is cleared when the loader hides (see [Styling](#styling)). |
 | `loaderClass`           | `string?`                                                  | CSS class added to the loader element alongside `dial-overlay-loader`.                 |
 | `loaderInnerHTML`       | `string?`                                                  | Custom HTML rendered inside the loader, replacing the default spinner.                 |
 | `loaderHideEvent`       | `OverlayEventType?`                                        | Event whose receipt hides the loader. Defaults to `OverlayEventType.Ready`.            |
@@ -206,10 +206,38 @@ and elements carry classes instead of inline styles:
 | `dial-overlay-loader`          | The loader element.                                                             |
 | `dial-overlay-loader--hidden`  | The loader once `loaderHideEvent` arrives (`display: none !important`).          |
 
-Host CSS of equal or higher specificity can restyle any of these; `loaderStyles`
-remains an inline-style escape hatch that wins over both. `ChatOverlayManager`
-injects its own `<style id="dial-overlay-manager-styles">` element for the
-`dial-overlay-btn` chrome buttons.
+Host CSS of equal or higher specificity can restyle any of these, and
+`loaderStyles` is an inline-style escape hatch that wins over both — with one
+exception. Visibility is not styling: `dial-overlay-loader--hidden` declares
+`display: none !important`, and `hideLoader()` also clears any inline `display`
+the host set through `loaderStyles`, so the loader always disappears when
+`loaderHideEvent` arrives. Set every other property freely; do not use `display`
+to drive loader visibility — configure `loaderHideEvent` instead.
+
+The colors are fixed by design (this lib ships no CSS file and does not
+participate in the `--cs-*` / `buildCssVars` theming channel), but each one is
+read through a custom property with a literal fallback. Set these on any
+ancestor of the overlay root to retheme without an `!important` override:
+
+| Custom property                        | Default   | Applies to                                                    |
+| -------------------------------------- | --------- | ------------------------------------------------------------- |
+| `--dial-overlay-loader-background`     | `#ffffff` | Loader backdrop.                                              |
+| `--dial-overlay-loader-color`          | `#2764d9` | Loader foreground — the spinner's `currentColor` stroke.      |
+| `--dial-overlay-btn-background`        | `#2764d9` | `ChatOverlayManager` chrome buttons.                          |
+| `--dial-overlay-btn-color`             | `#ffffff` | Chrome button icon.                                           |
+| `--dial-overlay-btn-background-hover`  | `#1d4fb8` | Chrome button on `:hover` / `:focus-visible`.                 |
+| `--dial-overlay-btn-outline`           | `#1d4fb8` | Chrome button focus outline.                                  |
+
+```css
+:root {
+  --dial-overlay-loader-background: #131319;
+  --dial-overlay-loader-color: #5c8dea;
+}
+```
+
+`ChatOverlayManager` injects its own
+`<style id="dial-overlay-manager-styles">` element for the `dial-overlay-btn`
+chrome buttons.
 
 ## Deployment prerequisites
 

--- a/libs/chat-overlay/README.md
+++ b/libs/chat-overlay/README.md
@@ -168,8 +168,8 @@ manager.destroy();
 | ----------------------- | ---------------------------------------------------------- | -------------------------------------------------------------------------------------- |
 | `domain`                | `string`                                                   | Full URL of the chat app instance to embed (origin + optional path).                   |
 | `requestTimeout`        | `number?`                                                  | Milliseconds to wait for a request's response before rejecting. Defaults to `10000`.   |
-| `loaderStyles`          | `Record<string, string>?`                                  | Inline CSS properties applied to the loader element while visible.                     |
-| `loaderClass`           | `string?`                                                  | CSS class applied to the loader element.                                               |
+| `loaderStyles`          | `Record<string, string>?`                                  | Inline CSS properties applied to the loader element, overriding the injected defaults. |
+| `loaderClass`           | `string?`                                                  | CSS class added to the loader element alongside `dial-overlay-loader`.                 |
 | `loaderInnerHTML`       | `string?`                                                  | Custom HTML rendered inside the loader, replacing the default spinner.                 |
 | `loaderHideEvent`       | `OverlayEventType?`                                        | Event whose receipt hides the loader. Defaults to `OverlayEventType.Ready`.            |
 | `enabledFeatures`       | `OverlayFeature[]?`                                        | Embed-time features to enable, e.g. `OverlayFeature.VoiceInput` for microphone access. |
@@ -192,6 +192,24 @@ manager.destroy();
 | `GptEndGenerating`           | When a generation completes normally (not on user-initiated stop).     |
 | `StopGenerating`             | When the user (or host) stops an in-flight generation.                 |
 | `ConversationsUpdated`       | Whenever the app's conversation list changes.                          |
+
+## Styling
+
+The overlay ships no CSS file — the first `ChatOverlay` constructed appends a
+`<style id="dial-overlay-styles">` element to `document.head`, once per document,
+and elements carry classes instead of inline styles:
+
+| Class                          | Applied to                                                                      |
+| ------------------------------ | ------------------------------------------------------------------------------- |
+| `dial-overlay-root`            | The host root element, only when its computed `position` is `static`.            |
+| `dial-overlay-iframe`          | The embedded chat iframe.                                                       |
+| `dial-overlay-loader`          | The loader element.                                                             |
+| `dial-overlay-loader--hidden`  | The loader once `loaderHideEvent` arrives (`display: none !important`).          |
+
+Host CSS of equal or higher specificity can restyle any of these; `loaderStyles`
+remains an inline-style escape hatch that wins over both. `ChatOverlayManager`
+injects its own `<style id="dial-overlay-manager-styles">` element for the
+`dial-overlay-btn` chrome buttons.
 
 ## Deployment prerequisites
 

--- a/libs/chat-overlay/src/lib/ChatOverlay.ts
+++ b/libs/chat-overlay/src/lib/ChatOverlay.ts
@@ -470,6 +470,14 @@ export class ChatOverlay {
 
   private hideLoader(): void {
     this.loader.classList.add(OverlayClassName.LoaderHidden);
+    /*
+     * `loaderStyles` is an inline-style escape hatch for the loader's look, but
+     * a `display` entry in it competes with the hidden state rather than
+     * describing it. Dropping it here keeps the class the single source of
+     * truth for visibility, including when the host marked it `!important` —
+     * the one declaration the stylesheet's own `!important` cannot outrank.
+     */
+    this.loader.style.removeProperty('display');
   }
 
   private notifySubscribers(

--- a/libs/chat-overlay/src/lib/ChatOverlay.ts
+++ b/libs/chat-overlay/src/lib/ChatOverlay.ts
@@ -34,6 +34,10 @@ import {
 import { DEFAULT_LOADER_INNER_HTML } from './internal/default-loader';
 import { DeferredRequest } from './internal/deferred-request';
 import { setStyles } from './internal/dom-styles';
+import {
+  ensureOverlayStylesInjected,
+  OverlayClassName,
+} from './internal/overlay-styles';
 import { Task } from './internal/task';
 
 const DEFAULT_REQUEST_TIMEOUT_MS = 10000;
@@ -81,12 +85,7 @@ const createIframe = (options: ChatOverlayOptions): HTMLIFrameElement => {
     allowedPermissions.push('microphone');
   }
   iframe.setAttribute('allow', allowedPermissions.join('; '));
-  setStyles(iframe, {
-    border: 'none',
-    display: 'block',
-    width: '100%',
-    height: '100%',
-  });
+  iframe.className = OverlayClassName.Iframe;
   return iframe;
 };
 
@@ -94,20 +93,9 @@ const createLoader = (options: ChatOverlayOptions): HTMLElement => {
   const loader = document.createElement('div');
   loader.setAttribute(LOADER_ATTRIBUTE, '');
   loader.innerHTML = options.loaderInnerHTML ?? DEFAULT_LOADER_INNER_HTML;
-  setStyles(loader, {
-    position: 'absolute',
-    inset: '0',
-    zIndex: '2',
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    boxSizing: 'border-box',
-    background: '#ffffff',
-    color: '#2764d9',
-  });
-  if (options.loaderClass) {
-    loader.className = options.loaderClass;
-  }
+  loader.className = [OverlayClassName.Loader, options.loaderClass]
+    .filter(Boolean)
+    .join(' ');
   if (options.loaderStyles) {
     setStyles(loader, options.loaderStyles);
   }
@@ -143,11 +131,12 @@ export class ChatOverlay {
     this.root = resolveRoot(root);
     this.options = { ...options };
     this.targetOrigin = new URL(options.domain).origin;
+    ensureOverlayStylesInjected();
     this.iframe = createIframe(this.options);
     this.loader = createLoader(this.options);
     const rootPosition = window.getComputedStyle(this.root).position;
     if (rootPosition === 'static' || rootPosition === '') {
-      setStyles(this.root, { position: 'relative' });
+      this.root.classList.add(OverlayClassName.Root);
     }
     this.root.appendChild(this.loader);
     this.root.appendChild(this.iframe);
@@ -480,7 +469,7 @@ export class ChatOverlay {
   }
 
   private hideLoader(): void {
-    this.loader.style.display = 'none';
+    this.loader.classList.add(OverlayClassName.LoaderHidden);
   }
 
   private notifySubscribers(

--- a/libs/chat-overlay/src/lib/ChatOverlayManager.ts
+++ b/libs/chat-overlay/src/lib/ChatOverlayManager.ts
@@ -32,6 +32,12 @@ const ICON_FULLSCREEN =
 
 const STYLE_ELEMENT_ID = 'dial-overlay-manager-styles';
 
+/*
+ * The chrome palette is read through custom properties with literal fallbacks,
+ * so a host retheming the toggle sets `--dial-overlay-btn-*` on any ancestor
+ * instead of overriding the injected source order. See `OverlayCssVariable`
+ * for the loader's equivalent knobs.
+ */
 const MANAGER_CSS = `
 .dial-overlay-btn {
   display: inline-flex;
@@ -42,13 +48,13 @@ const MANAGER_CSS = `
   border: none;
   border-radius: 999px;
   cursor: pointer;
-  background: #2764d9;
-  color: #ffffff;
+  background: var(--dial-overlay-btn-background, #2764d9);
+  color: var(--dial-overlay-btn-color, #ffffff);
 }
 .dial-overlay-btn:hover,
 .dial-overlay-btn:focus-visible {
-  background: #1d4fb8;
-  outline: 2px solid #1d4fb8;
+  background: var(--dial-overlay-btn-background-hover, #1d4fb8);
+  outline: 2px solid var(--dial-overlay-btn-outline, #1d4fb8);
   outline-offset: 2px;
 }
 `;

--- a/libs/chat-overlay/src/lib/ChatOverlayManager.ts
+++ b/libs/chat-overlay/src/lib/ChatOverlayManager.ts
@@ -15,7 +15,7 @@ import type {
   SetTemperatureResponse,
 } from '../protocol';
 import { ChatOverlay } from './ChatOverlay';
-import { setStyles } from './internal/dom-styles';
+import { injectStyleSheet, setStyles } from './internal/dom-styles';
 
 const MOBILE_BREAKPOINT_PX = 768;
 const DEFAULT_WIDTH = 380;
@@ -32,13 +32,7 @@ const ICON_FULLSCREEN =
 
 const STYLE_ELEMENT_ID = 'dial-overlay-manager-styles';
 
-const ensureManagerStylesInjected = (): void => {
-  if (document.getElementById(STYLE_ELEMENT_ID)) {
-    return;
-  }
-  const style = document.createElement('style');
-  style.id = STYLE_ELEMENT_ID;
-  style.textContent = `
+const MANAGER_CSS = `
 .dial-overlay-btn {
   display: inline-flex;
   align-items: center;
@@ -58,7 +52,9 @@ const ensureManagerStylesInjected = (): void => {
   outline-offset: 2px;
 }
 `;
-  document.head.appendChild(style);
+
+const ensureManagerStylesInjected = (): void => {
+  injectStyleSheet(STYLE_ELEMENT_ID, MANAGER_CSS);
 };
 
 const createButton = (

--- a/libs/chat-overlay/src/lib/internal/dom-styles.ts
+++ b/libs/chat-overlay/src/lib/internal/dom-styles.ts
@@ -5,3 +5,18 @@ export const setStyles = (
 ): void => {
   Object.assign(element.style, styles);
 };
+
+/**
+ * Appends a `<style id="{id}">` element carrying `css` to `document.head`,
+ * once per document. Repeat calls with the same `id` are a no-op, so every
+ * overlay instance can call it during construction.
+ */
+export const injectStyleSheet = (id: string, css: string): void => {
+  if (document.getElementById(id)) {
+    return;
+  }
+  const style = document.createElement('style');
+  style.id = id;
+  style.textContent = css;
+  document.head.appendChild(style);
+};

--- a/libs/chat-overlay/src/lib/internal/overlay-styles.ts
+++ b/libs/chat-overlay/src/lib/internal/overlay-styles.ts
@@ -14,10 +14,27 @@ export enum OverlayClassName {
   LoaderHidden = 'dial-overlay-loader--hidden',
 }
 
+/**
+ * Custom properties the injected stylesheet reads, each with a literal
+ * fallback. This lib deliberately ships no CSS file and no `--cs-*` theming
+ * channel, so these are the supported way for a host to retheme the loader
+ * palette without an `!important` fight against the injected source order.
+ */
+export enum OverlayCssVariable {
+  /** Loader backdrop. Defaults to `#ffffff`. */
+  LoaderBackground = '--dial-overlay-loader-background',
+  /** Loader foreground, inherited by the spinner's `currentColor` stroke. Defaults to `#2764d9`. */
+  LoaderColor = '--dial-overlay-loader-color',
+}
+
 /*
- * `display: none !important` is deliberate: the loader look is overridable
- * through `loaderClass`/`loaderStyles`, but hiding it once the embedded app is
- * ready must never lose to host CSS or to a `display` entry in `loaderStyles`.
+ * Every declaration below is a look a host may override — except the hidden
+ * state. `display: none !important` is deliberate there: hiding the loader once
+ * the embedded app is ready is a state change, not styling, so it must not lose
+ * to `loaderClass` host CSS that happens to sit later in the cascade. The one
+ * layer an author `!important` cannot outrank is an inline declaration that is
+ * itself `!important`, so `ChatOverlay.hideLoader()` additionally clears any
+ * inline `display` the host set through the `loaderStyles` escape hatch.
  */
 const OVERLAY_CSS = `
 .${OverlayClassName.Root} {
@@ -37,8 +54,8 @@ const OVERLAY_CSS = `
   align-items: center;
   justify-content: center;
   box-sizing: border-box;
-  background: #ffffff;
-  color: #2764d9;
+  background: var(${OverlayCssVariable.LoaderBackground}, #ffffff);
+  color: var(${OverlayCssVariable.LoaderColor}, #2764d9);
 }
 .${OverlayClassName.LoaderHidden} {
   display: none !important;

--- a/libs/chat-overlay/src/lib/internal/overlay-styles.ts
+++ b/libs/chat-overlay/src/lib/internal/overlay-styles.ts
@@ -1,0 +1,51 @@
+import { injectStyleSheet } from './dom-styles';
+
+const STYLE_ELEMENT_ID = 'dial-overlay-styles';
+
+/** Class names applied by `ChatOverlay` to the host root, iframe, and loader. */
+export enum OverlayClassName {
+  /** Positioning context on the host-provided root element. */
+  Root = 'dial-overlay-root',
+  /** The embedded chat iframe. */
+  Iframe = 'dial-overlay-iframe',
+  /** The loader shown until the configured hide event arrives. */
+  Loader = 'dial-overlay-loader',
+  /** Hidden state of the loader. */
+  LoaderHidden = 'dial-overlay-loader--hidden',
+}
+
+/*
+ * `display: none !important` is deliberate: the loader look is overridable
+ * through `loaderClass`/`loaderStyles`, but hiding it once the embedded app is
+ * ready must never lose to host CSS or to a `display` entry in `loaderStyles`.
+ */
+const OVERLAY_CSS = `
+.${OverlayClassName.Root} {
+  position: relative;
+}
+.${OverlayClassName.Iframe} {
+  display: block;
+  width: 100%;
+  height: 100%;
+  border: none;
+}
+.${OverlayClassName.Loader} {
+  position: absolute;
+  inset: 0;
+  z-index: 2;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-sizing: border-box;
+  background: #ffffff;
+  color: #2764d9;
+}
+.${OverlayClassName.LoaderHidden} {
+  display: none !important;
+}
+`;
+
+/** Injects the `ChatOverlay` stylesheet into `document.head`, once per document. */
+export const ensureOverlayStylesInjected = (): void => {
+  injectStyleSheet(STYLE_ELEMENT_ID, OVERLAY_CSS);
+};

--- a/libs/chat-overlay/src/lib/tests/ChatOverlay.spec.ts
+++ b/libs/chat-overlay/src/lib/tests/ChatOverlay.spec.ts
@@ -194,6 +194,52 @@ describe('ChatOverlay', () => {
     expect(loader.classList.contains(OverlayClassName.LoaderHidden)).toBe(true);
   });
 
+  it('hides the loader even when loaderStyles pins an inline display', () => {
+    const { root, iframe } = setup({
+      loaderStyles: { display: 'flex' },
+      loaderHideEvent: OverlayEventType.ReadyToInteract,
+    });
+    const loader = root.querySelector(
+      '[data-dial-overlay-loader]',
+    ) as HTMLElement;
+    expect(loader.style.display).toBe('flex');
+
+    dispatchFromApp(iframe, { type: OverlayEventType.InitReady });
+    dispatchFromApp(iframe, { type: OverlayEventType.Ready });
+    expect(loader.style.display).toBe('flex');
+
+    dispatchFromApp(iframe, { type: OverlayEventType.ReadyToInteract });
+    expect(loader.classList.contains(OverlayClassName.LoaderHidden)).toBe(true);
+    expect(loader.style.display).toBe('');
+  });
+
+  it('keeps non-display loaderStyles entries after the loader hides', () => {
+    const { root, iframe } = setup({
+      loaderStyles: { display: 'flex', backgroundColor: 'rgb(1, 2, 3)' },
+    });
+    const loader = root.querySelector(
+      '[data-dial-overlay-loader]',
+    ) as HTMLElement;
+
+    dispatchFromApp(iframe, { type: OverlayEventType.InitReady });
+    dispatchFromApp(iframe, { type: OverlayEventType.Ready });
+
+    expect(loader.style.display).toBe('');
+    expect(loader.style.backgroundColor).toBe('rgb(1, 2, 3)');
+  });
+
+  it('reads the loader palette from themable custom properties', () => {
+    setup();
+    const styleSheet = document.getElementById('dial-overlay-styles');
+
+    expect(styleSheet?.textContent).toContain(
+      'background: var(--dial-overlay-loader-background, #ffffff);',
+    );
+    expect(styleSheet?.textContent).toContain(
+      'color: var(--dial-overlay-loader-color, #2764d9);',
+    );
+  });
+
   it('does not resolve ready() on READY alone', async () => {
     const { overlay, iframe } = setup();
     let resolved = false;

--- a/libs/chat-overlay/src/lib/tests/ChatOverlay.spec.ts
+++ b/libs/chat-overlay/src/lib/tests/ChatOverlay.spec.ts
@@ -9,6 +9,7 @@ import {
   type ChatOverlayOptions,
 } from '../../protocol';
 import { ChatOverlay, ChatOverlayRequestError } from '../ChatOverlay';
+import { OverlayClassName } from '../internal/overlay-styles';
 
 const DOMAIN = 'https://chat.example.com/embed';
 
@@ -100,21 +101,40 @@ describe('ChatOverlay', () => {
     expect(sandbox).toContain('allow-popups-to-escape-sandbox');
   });
 
-  it('keeps the loader positioned over the iframe without contributing layout height', () => {
+  it('styles the root, iframe, and loader from an injected stylesheet instead of inline styles', () => {
     const { root, iframe } = setup();
     const loader = root.querySelector(
       '[data-dial-overlay-loader]',
     ) as HTMLElement;
+    const styleSheet = document.getElementById('dial-overlay-styles');
 
-    expect(root.style.position).toBe('relative');
-    expect(loader.style.position).toBe('absolute');
-    expect(loader.style.inset).toBe('0');
-    expect(loader.style.display).toBe('flex');
-    expect(iframe.style.display).toBe('block');
-    expect(iframe.style.height).toBe('100%');
+    expect(styleSheet?.textContent).toContain(`.${OverlayClassName.Loader} {`);
+    expect(root.classList.contains(OverlayClassName.Root)).toBe(true);
+    expect(iframe.classList.contains(OverlayClassName.Iframe)).toBe(true);
+    expect(loader.classList.contains(OverlayClassName.Loader)).toBe(true);
+    expect(root.getAttribute('style')).toBeNull();
+    expect(iframe.getAttribute('style')).toBeNull();
+    expect(loader.getAttribute('style')).toBeNull();
   });
 
-  it('does not override a root element with existing non-static positioning', () => {
+  it('injects the stylesheet once per document', () => {
+    setup();
+    setup();
+
+    expect(document.querySelectorAll('#dial-overlay-styles')).toHaveLength(1);
+  });
+
+  it('keeps a host loaderClass alongside the default loader class', () => {
+    const { root } = setup({ loaderClass: 'host-loader' });
+    const loader = root.querySelector(
+      '[data-dial-overlay-loader]',
+    ) as HTMLElement;
+
+    expect(loader.classList.contains(OverlayClassName.Loader)).toBe(true);
+    expect(loader.classList.contains('host-loader')).toBe(true);
+  });
+
+  it('does not add the positioning class to a root with existing non-static positioning', () => {
     const root = document.createElement('div');
     root.style.position = 'fixed';
     document.body.appendChild(root);
@@ -126,6 +146,7 @@ describe('ChatOverlay', () => {
       iframe: root.querySelector('iframe') as HTMLIFrameElement,
     });
 
+    expect(root.classList.contains(OverlayClassName.Root)).toBe(false);
     expect(root.style.position).toBe('fixed');
   });
 
@@ -144,10 +165,12 @@ describe('ChatOverlay', () => {
     const loader = root.querySelector(
       '[data-dial-overlay-loader]',
     ) as HTMLElement;
-    expect(loader.style.display).not.toBe('none');
+    expect(loader.classList.contains(OverlayClassName.LoaderHidden)).toBe(
+      false,
+    );
     dispatchFromApp(iframe, { type: OverlayEventType.InitReady });
     dispatchFromApp(iframe, { type: OverlayEventType.Ready });
-    expect(loader.style.display).toBe('none');
+    expect(loader.classList.contains(OverlayClassName.LoaderHidden)).toBe(true);
   });
 
   it('keeps the loader visible until the configured loaderHideEvent', () => {
@@ -159,14 +182,16 @@ describe('ChatOverlay', () => {
     ) as HTMLElement;
     dispatchFromApp(iframe, { type: OverlayEventType.InitReady });
     dispatchFromApp(iframe, { type: OverlayEventType.Ready });
-    expect(loader.style.display).not.toBe('none');
+    expect(loader.classList.contains(OverlayClassName.LoaderHidden)).toBe(
+      false,
+    );
     dispatchFromApp(iframe, {
       type: `${OverlayRequestType.SetOverlayOptions}/RESPONSE`,
       requestId: 'irrelevant',
       payload: {},
     });
     dispatchFromApp(iframe, { type: OverlayEventType.ReadyToInteract });
-    expect(loader.style.display).toBe('none');
+    expect(loader.classList.contains(OverlayClassName.LoaderHidden)).toBe(true);
   });
 
   it('does not resolve ready() on READY alone', async () => {

--- a/libs/chat-overlay/src/protocol/overlay-protocol.ts
+++ b/libs/chat-overlay/src/protocol/overlay-protocol.ts
@@ -220,7 +220,11 @@ export interface ChatOverlayOptions {
   domain: string;
   /** Milliseconds to wait for a request's response before rejecting. Defaults to `10000`. */
   requestTimeout?: number;
-  /** Inline CSS properties applied to the loader element while it is visible. */
+  /**
+   * Inline CSS properties applied to the loader element while it is visible.
+   * A `display` entry is dropped once `loaderHideEvent` arrives — use
+   * `loaderHideEvent` to control visibility, not `display`.
+   */
   loaderStyles?: Record<string, string>;
   /** CSS class applied to the loader element. */
   loaderClass?: string;

--- a/openspec/changes/archive/2026-08-28-chat-overlay-injected-styles/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-28-chat-overlay-injected-styles/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-28

--- a/openspec/changes/archive/2026-08-28-chat-overlay-injected-styles/design.md
+++ b/openspec/changes/archive/2026-08-28-chat-overlay-injected-styles/design.md
@@ -1,0 +1,176 @@
+## Context
+
+`libs/chat-overlay` is a publishable, framework-free widget package. Two classes in it styled DOM
+they own, by two different mechanisms:
+
+| Class                | Mechanism (before)                                                                                                                                   |
+| -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ChatOverlayManager` | `<style id="dial-overlay-manager-styles">` injected once per document for `.dial-overlay-btn`, plus `setStyles` for the genuinely dynamic layout (`width`/`height`/`zIndex`/position) |
+| `ChatOverlay`        | `setStyles` for everything — iframe box, loader box, root `position`, loader hide                                                                     |
+
+Everything `ChatOverlay` set inline is static: it does not vary with options, viewport, or state.
+The one dynamic input, `options.loaderStyles`, is a host-supplied `Record<string, string>` and is
+inherently inline. So the whole of `ChatOverlay`'s own styling could move to a stylesheet without
+losing anything, which is what this change does.
+
+Constraints that shaped the result:
+
+- The package ships as a single ESM entry with no CSS asset and no build step on the host side.
+  Hosts embed it with one `import`; that must keep working.
+- `openspec/specs/chat-overlay-library/spec.md` already requires the loader to hide on
+  `loaderHideEvent` (default `READY`). The hide must stay unconditional in practice, whatever host
+  CSS is on the page.
+- `libs/*` isolation rules apply: no i18n, no app knowledge. CSS class names and a `<style>` element
+  are host-agnostic, so nothing here approaches that boundary.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Remove every inline style `ChatOverlay` writes for itself.
+- Let hosts restyle the overlay's iframe and loader with ordinary CSS, no `!important` needed.
+- Keep loader hiding unconditional.
+- Have one style-injection helper in the package rather than two copies.
+- Keep `loaderClass`, `loaderStyles`, `loaderInnerHTML`, and `loaderHideEvent` working as documented.
+
+**Non-Goals:**
+
+- Converting `ChatOverlayManager`'s container/header/body styling. Most of it is dynamic
+  (`width`/`height`/`zIndex`/corner/mobile layout) and would need CSS custom properties, not plain
+  classes — a separate change with a real design question in it.
+- Theming tokens, CSS custom properties, or a `*Colors` prop surface for the overlay.
+- Shipping a `.css` file from the package (see D2).
+- Any change to the `postMessage` protocol, the v1 method surface, or the iframe `sandbox`/`allow`
+  attributes.
+
+## Decisions
+
+### D1 — Inject one `<style>` element per document, keyed by id
+
+`ensureOverlayStylesInjected()` calls `injectStyleSheet('dial-overlay-styles', css)`, which returns
+early when `document.getElementById(id)` already resolves. It is called from the `ChatOverlay`
+constructor, so N overlays on a page produce one stylesheet.
+
+Alternative — inject at module load: rejected. The package is imported in SSR and test contexts
+where `document` may not exist at import time; a constructor already implies a DOM.
+
+Alternative — one stylesheet per overlay instance: rejected. Identical CSS repeated per instance, and
+cleanup on `destroy()` would have to reference-count for no benefit.
+
+### D2 — A `<style>` element, not a shipped `.css` file
+
+A stylesheet asset is the cleaner cascade story, but it would require every host to import a second
+entry point. Hosts embedding this package are arbitrary third-party pages, many with no bundler at
+all — the migration guide's whole selling point is a single import. `ChatOverlayManager` had already
+made this call for its buttons; matching it keeps one convention in the package instead of two.
+
+### D3 — `display: none !important` on the hidden-loader class, and nowhere else
+
+The inline `style.display = 'none'` this replaces was unbeatable by construction. A plain class is
+not: a host rule of equal specificity declared later wins, and a `display` entry in `loaderStyles` —
+an inline style — always wins. Since a loader that fails to hide covers the entire chat, the hidden
+modifier keeps `!important`.
+
+Nothing else in the stylesheet uses `!important`: the visible-state declarations are exactly what
+hosts are now meant to be able to override.
+
+Alternative — keep writing `style.display` inline just for hiding: rejected, it reintroduces the
+thing this change removes and leaves the loader's `style` attribute mutating at runtime.
+
+Alternative — no `!important`, rely on source order: rejected. Injection order relative to host
+stylesheets is not controllable, and `loaderStyles` would silently defeat hiding.
+
+### D4 — CSP posture is a lateral move, and it is documented
+
+Inline `style` attributes fall under `style-src-attr`; a `<style>` element falls under
+`style-src-elem`. Both fall back to `style-src`. A host with no CSP, or with a single `style-src`
+allowing inline, is unaffected either way, and any host already using `ChatOverlayManager` was
+already receiving an injected `<style>` element. The only newly-affected host is one that split the
+two directives and allowed attributes but not elements — rare enough to document rather than design
+around. Should a host hit it, the fix on their side is a nonce or `style-src-elem 'unsafe-inline'`;
+the package does not attempt nonce plumbing, since there is no host-agnostic way to obtain one.
+
+### D5 — `loaderClass` becomes additive
+
+`loader.className = options.loaderClass` overwrote the class attribute. With a default class to
+preserve, the options were: put the host class first, put it last, or keep overwriting and lose the
+defaults entirely. Chosen: `[OverlayClassName.Loader, options.loaderClass].filter(Boolean).join(' ')`.
+
+Class-attribute order does not affect specificity, so this does not by itself decide who wins — the
+cascade does. What it does guarantee is that the loader always keeps its positioning/centering
+defaults, which is what the previous inline behaviour effectively guaranteed too. The observable
+delta is that a host class can now beat a default declaration where before inline styles made that
+impossible; that is the point of the change, and `loaderStyles` remains available for hosts that want
+the old "nothing can override me" behaviour.
+
+### D6 — Class names are a public contract, so they are documented and enumerated
+
+The four names live in an `OverlayClassName` string enum (repo convention: string enums over union
+literals for named finite sets) and are listed in the lib README with what each attaches to. They are
+deliberately `dial-overlay-`-prefixed to match the existing `dial-overlay-btn` and to make collision
+with host classes implausible.
+
+The enum is **not** exported from `src/index.ts`. Hosts write these names in CSS, not TypeScript, so
+a public export would widen the API surface with no call site — the repo's libs rule against
+exporting symbols nothing imports.
+
+### D7 — Root gets the positioning class only when its computed `position` is `static`
+
+Unchanged logic, new mechanism: the constructor still reads
+`window.getComputedStyle(this.root).position` and only acts when it is `static` or empty. It adds
+`dial-overlay-root` where it used to write `position: relative` inline.
+
+Note the asymmetry this keeps: `destroy()` does not remove the class, exactly as it never removed the
+inline `position: relative`. Leaving a class on a host element after teardown is untidy, but changing
+it here would be an unrequested behaviour change on a host-owned element — flagged for a follow-up
+rather than folded in.
+
+### D8 — `injectStyleSheet` lives in `internal/dom-styles.ts`
+
+That module was already the package's one styling utility (`setStyles`). Putting the injector beside
+it keeps both style mechanisms in one place, and lets `ChatOverlayManager` drop its duplicated
+eight-line injection block. The CSS strings stay with their owners — `MANAGER_CSS` in
+`ChatOverlayManager.ts`, `OVERLAY_CSS` in `internal/overlay-styles.ts` — so neither class reaches
+into the other's presentation.
+
+## Risks / Trade-offs
+
+- **A host stylesheet accidentally matches `dial-overlay-*` and breaks the overlay.** → The prefix
+  makes collision implausible, and the names are documented so a host can see what to avoid.
+- **A host's `loaderClass` now overrides a default it previously could not, changing the loader's
+  appearance on upgrade.** → Called out as breaking in the proposal and in the README's Styling
+  section; `loaderStyles` restores unbeatable precedence.
+- **Loader fails to hide because of host CSS.** → `!important` on the hidden modifier (D3), covered by
+  the two existing loader-visibility scenarios, now asserted through the class rather than the inline
+  `display`.
+- **A host with split `style-src-attr`/`style-src-elem` directives loses the styles entirely.** → D4:
+  documented, not designed around. Failure mode is cosmetic (unstyled iframe/loader), not a broken
+  handshake.
+- **Someone later adds a dynamic value to `OVERLAY_CSS`.** → It is a module-level constant with no
+  interpolation of runtime data; dynamic values belong in `setStyles` or, if the need is real, in a
+  CSS-custom-property channel added deliberately.
+- **`nx test` for this project cannot verify the change.** → Pre-existing and unrelated: all three
+  suites fail to load under `nx test @epam/ai-dial-chat-overlay` on a clean `development`
+  (`Cannot read properties of undefined (reading 'config')`). Verified by running `vitest` directly in
+  the lib — 81/81 pass. The nx-vitest wiring break is out of scope here and left unfixed.
+
+## Migration Plan
+
+No host action required for hosts that do not style the overlay. For hosts that do:
+
+1. If you passed `loaderClass` and relied on it _not_ overriding the built-in loader look, check the
+   loader after upgrading; move any declaration you need to win into `loaderStyles`.
+2. If you matched the loader or iframe on their `style` attribute, switch to the documented classes.
+3. If your CSP sets `style-src-elem` without `'unsafe-inline'`, add a nonce or allow inline style
+   elements.
+
+Rollback is reverting the commit — no persisted state, protocol field, or HTTP contract is involved.
+
+## Open Questions
+
+- Should `destroy()` remove `dial-overlay-root` from the host root (D7)? Today it leaks, as the inline
+  style did before it. Fixing it is a two-line change plus a flag on the entry, but it is a behaviour
+  change on a host-owned element and belongs to whoever owns the teardown semantics.
+- Should the same treatment be applied to `ChatOverlayManager`'s container/header/body? It needs CSS
+  custom properties for `width`/`height`/`zIndex`/corner, so it is a design decision, not a mechanical
+  port. Deliberately out of scope (Non-Goals).

--- a/openspec/changes/archive/2026-08-28-chat-overlay-injected-styles/proposal.md
+++ b/openspec/changes/archive/2026-08-28-chat-overlay-injected-styles/proposal.md
@@ -1,0 +1,76 @@
+## Why
+
+`ChatOverlay` wrote every one of its own styles inline through `setStyles` — `border`/`display`/
+`width`/`height` on the iframe, nine declarations on the loader, `position: relative` on the host's
+root element, and `display: none` on the loader when it hid. Inline styles are the highest-priority
+author-level origin short of `!important`, so a host embedding the overlay could not restyle any of
+it without `!important` of its own. `ChatOverlayManager`, in the same package, already solved this
+for its chrome buttons with a `<style id="dial-overlay-manager-styles">` element injected once per
+document — `ChatOverlay` simply never adopted the pattern.
+
+## What Changes
+
+- `ChatOverlay` injects a `<style id="dial-overlay-styles">` element into `document.head`, once per
+  document, and applies classes instead of inline styles: `dial-overlay-root`,
+  `dial-overlay-iframe`, `dial-overlay-loader`, `dial-overlay-loader--hidden`.
+- `hideLoader()` adds `dial-overlay-loader--hidden` rather than writing `style.display`. That rule
+  carries `display: none !important` so hiding cannot lose to host CSS or to a `display` entry in
+  `loaderStyles` — the guarantee the inline write used to provide for free.
+- **BREAKING (host CSS only, no API change):** `loaderClass` is now added *alongside*
+  `dial-overlay-loader` instead of overwriting `className`. Previously the default look was inline
+  and therefore unbeatable, so `loaderClass` could only add declarations the defaults did not set;
+  now a host class of equal specificity that is declared later in the cascade can override them.
+  `loaderStyles` is unchanged and still wins over both.
+- The four class names are documented in `libs/chat-overlay/README.md`, making them part of the
+  package's public contract.
+- `injectStyleSheet(id, css)` moves into `internal/dom-styles.ts` and `ChatOverlayManager` reuses it
+  instead of its own copy of the same eight lines.
+
+## Capabilities
+
+### New Capabilities
+
+<!-- none: this change adds no capability -->
+
+### Modified Capabilities
+
+- `chat-overlay-library`: gains a requirement fixing the styling mechanism (injected stylesheet,
+  the four public class names, `loaderClass`/`loaderStyles`/stylesheet precedence, and the
+  computed-`position` condition on the root class). The loader-visibility requirement is restated
+  because hiding is now a class toggle rather than an inline `display` write, and because its
+  parenthetical "styled via `options.loaderStyles`/`options.loaderClass`" no longer describes the
+  whole styling story.
+
+## Impact
+
+- **Affected lib**: `libs/chat-overlay` only. New `src/lib/internal/overlay-styles.ts`;
+  `internal/dom-styles.ts` gains `injectStyleSheet`; `ChatOverlay.ts` and `ChatOverlayManager.ts`
+  updated; `README.md` gains a Styling section.
+- **Public API**: no TypeScript surface change — no export added, removed, or retyped. The new
+  contract is CSS-level: four class names and two `<style>` element ids.
+- **Hosts**: a host that relied on `loaderClass` being unable to override the defaults, or that
+  matched on the loader's inline `style` attribute, is affected. Both are unlikely; `loaderStyles`
+  remains the escape hatch for either.
+- **CSP**: the styling moves from the `style-src-attr` bucket (inline `style` attributes) to the
+  `style-src-elem` bucket (a `<style>` element). Both already needed `'unsafe-inline'` or a nonce
+  under a plain `style-src`, so a host with no `style-src` at all, or one `style-src` covering both,
+  is unaffected — and any host using `ChatOverlayManager` already allowed a `<style>` element. Only a
+  host that split the directives and allowed attributes but not elements is newly affected
+  (see design D4).
+- **i18n / a11y / RTL**: nothing user-visible. The stylesheet uses `inset: 0` and no physical-
+  direction properties, so RTL behaviour is unchanged.
+- **Rollback**: revert the commit; no data, route, protocol, or HTTP contract is touched.
+
+### Alternatives considered
+
+1. **Leave the inline styles** (baseline). Zero risk, but hosts stay unable to restyle the overlay
+   and the package keeps two contradictory conventions for the same problem. Rejected.
+2. **Ship a real `.css` file from the package.** Cleanest cascade story, but the package is a
+   plain-ESM widget consumed by arbitrary host pages, many without a bundler — it would force every
+   host into a separate stylesheet import and break the "one import, it works" embed. Rejected.
+3. **Constructable stylesheets (`adoptedStyleSheets`).** Avoids the `<style>` element, but needs a
+   fallback path anyway for older Safari, and `document.adoptedStyleSheets` is not covered by
+   `style-src` in a way that helps. More code, same CSP position. Rejected.
+4. **Inject a `<style>` element once per document** (chosen). Matches what `ChatOverlayManager`
+   already does in this same package, needs no host build step, and puts the defaults at normal
+   author specificity where hosts can beat them.

--- a/openspec/changes/archive/2026-08-28-chat-overlay-injected-styles/specs/chat-overlay-library/spec.md
+++ b/openspec/changes/archive/2026-08-28-chat-overlay-injected-styles/specs/chat-overlay-library/spec.md
@@ -1,0 +1,87 @@
+## ADDED Requirements
+
+### Requirement: ChatOverlay styles its own elements through an injected stylesheet, not inline styles
+
+`ChatOverlay` SHALL NOT write inline styles onto the root element, the iframe, or the loader for its
+own presentation. Instead, its constructor SHALL append a `<style id="dial-overlay-styles">` element
+to `document.head` — at most once per document, guarded on that id, so any number of `ChatOverlay`
+instances share one stylesheet — and SHALL apply these classes:
+
+| Class                         | Applied to                                                                                  |
+| ----------------------------- | ------------------------------------------------------------------------------------------- |
+| `dial-overlay-root`           | The host-provided root element, and only when its computed `position` is `static` or empty. |
+| `dial-overlay-iframe`         | The embedded chat iframe (`display: block`, full width/height, no border).                  |
+| `dial-overlay-loader`         | The loader element (absolutely positioned over the iframe, centered content).               |
+| `dial-overlay-loader--hidden` | The loader once its configured hide event has arrived.                                      |
+
+The stylesheet SHALL use `!important` only on the `dial-overlay-loader--hidden` rule's `display`
+declaration, so that hiding the loader cannot be defeated by host CSS or by a `display` entry in
+`options.loaderStyles`. Every other declaration SHALL be overridable by host CSS of equal or higher
+specificity.
+
+The four class names and both `<style>` element ids SHALL be documented in
+`libs/chat-overlay/README.md`, since hosts target them from their own CSS. The enum that declares
+them SHALL remain internal to the package — it SHALL NOT be exported from
+`libs/chat-overlay/src/index.ts`, because hosts consume these names as CSS strings, not as
+TypeScript symbols.
+
+`ChatOverlayManager` SHALL keep injecting its own separate `<style id="dial-overlay-manager-styles">`
+element for its `dial-overlay-btn` chrome buttons, and both classes SHALL share one injection helper
+rather than duplicating the inject-once logic.
+
+#### Scenario: Overlay elements carry classes and no style attribute
+
+- **WHEN** a `ChatOverlay` is constructed on a root element whose computed `position` is `static`
+- **THEN** the root element has class `dial-overlay-root`, the iframe has class `dial-overlay-iframe`,
+  and the loader has class `dial-overlay-loader`
+- **AND** none of the three has a `style` attribute
+
+#### Scenario: Stylesheet is injected once per document
+
+- **WHEN** two `ChatOverlay` instances are constructed in the same document
+- **THEN** `document` contains exactly one element with id `dial-overlay-styles`
+
+#### Scenario: Root positioning class is not applied over existing positioning
+
+- **WHEN** a `ChatOverlay` is constructed on a root element whose computed `position` is `fixed`
+- **THEN** the root element does NOT get the `dial-overlay-root` class
+- **AND** its existing `position` is left untouched
+
+#### Scenario: Host loaderClass is added alongside the default loader class
+
+- **WHEN** a `ChatOverlay` is constructed with `options.loaderClass` set to `'host-loader'`
+- **THEN** the loader element carries both `dial-overlay-loader` and `host-loader`
+- **AND** the default class is NOT replaced, so the loader keeps its positioning and centering
+
+#### Scenario: loaderStyles remains the inline escape hatch
+
+- **WHEN** a `ChatOverlay` is constructed with `options.loaderStyles`
+- **THEN** those entries are applied as inline styles on the loader and therefore take precedence over
+  the injected stylesheet
+- **AND** they are the only inline styles the loader carries
+
+## MODIFIED Requirements
+
+### Requirement: Loader visibility follows configured hide event
+
+`ChatOverlay` SHALL render a loader — the default animated SVG, or `options.loaderInnerHTML` if
+provided — that stays visible until the event named by `options.loaderHideEvent` occurs; if
+`loaderHideEvent` is unset, the loader hides on the app's `READY` event. Hiding SHALL be performed by
+adding the `dial-overlay-loader--hidden` class, not by writing an inline `display` value, and SHALL
+take effect regardless of host CSS or of a `display` entry in `options.loaderStyles`.
+
+The loader's appearance comes from three layers, in increasing precedence: the injected
+`dial-overlay-loader` defaults, then `options.loaderClass` (added alongside the default class, so it
+competes with the defaults through the normal cascade rather than replacing them), then
+`options.loaderStyles` (inline, always wins).
+
+#### Scenario: Default loader hides on READY
+
+- **WHEN** no `loaderHideEvent` option is provided and the app sends its `READY` event
+- **THEN** the loader element gains the `dial-overlay-loader--hidden` class and is hidden
+
+#### Scenario: Custom loaderHideEvent postpones hiding
+
+- **WHEN** `loaderHideEvent` is set to `READY_TO_INTERACT` and only `READY` has been received so far
+- **THEN** the loader does NOT yet carry `dial-overlay-loader--hidden` and remains visible until
+  `READY_TO_INTERACT` is received

--- a/openspec/changes/archive/2026-08-28-chat-overlay-injected-styles/tasks.md
+++ b/openspec/changes/archive/2026-08-28-chat-overlay-injected-styles/tasks.md
@@ -1,0 +1,66 @@
+**As built:** this change was implemented in one slice, in `libs/chat-overlay` only, and is committed
+as `ec7378b41` on branch `refactor/chat-overlay-injected-styles`. Every task below is done; the
+verification notes record what actually ran.
+
+## 1. Style-injection plumbing
+
+- [x] 1.1 Add `injectStyleSheet(id, css)` to `libs/chat-overlay/src/lib/internal/dom-styles.ts` —
+      appends a `<style>` with that id to `document.head`, returning early when the id already exists
+      (design **D1**, **D8**). `setStyles` stays, for host-supplied `loaderStyles` only.
+- [x] 1.2 Add `libs/chat-overlay/src/lib/internal/overlay-styles.ts` with the `OverlayClassName`
+      string enum (`Root`, `Iframe`, `Loader`, `LoaderHidden`), the `OVERLAY_CSS` constant, and
+      `ensureOverlayStylesInjected()`. `!important` appears on the hidden-loader `display` only, with
+      a comment stating why (design **D3**). Do NOT export the enum from `src/index.ts` (**D6**).
+- [x] 1.3 Replace `ChatOverlayManager`'s inline copy of the inject-once logic with a call to
+      `injectStyleSheet(STYLE_ELEMENT_ID, MANAGER_CSS)`, leaving its CSS string and its own dynamic
+      `setStyles` layout calls untouched (**D8**, Non-Goals).
+
+## 2. ChatOverlay class-based styling
+
+- [x] 2.1 Call `ensureOverlayStylesInjected()` from the `ChatOverlay` constructor, before the iframe
+      and loader are created.
+- [x] 2.2 Replace the iframe's `setStyles` call with `iframe.className = OverlayClassName.Iframe`.
+- [x] 2.3 Replace the loader's `setStyles` defaults with
+      `[OverlayClassName.Loader, options.loaderClass].filter(Boolean).join(' ')`, so `loaderClass` is
+      additive rather than overwriting `className` (**D5**). Keep the `options.loaderStyles`
+      `setStyles` call as the inline escape hatch, applied after the class assignment.
+- [x] 2.4 Replace `setStyles(this.root, { position: 'relative' })` with
+      `this.root.classList.add(OverlayClassName.Root)`, keeping the existing
+      `window.getComputedStyle(...).position` guard exactly as it was (**D7**).
+- [x] 2.5 Change `hideLoader()` to add `OverlayClassName.LoaderHidden` instead of writing
+      `style.display`.
+
+## 3. Tests
+
+- [x] 3.1 Replace the inline-style assertions in `ChatOverlay.spec.ts` (`root.style.position`,
+      `loader.style.position/inset/display`, `iframe.style.display/height`) with class assertions plus
+      an assertion that none of the three elements has a `style` attribute.
+- [x] 3.2 Add a test that two overlays in one document produce exactly one `#dial-overlay-styles`
+      element.
+- [x] 3.3 Add a test that a host `loaderClass` sits alongside `dial-overlay-loader` rather than
+      replacing it.
+- [x] 3.4 Convert both loader-visibility tests to assert the `dial-overlay-loader--hidden` class
+      instead of `style.display === 'none'`, keeping the two existing spec scenarios covered.
+- [x] 3.5 Keep the non-static-root test, now asserting the class is absent and `position: fixed`
+      survives.
+
+## 4. Documentation
+
+- [x] 4.1 Add a **Styling** section to `libs/chat-overlay/README.md`: the injected `<style>` ids, a
+      table of the four class names and what each attaches to, the
+      stylesheet → `loaderClass` → `loaderStyles` precedence order, and the manager's separate sheet.
+- [x] 4.2 Correct the `loaderStyles` and `loaderClass` rows in the README's options table —
+      `loaderClass` is now "added alongside `dial-overlay-loader`", not "applied to the loader
+      element".
+
+## 5. Verification
+
+- [x] 5.1 `vitest run` in `libs/chat-overlay` — 81/81 pass.
+      **Note:** `npm exec nx test @epam/ai-dial-chat-overlay` cannot be used to verify this change.
+      All three suites fail to load with `Cannot read properties of undefined (reading 'config')` on a
+      clean `development` checkout, before this change — confirmed by stashing. The nx-vitest wiring
+      break is pre-existing, out of scope, and left unfixed (design **Risks**).
+- [x] 5.2 `npm exec nx lint @epam/ai-dial-chat-overlay` — clean.
+- [x] 5.3 `npm exec nx build @epam/ai-dial-chat-overlay` — succeeds, `dist/index.js` emitted with
+      declarations.
+- [x] 5.4 `npm run validate:docs` — passes (40 markdown files).

--- a/openspec/specs/chat-overlay-library/spec.md
+++ b/openspec/specs/chat-overlay-library/spec.md
@@ -3,9 +3,7 @@
 ## Purpose
 
 The publishable `chat-overlay` package: iframe lifecycle management, the v1 method surface, structured request errors, and `ChatOverlayManager`.
-
 ## Requirements
-
 ### Requirement: Publishable package metadata
 
 `libs/chat-overlay/package.json` SHALL declare `"name": "@epam/ai-dial-chat-overlay"`, `"license": "Apache-2.0"`, and a one-sentence `"description"` (no trailing period, not equal to the package name), placed directly after `"name"`/`"version"` per this repo's lib conventions. The `project.json` SHALL tag the project `"publishable"` and define a `publish` target that runs `node tools/publish-lib.mjs chat-overlay --version={args.ver} --dry={args.dry} --tag={args.tag} --development={args.development}`, matching `libs/conversation-input/project.json`.
@@ -81,17 +79,27 @@ The publishable `chat-overlay` package: iframe lifecycle management, the v1 meth
 
 ### Requirement: Loader visibility follows configured hide event
 
-`ChatOverlay` SHALL render a loader (default animated SVG, or `options.loaderInnerHTML` if provided, styled via `options.loaderStyles`/`options.loaderClass`) that stays visible until the event named by `options.loaderHideEvent` occurs; if `loaderHideEvent` is unset, the loader hides on the app's `READY` event.
+`ChatOverlay` SHALL render a loader — the default animated SVG, or `options.loaderInnerHTML` if
+provided — that stays visible until the event named by `options.loaderHideEvent` occurs; if
+`loaderHideEvent` is unset, the loader hides on the app's `READY` event. Hiding SHALL be performed by
+adding the `dial-overlay-loader--hidden` class, not by writing an inline `display` value, and SHALL
+take effect regardless of host CSS or of a `display` entry in `options.loaderStyles`.
+
+The loader's appearance comes from three layers, in increasing precedence: the injected
+`dial-overlay-loader` defaults, then `options.loaderClass` (added alongside the default class, so it
+competes with the defaults through the normal cascade rather than replacing them), then
+`options.loaderStyles` (inline, always wins).
 
 #### Scenario: Default loader hides on READY
 
 - **WHEN** no `loaderHideEvent` option is provided and the app sends its `READY` event
-- **THEN** the loader element becomes hidden
+- **THEN** the loader element gains the `dial-overlay-loader--hidden` class and is hidden
 
 #### Scenario: Custom loaderHideEvent postpones hiding
 
 - **WHEN** `loaderHideEvent` is set to `READY_TO_INTERACT` and only `READY` has been received so far
-- **THEN** the loader remains visible until `READY_TO_INTERACT` is received
+- **THEN** the loader does NOT yet carry `dial-overlay-loader--hidden` and remains visible until
+  `READY_TO_INTERACT` is received
 
 ### Requirement: v1 method surface
 
@@ -329,3 +337,64 @@ Enabling `enabledFeatures` after construction does not retroactively change the 
 
 - **WHEN** the README is inspected
 - **THEN** the `auth.providerUiModes` example contains a comment about host responsibility for verifying iframe compatibility
+
+### Requirement: ChatOverlay styles its own elements through an injected stylesheet, not inline styles
+
+`ChatOverlay` SHALL NOT write inline styles onto the root element, the iframe, or the loader for its
+own presentation. Instead, its constructor SHALL append a `<style id="dial-overlay-styles">` element
+to `document.head` — at most once per document, guarded on that id, so any number of `ChatOverlay`
+instances share one stylesheet — and SHALL apply these classes:
+
+| Class                         | Applied to                                                                                  |
+| ----------------------------- | ------------------------------------------------------------------------------------------- |
+| `dial-overlay-root`           | The host-provided root element, and only when its computed `position` is `static` or empty. |
+| `dial-overlay-iframe`         | The embedded chat iframe (`display: block`, full width/height, no border).                  |
+| `dial-overlay-loader`         | The loader element (absolutely positioned over the iframe, centered content).               |
+| `dial-overlay-loader--hidden` | The loader once its configured hide event has arrived.                                      |
+
+The stylesheet SHALL use `!important` only on the `dial-overlay-loader--hidden` rule's `display`
+declaration, so that hiding the loader cannot be defeated by host CSS or by a `display` entry in
+`options.loaderStyles`. Every other declaration SHALL be overridable by host CSS of equal or higher
+specificity.
+
+The four class names and both `<style>` element ids SHALL be documented in
+`libs/chat-overlay/README.md`, since hosts target them from their own CSS. The enum that declares
+them SHALL remain internal to the package — it SHALL NOT be exported from
+`libs/chat-overlay/src/index.ts`, because hosts consume these names as CSS strings, not as
+TypeScript symbols.
+
+`ChatOverlayManager` SHALL keep injecting its own separate `<style id="dial-overlay-manager-styles">`
+element for its `dial-overlay-btn` chrome buttons, and both classes SHALL share one injection helper
+rather than duplicating the inject-once logic.
+
+#### Scenario: Overlay elements carry classes and no style attribute
+
+- **WHEN** a `ChatOverlay` is constructed on a root element whose computed `position` is `static`
+- **THEN** the root element has class `dial-overlay-root`, the iframe has class `dial-overlay-iframe`,
+  and the loader has class `dial-overlay-loader`
+- **AND** none of the three has a `style` attribute
+
+#### Scenario: Stylesheet is injected once per document
+
+- **WHEN** two `ChatOverlay` instances are constructed in the same document
+- **THEN** `document` contains exactly one element with id `dial-overlay-styles`
+
+#### Scenario: Root positioning class is not applied over existing positioning
+
+- **WHEN** a `ChatOverlay` is constructed on a root element whose computed `position` is `fixed`
+- **THEN** the root element does NOT get the `dial-overlay-root` class
+- **AND** its existing `position` is left untouched
+
+#### Scenario: Host loaderClass is added alongside the default loader class
+
+- **WHEN** a `ChatOverlay` is constructed with `options.loaderClass` set to `'host-loader'`
+- **THEN** the loader element carries both `dial-overlay-loader` and `host-loader`
+- **AND** the default class is NOT replaced, so the loader keeps its positioning and centering
+
+#### Scenario: loaderStyles remains the inline escape hatch
+
+- **WHEN** a `ChatOverlay` is constructed with `options.loaderStyles`
+- **THEN** those entries are applied as inline styles on the loader and therefore take precedence over
+  the injected stylesheet
+- **AND** they are the only inline styles the loader carries
+

--- a/openspec/specs/chat-overlay-library/spec.md
+++ b/openspec/specs/chat-overlay-library/spec.md
@@ -83,12 +83,16 @@ The publishable `chat-overlay` package: iframe lifecycle management, the v1 meth
 provided — that stays visible until the event named by `options.loaderHideEvent` occurs; if
 `loaderHideEvent` is unset, the loader hides on the app's `READY` event. Hiding SHALL be performed by
 adding the `dial-overlay-loader--hidden` class, not by writing an inline `display` value, and SHALL
-take effect regardless of host CSS or of a `display` entry in `options.loaderStyles`.
+take effect regardless of host CSS or of a `display` entry in `options.loaderStyles`. To make that
+guarantee hold against an inline declaration the host marked `!important` — the one layer an author
+`!important` cannot outrank — hiding SHALL additionally remove any inline `display` property from
+the loader element, leaving every other `loaderStyles` entry in place.
 
 The loader's appearance comes from three layers, in increasing precedence: the injected
 `dial-overlay-loader` defaults, then `options.loaderClass` (added alongside the default class, so it
 competes with the defaults through the normal cascade rather than replacing them), then
-`options.loaderStyles` (inline, always wins).
+`options.loaderStyles` (inline, always wins). Visibility is exempt from that ordering: `display` is
+owned by `loaderHideEvent`, not by the styling layers.
 
 #### Scenario: Default loader hides on READY
 
@@ -357,7 +361,21 @@ declaration, so that hiding the loader cannot be defeated by host CSS or by a `d
 `options.loaderStyles`. Every other declaration SHALL be overridable by host CSS of equal or higher
 specificity.
 
-The four class names and both `<style>` element ids SHALL be documented in
+Because this package deliberately ships no CSS file and does not participate in the
+`--cs-*`/`buildCssVars` theming channel, every color literal in either injected stylesheet SHALL be
+read through a custom property carrying that literal as its fallback, so a host can retheme by
+declaring the property on an ancestor instead of overriding the injected source order:
+
+| Custom property                       | Fallback  | Applies to                                               |
+| ------------------------------------- | --------- | -------------------------------------------------------- |
+| `--dial-overlay-loader-background`    | `#ffffff` | Loader backdrop.                                          |
+| `--dial-overlay-loader-color`         | `#2764d9` | Loader foreground, inherited by the spinner's stroke.     |
+| `--dial-overlay-btn-background`       | `#2764d9` | `ChatOverlayManager` chrome buttons.                      |
+| `--dial-overlay-btn-color`            | `#ffffff` | Chrome button icon.                                       |
+| `--dial-overlay-btn-background-hover` | `#1d4fb8` | Chrome button on `:hover` / `:focus-visible`.             |
+| `--dial-overlay-btn-outline`          | `#1d4fb8` | Chrome button focus outline.                              |
+
+The four class names, the custom properties, and both `<style>` element ids SHALL be documented in
 `libs/chat-overlay/README.md`, since hosts target them from their own CSS. The enum that declares
 them SHALL remain internal to the package — it SHALL NOT be exported from
 `libs/chat-overlay/src/index.ts`, because hosts consume these names as CSS strings, not as
@@ -397,4 +415,17 @@ rather than duplicating the inject-once logic.
 - **THEN** those entries are applied as inline styles on the loader and therefore take precedence over
   the injected stylesheet
 - **AND** they are the only inline styles the loader carries
+
+#### Scenario: An inline display from loaderStyles does not survive hiding
+
+- **WHEN** a `ChatOverlay` is constructed with `loaderStyles: { display: 'flex' }` and the configured
+  hide event arrives
+- **THEN** the loader gains the `dial-overlay-loader--hidden` class and its inline `display` is removed
+- **AND** every other `loaderStyles` entry remains applied
+
+#### Scenario: Host retheming through custom properties
+
+- **WHEN** a host declares `--dial-overlay-loader-color` on an ancestor of the overlay root
+- **THEN** the loader's spinner adopts that color without the host needing an `!important` override
+- **AND** with the property unset the injected fallback `#2764d9` applies
 


### PR DESCRIPTION


ChatOverlay wrote its iframe, loader, and root styles inline through setStyles. Move them into a `<style id="dial-overlay-styles">` element injected once per document, mirroring the pattern ChatOverlayManager already used for its chrome buttons.

- add internal/overlay-styles.ts: OverlayClassName enum plus the CSS and ensureOverlayStylesInjected()
- add injectStyleSheet(id, css) to internal/dom-styles.ts and reuse it in ChatOverlayManager instead of its duplicated injection logic
- hideLoader() toggles a class instead of writing style.display; the hidden modifier keeps !important so it cannot lose to host CSS or to a `display` entry in loaderStyles
- loaderClass is now added alongside the default loader class rather than overwriting className, so hosts can restyle the loader with ordinary CSS; loaderStyles stays the inline escape hatch
- document the injected classes in the lib README

**Description:**

<SHORT_DESCRIPTION>

Issues:

- Issue #<TICKET_ID>

**UI changes**

<Please, provide Screenshots or Figma links>

**Checklist:**

- [ ] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [ ] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
