### PR TITLE
fix: correct UI component colors and tighten citation card layout

### DIFF
--- a/.claude/rules/all-tsx.md
+++ b/.claude/rules/all-tsx.md
@@ -95,6 +95,45 @@ const Outer: FC<OuterProps> = ({
 
 Props with non-trivial defaults that are also needed locally must still be destructured with their defaults; pass them explicitly to the inner component before `{...innerProps}` so that caller-supplied values in the spread override the defaults correctly. Derived or locally-managed props (e.g. state, computed values) go after `{...innerProps}` so they always take precedence.
 
+## Tabler icon stroke
+
+Tabler renders every outline icon at `stroke={2}`, and the 2.0 design scale
+puts icons at 1.5, so the weight has to be passed on **every** icon — an
+omitted prop is a visibly heavier glyph sitting next to its neighbours.
+Pass the kit token, never the literal, so the scale has one owner.
+
+```tsx
+import { DIAL_ICON_SIZE, DIAL_KIT_ICON_STROKE } from '@epam/ai-dial-ui-kit';
+import { IconPlus } from '@tabler/icons-react';
+
+// Correct
+<IconPlus size={DIAL_ICON_SIZE.MD} stroke={DIAL_KIT_ICON_STROKE} aria-hidden />;
+
+// Wrong — falls back to Tabler's 2px default
+<IconPlus size={DIAL_ICON_SIZE.MD} aria-hidden />;
+
+// Wrong — restates the scale at the call site
+<IconPlus size={DIAL_ICON_SIZE.MD} stroke={1.5} aria-hidden />;
+```
+
+When size, stroke and `aria-hidden` are all an icon needs, spread
+`BASE_MD_ICON_PROPS` / `BASE_LG_ICON_PROPS` from `@epam/ai-dial-chat-shared`
+— they already carry the token.
+
+Two exceptions, and only these two:
+
+- **Filled glyphs** (`Icon*Filled`) — Tabler drops the `stroke` prop for the
+  filled set, so passing it is dead code. Leave it off.
+- **Empty-state illustrations** — a 48px+ icon inside `PanelEmptyState` stays at
+  `stroke={1}`; 1.5 reads as a fence at that size. The kit makes the same
+  exception for its own `NoDataContent`.
+
+The border half of the same scale is plain Tailwind: `border` (1px) for
+controls, standalone dividers and table frames, `border-2` for active/selected
+highlighting, and `0.5px solid` in a stylesheet for dividers **inside** a table.
+A named `borderWidth` token cannot work — `borderColor` already owns `warning`,
+`error` and friends, so `border-warning` would set a width and a colour at once.
+
 ## aria-label values go through i18n
 
 All `aria-label` values must go through i18n: in apps use `t()` with a key from `translation-keys.ts`; in libs expose an `ariaLabel`/`ariaLabels` prop with an English default string. Never hardcode English `aria-label` text in apps, and never use `useTranslation` in libs.

--- a/.claude/rules/spec.md
+++ b/.claude/rules/spec.md
@@ -53,6 +53,7 @@ fireEvent.keyDown(textarea, { key: 'Enter', shiftKey: false });
 - For partial mocks of real modules use `vi.mock('module', async (importOriginal) => { const actual = await importOriginal(); return { ...actual, ... }; })`.
 - Prefer `vi.mocked(fn)` for typed access to mocked imports.
 - Call `vi.clearAllMocks()` in `beforeEach` whenever shared mock state could leak between tests.
+- An object-literal mock of `@epam/ai-dial-ui-kit` must include `DIAL_KIT_ICON_STROKE: 1.5` — every icon in the component under test reads it, and a missing export fails the whole file at import time, not at an assertion.
 
 ## Describe / it naming
 

--- a/.claude/skills/git-ship/areas.md
+++ b/.claude/skills/git-ship/areas.md
@@ -65,6 +65,7 @@ Apply in order, stop at the first match:
 | `docs`     | Design docs and Markdown documentation (`docs/**`, README)                               |
 | `agents`   | Agent config: `.agents/**`, `.claude/**`, `.cursor/**`, `AGENTS.md`, `CLAUDE.md`, skills |
 | `e2e`      | End-to-end tests                                                                         |
+| `styles`   | Styling, theming, and shadow token configuration (`tailwind.config.js`, theme variables) |
 
 ## Self-extend (append-only)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -157,6 +157,14 @@ Use these two tools for all UI kit discovery and documentation needs: `searchEnt
 
 The kit ships two generations: **2.0** (current design system, exported without the `Dial` prefix — `Button`, `Input`, `Select`, `Popup`, `Tabs`) and **1.0** (legacy `Dial*`). Always use the 2.0 component; fall back to a `Dial*` one only when the MCP lookup shows no 2.0 replacement exists. `searchEntity` ranks 2.0 first and flags superseded 1.0 entries with "Use instead". See `.claude/rules/all-tsx.md` for details.
 
+### Icon stroke — always pass the token
+
+Tabler renders every outline icon at `stroke={2}`; the design scale puts icons
+at 1.5. Pass `stroke={DIAL_KIT_ICON_STROKE}` (exported from
+`@epam/ai-dial-ui-kit`) on every Tabler icon you write — never the literal 1.5,
+and never nothing. Filled glyphs (`Icon*Filled`) ignore the prop, and
+empty-state illustrations stay at `stroke={1}`. See `.claude/rules/all-tsx.md`.
+
 ### UI Kit Breaking Changes & Migration
 
 When you encounter errors after a ui kit package upgrade, or when a prop no longer exists on a component:

--- a/apps/chat-overlay-sandbox/package.json
+++ b/apps/chat-overlay-sandbox/package.json
@@ -5,6 +5,6 @@
   "private": true,
   "dependencies": {
     "@epam/ai-dial-chat-overlay": "*",
-    "@epam/ai-dial-ui-kit": "^0.14.0-dev.13"
+    "@epam/ai-dial-ui-kit": "^0.14.0-dev.15"
   }
 }

--- a/apps/chat/src/components/AnnouncementBanner/AnnouncementBanner.tsx
+++ b/apps/chat/src/components/AnnouncementBanner/AnnouncementBanner.tsx
@@ -5,7 +5,11 @@ import {
   type AnnouncementContent,
 } from '@epam/ai-dial-chat-hooks';
 import { mergeClasses } from '@epam/ai-dial-chat-shared';
-import { DIAL_ICON_SIZE, StaticIconButton } from '@epam/ai-dial-ui-kit';
+import {
+  DIAL_ICON_SIZE,
+  DIAL_KIT_ICON_STROKE,
+  StaticIconButton,
+} from '@epam/ai-dial-ui-kit';
 import { IconX } from '@tabler/icons-react';
 import type { FC } from 'react';
 import { memo, useMemo } from 'react';
@@ -69,7 +73,13 @@ const AnnouncementBanner: FC<Props> = ({ className }) => {
 
   const closeButton = (
     <StaticIconButton
-      icon={<IconX stroke={1.5} size={DIAL_ICON_SIZE.LG} aria-hidden />}
+      icon={
+        <IconX
+          stroke={DIAL_KIT_ICON_STROKE}
+          size={DIAL_ICON_SIZE.LG}
+          aria-hidden
+        />
+      }
       aria-label={t(AnnouncementBannerI18nKeys.CloseLabel)}
       onClick={dismiss}
     />

--- a/apps/chat/src/components/ChatLayout/ChatLayout.tsx
+++ b/apps/chat/src/components/ChatLayout/ChatLayout.tsx
@@ -1,6 +1,10 @@
 import { OverlayFeature } from '@epam/ai-dial-chat-overlay';
 import { mergeClasses } from '@epam/ai-dial-chat-shared';
-import { DIAL_ICON_SIZE, GhostIconButton } from '@epam/ai-dial-ui-kit';
+import {
+  DIAL_ICON_SIZE,
+  DIAL_KIT_ICON_STROKE,
+  GhostIconButton,
+} from '@epam/ai-dial-ui-kit';
 import { IconLayoutSidebarRight, IconPlus } from '@tabler/icons-react';
 import type { FC } from 'react';
 import { memo } from 'react';
@@ -42,7 +46,7 @@ const ChatLayout: FC<Props> = ({ isPanelOpen, onTogglePanel, onNewChat }) => {
             icon={
               <IconLayoutSidebarRight
                 size={DIAL_ICON_SIZE.LG}
-                stroke={1.5}
+                stroke={DIAL_KIT_ICON_STROKE}
                 className="rtl:scale-x-[-1]"
               />
             }
@@ -55,7 +59,12 @@ const ChatLayout: FC<Props> = ({ isPanelOpen, onTogglePanel, onNewChat }) => {
         )}
         {!isPanelOpen && !isNewConversationHidden && (
           <GhostIconButton
-            icon={<IconPlus size={DIAL_ICON_SIZE.LG} stroke={1.5} />}
+            icon={
+              <IconPlus
+                size={DIAL_ICON_SIZE.LG}
+                stroke={DIAL_KIT_ICON_STROKE}
+              />
+            }
             aria-label={t(ButtonsI18nKeys.NewChat)}
             tooltipProps={{ tooltip: t(ButtonsI18nKeys.NewChat) }}
             onClick={onNewChat}

--- a/apps/chat/src/components/ChatLayout/tests/ChatLayout.spec.tsx
+++ b/apps/chat/src/components/ChatLayout/tests/ChatLayout.spec.tsx
@@ -15,6 +15,7 @@ vi.mock('../../Header/SourcesSidebarToggle', () => ({
   default: () => <div />,
 }));
 vi.mock('@epam/ai-dial-ui-kit', () => ({
+  DIAL_KIT_ICON_STROKE: 1.5,
   DIAL_ICON_SIZE: { LG: 24 },
   GhostIconButton: ({
     'aria-label': ariaLabel,

--- a/apps/chat/src/components/ConversationPanel/ConversationPanelMenu.tsx
+++ b/apps/chat/src/components/ConversationPanel/ConversationPanelMenu.tsx
@@ -1,8 +1,9 @@
 import { useAsyncConfirmDialog } from '@epam/ai-dial-chat-hooks';
 import {
+  ConfirmationPopup,
   ConfirmationPopupVariant,
   DIAL_ICON_SIZE,
-  ConfirmationPopup,
+  DIAL_KIT_ICON_STROKE,
   Dropdown,
   ElementSize,
   GhostIconButton,
@@ -44,6 +45,7 @@ const PanelMenuTrigger: FC<PanelMenuTriggerProps> = ({ items, label }) => {
           <IconDotsVertical
             size={DIAL_ICON_SIZE.SM}
             className={isOpen ? 'text-accent' : 'text-secondary'}
+            stroke={DIAL_KIT_ICON_STROKE}
           />
         }
         className={isOpen ? 'bg-control-accent-alpha-hover' : undefined}
@@ -85,6 +87,7 @@ const ConversationPanelMenu: FC<Props> = ({
           <IconFileArrowRight
             size={DIAL_ICON_SIZE.SM}
             className="text-secondary"
+            stroke={DIAL_KIT_ICON_STROKE}
           />
         ),
         onClick: onExportAll,
@@ -96,6 +99,7 @@ const ConversationPanelMenu: FC<Props> = ({
           <IconFileArrowLeft
             size={DIAL_ICON_SIZE.SM}
             className="text-secondary"
+            stroke={DIAL_KIT_ICON_STROKE}
           />
         ),
         onClick: onImport,
@@ -103,7 +107,13 @@ const ConversationPanelMenu: FC<Props> = ({
       {
         key: 'delete-all',
         label: t(ConversationPanelI18nKeys.DeleteAllChatsLabel),
-        icon: <IconTrashX size={DIAL_ICON_SIZE.SM} className="text-error" />,
+        icon: (
+          <IconTrashX
+            size={DIAL_ICON_SIZE.SM}
+            className="text-error"
+            stroke={DIAL_KIT_ICON_STROKE}
+          />
+        ),
         onClick: () => openDeleteDialog(true),
         className: 'text-error',
       },

--- a/apps/chat/src/components/ConversationPanel/ConversationPanelView.tsx
+++ b/apps/chat/src/components/ConversationPanel/ConversationPanelView.tsx
@@ -37,9 +37,10 @@ import {
   type RenameConversationPopupLabels,
 } from '@epam/ai-dial-conversation-panel';
 import {
+  ConfirmationPopup,
   ConfirmationPopupVariant,
   DIAL_ICON_SIZE,
-  ConfirmationPopup,
+  DIAL_KIT_ICON_STROKE,
   Popup,
   PopupSize,
   RadioGroup,
@@ -645,7 +646,11 @@ const ConversationPanelView: FC<ConversationPanelViewProps> = ({
             className="text-secondary"
           />
         ) : (
-          <IconPin size={DIAL_ICON_SIZE.SM} className="text-secondary" />
+          <IconPin
+            size={DIAL_ICON_SIZE.SM}
+            className="text-secondary"
+            stroke={DIAL_KIT_ICON_STROKE}
+          />
         ),
         onClick: () => pinConversation(contextId, !panelItem.isPinned),
       };
@@ -653,7 +658,13 @@ const ConversationPanelView: FC<ConversationPanelViewProps> = ({
       const duplicateAction: DropdownItem = {
         key: 'duplicate',
         label: t(ButtonsI18nKeys.Duplicate),
-        icon: <IconCopy size={DIAL_ICON_SIZE.SM} className="text-secondary" />,
+        icon: (
+          <IconCopy
+            size={DIAL_ICON_SIZE.SM}
+            className="text-secondary"
+            stroke={DIAL_KIT_ICON_STROKE}
+          />
+        ),
         onClick: async () => {
           try {
             const newPath = await duplicateConversation(contextId);
@@ -688,7 +699,11 @@ const ConversationPanelView: FC<ConversationPanelViewProps> = ({
         key: 'export',
         label: t(ConversationExportI18nKeys.ExportLabel),
         icon: (
-          <IconDownload size={DIAL_ICON_SIZE.SM} className="text-secondary" />
+          <IconDownload
+            size={DIAL_ICON_SIZE.SM}
+            className="text-secondary"
+            stroke={DIAL_KIT_ICON_STROKE}
+          />
         ),
         children: [
           {
@@ -711,7 +726,12 @@ const ConversationPanelView: FC<ConversationPanelViewProps> = ({
           readonlyActions.push({
             key: 'unshare',
             label: t(ButtonsI18nKeys.RemoveFromMyList),
-            icon: <IconTrashX size={DIAL_ICON_SIZE.SM} />,
+            icon: (
+              <IconTrashX
+                size={DIAL_ICON_SIZE.SM}
+                stroke={DIAL_KIT_ICON_STROKE}
+              />
+            ),
             onClick: () => openUnshareDialog(contextId),
           });
         }
@@ -727,6 +747,7 @@ const ConversationPanelView: FC<ConversationPanelViewProps> = ({
             <IconPencilMinus
               size={DIAL_ICON_SIZE.SM}
               className="text-secondary"
+              stroke={DIAL_KIT_ICON_STROKE}
             />
           ),
           onClick: () =>
@@ -743,6 +764,7 @@ const ConversationPanelView: FC<ConversationPanelViewProps> = ({
                   <IconShare
                     size={DIAL_ICON_SIZE.SM}
                     className="text-secondary"
+                    stroke={DIAL_KIT_ICON_STROKE}
                   />
                 ),
                 onClick: () => setPendingShareConversationPath(contextId),
@@ -766,6 +788,7 @@ const ConversationPanelView: FC<ConversationPanelViewProps> = ({
                   <IconWorldShare
                     size={DIAL_ICON_SIZE.SM}
                     className="text-secondary"
+                    stroke={DIAL_KIT_ICON_STROKE}
                   />
                 ),
                 /*
@@ -802,6 +825,7 @@ const ConversationPanelView: FC<ConversationPanelViewProps> = ({
                     size={DIAL_ICON_SIZE.SM}
                     aria-hidden
                     className="text-secondary"
+                    stroke={DIAL_KIT_ICON_STROKE}
                   />
                 ),
                 onClick: () => {
@@ -840,6 +864,7 @@ const ConversationPanelView: FC<ConversationPanelViewProps> = ({
                   <IconUserOff
                     size={DIAL_ICON_SIZE.SM}
                     className="text-secondary"
+                    stroke={DIAL_KIT_ICON_STROKE}
                   />
                 ),
                 onClick: () => openRevokeDialog(contextId),
@@ -849,7 +874,13 @@ const ConversationPanelView: FC<ConversationPanelViewProps> = ({
         {
           key: 'delete',
           label: t(ButtonsI18nKeys.Delete),
-          icon: <IconTrashX size={DIAL_ICON_SIZE.SM} className="text-error" />,
+          icon: (
+            <IconTrashX
+              size={DIAL_ICON_SIZE.SM}
+              className="text-error"
+              stroke={DIAL_KIT_ICON_STROKE}
+            />
+          ),
           className: 'text-error',
           onClick: () => openDeleteDialog(contextId),
         },

--- a/apps/chat/src/components/ConversationView/ConversationMessageItem.tsx
+++ b/apps/chat/src/components/ConversationView/ConversationMessageItem.tsx
@@ -40,7 +40,11 @@ import {
   useCitationMarkdownComponents,
   type AnnotationGroup,
 } from '@epam/ai-dial-quotations';
-import { ErrorMessageNotification, PrimaryButton } from '@epam/ai-dial-ui-kit';
+import {
+  DIAL_KIT_ICON_STROKE,
+  ErrorMessageNotification,
+  PrimaryButton,
+} from '@epam/ai-dial-ui-kit';
 import { IconLink } from '@tabler/icons-react';
 import { FC, lazy, memo, Suspense, useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -558,7 +562,13 @@ const ConversationMessageItem: FC<Props> = ({
                           isPdfPagePreviewable ? onPreviewReference : undefined
                         }
                         onOpenInBrowser={handleOpenReferenceInBrowser}
-                        icon={<IconLink size={14} aria-hidden />}
+                        icon={
+                          <IconLink
+                            size={14}
+                            aria-hidden
+                            stroke={DIAL_KIT_ICON_STROKE}
+                          />
+                        }
                         cardLabels={{
                           ariaLabel: t(CitationsI18nKeys.MarkerAriaLabel, {
                             source: group.sourceName,

--- a/apps/chat/src/components/ConversationView/ConversationView.tsx
+++ b/apps/chat/src/components/ConversationView/ConversationView.tsx
@@ -38,6 +38,7 @@ import type {
 } from '@epam/ai-dial-conversation-messages';
 import {
   DIAL_ICON_SIZE,
+  DIAL_KIT_ICON_STROKE,
   ErrorMessageNotification,
   FabButton,
   NeutralButton,
@@ -812,7 +813,12 @@ const ConversationView: FC<Props> = ({
             )}
             <NeutralButton
               label={t(ConversationPanelI18nKeys.DuplicateReadOnlyDescription)}
-              iconBefore={<IconCopy size={DIAL_ICON_SIZE.MD} />}
+              iconBefore={
+                <IconCopy
+                  size={DIAL_ICON_SIZE.MD}
+                  stroke={DIAL_KIT_ICON_STROKE}
+                />
+              }
               onClick={onDuplicateConversation}
             />
           </div>

--- a/apps/chat/src/components/DeploymentSelector/DeploymentSelectorFieldTrigger.tsx
+++ b/apps/chat/src/components/DeploymentSelector/DeploymentSelectorFieldTrigger.tsx
@@ -1,5 +1,11 @@
 import { mergeClasses } from '@epam/ai-dial-chat-shared';
-import { DIAL_ICON_SIZE, Dropdown, Input, Spinner } from '@epam/ai-dial-ui-kit';
+import {
+  DIAL_ICON_SIZE,
+  DIAL_KIT_ICON_STROKE,
+  Dropdown,
+  Input,
+  Spinner,
+} from '@epam/ai-dial-ui-kit';
 import { IconChevronDown } from '@tabler/icons-react';
 import {
   memo,
@@ -138,6 +144,7 @@ const DeploymentSelectorFieldTrigger: FC<Props> = ({
                   isOpen && 'rotate-180',
                 )}
                 aria-hidden
+                stroke={DIAL_KIT_ICON_STROKE}
               />
             )
           }

--- a/apps/chat/src/components/DeploymentSelector/DeploymentSelectorPanel.tsx
+++ b/apps/chat/src/components/DeploymentSelector/DeploymentSelectorPanel.tsx
@@ -6,8 +6,9 @@ import {
 } from '@epam/ai-dial-chat-shared';
 import {
   DIAL_ICON_SIZE,
-  GhostButton,
+  DIAL_KIT_ICON_STROKE,
   EllipsisTooltip,
+  GhostButton,
   Highlight,
   Search,
   ToggleIconButton,
@@ -286,10 +287,17 @@ const DeploymentSelectorPanel: FC<Props> = ({
               size={DIAL_ICON_SIZE.SM}
               className="shrink-0 text-accent"
               aria-hidden
+              stroke={DIAL_KIT_ICON_STROKE}
             />
           )}
           <ToggleIconButton
-            icon={<IconStar size={DIAL_ICON_SIZE.SM} aria-hidden />}
+            icon={
+              <IconStar
+                size={DIAL_ICON_SIZE.SM}
+                aria-hidden
+                stroke={DIAL_KIT_ICON_STROKE}
+              />
+            }
             selectedIcon={
               <IconStarFilled
                 size={DIAL_ICON_SIZE.SM}

--- a/apps/chat/src/components/EditorHeader/EditorHeader.tsx
+++ b/apps/chat/src/components/EditorHeader/EditorHeader.tsx
@@ -1,16 +1,17 @@
 import { mergeClasses } from '@epam/ai-dial-chat-shared';
 import {
   DIAL_ICON_SIZE,
+  DIAL_KIT_ICON_STROKE,
   Dropdown,
-  type DropdownItem,
   ElementSize,
   GhostButton,
   GhostIconButton,
   NeutralButton,
   PrimaryButton,
   ProgressBar,
-  type Step,
   StepStatus,
+  type DropdownItem,
+  type Step,
 } from '@epam/ai-dial-ui-kit';
 import {
   IconCheck,
@@ -136,7 +137,11 @@ const EditorHeader: FC<Props> = ({
         label: step.name,
         icon:
           step.id === currentStep ? (
-            <IconCheck size={DIAL_ICON_SIZE.SM} className="text-accent" />
+            <IconCheck
+              size={DIAL_ICON_SIZE.SM}
+              className="text-accent"
+              stroke={DIAL_KIT_ICON_STROKE}
+            />
           ) : undefined,
         onClick: () => onChangeStep(step.id),
       })),
@@ -171,6 +176,7 @@ const EditorHeader: FC<Props> = ({
                 <IconChevronDown
                   size={DIAL_ICON_SIZE.SM}
                   className="shrink-0 text-secondary"
+                  stroke={DIAL_KIT_ICON_STROKE}
                 />
               </span>
             </button>
@@ -179,7 +185,12 @@ const EditorHeader: FC<Props> = ({
             {isPreviewing ? (
               <GhostButton
                 label={exitPreviewButtonLabel}
-                iconBefore={<IconEyeOff size={DIAL_ICON_SIZE.SM} />}
+                iconBefore={
+                  <IconEyeOff
+                    size={DIAL_ICON_SIZE.SM}
+                    stroke={DIAL_KIT_ICON_STROKE}
+                  />
+                }
                 onClick={onPreview}
               />
             ) : (
@@ -187,7 +198,12 @@ const EditorHeader: FC<Props> = ({
                 <Dropdown items={mobileMenuItems} placement="bottom-end">
                   <GhostIconButton
                     aria-label={t(EditorI18nKeys.MoreActionsLabel)}
-                    icon={<IconDotsVertical size={DIAL_ICON_SIZE.SM} />}
+                    icon={
+                      <IconDotsVertical
+                        size={DIAL_ICON_SIZE.SM}
+                        stroke={DIAL_KIT_ICON_STROKE}
+                      />
+                    }
                   />
                 </Dropdown>
                 <PrimaryButton
@@ -263,9 +279,15 @@ const EditorHeader: FC<Props> = ({
             label={isPreviewing ? exitPreviewButtonLabel : previewButtonLabel}
             iconBefore={
               isPreviewing ? (
-                <IconEyeOff size={DIAL_ICON_SIZE.SM} />
+                <IconEyeOff
+                  size={DIAL_ICON_SIZE.SM}
+                  stroke={DIAL_KIT_ICON_STROKE}
+                />
               ) : (
-                <IconEye size={DIAL_ICON_SIZE.SM} />
+                <IconEye
+                  size={DIAL_ICON_SIZE.SM}
+                  stroke={DIAL_KIT_ICON_STROKE}
+                />
               )
             }
             onClick={onPreview}

--- a/apps/chat/src/components/ErrorBoundary/ErrorFallback.tsx
+++ b/apps/chat/src/components/ErrorBoundary/ErrorFallback.tsx
@@ -1,3 +1,4 @@
+import { DIAL_KIT_ICON_STROKE } from '@epam/ai-dial-ui-kit';
 import { IconAlertTriangle } from '@tabler/icons-react';
 import type { ParseKeys } from 'i18next';
 import { memo, type FC } from 'react';
@@ -23,7 +24,7 @@ const ErrorFallback: FC<Props> = ({
         <IconAlertTriangle
           aria-hidden="true"
           size={48}
-          stroke={1.5}
+          stroke={DIAL_KIT_ICON_STROKE}
           className="text-error"
         />
       }

--- a/apps/chat/src/components/Header/Header.tsx
+++ b/apps/chat/src/components/Header/Header.tsx
@@ -1,6 +1,10 @@
 import { OverlayFeature } from '@epam/ai-dial-chat-overlay';
 import { mergeClasses } from '@epam/ai-dial-chat-shared';
-import { DIAL_ICON_SIZE, GhostIconButton } from '@epam/ai-dial-ui-kit';
+import {
+  DIAL_ICON_SIZE,
+  DIAL_KIT_ICON_STROKE,
+  GhostIconButton,
+} from '@epam/ai-dial-ui-kit';
 import {
   IconLayoutSidebarRight,
   IconMenu2,
@@ -68,7 +72,7 @@ const Header: FC<Props> = ({
               icon={
                 <IconLayoutSidebarRight
                   size={DIAL_ICON_SIZE.LG}
-                  stroke={1.5}
+                  stroke={DIAL_KIT_ICON_STROKE}
                   className={
                     !isConversationPanelOpen ? 'scale-x-[-1]' : undefined
                   }
@@ -97,7 +101,7 @@ const Header: FC<Props> = ({
                 icon={
                   <IconPlus
                     size={DIAL_ICON_SIZE.LG}
-                    stroke={1.5}
+                    stroke={DIAL_KIT_ICON_STROKE}
                     className={
                       !isConversationPanelOpen
                         ? styles.newChatIconPop
@@ -113,7 +117,12 @@ const Header: FC<Props> = ({
           )}
         {!isNavigationMenuHidden && (
           <GhostIconButton
-            icon={<IconMenu2 size={DIAL_ICON_SIZE.LG} stroke={1.5} />}
+            icon={
+              <IconMenu2
+                size={DIAL_ICON_SIZE.LG}
+                stroke={DIAL_KIT_ICON_STROKE}
+              />
+            }
             aria-label={t(NavigationI18nKeys.OpenMenu)}
             onClick={onMenuToggle}
           />

--- a/apps/chat/src/components/Header/SourcesSidebarToggle.tsx
+++ b/apps/chat/src/components/Header/SourcesSidebarToggle.tsx
@@ -1,5 +1,9 @@
 import { useAttachmentCanvas } from '@epam/ai-dial-attachment-canvas';
-import { DIAL_ICON_SIZE, GhostIconButton } from '@epam/ai-dial-ui-kit';
+import {
+  DIAL_ICON_SIZE,
+  DIAL_KIT_ICON_STROKE,
+  GhostIconButton,
+} from '@epam/ai-dial-ui-kit';
 import { IconFileDescription } from '@tabler/icons-react';
 import { memo, useCallback, type FC } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -25,7 +29,12 @@ const SourcesSidebarToggle: FC = () => {
 
   return (
     <GhostIconButton
-      icon={<IconFileDescription size={DIAL_ICON_SIZE.LG} stroke={1.5} />}
+      icon={
+        <IconFileDescription
+          size={DIAL_ICON_SIZE.LG}
+          stroke={DIAL_KIT_ICON_STROKE}
+        />
+      }
       aria-label={t(SidebarI18nKeys.ToggleOpen)}
       aria-pressed={isOpen}
       tooltipProps={{ tooltip: t(SidebarI18nKeys.ToggleOpen) }}

--- a/apps/chat/src/components/Header/tests/Header.spec.tsx
+++ b/apps/chat/src/components/Header/tests/Header.spec.tsx
@@ -24,6 +24,7 @@ vi.mock('@epam/ai-dial-attachment-canvas', () => ({
   useAttachmentCanvas: () => ({ closeCanvas: vi.fn() }),
 }));
 vi.mock('@epam/ai-dial-ui-kit', () => ({
+  DIAL_KIT_ICON_STROKE: 1.5,
   DIAL_ICON_SIZE: { LG: 24 },
   GhostIconButton: ({
     'aria-label': ariaLabel,

--- a/apps/chat/src/components/Icons/ScheduledTasksIcon/ScheduledTasksIcon.tsx
+++ b/apps/chat/src/components/Icons/ScheduledTasksIcon/ScheduledTasksIcon.tsx
@@ -1,3 +1,4 @@
+import { DIAL_KIT_ICON_STROKE } from '@epam/ai-dial-ui-kit';
 import { FC, memo } from 'react';
 
 interface Props {
@@ -5,7 +6,10 @@ interface Props {
   stroke?: number;
 }
 
-const ScheduledTasksIcon: FC<Props> = ({ size = 20, stroke = 1.5 }) => (
+const ScheduledTasksIcon: FC<Props> = ({
+  size = 20,
+  stroke = DIAL_KIT_ICON_STROKE,
+}) => (
   <svg
     width={size}
     height={size}

--- a/apps/chat/src/components/LogoutConfirmation/tests/LogoutConfirmationModal.spec.tsx
+++ b/apps/chat/src/components/LogoutConfirmation/tests/LogoutConfirmationModal.spec.tsx
@@ -31,6 +31,7 @@ vi.mock('../../../server-api/auth.api', () => ({
 }));
 
 vi.mock('@epam/ai-dial-ui-kit', () => ({
+  DIAL_KIT_ICON_STROKE: 1.5,
   ConfirmationPopup: ({
     open,
     confirmLabel,

--- a/apps/chat/src/components/Navigation/tests/Navigation.spec.tsx
+++ b/apps/chat/src/components/Navigation/tests/Navigation.spec.tsx
@@ -49,6 +49,7 @@ interface MockDropdownItem {
 /* The real Dropdown renders into a floating overlay; the mock renders items
    inline so the assertions stay about menu content, not positioning. */
 vi.mock('@epam/ai-dial-ui-kit', () => ({
+  DIAL_KIT_ICON_STROKE: 1.5,
   BASE_ICON_SIZE: 20,
   DIAL_ICON_SIZE: { SM: 16, MD: 20, LG: 24 },
   ElementSize: { Standard: 'standard' },

--- a/apps/chat/src/components/NewVersionFallback/NewVersionFallback.tsx
+++ b/apps/chat/src/components/NewVersionFallback/NewVersionFallback.tsx
@@ -1,3 +1,4 @@
+import { DIAL_KIT_ICON_STROKE } from '@epam/ai-dial-ui-kit';
 import { IconRefresh } from '@tabler/icons-react';
 import { memo, type FC } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -21,7 +22,7 @@ const NewVersionFallback: FC = () => {
         <IconRefresh
           aria-hidden="true"
           size={48}
-          stroke={1.5}
+          stroke={DIAL_KIT_ICON_STROKE}
           className="text-accent"
         />
       }

--- a/apps/chat/src/components/Notification/NotificationContainer.tsx
+++ b/apps/chat/src/components/Notification/NotificationContainer.tsx
@@ -1,5 +1,6 @@
 import {
   DIAL_ICON_SIZE,
+  DIAL_KIT_ICON_STROKE,
   GhostIconButton,
   Notification,
 } from '@epam/ai-dial-ui-kit';
@@ -67,7 +68,13 @@ const RequestIdRow: FC<RequestIdRowProps> = ({ requestId }) => {
         {requestId}
       </span>
       <GhostIconButton
-        icon={<IconCopy size={DIAL_ICON_SIZE.SM} aria-hidden />}
+        icon={
+          <IconCopy
+            size={DIAL_ICON_SIZE.SM}
+            aria-hidden
+            stroke={DIAL_KIT_ICON_STROKE}
+          />
+        }
         aria-label={t(NotificationI18nKeys.RequestIdCopyAriaLabel)}
         onClick={() => void handleCopy()}
       />

--- a/apps/chat/src/components/Notification/tests/NotificationContainer.spec.tsx
+++ b/apps/chat/src/components/Notification/tests/NotificationContainer.spec.tsx
@@ -13,6 +13,7 @@ vi.mock('../../../context/NotificationContext', () => ({
 }));
 
 vi.mock('@epam/ai-dial-ui-kit', () => ({
+  DIAL_KIT_ICON_STROKE: 1.5,
   mergeClasses: (...args: (string | undefined)[]) =>
     args.filter(Boolean).join(' '),
   DIAL_ICON_SIZE: { SM: 16, LG: 24 },

--- a/apps/chat/src/components/ScheduledTaskConversationBanner/ScheduledTaskConversationBanner.tsx
+++ b/apps/chat/src/components/ScheduledTaskConversationBanner/ScheduledTaskConversationBanner.tsx
@@ -1,4 +1,9 @@
-import { GhostButton, Skeleton, SkeletonVariant } from '@epam/ai-dial-ui-kit';
+import {
+  DIAL_KIT_ICON_STROKE,
+  GhostButton,
+  Skeleton,
+  SkeletonVariant,
+} from '@epam/ai-dial-ui-kit';
 import { IconChevronRight } from '@tabler/icons-react';
 import { FC, memo, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -122,7 +127,12 @@ const ScheduledTaskConversationBanner: FC = () => {
         className="dial-tiny-semi-text flex h-6 shrink-0 items-center gap-1 rounded-full px-2 text-accent hover:bg-control-accent-alpha-hover focus-visible:outline focus-visible:-outline-offset-1 focus-visible:outline-focus"
       >
         {t(ScheduledTasksI18nKeys.ConversationBannerTaskDetailsLabel)}
-        <IconChevronRight size={16} className="rtl:scale-x-[-1]" aria-hidden />
+        <IconChevronRight
+          size={16}
+          className="rtl:scale-x-[-1]"
+          aria-hidden
+          stroke={DIAL_KIT_ICON_STROKE}
+        />
       </Link>
     </div>
   );

--- a/apps/chat/src/hooks/navigation/useNavigationMenuGroups.tsx
+++ b/apps/chat/src/hooks/navigation/useNavigationMenuGroups.tsx
@@ -1,7 +1,7 @@
 import { OverlayFeature } from '@epam/ai-dial-chat-overlay';
 import { SendOnEnter } from '@epam/ai-dial-conversation-input';
 import type { NavigationMenuGroup } from '@epam/ai-dial-navigation-panel';
-import { DIAL_ICON_SIZE } from '@epam/ai-dial-ui-kit';
+import { DIAL_ICON_SIZE, DIAL_KIT_ICON_STROKE } from '@epam/ai-dial-ui-kit';
 import { IconKeyboard, IconLanguage } from '@tabler/icons-react';
 import { useTranslation } from 'react-i18next';
 import { SettingsI18nKeys } from '../../constants/translation-keys';
@@ -48,7 +48,13 @@ export const useNavigationMenuGroups = (): NavigationMenuGroups => {
       ? {
           id: 'language',
           label: t(SettingsI18nKeys.Language),
-          icon: <IconLanguage size={DIAL_ICON_SIZE.SM} aria-hidden />,
+          icon: (
+            <IconLanguage
+              size={DIAL_ICON_SIZE.SM}
+              aria-hidden
+              stroke={DIAL_KIT_ICON_STROKE}
+            />
+          ),
           options: SUPPORTED_LANGUAGES.map(({ code, nativeName }) => ({
             id: `language-${code}`,
             label: nativeName,
@@ -61,7 +67,13 @@ export const useNavigationMenuGroups = (): NavigationMenuGroups => {
       ? {
           id: 'keyboard-shortcuts',
           label: t(SettingsI18nKeys.KeyboardShortcuts),
-          icon: <IconKeyboard size={DIAL_ICON_SIZE.SM} aria-hidden />,
+          icon: (
+            <IconKeyboard
+              size={DIAL_ICON_SIZE.SM}
+              aria-hidden
+              stroke={DIAL_KIT_ICON_STROKE}
+            />
+          ),
           options: [
             {
               id: 'shortcut-enter',

--- a/apps/chat/src/hooks/useSettingsTabConfig.tsx
+++ b/apps/chat/src/hooks/useSettingsTabConfig.tsx
@@ -1,5 +1,5 @@
 import type { SettingsPanelItem } from '@epam/ai-dial-settings-panel';
-import { DIAL_ICON_SIZE } from '@epam/ai-dial-ui-kit';
+import { DIAL_ICON_SIZE, DIAL_KIT_ICON_STROKE } from '@epam/ai-dial-ui-kit';
 import { IconChartBar } from '@tabler/icons-react';
 import type { ComponentType } from 'react';
 import { useMemo } from 'react';
@@ -31,7 +31,13 @@ export const useSettingsTabConfig = (): UseSettingsTabConfigResult => {
         item: {
           id: SettingsTabs.Usage,
           label: t(BasicI18nKeys.Usage),
-          icon: <IconChartBar size={DIAL_ICON_SIZE.MD} aria-hidden />,
+          icon: (
+            <IconChartBar
+              size={DIAL_ICON_SIZE.MD}
+              aria-hidden
+              stroke={DIAL_KIT_ICON_STROKE}
+            />
+          ),
         },
         Component: UsageTab,
       },

--- a/apps/chat/src/pages/AppsEditor/tests/AppEditorIframe.spec.tsx
+++ b/apps/chat/src/pages/AppsEditor/tests/AppEditorIframe.spec.tsx
@@ -29,6 +29,7 @@ vi.mock('../../../server-api/deployments', () => ({
 }));
 
 vi.mock('@epam/ai-dial-ui-kit', () => ({
+  DIAL_KIT_ICON_STROKE: 1.5,
   DIAL_ICON_SIZE: { SM: 16, MD: 20, LG: 24 },
   Spinner: ({ ariaLabel }: { ariaLabel?: string }) => (
     <div role="status" aria-label={ariaLabel ?? 'Loading'} />

--- a/apps/chat/src/pages/Conversation/Conversation.tsx
+++ b/apps/chat/src/pages/Conversation/Conversation.tsx
@@ -18,9 +18,10 @@ import {
   type Message,
 } from '@epam/ai-dial-chat-shared';
 import {
-  ConfirmationPopupVariant,
   ConfirmationPopup,
+  ConfirmationPopupVariant,
   DIAL_ICON_SIZE,
+  DIAL_KIT_ICON_STROKE,
   Spinner,
 } from '@epam/ai-dial-ui-kit';
 import { IconTelescope } from '@tabler/icons-react';
@@ -104,7 +105,13 @@ export const ConversationPage: FC<Props> = ({ onDuplicateReadonly }) => {
   } = useToolsMenu({
     selectedItemId: currentSelectedItemId,
     selectedDeploymentConfiguration,
-    toolIcon: <IconTelescope size={DIAL_ICON_SIZE.SM} aria-hidden />,
+    toolIcon: (
+      <IconTelescope
+        size={DIAL_ICON_SIZE.SM}
+        aria-hidden
+        stroke={DIAL_KIT_ICON_STROKE}
+      />
+    ),
   });
   const { handleClose: handleCloseSourcesSidebar, setMessages } =
     useSourcesSidebar();

--- a/apps/chat/src/pages/ConversationRoute/ConversationRoute.tsx
+++ b/apps/chat/src/pages/ConversationRoute/ConversationRoute.tsx
@@ -15,7 +15,7 @@ import type {
   DeploymentItem,
   StarterOption,
 } from '@epam/ai-dial-chat-shared';
-import { DIAL_ICON_SIZE } from '@epam/ai-dial-ui-kit';
+import { DIAL_ICON_SIZE, DIAL_KIT_ICON_STROKE } from '@epam/ai-dial-ui-kit';
 import { IconTelescope } from '@tabler/icons-react';
 import {
   FC,
@@ -162,7 +162,13 @@ const ConversationRoute: FC = () => {
     {
       selectedItemId,
       selectedDeploymentConfiguration,
-      toolIcon: <IconTelescope size={DIAL_ICON_SIZE.SM} aria-hidden />,
+      toolIcon: (
+        <IconTelescope
+          size={DIAL_ICON_SIZE.SM}
+          aria-hidden
+          stroke={DIAL_KIT_ICON_STROKE}
+        />
+      ),
     },
   );
 

--- a/apps/chat/src/pages/NotFound/NotFound.tsx
+++ b/apps/chat/src/pages/NotFound/NotFound.tsx
@@ -1,9 +1,10 @@
 import { mergeClasses } from '@epam/ai-dial-chat-shared';
 import {
   DIAL_ICON_SIZE,
+  DIAL_KIT_ICON_STROKE,
+  GhostButton,
   NeutralButton,
   PrimaryButton,
-  GhostButton,
 } from '@epam/ai-dial-ui-kit';
 import {
   IconArrowLeft,
@@ -69,12 +70,22 @@ const NotFoundPage: FC = () => {
           <div className="mt-8 flex flex-col items-stretch gap-3 desktop:flex-row desktop:items-center">
             <PrimaryButton
               label={t(NotFoundI18nKeys.OpenCatalog)}
-              iconBefore={<IconLayoutGrid size={DIAL_ICON_SIZE.SM} />}
+              iconBefore={
+                <IconLayoutGrid
+                  size={DIAL_ICON_SIZE.SM}
+                  stroke={DIAL_KIT_ICON_STROKE}
+                />
+              }
               onClick={() => navigate(ROUTES.Catalog)}
             />
             <NeutralButton
               label={t(ButtonsI18nKeys.NewChat)}
-              iconBefore={<IconMessagePlus size={DIAL_ICON_SIZE.SM} />}
+              iconBefore={
+                <IconMessagePlus
+                  size={DIAL_ICON_SIZE.SM}
+                  stroke={DIAL_KIT_ICON_STROKE}
+                />
+              }
               onClick={() => navigate(ROUTES.Root)}
             />
           </div>
@@ -87,6 +98,7 @@ const NotFoundPage: FC = () => {
                 size={DIAL_ICON_SIZE.SM}
                 className="rtl:scale-x-[-1]"
                 aria-hidden="true"
+                stroke={DIAL_KIT_ICON_STROKE}
               />
             }
             onClick={() => navigate(-1)}

--- a/apps/chat/src/pages/ScheduledTaskDetailPage/tests/ScheduledTaskDetailPage.spec.tsx
+++ b/apps/chat/src/pages/ScheduledTaskDetailPage/tests/ScheduledTaskDetailPage.spec.tsx
@@ -174,6 +174,7 @@ vi.mock('@epam/ai-dial-scheduled-tasks', () => ({
 }));
 
 vi.mock('@epam/ai-dial-ui-kit', () => ({
+  DIAL_KIT_ICON_STROKE: 1.5,
   DIAL_ICON_SIZE: { SM: 16, MD: 20, LG: 24 },
   NotificationVariant: { Success: 'success', Error: 'error' },
   PrimaryButton: ({

--- a/apps/chat/src/pages/SkillEditor/SkillEditor.tsx
+++ b/apps/chat/src/pages/SkillEditor/SkillEditor.tsx
@@ -21,6 +21,7 @@ import {
 import {
   ConfirmationPopup,
   ConfirmationPopupVariant,
+  DIAL_KIT_ICON_STROKE,
   EditorThemes,
   ErrorText,
   GhostIconButton,
@@ -321,7 +322,12 @@ const SkillEditorPage: FC = () => {
     <>
       <GhostIconButton
         icon={
-          <IconArrowLeft size={20} className="rtl:scale-x-[-1]" aria-hidden />
+          <IconArrowLeft
+            size={20}
+            className="rtl:scale-x-[-1]"
+            aria-hidden
+            stroke={DIAL_KIT_ICON_STROKE}
+          />
         }
         aria-label={t(SkillEditorI18nKeys.BackAriaLabel)}
         onClick={handleCancel}

--- a/apps/chat/src/pages/ToolsetEditor/EditorForm/SettingsForm.tsx
+++ b/apps/chat/src/pages/ToolsetEditor/EditorForm/SettingsForm.tsx
@@ -2,6 +2,7 @@ import { buildToolsetMcpUrl } from '@epam/ai-dial-chat-hooks';
 import { CatalogEntityType } from '@epam/ai-dial-chat-shared';
 import {
   DIAL_ICON_SIZE,
+  DIAL_KIT_ICON_STROKE,
   ElementSize,
   GhostIconButton,
   Input,
@@ -115,12 +116,14 @@ const SettingsForm: FC<Props> = ({
                 size={DIAL_ICON_SIZE.SM}
                 className="text-success"
                 aria-hidden
+                stroke={DIAL_KIT_ICON_STROKE}
               />
             ) : (
               <IconCopy
                 size={DIAL_ICON_SIZE.SM}
                 className="text-secondary"
                 aria-hidden
+                stroke={DIAL_KIT_ICON_STROKE}
               />
             )
           }

--- a/apps/chat/src/pages/ToolsetEditor/EditorForm/tests/AuthSection.spec.tsx
+++ b/apps/chat/src/pages/ToolsetEditor/EditorForm/tests/AuthSection.spec.tsx
@@ -58,6 +58,7 @@ vi.mock('../../../../context/NotificationContext');
 const mockShowNotification = vi.fn();
 
 vi.mock('@epam/ai-dial-ui-kit', () => ({
+  DIAL_KIT_ICON_STROKE: 1.5,
   Input: ({
     value,
     onChange,

--- a/apps/chat/src/pages/ToolsetEditor/EditorForm/tests/SettingsForm.spec.tsx
+++ b/apps/chat/src/pages/ToolsetEditor/EditorForm/tests/SettingsForm.spec.tsx
@@ -54,6 +54,7 @@ vi.mock('@epam/ai-dial-chat-hooks', async (importOriginal) => {
 });
 
 vi.mock('@epam/ai-dial-ui-kit', () => ({
+  DIAL_KIT_ICON_STROKE: 1.5,
   PrimaryButton: ({
     label,
     onClick,

--- a/docs/theme-customization.md
+++ b/docs/theme-customization.md
@@ -211,18 +211,25 @@ stroke-control-disable-primary
 **Shadows**
 
 ```text
-shadow-xs-sm-1  shadow-xs-sm-2  shadow-md  shadow-lg
+shadow-xs-1  shadow-xs-2  shadow-sm  shadow-md  shadow-lg
 ```
 
 The variables are named after the elevation that consumes them, not after their
-hue. `shadow-xs` and `shadow-sm` each paint two layers — a blue one from
-`shadow-xs-sm-1` and a grey one from `shadow-xs-sm-2` — and differ from each
-other only in offset and blur. `shadow-md` and `shadow-lg` are a single blue
-layer each, so they take one variable apiece.
+hue. `shadow-xs` paints two layers — a wide blue one from `shadow-xs-1` and a
+tight grey one from `shadow-xs-2`. `shadow-sm`, `shadow-md`, and `shadow-lg`
+are a single blue layer each, so they take one variable apiece. Themes that set
+the pre-spec `shadow-xs-sm-1` / `shadow-xs-sm-2` need to move to the
+`shadow-xs-*` names; `shadow-sm` was retuned for the side panels and now has
+its own variable.
 
-There are four elevations and no inset variant: a recessed seam between a panel
-and the content beside it is painted by the panel's own `shadow-sm`, not by an
-inset shadow on the content.
+Besides the four scale steps there is `shadow-chat-button`, the resting shadow
+the chat button kept when `shadow-sm` was retuned. It is not a foundations
+elevation and has no variable of its own — it paints the same two variables as
+`shadow-xs` at a wider offset and blur.
+
+There is no inset variant: a recessed seam between a panel and the content
+beside it is painted by the panel's own `shadow-sm`, not by an inset shadow on
+the content.
 
 ### Renamed in ui-kit 0.14
 

--- a/docs/theme-customization.md
+++ b/docs/theme-customization.md
@@ -208,6 +208,24 @@ stroke-accent-focus stroke-gradient-1    stroke-gradient-2
 stroke-control-disable-primary
 ```
 
+These name the stroke _colour_. Stroke _width_ is not themable: the design
+scale is four fixed widths, written as plain Tailwind utilities, because
+`borderColor` already owns names like `warning` and `error` and a
+`border-warning` utility would then set a width and a colour at once.
+
+| Width | Written as                    | Used for                                    |
+| ----- | ----------------------------- | ------------------------------------------- |
+| 0.5px | `0.5px solid` in a stylesheet | Dividers inside a table                     |
+| 1px   | `border`                      | Controls, standalone dividers, table frames |
+| 1.5px | `DIAL_KIT_ICON_STROKE`        | Tabler icon `stroke` (its own default is 2) |
+| 2px   | `border-2`                    | Active/selected highlighting                |
+
+Tabler renders every outline icon at 2px unless told otherwise, so the icon
+weight has to be passed explicitly on each icon:
+`<IconPlus stroke={DIAL_KIT_ICON_STROKE} />`. Two departures are deliberate:
+empty-state illustrations stay lighter (`stroke={1}`), since 1.5px reads as a
+fence at 48px, and filled glyphs carry no icon stroke at all.
+
 **Shadows**
 
 ```text

--- a/libs/attachment-canvas/package.json
+++ b/libs/attachment-canvas/package.json
@@ -24,7 +24,7 @@
     "@epam/ai-dial-shared": "0.48.0",
     "@epam/ai-dial-sidebar": "0.0.1",
     "@epam/ai-dial-visualizer-connector": "0.48.0",
-    "@epam/ai-dial-ui-kit": "^0.14.0-dev.13",
+    "@epam/ai-dial-ui-kit": "^0.14.0-dev.15",
     "@epam/pdf-highlighter-kit": ">=0.0.14",
     "@mcp-ui/client": "^7.1.1",
     "@modelcontextprotocol/sdk": "^1.27.1",

--- a/libs/attachment-canvas/src/components/AttachmentCanvas/AttachmentCanvas.tsx
+++ b/libs/attachment-canvas/src/components/AttachmentCanvas/AttachmentCanvas.tsx
@@ -1,6 +1,10 @@
 import { mergeClasses } from '@epam/ai-dial-chat-shared';
 import { SidebarOrientation, SidebarPanel } from '@epam/ai-dial-sidebar';
-import { DIAL_ICON_SIZE, GhostIconButton } from '@epam/ai-dial-ui-kit';
+import {
+  DIAL_ICON_SIZE,
+  DIAL_KIT_ICON_STROKE,
+  GhostIconButton,
+} from '@epam/ai-dial-ui-kit';
 import {
   IconCheck,
   IconCode,
@@ -182,13 +186,13 @@ const AttachmentCanvasBase: FC<AttachmentCanvasProps> = ({
                   isHtmlSourceView ? (
                     <IconEye
                       size={DIAL_ICON_SIZE.LG}
-                      stroke={1.5}
+                      stroke={DIAL_KIT_ICON_STROKE}
                       aria-hidden
                     />
                   ) : (
                     <IconCode
                       size={DIAL_ICON_SIZE.LG}
-                      stroke={1.5}
+                      stroke={DIAL_KIT_ICON_STROKE}
                       aria-hidden
                     />
                   )
@@ -211,13 +215,13 @@ const AttachmentCanvasBase: FC<AttachmentCanvasProps> = ({
                   isCopiedText ? (
                     <IconCheck
                       size={DIAL_ICON_SIZE.LG}
-                      stroke={1.5}
+                      stroke={DIAL_KIT_ICON_STROKE}
                       aria-hidden
                     />
                   ) : (
                     <IconCopy
                       size={DIAL_ICON_SIZE.LG}
-                      stroke={1.5}
+                      stroke={DIAL_KIT_ICON_STROKE}
                       aria-hidden
                     />
                   )
@@ -235,13 +239,13 @@ const AttachmentCanvasBase: FC<AttachmentCanvasProps> = ({
                   isCopiedMarkdown ? (
                     <IconCheck
                       size={DIAL_ICON_SIZE.LG}
-                      stroke={1.5}
+                      stroke={DIAL_KIT_ICON_STROKE}
                       aria-hidden
                     />
                   ) : (
                     <IconMarkdown
                       size={DIAL_ICON_SIZE.LG}
-                      stroke={1.5}
+                      stroke={DIAL_KIT_ICON_STROKE}
                       aria-hidden
                     />
                   )
@@ -263,13 +267,13 @@ const AttachmentCanvasBase: FC<AttachmentCanvasProps> = ({
                   isCopiedJson ? (
                     <IconCheck
                       size={DIAL_ICON_SIZE.LG}
-                      stroke={1.5}
+                      stroke={DIAL_KIT_ICON_STROKE}
                       aria-hidden
                     />
                   ) : (
                     <IconCopy
                       size={DIAL_ICON_SIZE.LG}
-                      stroke={1.5}
+                      stroke={DIAL_KIT_ICON_STROKE}
                       aria-hidden
                     />
                   )
@@ -283,7 +287,12 @@ const AttachmentCanvasBase: FC<AttachmentCanvasProps> = ({
             )}
             {showDownload && (
               <GhostIconButton
-                icon={<IconDownload size={DIAL_ICON_SIZE.LG} stroke={1.5} />}
+                icon={
+                  <IconDownload
+                    size={DIAL_ICON_SIZE.LG}
+                    stroke={DIAL_KIT_ICON_STROKE}
+                  />
+                }
                 aria-label={downloadLabel}
                 tooltipProps={{ tooltip: downloadLabel }}
                 onClick={onDownload}

--- a/libs/attachment-canvas/src/components/AttachmentCanvasBody/AttachmentCanvasBody.tsx
+++ b/libs/attachment-canvas/src/components/AttachmentCanvasBody/AttachmentCanvasBody.tsx
@@ -4,7 +4,7 @@ import {
   MarkdownRenderer,
   mergeClasses,
 } from '@epam/ai-dial-chat-shared';
-import { Spinner } from '@epam/ai-dial-ui-kit';
+import { DIAL_KIT_ICON_STROKE, Spinner } from '@epam/ai-dial-ui-kit';
 import { IconAlertTriangle, IconLock } from '@tabler/icons-react';
 import { type FC, memo, useEffect, useMemo, useState } from 'react';
 import { defaultStyles, JsonView } from 'react-json-view-lite';
@@ -45,7 +45,7 @@ const ImageContent: FC<ImageContentProps> = ({
       <div className="flex flex-col items-center gap-2">
         <IconAlertTriangle
           size={60}
-          stroke={1.5}
+          stroke={DIAL_KIT_ICON_STROKE}
           className={styles.errorIcon}
         />
         <p className={mergeClasses('text-center', styles.statusLabel)}>
@@ -326,11 +326,15 @@ const AttachmentCanvasBodyBase: FC<AttachmentCanvasBodyProps> = ({
         return (
           <div className="flex flex-col items-center gap-2">
             {isForbidden ? (
-              <IconLock size={60} stroke={1.5} className={styles.errorIcon} />
+              <IconLock
+                size={60}
+                stroke={DIAL_KIT_ICON_STROKE}
+                className={styles.errorIcon}
+              />
             ) : (
               <IconAlertTriangle
                 size={60}
-                stroke={1.5}
+                stroke={DIAL_KIT_ICON_STROKE}
                 className={styles.errorIcon}
               />
             )}

--- a/libs/attachment-canvas/src/components/McpAppCanvasRenderer/McpAppCanvasRenderer.tsx
+++ b/libs/attachment-canvas/src/components/McpAppCanvasRenderer/McpAppCanvasRenderer.tsx
@@ -1,5 +1,5 @@
 import { mergeClasses } from '@epam/ai-dial-chat-shared';
-import { Spinner } from '@epam/ai-dial-ui-kit';
+import { DIAL_KIT_ICON_STROKE, Spinner } from '@epam/ai-dial-ui-kit';
 import { AppRenderer } from '@mcp-ui/client';
 import { IconAlertTriangle } from '@tabler/icons-react';
 import { type FC, useState } from 'react';
@@ -77,7 +77,7 @@ export const McpAppCanvasRenderer: FC<McpAppCanvasRendererProps> = ({
         <div className="absolute inset-0 flex flex-col items-center justify-center gap-2">
           <IconAlertTriangle
             size={60}
-            stroke={1.5}
+            stroke={DIAL_KIT_ICON_STROKE}
             aria-hidden
             className={styles.errorIcon}
           />

--- a/libs/attachment-canvas/src/components/OoxmlContent/OoxmlContent.tsx
+++ b/libs/attachment-canvas/src/components/OoxmlContent/OoxmlContent.tsx
@@ -1,5 +1,5 @@
 import { mergeClasses } from '@epam/ai-dial-chat-shared';
-import { Spinner } from '@epam/ai-dial-ui-kit';
+import { DIAL_KIT_ICON_STROKE, Spinner } from '@epam/ai-dial-ui-kit';
 import { IconAlertTriangle } from '@tabler/icons-react';
 import { type FC, useEffect, useRef, useState } from 'react';
 import type { OoxmlCanvasContent } from '../../models/attachment-canvas';
@@ -133,7 +133,7 @@ export const OoxmlContent: FC<OoxmlContentProps> = ({
               <IconAlertTriangle
                 aria-hidden="true"
                 size={60}
-                stroke={1.5}
+                stroke={DIAL_KIT_ICON_STROKE}
                 className={styles.errorIcon}
               />
               <p className="text-center">{loadErrorLabel}</p>

--- a/libs/attachment-canvas/src/components/PdfContent/PdfContent.tsx
+++ b/libs/attachment-canvas/src/components/PdfContent/PdfContent.tsx
@@ -6,6 +6,7 @@ import {
 } from '@epam/ai-dial-react-pdf-highlighter';
 import {
   DIAL_ICON_SIZE,
+  DIAL_KIT_ICON_STROKE,
   Dropdown,
   ElementSize,
   FabButton,
@@ -423,11 +424,15 @@ export const PdfContent: FC<PdfContentProps> = ({
             <FabButton
               icon={
                 isThumbnailsOpen ? (
-                  <IconX size={DIAL_ICON_SIZE.LG} stroke={1.5} aria-hidden />
+                  <IconX
+                    size={DIAL_ICON_SIZE.LG}
+                    stroke={DIAL_KIT_ICON_STROKE}
+                    aria-hidden
+                  />
                 ) : (
                   <IconMenu2
                     size={DIAL_ICON_SIZE.LG}
-                    stroke={1.5}
+                    stroke={DIAL_KIT_ICON_STROKE}
                     aria-hidden
                   />
                 )

--- a/libs/attachment-canvas/src/components/PdfContent/tests/PdfContent.spec.tsx
+++ b/libs/attachment-canvas/src/components/PdfContent/tests/PdfContent.spec.tsx
@@ -67,6 +67,7 @@ vi.mock('@epam/ai-dial-react-pdf-highlighter', () => ({
 
 vi.mock('@epam/ai-dial-ui-kit', () => ({
   DIAL_ICON_SIZE: { SM: 16, MD: 20, LG: 24 },
+  DIAL_KIT_ICON_STROKE: 1.5,
   ElementSize: { Small: 'small', Medium: 'medium', Large: 'large' },
   FabButton: ({
     icon,

--- a/libs/attachment-canvas/src/components/VisualizerCanvasRenderer/VisualizerCanvasRenderer.tsx
+++ b/libs/attachment-canvas/src/components/VisualizerCanvasRenderer/VisualizerCanvasRenderer.tsx
@@ -31,7 +31,7 @@ import {
  * 8. Update `openspec/specs/custom-visualizers/spec.md` accordingly.
  */
 import { VisualizerConnectorRequests } from '@epam/ai-dial-shared';
-import { Spinner } from '@epam/ai-dial-ui-kit';
+import { DIAL_KIT_ICON_STROKE, Spinner } from '@epam/ai-dial-ui-kit';
 import { VisualizerConnector } from '@epam/ai-dial-visualizer-connector';
 import { IconAlertTriangle } from '@tabler/icons-react';
 import { type FC, useEffect, useRef, useState } from 'react';
@@ -168,7 +168,7 @@ export const VisualizerCanvasRenderer: FC<VisualizerCanvasRendererProps> = ({
         <div className="absolute inset-0 flex flex-col items-center justify-center gap-2">
           <IconAlertTriangle
             size={60}
-            stroke={1.5}
+            stroke={DIAL_KIT_ICON_STROKE}
             aria-hidden
             className={styles.errorIcon}
           />

--- a/libs/attachment-canvas/src/hooks/useOpenAttachmentCanvas/tests/useOpenAttachmentCanvas.spec.ts
+++ b/libs/attachment-canvas/src/hooks/useOpenAttachmentCanvas/tests/useOpenAttachmentCanvas.spec.ts
@@ -524,7 +524,7 @@ describe('useOpenAttachmentCanvas routing', () => {
       expect(mockOpenCanvas).toHaveBeenCalledWith(
         htmlContent,
         'PG AI Factory scope roadmap',
-        undefined,
+        'PG AI Factory scope roadmap',
       );
     });
 

--- a/libs/attachment-canvas/src/hooks/useOpenAttachmentCanvas/tests/useOpenAttachmentCanvas.spec.ts
+++ b/libs/attachment-canvas/src/hooks/useOpenAttachmentCanvas/tests/useOpenAttachmentCanvas.spec.ts
@@ -501,6 +501,33 @@ describe('useOpenAttachmentCanvas routing', () => {
       );
     });
 
+    it('routes a cited source whose title has no extension by its DIAL-relative .html url', async () => {
+      /*
+       * A DIAL resource path is relative, so `new URL(url)` throws for it —
+       * the file name still has to be recovered from the last path segment.
+       */
+      const htmlContent = { type: 'html', srcdoc: '<p>roadmap</p>' };
+      mockResolveHtml.mockResolvedValue(htmlContent);
+
+      const attachment = {
+        id: 'PG AI Factory scope roadmap',
+        name: 'PG AI Factory scope roadmap',
+        contentType: 'text/html',
+        type: AttachmentType.File,
+        url: 'files/7bKTZyWQAe8Aht4USAmWYAHdXd9qgc3aFhBJ5V9tg27DrzkZDvwwaXoQnRLkchfngQ/uploads/2026-08/pg_ai_factory_scope_roadmap.html',
+      } as DisplayAttachment;
+
+      const { result } = renderOpenAttachmentCanvas();
+      const opened = await result.current.openAttachmentCanvas(attachment);
+
+      expect(opened).toBe(true);
+      expect(mockOpenCanvas).toHaveBeenCalledWith(
+        htmlContent,
+        'PG AI Factory scope roadmap',
+        undefined,
+      );
+    });
+
     it('opens unsupported canvas when the html resolver rejects fetched text', async () => {
       /*
        * The resolver returns null for text that exceeded the srcdoc size

--- a/libs/attachment-canvas/src/hooks/useOpenAttachmentCanvas/useOpenAttachmentCanvas.ts
+++ b/libs/attachment-canvas/src/hooks/useOpenAttachmentCanvas/useOpenAttachmentCanvas.ts
@@ -117,15 +117,29 @@ export type OpenAttachmentCanvas = (
 ) => Promise<boolean>;
 
 /**
- * Returns the last path segment of `url`, or an empty string when `url` is not
- * absolute. Used to classify a resource by extension when its display name is
- * a citation title rather than a file name.
+ * Returns the last path segment of `url` — its file name — for both absolute
+ * URLs and DIAL-relative resource paths such as
+ * `files/<bucket>/uploads/report.html`. Any query string or hash is dropped
+ * and percent escapes are decoded. Returns an empty string when no segment can
+ * be extracted. Used to classify a resource by extension when its display name
+ * is a citation title rather than a file name.
  */
 const getUrlFileName = (url: string): string => {
+  let path: string;
   try {
-    return new URL(url).pathname.split('/').pop() ?? '';
+    path = new URL(url).pathname;
   } catch {
-    return '';
+    /* A relative DIAL resource path has no base to resolve against, so the
+     * query and hash are stripped by hand instead. */
+    path = url.split(/[?#]/)[0];
+  }
+  const segment = path.split('/').filter(Boolean).pop() ?? '';
+  try {
+    return decodeURIComponent(segment);
+  } catch {
+    /* Malformed percent escape — the raw segment still works for extension
+     * matching. */
+    return segment;
   }
 };
 

--- a/libs/attachment-input/package.json
+++ b/libs/attachment-input/package.json
@@ -22,7 +22,7 @@
     "@epam/ai-dial-chat-shared": "*",
     "@tabler/icons-react": "^3.44.0",
     "react": "^19.0.0",
-    "@epam/ai-dial-ui-kit": "^0.14.0-dev.13"
+    "@epam/ai-dial-ui-kit": "^0.14.0-dev.15"
   },
   "nx": {
     "tags": [

--- a/libs/attachment-input/src/components/AttachmentCard/Attachments/Actions.tsx
+++ b/libs/attachment-input/src/components/AttachmentCard/Attachments/Actions.tsx
@@ -1,6 +1,7 @@
 import { mergeClasses } from '@epam/ai-dial-chat-shared';
 import {
   DIAL_ICON_SIZE,
+  DIAL_KIT_ICON_STROKE,
   ElementSize,
   StaticIconButton,
 } from '@epam/ai-dial-ui-kit';
@@ -63,7 +64,13 @@ const ActionButton: FC<ActionProps> = ({
 export const ReloadAction: FC<Omit<ActionProps, 'icon'>> = ({ ...props }) => {
   return (
     <ActionButton
-      icon={<IconReload size={DIAL_ICON_SIZE.SM} aria-hidden />}
+      icon={
+        <IconReload
+          size={DIAL_ICON_SIZE.SM}
+          aria-hidden
+          stroke={DIAL_KIT_ICON_STROKE}
+        />
+      }
       className={styles.retryIcon}
       {...props}
     />
@@ -74,7 +81,13 @@ export const ReloadAction: FC<Omit<ActionProps, 'icon'>> = ({ ...props }) => {
 export const DownloadAction: FC<Omit<ActionProps, 'icon'>> = ({ ...props }) => {
   return (
     <ActionButton
-      icon={<IconDownload size={DIAL_ICON_SIZE.SM} aria-hidden />}
+      icon={
+        <IconDownload
+          size={DIAL_ICON_SIZE.SM}
+          aria-hidden
+          stroke={DIAL_KIT_ICON_STROKE}
+        />
+      }
       {...props}
     />
   );
@@ -84,7 +97,13 @@ export const DownloadAction: FC<Omit<ActionProps, 'icon'>> = ({ ...props }) => {
 export const OpenLinkAction: FC<Omit<ActionProps, 'icon'>> = ({ ...props }) => {
   return (
     <ActionButton
-      icon={<IconExternalLink size={DIAL_ICON_SIZE.SM} aria-hidden />}
+      icon={
+        <IconExternalLink
+          size={DIAL_ICON_SIZE.SM}
+          aria-hidden
+          stroke={DIAL_KIT_ICON_STROKE}
+        />
+      }
       {...props}
     />
   );
@@ -94,7 +113,13 @@ export const OpenLinkAction: FC<Omit<ActionProps, 'icon'>> = ({ ...props }) => {
 export const RemoveAction: FC<Omit<ActionProps, 'icon'>> = ({ ...props }) => {
   return (
     <ActionButton
-      icon={<IconX size={DIAL_ICON_SIZE.SM} aria-hidden />}
+      icon={
+        <IconX
+          size={DIAL_ICON_SIZE.SM}
+          aria-hidden
+          stroke={DIAL_KIT_ICON_STROKE}
+        />
+      }
       {...props}
     />
   );

--- a/libs/attachment-input/src/components/AttachmentCard/Attachments/Image.tsx
+++ b/libs/attachment-input/src/components/AttachmentCard/Attachments/Image.tsx
@@ -5,6 +5,7 @@ import {
 } from '@epam/ai-dial-chat-shared';
 import {
   DIAL_ICON_SIZE,
+  DIAL_KIT_ICON_STROKE,
   Skeleton,
   SkeletonVariant,
 } from '@epam/ai-dial-ui-kit';
@@ -131,6 +132,7 @@ export const ImageAttachment: FC<ImageAttachmentProps> = ({
                 size={DIAL_ICON_SIZE.LG}
                 className={styles.typeText}
                 aria-hidden
+                stroke={DIAL_KIT_ICON_STROKE}
               />
             }
             className="absolute inset-0 rounded-xl"

--- a/libs/attachment-input/src/components/AttachmentGroup/AttachmentGroup.tsx
+++ b/libs/attachment-input/src/components/AttachmentGroup/AttachmentGroup.tsx
@@ -6,6 +6,7 @@ import {
 } from '@epam/ai-dial-chat-shared';
 import {
   DIAL_ICON_SIZE,
+  DIAL_KIT_ICON_STROKE,
   ElementSize,
   GhostIconButton,
 } from '@epam/ai-dial-ui-kit';
@@ -118,7 +119,13 @@ export const AttachmentGroup: FC<AttachmentGroupProps> = ({
         </div>
         {attachments.length >= 2 && (onDownloadAll || onAttachmentClick) && (
           <GhostIconButton
-            icon={<IconDownload size={DIAL_ICON_SIZE.SM} aria-hidden />}
+            icon={
+              <IconDownload
+                size={DIAL_ICON_SIZE.SM}
+                aria-hidden
+                stroke={DIAL_KIT_ICON_STROKE}
+              />
+            }
             size={ElementSize.Small}
             aria-label={downloadAllLabel}
             onClick={handleDownloadAll}

--- a/libs/builder-form/package.json
+++ b/libs/builder-form/package.json
@@ -20,7 +20,7 @@
   },
   "peerDependencies": {
     "@epam/ai-dial-chat-shared": "*",
-    "@epam/ai-dial-ui-kit": "^0.14.0-dev.13",
+    "@epam/ai-dial-ui-kit": "^0.14.0-dev.15",
     "@tabler/icons-react": "^3.44.0",
     "react": "^19.0.0"
   },

--- a/libs/builder-form/src/components/BuilderFormHeader/BuilderFormHeader.tsx
+++ b/libs/builder-form/src/components/BuilderFormHeader/BuilderFormHeader.tsx
@@ -1,6 +1,7 @@
 import { buildCssVars, mergeClasses } from '@epam/ai-dial-chat-shared';
 import {
   DIAL_ICON_SIZE,
+  DIAL_KIT_ICON_STROKE,
   GhostIconButton,
   NeutralButton,
   PrimaryButton,
@@ -45,6 +46,7 @@ export const BuilderFormHeader: FC<BuilderFormHeaderProps> = ({
               size={DIAL_ICON_SIZE.LG}
               className="rtl:scale-x-[-1]"
               aria-hidden
+              stroke={DIAL_KIT_ICON_STROKE}
             />
           }
           aria-label={labels.backButtonLabel}

--- a/libs/catalog/README.md
+++ b/libs/catalog/README.md
@@ -64,6 +64,31 @@ confirmation step and calls them only once the user confirms:
 />
 ```
 
+#### Read-only mode
+
+`isReadonly` turns the whole catalog into a pure browsing surface. It is a
+single switch — the host does not have to withhold each callback by hand:
+
+- Browse cards drop the favorite star, the footer divider, and the "Featured"
+  tag. The footer row goes away entirely for an item with no folder path, since
+  the path is the only thing left in it.
+- The list view drops its "Favorite" column.
+- The "Create" button and the favorites strip are not rendered.
+- The details panel withholds its favorite star and every action that mutates
+  the item or the caller's relationship to it: Share, Publish, Unpublish, Edit,
+  Delete, "Remove from My List", "Revoke access", and the credentials
+  Log in / Log out / manage button.
+
+The non-mutating actions stay: the primary "Use in chat" and Download still
+render, as do search, sort, filters, tabs, and the details tabs.
+
+```tsx
+<Catalog items={catalogItems} favorites={[]} isReadonly />
+```
+
+`Card`, `CardGrid`, `ListView`, and `DetailsPanel` each accept `isReadonly`
+directly too, for hosts composing their own layout instead of using `Catalog`.
+
 ### CardGrid
 
 Virtualized grid view of catalog cards.

--- a/libs/catalog/package.json
+++ b/libs/catalog/package.json
@@ -24,7 +24,7 @@
     "@epam/ai-dial-chat-shared": "*",
     "@epam/ai-dial-publish-panel": "*",
     "ag-grid-community": "35.3.0",
-    "@epam/ai-dial-ui-kit": "^0.14.0-dev.13"
+    "@epam/ai-dial-ui-kit": "^0.14.0-dev.15"
   },
   "nx": {
     "tags": [

--- a/libs/catalog/src/components/CardGrid/Card.tsx
+++ b/libs/catalog/src/components/CardGrid/Card.tsx
@@ -6,6 +6,7 @@ import {
 import {
   CardShell,
   DIAL_ICON_SIZE,
+  DIAL_KIT_ICON_STROKE,
   ElementSize,
   FolderPath,
 } from '@epam/ai-dial-ui-kit';
@@ -140,6 +141,7 @@ export const Card: FC<CardProps> = ({
             styles.checkIcon,
           )}
           aria-hidden
+          stroke={DIAL_KIT_ICON_STROKE}
         />
       )}
 

--- a/libs/catalog/src/components/CardGrid/Card.tsx
+++ b/libs/catalog/src/components/CardGrid/Card.tsx
@@ -41,6 +41,7 @@ export const Card: FC<CardProps> = ({
   className,
   styles: cardStyles,
   credentialsBadgeLoggedOutLabel,
+  isReadonly = false,
 }) => {
   const [isStarred, setIsStarred] = useState(initialIsStarred);
 
@@ -71,6 +72,12 @@ export const Card: FC<CardProps> = ({
     '--cg-check-icon': cardStyles?.colors?.checkIcon,
     '--cg-footer-border': cardStyles?.colors?.footerBorder,
   });
+
+  const isFeaturedVisible = !isReadonly && item.isFeatured === true;
+  const isStarVisible = !isReadonly && isFavoriteVisible?.(item) !== false;
+  /* Read-only cards drop the whole footer row once the folder path — the only
+   * thing left in it without the star — has nothing to render. */
+  const isFooterVisible = !isReadonly || item.folder.length > 0;
 
   const handleClick = onClick ? () => onClick(item) : undefined;
 
@@ -110,12 +117,12 @@ export const Card: FC<CardProps> = ({
       className={mergeClasses(
         'box-border cursor-pointer gap-3',
         styles.card,
-        item.isFeatured ? styles.featuredCard : undefined,
+        isFeaturedVisible ? styles.featuredCard : undefined,
         isSelected ? styles.selectedCard : undefined,
         className,
       )}
     >
-      {item.isFeatured && (
+      {isFeaturedVisible && (
         <div className="absolute end-[22px] top-0 -translate-y-1/2">
           <FeaturedChip
             label={featuredLabel}
@@ -175,35 +182,42 @@ export const Card: FC<CardProps> = ({
         <TopicsLine topics={item.topics} />
       </div>
 
-      <div className={mergeClasses('border-t pt-3', styles.footer)}>
-        <div className="flex items-center gap-2">
-          <div className="min-w-0 flex-1">
-            {item.folder.length > 0 && (
-              <FolderPath
-                segments={item.folder}
-                labelClassName={folderLabelClassName}
-                leafClassName={folderLeafClassName}
+      {isFooterVisible && (
+        <div
+          className={mergeClasses(
+            'pt-3',
+            !isReadonly && mergeClasses('border-t', styles.footer),
+          )}
+        >
+          <div className="flex items-center gap-2">
+            <div className="min-w-0 flex-1">
+              {item.folder.length > 0 && (
+                <FolderPath
+                  segments={item.folder}
+                  labelClassName={folderLabelClassName}
+                  leafClassName={folderLeafClassName}
+                />
+              )}
+            </div>
+            {isStarVisible && (
+              <StarToggleButton
+                isStarred={isStarred}
+                size={ElementSize.Small}
+                onClick={handleStarToggle}
+                ariaLabel={
+                  isStarred
+                    ? removeFromFavoritesAriaLabel
+                    : addToFavoritesAriaLabel
+                }
+                className={mergeClasses(
+                  styles.starBtn,
+                  !isStarred && styles.emptyStarHidden,
+                )}
               />
             )}
           </div>
-          {isFavoriteVisible?.(item) !== false && (
-            <StarToggleButton
-              isStarred={isStarred}
-              size={ElementSize.Small}
-              onClick={handleStarToggle}
-              ariaLabel={
-                isStarred
-                  ? removeFromFavoritesAriaLabel
-                  : addToFavoritesAriaLabel
-              }
-              className={mergeClasses(
-                styles.starBtn,
-                !isStarred && styles.emptyStarHidden,
-              )}
-            />
-          )}
         </div>
-      </div>
+      )}
     </CardShell>
   );
 };

--- a/libs/catalog/src/components/CardGrid/CardGrid.tsx
+++ b/libs/catalog/src/components/CardGrid/CardGrid.tsx
@@ -25,6 +25,7 @@ export const CardGrid: FC<CardGridProps> = memo(
     selectedItemId,
     skeletonColor = styles.skeletonColor,
     skeletonCardBackground,
+    isReadonly = false,
   }) => {
     const noResultsTitle = titles?.noResultsTitle ?? 'No results';
     const featuredLabel = titles?.featuredLabel ?? 'Featured';
@@ -52,6 +53,7 @@ export const CardGrid: FC<CardGridProps> = memo(
         removeFromFavoritesAriaLabel,
         selectedItemId,
         credentialsBadgeLoggedOutLabel,
+        isReadonly,
       }),
       [
         items,
@@ -65,6 +67,7 @@ export const CardGrid: FC<CardGridProps> = memo(
         removeFromFavoritesAriaLabel,
         selectedItemId,
         credentialsBadgeLoggedOutLabel,
+        isReadonly,
       ],
     );
 

--- a/libs/catalog/src/components/CardGrid/CardRowRenderer.tsx
+++ b/libs/catalog/src/components/CardGrid/CardRowRenderer.tsx
@@ -27,6 +27,7 @@ export const CardRowRenderer: FC<CardRowRendererProps> = ({
   removeFromFavoritesAriaLabel,
   selectedItemId,
   credentialsBadgeLoggedOutLabel,
+  isReadonly,
 }) => {
   const start = rowIndex * columnCount;
   const rowItems = items.slice(start, start + columnCount);
@@ -59,6 +60,7 @@ export const CardRowRenderer: FC<CardRowRendererProps> = ({
                 isSelected={item.id === selectedItemId}
                 className="h-full"
                 credentialsBadgeLoggedOutLabel={credentialsBadgeLoggedOutLabel}
+                isReadonly={isReadonly}
               />
             )}
           </div>

--- a/libs/catalog/src/components/CardGrid/tests/Card.spec.tsx
+++ b/libs/catalog/src/components/CardGrid/tests/Card.spec.tsx
@@ -173,3 +173,39 @@ describe('Card — credentials badge', () => {
     ).toBeNull();
   });
 });
+
+describe('Card — read-only state', () => {
+  const featuredItem = makeItem({ isFeatured: true, folder: ['Root', 'Team'] });
+
+  it('shows the Featured tag, the star, and the footer divider by default', () => {
+    render(<Card item={featuredItem} />);
+
+    const card = screen.getByRole('article', { hidden: true });
+    expect(screen.getByText('Featured')).toBeTruthy();
+    expect(
+      screen.getByRole('button', { name: 'Add to favorites' }),
+    ).toBeTruthy();
+    expect(screen.getByText('Team')).toBeTruthy();
+    expect(card.innerHTML).toContain('border-t');
+  });
+
+  it('withholds the Featured tag, the star, and the footer divider when isReadonly is set', () => {
+    render(<Card item={featuredItem} isReadonly onToggle={vi.fn()} />);
+
+    const card = screen.getByRole('article', { hidden: true });
+    expect(screen.queryByText('Featured')).toBeNull();
+    expect(
+      screen.queryByRole('button', { name: 'Add to favorites' }),
+    ).toBeNull();
+    expect(card.innerHTML).not.toContain('border-t');
+    // The folder path is the one footer element a read-only card keeps.
+    expect(screen.getByText('Team')).toBeTruthy();
+  });
+
+  it('drops the footer row entirely when a read-only item has no folder path', () => {
+    render(<Card item={makeItem({ isFeatured: true })} isReadonly />);
+
+    const card = screen.getByRole('article', { hidden: true });
+    expect(card.innerHTML).not.toContain('pt-3');
+  });
+});

--- a/libs/catalog/src/components/Catalog/Catalog.tsx
+++ b/libs/catalog/src/components/Catalog/Catalog.tsx
@@ -73,6 +73,7 @@ export const Catalog: FC<CatalogProps> = ({
   createOptions,
   hideCreateButton = false,
   hidePageTitle = false,
+  isReadonly = false,
   initialViewMode = CatalogViewMode.Grid,
   selectedItemId,
   onCardClick,
@@ -371,6 +372,11 @@ export const Catalog: FC<CatalogProps> = ({
     setViewMode(mode);
   }, []);
 
+  const isCreateButtonVisible = !hideCreateButton && !isReadonly;
+  /* A read-only catalog cannot favorite anything, so the strip has no way to
+   * gain or lose entries and is dropped rather than shown frozen. */
+  const isFavoritesVisible = isFavoritesRendered && !isReadonly;
+
   const emptyTitle = query ? noResultsTitle(query) : 'No items';
   const cardGridTitles = useMemo(
     () => ({
@@ -399,7 +405,7 @@ export const Catalog: FC<CatalogProps> = ({
       )}
       style={cssVars}
     >
-      {(!hidePageTitle || !hideCreateButton) && (
+      {(!hidePageTitle || isCreateButtonVisible) && (
         <div className={mergeClasses('shrink-0', styles.heading)}>
           <div className="flex h-[64px] w-full items-center justify-between px-8">
             {!hidePageTitle && (
@@ -412,7 +418,7 @@ export const Catalog: FC<CatalogProps> = ({
                 {pageTitle}
               </h1>
             )}
-            {!hideCreateButton && (
+            {isCreateButtonVisible && (
               <CreateButton
                 label={createLabel}
                 options={createOptions}
@@ -424,7 +430,7 @@ export const Catalog: FC<CatalogProps> = ({
       )}
 
       <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-y-auto overflow-x-hidden">
-        {isFavoritesRendered && (
+        {isFavoritesVisible && (
           <div className="w-full px-8">
             <Favorites
               items={favorites}
@@ -505,6 +511,7 @@ export const Catalog: FC<CatalogProps> = ({
               onItemClick={onCardClick ?? handleOpenDetails}
               titles={cardGridTitles}
               selectedItemId={selectedItemId}
+              isReadonly={isReadonly}
             />
           </div>
 
@@ -530,6 +537,7 @@ export const Catalog: FC<CatalogProps> = ({
                 credentialsBadgeLoggedOutLabel={
                   detailsTexts?.credentialsBadgeLoggedOutLabel
                 }
+                isReadonly={isReadonly}
               />
             </div>
           )}
@@ -542,6 +550,7 @@ export const Catalog: FC<CatalogProps> = ({
           isOpen={isDetailsOpen}
           isStarred={isSelectedItemStarred}
           isDetailsLoading={isDetailsLoading}
+          isReadonly={isReadonly}
           onClose={handleCloseDetails}
           onToggleFavorite={onToggleFavorite}
           isFavoriteVisible={isFavoriteVisible}

--- a/libs/catalog/src/components/Catalog/CreateButton.tsx
+++ b/libs/catalog/src/components/Catalog/CreateButton.tsx
@@ -3,6 +3,7 @@ import {
   ButtonDropdown,
   ButtonVariant,
   DIAL_ICON_SIZE,
+  DIAL_KIT_ICON_STROKE,
   DropdownItem,
   PrimaryButton,
 } from '@epam/ai-dial-ui-kit';
@@ -34,7 +35,9 @@ export const CreateButton: FC<CreateButtonProps> = ({
     return (
       <PrimaryButton
         label={label}
-        iconBefore={<IconPlus size={DIAL_ICON_SIZE.SM} />}
+        iconBefore={
+          <IconPlus size={DIAL_ICON_SIZE.SM} stroke={DIAL_KIT_ICON_STROKE} />
+        }
         onClick={onClick}
       />
     );
@@ -45,7 +48,9 @@ export const CreateButton: FC<CreateButtonProps> = ({
       <ButtonDropdown
         appearance={ButtonAppearance.Solid}
         label={label}
-        iconBefore={<IconPlus size={DIAL_ICON_SIZE.SM} />}
+        iconBefore={
+          <IconPlus size={DIAL_ICON_SIZE.SM} stroke={DIAL_KIT_ICON_STROKE} />
+        }
         variant={ButtonVariant.Primary}
         items={options}
       />

--- a/libs/catalog/src/components/Catalog/tests/Catalog.spec.tsx
+++ b/libs/catalog/src/components/Catalog/tests/Catalog.spec.tsx
@@ -9,6 +9,7 @@ import { CatalogViewMode } from '../../../types/view-mode';
 import { Catalog } from '../Catalog';
 
 vi.mock('@epam/ai-dial-ui-kit', () => ({
+  DIAL_KIT_ICON_STROKE: 1.5,
   DIAL_ICON_SIZE: { SM: 16, MD: 20, LG: 24 },
   Spinner: () => <div role="status" aria-label="Loading" />,
   EllipsisTooltip: ({

--- a/libs/catalog/src/components/Catalog/tests/Catalog.spec.tsx
+++ b/libs/catalog/src/components/Catalog/tests/Catalog.spec.tsx
@@ -738,3 +738,29 @@ describe('Catalog', () => {
     expect(onActiveTabChange).toHaveBeenCalledWith(CatalogEntityType.Prompt);
   });
 });
+
+describe('Catalog — read-only', () => {
+  const favorite: CatalogItem = {
+    id: 'f1',
+    type: CatalogEntityType.Model,
+    name: 'Claude',
+    version: '1',
+    lastUsed: 'now',
+    description: '',
+    folder: [],
+    topics: [],
+  };
+
+  it('withholds the Create button and the favorites strip when isReadonly is set', () => {
+    render(<Catalog items={[]} favorites={[favorite]} isReadonly />);
+
+    expect(screen.queryByRole('button', { name: 'Create' })).toBeNull();
+    expect(screen.queryByText('Your favorites')).toBeNull();
+  });
+
+  it('still renders the page title when the Create button is withheld', () => {
+    render(<Catalog items={[]} favorites={[]} isReadonly />);
+
+    expect(screen.getByRole('heading', { name: 'Catalog' })).toBeTruthy();
+  });
+});

--- a/libs/catalog/src/components/Details/ConfirmationView/ConfirmationFooter.tsx
+++ b/libs/catalog/src/components/Details/ConfirmationView/ConfirmationFooter.tsx
@@ -2,6 +2,7 @@ import { mergeClasses } from '@epam/ai-dial-chat-shared';
 import {
   DangerButton,
   DIAL_ICON_SIZE,
+  DIAL_KIT_ICON_STROKE,
   GhostButton,
   NeutralButton,
   Spinner,
@@ -54,7 +55,13 @@ export const ConfirmationFooter: FC<ConfirmationFooterProps> = ({
       return <Spinner size={DIAL_ICON_SIZE.SM} />;
     }
     if (isDanger) {
-      return <IconTrashX size={DIAL_ICON_SIZE.MD} aria-hidden />;
+      return (
+        <IconTrashX
+          size={DIAL_ICON_SIZE.MD}
+          aria-hidden
+          stroke={DIAL_KIT_ICON_STROKE}
+        />
+      );
     }
     return undefined;
   })();

--- a/libs/catalog/src/components/Details/Credentials/CredentialsBanner/CredentialsBanner.tsx
+++ b/libs/catalog/src/components/Details/Credentials/CredentialsBanner/CredentialsBanner.tsx
@@ -1,4 +1,4 @@
-import { DIAL_ICON_SIZE } from '@epam/ai-dial-ui-kit';
+import { DIAL_ICON_SIZE, DIAL_KIT_ICON_STROKE } from '@epam/ai-dial-ui-kit';
 import { IconBuildingCommunity, IconUser } from '@tabler/icons-react';
 import { FC } from 'react';
 import type { ItemDetailsTexts } from '../../../../models/item-details-props';
@@ -59,7 +59,13 @@ export const CredentialsBanner: FC<CredentialsBannerProps> = ({
   texts,
 }) => {
   /* Color comes from `CredentialsInfoCard`'s icon slot, which the icon inherits. */
-  const orgIcon = <IconBuildingCommunity size={BANNER_ICON_SIZE} aria-hidden />;
+  const orgIcon = (
+    <IconBuildingCommunity
+      size={BANNER_ICON_SIZE}
+      aria-hidden
+      stroke={DIAL_KIT_ICON_STROKE}
+    />
+  );
 
   if (state === CredentialsBannerState.PersonalCredentialsActive) {
     const title = (
@@ -70,7 +76,13 @@ export const CredentialsBanner: FC<CredentialsBannerProps> = ({
       <CredentialsInfoCard
         icon={
           <CredentialsIdentityIcon
-            icon={<IconUser size={DIAL_ICON_SIZE.SM} aria-hidden />}
+            icon={
+              <IconUser
+                size={DIAL_ICON_SIZE.SM}
+                aria-hidden
+                stroke={DIAL_KIT_ICON_STROKE}
+              />
+            }
             isActive
             surface={CredentialsIconSurface.Raised}
           />
@@ -90,7 +102,11 @@ export const CredentialsBanner: FC<CredentialsBannerProps> = ({
         icon={
           <CredentialsIdentityIcon
             icon={
-              <IconBuildingCommunity size={DIAL_ICON_SIZE.SM} aria-hidden />
+              <IconBuildingCommunity
+                size={DIAL_ICON_SIZE.SM}
+                aria-hidden
+                stroke={DIAL_KIT_ICON_STROKE}
+              />
             }
             isActive
             surface={CredentialsIconSurface.Raised}

--- a/libs/catalog/src/components/Details/Credentials/CredentialsIdentityIcon/tests/CredentialsIdentityIcon.spec.tsx
+++ b/libs/catalog/src/components/Details/Credentials/CredentialsIdentityIcon/tests/CredentialsIdentityIcon.spec.tsx
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { CredentialsIdentityIcon } from '../CredentialsIdentityIcon';
 
 vi.mock('@epam/ai-dial-ui-kit', () => ({
+  DIAL_KIT_ICON_STROKE: 1.5,
   DIAL_ICON_SIZE: { SM: 16, MD: 20, LG: 24 },
 }));
 

--- a/libs/catalog/src/components/Details/Credentials/CredentialsManagementPanel/CredentialsManagementPanel.tsx
+++ b/libs/catalog/src/components/Details/Credentials/CredentialsManagementPanel/CredentialsManagementPanel.tsx
@@ -3,6 +3,7 @@ import {
   ButtonAppearance,
   DangerButton,
   DIAL_ICON_SIZE,
+  DIAL_KIT_ICON_STROKE,
   Input,
   LinkButton,
   NeutralButton,
@@ -235,7 +236,13 @@ const CredentialsManagementRow: FC<CredentialsManagementRowProps> = ({
           isSignedIn && (
             <div className="animate-fadeIn pt-1">
               <CredentialsInfoCard
-                icon={<IconKey size={DIAL_ICON_SIZE.SM} aria-hidden />}
+                icon={
+                  <IconKey
+                    size={DIAL_ICON_SIZE.SM}
+                    aria-hidden
+                    stroke={DIAL_KIT_ICON_STROKE}
+                  />
+                }
                 title={configuredMessage}
                 description={addedWhenLabel}
                 titleClassName={keyCardTitleClassName}
@@ -355,7 +362,13 @@ export const CredentialsManagementPanel: FC<
               texts?.personalCredentialsDescription ??
               'These credentials apply only to your account.'
             }
-            icon={<IconUser size={DIAL_ICON_SIZE.SM} aria-hidden />}
+            icon={
+              <IconUser
+                size={DIAL_ICON_SIZE.SM}
+                aria-hidden
+                stroke={DIAL_KIT_ICON_STROKE}
+              />
+            }
             status={credentials.userStatus}
             isActive={isUserActive}
             authenticationType={credentials.authenticationType}
@@ -382,7 +395,11 @@ export const CredentialsManagementPanel: FC<
               'Once added, these credentials will grant all users in your organization access to this toolset.'
             }
             icon={
-              <IconBuildingCommunity size={DIAL_ICON_SIZE.SM} aria-hidden />
+              <IconBuildingCommunity
+                size={DIAL_ICON_SIZE.SM}
+                aria-hidden
+                stroke={DIAL_KIT_ICON_STROKE}
+              />
             }
             status={credentials.globalStatus}
             isActive={isGlobalActive}

--- a/libs/catalog/src/components/Details/Credentials/CredentialsManagementPanel/tests/CredentialsManagementPanel.spec.tsx
+++ b/libs/catalog/src/components/Details/Credentials/CredentialsManagementPanel/tests/CredentialsManagementPanel.spec.tsx
@@ -13,6 +13,7 @@ import {
 import { CredentialsManagementPanel } from '../CredentialsManagementPanel';
 
 vi.mock('@epam/ai-dial-ui-kit', () => ({
+  DIAL_KIT_ICON_STROKE: 1.5,
   DIAL_ICON_SIZE: { SM: 16, MD: 20, LG: 24 },
   ButtonAppearance: {
     Solid: 'solid',

--- a/libs/catalog/src/components/Details/DetailsPanel.tsx
+++ b/libs/catalog/src/components/Details/DetailsPanel.tsx
@@ -15,6 +15,7 @@ import {
 } from '@epam/ai-dial-publish-panel';
 import {
   CloseButton,
+  DIAL_KIT_ICON_STROKE,
   ElementSize,
   GhostIconButton,
   RadioGroup,
@@ -1116,7 +1117,12 @@ export const DetailsPanel: FC<DetailsPanelProps> = ({
           {subViewHeader != null && (
             <>
               <GhostIconButton
-                icon={<IconChevronLeft className="rtl:scale-x-[-1]" />}
+                icon={
+                  <IconChevronLeft
+                    className="rtl:scale-x-[-1]"
+                    stroke={DIAL_KIT_ICON_STROKE}
+                  />
+                }
                 aria-label={backToDetailsAriaLabel}
                 disabled={subViewHeader.isBackDisabled}
                 onClick={subViewHeader.onBack}

--- a/libs/catalog/src/components/Details/DetailsPanel.tsx
+++ b/libs/catalog/src/components/Details/DetailsPanel.tsx
@@ -191,6 +191,7 @@ export const DetailsPanel: FC<DetailsPanelProps> = ({
   isOpen,
   isStarred: initialIsStarred = false,
   isDetailsLoading = false,
+  isReadonly = false,
   onClose,
   onToggleFavorite,
   isFavoriteVisible,
@@ -1134,7 +1135,7 @@ export const DetailsPanel: FC<DetailsPanelProps> = ({
           {subViewHeader == null && (
             <>
               <div className="flex-1" />
-              {isFavoriteVisible?.(item) !== false && (
+              {!isReadonly && isFavoriteVisible?.(item) !== false && (
                 <StarToggleButton
                   isStarred={isStarred}
                   ariaLabel={starAriaLabel}
@@ -1283,6 +1284,7 @@ export const DetailsPanel: FC<DetailsPanelProps> = ({
                 onRequestLogout={handleRequestLogout}
                 texts={texts}
                 detailsStyles={detailsStyles}
+                isReadonly={isReadonly}
               />
 
               {item.credentials != null &&

--- a/libs/catalog/src/components/Details/Header/CredentialsApiKeyOverlay/CredentialsApiKeyOverlay.tsx
+++ b/libs/catalog/src/components/Details/Header/CredentialsApiKeyOverlay/CredentialsApiKeyOverlay.tsx
@@ -1,5 +1,6 @@
 import { mergeClasses } from '@epam/ai-dial-chat-shared';
 import {
+  DIAL_KIT_ICON_STROKE,
   Input,
   LinkButton,
   NeutralButton,
@@ -158,7 +159,9 @@ export const CredentialsApiKeyOverlay: FC<CredentialsApiKeyOverlayProps> = ({
       {isSignedIn && (
         <div className="animate-fadeIn px-4 py-3.5">
           <CredentialsInfoCard
-            icon={<IconKey size={20} aria-hidden />}
+            icon={
+              <IconKey size={20} aria-hidden stroke={DIAL_KIT_ICON_STROKE} />
+            }
             title={addedMessage}
             description={addedWhenLabel}
             action={

--- a/libs/catalog/src/components/Details/Header/CredentialsApiKeyOverlay/tests/CredentialsApiKeyOverlay.spec.tsx
+++ b/libs/catalog/src/components/Details/Header/CredentialsApiKeyOverlay/tests/CredentialsApiKeyOverlay.spec.tsx
@@ -11,6 +11,7 @@ import {
 import { CredentialsApiKeyOverlay } from '../CredentialsApiKeyOverlay';
 
 vi.mock('@epam/ai-dial-ui-kit', () => ({
+  DIAL_KIT_ICON_STROKE: 1.5,
   DIAL_ICON_SIZE: { SM: 16, MD: 20, LG: 24 },
   Input: ({
     onChange,

--- a/libs/catalog/src/components/Details/Header/Header.tsx
+++ b/libs/catalog/src/components/Details/Header/Header.tsx
@@ -5,6 +5,7 @@ import {
 } from '@epam/ai-dial-chat-shared';
 import {
   DIAL_ICON_SIZE,
+  DIAL_KIT_ICON_STROKE,
   Dropdown,
   FolderPath,
   NeutralButton,
@@ -566,6 +567,7 @@ export const Header: FC<HeaderProps> = ({
             size={DIAL_ICON_SIZE.SM}
             aria-hidden
             className="text-secondary"
+            stroke={DIAL_KIT_ICON_STROKE}
           />
         ),
         onClick: handleShare,
@@ -580,6 +582,7 @@ export const Header: FC<HeaderProps> = ({
             size={DIAL_ICON_SIZE.SM}
             aria-hidden
             className="text-secondary"
+            stroke={DIAL_KIT_ICON_STROKE}
           />
         ),
         onClick: handleEdit,
@@ -594,6 +597,7 @@ export const Header: FC<HeaderProps> = ({
             size={DIAL_ICON_SIZE.SM}
             aria-hidden
             className="text-secondary"
+            stroke={DIAL_KIT_ICON_STROKE}
           />
         ),
         onClick: handleDownload,
@@ -608,6 +612,7 @@ export const Header: FC<HeaderProps> = ({
             size={DIAL_ICON_SIZE.SM}
             aria-hidden
             className="text-secondary"
+            stroke={DIAL_KIT_ICON_STROKE}
           />
         ),
         onClick: handleOpenPublish,
@@ -625,6 +630,7 @@ export const Header: FC<HeaderProps> = ({
             size={DIAL_ICON_SIZE.SM}
             aria-hidden
             className="text-secondary"
+            stroke={DIAL_KIT_ICON_STROKE}
           />
         ),
         onClick: handleOpenUnpublish,
@@ -634,7 +640,13 @@ export const Header: FC<HeaderProps> = ({
       items.push({
         key: 'delete',
         label: texts?.deleteActionLabel ?? 'Delete',
-        icon: <IconTrash size={DIAL_ICON_SIZE.SM} aria-hidden />,
+        icon: (
+          <IconTrash
+            size={DIAL_ICON_SIZE.SM}
+            aria-hidden
+            stroke={DIAL_KIT_ICON_STROKE}
+          />
+        ),
         danger: true,
         onClick: handleDelete,
       });
@@ -650,7 +662,13 @@ export const Header: FC<HeaderProps> = ({
           recipientsCount == null
             ? revokeShareLabel
             : formatWithCount(recipientsCount),
-        icon: <IconUserOff size={DIAL_ICON_SIZE.SM} aria-hidden />,
+        icon: (
+          <IconUserOff
+            size={DIAL_ICON_SIZE.SM}
+            aria-hidden
+            stroke={DIAL_KIT_ICON_STROKE}
+          />
+        ),
         danger: true,
         onClick: handleRevokeShare,
       });
@@ -659,7 +677,13 @@ export const Header: FC<HeaderProps> = ({
       items.push({
         key: 'unshare',
         label: texts?.unshareLabel ?? 'Remove from My List',
-        icon: <IconTrash size={DIAL_ICON_SIZE.SM} aria-hidden />,
+        icon: (
+          <IconTrash
+            size={DIAL_ICON_SIZE.SM}
+            aria-hidden
+            stroke={DIAL_KIT_ICON_STROKE}
+          />
+        ),
 
         onClick: handleUnshare,
       });
@@ -754,23 +778,27 @@ export const Header: FC<HeaderProps> = ({
 
   const credentialsIconBefore = (() => {
     if (credentialsUiState === CredentialsUiState.ManageCredentials) {
-      return <IconKey size={DIAL_ICON_SIZE.MD} />;
+      return <IconKey size={DIAL_ICON_SIZE.MD} stroke={DIAL_KIT_ICON_STROKE} />;
     }
     if (authenticationType === ToolsetAuthenticationType.ApiKey) {
-      return <IconKey size={DIAL_ICON_SIZE.MD} />;
+      return <IconKey size={DIAL_ICON_SIZE.MD} stroke={DIAL_KIT_ICON_STROKE} />;
     }
     return credentialsUiState === CredentialsUiState.LogOut ? (
-      <IconLogout size={DIAL_ICON_SIZE.MD} />
+      <IconLogout size={DIAL_ICON_SIZE.MD} stroke={DIAL_KIT_ICON_STROKE} />
     ) : (
-      <IconLogin size={DIAL_ICON_SIZE.MD} />
+      <IconLogin size={DIAL_ICON_SIZE.MD} stroke={DIAL_KIT_ICON_STROKE} />
     );
   })();
 
   const credentialsIconAfter =
     credentialsUiState === CredentialsUiState.ManageCredentials ? (
-      <IconArrowRight size={DIAL_ICON_SIZE.MD} className="rtl:scale-x-[-1]" />
+      <IconArrowRight
+        size={DIAL_ICON_SIZE.MD}
+        className="rtl:scale-x-[-1]"
+        stroke={DIAL_KIT_ICON_STROKE}
+      />
     ) : isApiKeyOverlayTrigger ? (
-      <IconChevronDown size={DIAL_ICON_SIZE.MD} />
+      <IconChevronDown size={DIAL_ICON_SIZE.MD} stroke={DIAL_KIT_ICON_STROKE} />
     ) : undefined;
 
   const renderCredentialsButton = (
@@ -828,7 +856,13 @@ export const Header: FC<HeaderProps> = ({
          * the publish button's own state — are usually already settled by the
          * time the menu opens. */}
         <NeutralIconButton
-          icon={<IconDots size={DIAL_ICON_SIZE.LG} aria-hidden />}
+          icon={
+            <IconDots
+              size={DIAL_ICON_SIZE.LG}
+              aria-hidden
+              stroke={DIAL_KIT_ICON_STROKE}
+            />
+          }
           aria-label={texts?.manageActionLabel ?? 'Manage'}
           aria-haspopup="menu"
           onMouseEnter={handleManageTriggerIntent}
@@ -898,7 +932,11 @@ export const Header: FC<HeaderProps> = ({
                 isDownloading ? (
                   <Spinner size={DIAL_ICON_SIZE.MD} aria-hidden />
                 ) : (
-                  <IconDownload size={DIAL_ICON_SIZE.MD} aria-hidden />
+                  <IconDownload
+                    size={DIAL_ICON_SIZE.MD}
+                    aria-hidden
+                    stroke={DIAL_KIT_ICON_STROKE}
+                  />
                 )
               }
               onClick={handleDownloadPrimary}
@@ -928,7 +966,13 @@ export const Header: FC<HeaderProps> = ({
         {isPublishInActionRow && shouldShowUnpublish && (
           <NeutralButton
             label={texts?.unpublishLabel ?? 'Unpublish'}
-            iconBefore={<IconWorldOff size={DIAL_ICON_SIZE.MD} aria-hidden />}
+            iconBefore={
+              <IconWorldOff
+                size={DIAL_ICON_SIZE.MD}
+                aria-hidden
+                stroke={DIAL_KIT_ICON_STROKE}
+              />
+            }
             onClick={handleOpenUnpublish}
             onMouseEnter={handlePublishTriggerIntent}
             onFocus={handlePublishTriggerIntent}
@@ -937,7 +981,13 @@ export const Header: FC<HeaderProps> = ({
         {isPublishInActionRow && shouldShowPublish && (
           <NeutralButton
             label={texts?.publishLabel ?? 'Publish'}
-            iconBefore={<IconWorldShare size={DIAL_ICON_SIZE.MD} aria-hidden />}
+            iconBefore={
+              <IconWorldShare
+                size={DIAL_ICON_SIZE.MD}
+                aria-hidden
+                stroke={DIAL_KIT_ICON_STROKE}
+              />
+            }
             onClick={handleOpenPublish}
             onMouseEnter={handlePublishTriggerIntent}
             onFocus={handlePublishTriggerIntent}

--- a/libs/catalog/src/components/Details/Header/Header.tsx
+++ b/libs/catalog/src/components/Details/Header/Header.tsx
@@ -197,6 +197,14 @@ interface HeaderProps {
   onRequestPublishHistory?: () => void;
   /** Called when the "Unpublish" button is clicked; the host swaps this panel's content to the unpublish confirmation. */
   onOpenUnpublish?: () => void;
+  /**
+   * Renders the header read-only: every action that mutates the item or the
+   * caller's relationship to it — Share, Publish/Unpublish, Edit, Delete,
+   * "Remove from My List", "Revoke access", and the credentials Log in / Log
+   * out / manage button — is withheld. The non-mutating actions (the primary
+   * "Use in chat" and Download) still render. Default: false.
+   */
+  isReadonly?: boolean;
 }
 /** Details panel header bar: entity identity (icon + name + version), action buttons (primary action, Share, a "Manage" menu for Edit, Publish or Unpublish, and Delete), and inline credentials section. For Toolsets, the credentials action (Log in / Log out / manage) renders first and styled as the primary action, since Toolsets have no "Use in chat" action. Shows a "Running low"/"Limit reached" badge from `item.details?.limits?.status`, disabling "Use in chat" once a limit is reached. */
 export const Header: FC<HeaderProps> = ({
@@ -230,6 +238,7 @@ export const Header: FC<HeaderProps> = ({
   hasPublishedFolders = false,
   onRequestPublishHistory,
   onOpenUnpublish,
+  isReadonly = false,
 }) => {
   const {
     nameClassName = 'dial-body-semi-text',
@@ -434,6 +443,7 @@ export const Header: FC<HeaderProps> = ({
    * request, so an entry shown without one could not do anything if clicked.
    */
   const shouldShowUnpublish =
+    !isReadonly &&
     !!onOpenUnpublish &&
     hasPublishedFolders &&
     (isUnpublishVisible?.(item) ?? true);
@@ -456,13 +466,14 @@ export const Header: FC<HeaderProps> = ({
    * settled before the action becomes visible.
    */
   const shouldShowPublish =
+    !isReadonly &&
     !shouldShowUnpublish &&
     (isPublishVisible?.(item) ??
       (item.type === CatalogEntityType.Model ||
         item.type === CatalogEntityType.Toolset ||
         item.type === CatalogEntityType.Agent));
 
-  const shouldShowEditAction = !!onEdit && !!item.isEditable;
+  const shouldShowEditAction = !isReadonly && !!onEdit && !!item.isEditable;
 
   /*
    * Sharing is limited to entities the current user owns (deployments and
@@ -471,7 +482,7 @@ export const Header: FC<HeaderProps> = ({
    * same rule itself, so this only gates the Manage-menu arrangement.
    */
   const shouldShowShareAction =
-    item.isMyApp === true && (isShareVisible?.(item) ?? true);
+    !isReadonly && item.isMyApp === true && (isShareVisible?.(item) ?? true);
 
   /*
    * Which surface each of Share and Publish lands on. The defaults are the
@@ -490,7 +501,7 @@ export const Header: FC<HeaderProps> = ({
       ? getCredentialsUiState(item.credentials)
       : undefined;
   const shouldShowCredentialsAction =
-    credentialsUiState != null && (!!onLogin || !!onLogout);
+    !isReadonly && credentialsUiState != null && (!!onLogin || !!onLogout);
   /* Toolsets have no "Use in chat" primary action, so the credentials
    * button (Log in / Log out / manage) takes over as their primary,
    * leading action instead. */
@@ -507,7 +518,7 @@ export const Header: FC<HeaderProps> = ({
   /* A promoted Download renders in the primary slot only — never duplicated in the Manage menu. */
   const shouldShowDownloadAction =
     isDownloadActionEnabled && !isDownloadActionPrimary;
-  const shouldShowDeleteAction = item.isMyApp;
+  const shouldShowDeleteAction = !isReadonly && item.isMyApp;
   /*
    * The recipient-side "Remove from My List" action is the counterpart of
    * Delete: it discards only the current user's own access, so it shows
@@ -516,6 +527,7 @@ export const Header: FC<HeaderProps> = ({
    * render at the same time.
    */
   const shouldShowUnshareAction =
+    !isReadonly &&
     !!onUnshare &&
     item.isMyApp !== true &&
     item.sharedWithMe === true &&
@@ -534,6 +546,7 @@ export const Header: FC<HeaderProps> = ({
    * revoke.
    */
   const shouldShowRevokeShareAction =
+    !isReadonly &&
     !!onRevokeShare &&
     item.isMyApp === true &&
     (!onFetchRecipientsCount ||
@@ -899,7 +912,7 @@ export const Header: FC<HeaderProps> = ({
             )}
           </>
         )}
-        {isShareInActionRow && (
+        {isShareInActionRow && shouldShowShareAction && (
           <ShareButton
             item={item}
             onShare={onShare}

--- a/libs/catalog/src/components/Details/Header/ShareButton/ShareButton.tsx
+++ b/libs/catalog/src/components/Details/Header/ShareButton/ShareButton.tsx
@@ -1,4 +1,9 @@
-import { DIAL_ICON_SIZE, NeutralButton, Dropdown } from '@epam/ai-dial-ui-kit';
+import {
+  DIAL_ICON_SIZE,
+  DIAL_KIT_ICON_STROKE,
+  Dropdown,
+  NeutralButton,
+} from '@epam/ai-dial-ui-kit';
 import { IconChevronDown, IconShare } from '@tabler/icons-react';
 import { FC, type ReactNode, useCallback, useState } from 'react';
 import { CatalogItem } from '../../../../models/catalog-item';
@@ -61,8 +66,15 @@ export const ShareButton: FC<ShareButtonProps> = ({
   const button = (
     <NeutralButton
       label={label}
-      iconBefore={<IconShare size={DIAL_ICON_SIZE.MD} />}
-      iconAfter={<IconChevronDown size={DIAL_ICON_SIZE.MD} />}
+      iconBefore={
+        <IconShare size={DIAL_ICON_SIZE.MD} stroke={DIAL_KIT_ICON_STROKE} />
+      }
+      iconAfter={
+        <IconChevronDown
+          size={DIAL_ICON_SIZE.MD}
+          stroke={DIAL_KIT_ICON_STROKE}
+        />
+      }
       onClick={handleClick}
       aria-haspopup={shareOverlay ? 'menu' : undefined}
       aria-expanded={shareOverlay ? isOpen : undefined}

--- a/libs/catalog/src/components/Details/Header/ShareButton/tests/ShareButton.spec.tsx
+++ b/libs/catalog/src/components/Details/Header/ShareButton/tests/ShareButton.spec.tsx
@@ -7,6 +7,7 @@ import type { CatalogItem } from '../../../../../models/catalog-item';
 import { ShareButton } from '../ShareButton';
 
 vi.mock('@epam/ai-dial-ui-kit', () => ({
+  DIAL_KIT_ICON_STROKE: 1.5,
   NeutralButton: ({
     label,
     onClick,

--- a/libs/catalog/src/components/Details/Header/tests/Header.spec.tsx
+++ b/libs/catalog/src/components/Details/Header/tests/Header.spec.tsx
@@ -18,6 +18,7 @@ import {
 import { Header } from '../Header';
 
 vi.mock('@epam/ai-dial-ui-kit', () => ({
+  DIAL_KIT_ICON_STROKE: 1.5,
   DIAL_ICON_SIZE: { SM: 16, MD: 20, LG: 24 },
   Spinner: () => <svg />,
   FolderPath: () => <div />,

--- a/libs/catalog/src/components/Details/Header/tests/Header.spec.tsx
+++ b/libs/catalog/src/components/Details/Header/tests/Header.spec.tsx
@@ -1770,3 +1770,71 @@ describe('Header action-surface arrangement', () => {
     expect(screen.getByRole('button', { name: 'Delete' })).toBeTruthy();
   });
 });
+
+describe('Header — read-only', () => {
+  it('withholds Share, Publish, Edit, and Delete — leaving no Manage menu at all', () => {
+    render(
+      <Header
+        item={{ ...makeItem(CatalogEntityType.Model), isEditable: true }}
+        onShare={vi.fn()}
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+        isPublishPrimary={() => true}
+        isReadonly
+      />,
+    );
+
+    expect(screen.queryByRole('button', { name: 'Share' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Publish' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Manage' })).toBeNull();
+  });
+
+  it('withholds Unpublish and "Revoke access" even once their lookups have resolved', () => {
+    render(
+      <Header
+        item={makeItem(CatalogEntityType.Model)}
+        onOpenUnpublish={vi.fn()}
+        hasPublishedFolders
+        isPublishPrimary={() => true}
+        onRevokeShare={vi.fn()}
+        isReadonly
+      />,
+    );
+
+    expect(screen.queryByRole('button', { name: 'Unpublish' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Manage' })).toBeNull();
+  });
+
+  it('withholds the credentials Log in button for a signed-out toolset', () => {
+    render(
+      <Header
+        item={{
+          ...makeItem(CatalogEntityType.Toolset),
+          credentials: {
+            authenticationType: ToolsetAuthenticationType.OAuth,
+            userStatus: CredentialStatus.SignedOut,
+          },
+        }}
+        onLogin={vi.fn()}
+        isReadonly
+      />,
+    );
+
+    expect(screen.queryByRole('button', { name: 'Log in' })).toBeNull();
+  });
+
+  it('keeps the non-mutating actions — "Use in chat" and Download', () => {
+    render(
+      <Header
+        item={makeItem(CatalogEntityType.Model)}
+        onUseInChat={vi.fn()}
+        onDownload={vi.fn()}
+        isDownloadPrimary={() => true}
+        isReadonly
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: 'Use in chat' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Download' })).toBeTruthy();
+  });
+});

--- a/libs/catalog/src/components/Details/TabsContent/ContentFileTree/ContentFileTree.tsx
+++ b/libs/catalog/src/components/Details/TabsContent/ContentFileTree/ContentFileTree.tsx
@@ -1,5 +1,5 @@
 import { mergeClasses } from '@epam/ai-dial-chat-shared';
-import { DIAL_ICON_SIZE } from '@epam/ai-dial-ui-kit';
+import { DIAL_ICON_SIZE, DIAL_KIT_ICON_STROKE } from '@epam/ai-dial-ui-kit';
 import { IconChevronDown, IconFolder } from '@tabler/icons-react';
 import {
   FC,
@@ -213,6 +213,7 @@ export const ContentFileTree: FC<ContentFileTreeProps> = ({
             size={DIAL_ICON_SIZE.SM}
             className="shrink-0"
             aria-hidden
+            stroke={DIAL_KIT_ICON_STROKE}
           />
           <span
             className={mergeClasses(
@@ -229,6 +230,7 @@ export const ContentFileTree: FC<ContentFileTreeProps> = ({
               !isExpanded && '-rotate-90 rtl:rotate-90',
             )}
             aria-hidden
+            stroke={DIAL_KIT_ICON_STROKE}
           />
         </div>
         {isExpanded && node.items.length > 0 && (

--- a/libs/catalog/src/components/Details/TabsContent/DataGrid/DataGrid.module.scss
+++ b/libs/catalog/src/components/Details/TabsContent/DataGrid/DataGrid.module.scss
@@ -9,7 +9,9 @@
 
 .cell {
   color: var(--cat-grid-cell-text, var(--text-primary, #161b2d));
-  border-top: 1px solid
+  /* Row divider, so the thin stroke (0.5px); the wrapper above frames the
+     table and stays on the 1px main stroke. */
+  border-top: 0.5px solid
     var(--cat-grid-cell-divider, var(--stroke-secondary, #d1dbea));
 }
 

--- a/libs/catalog/src/components/Details/TabsContent/tests/Limits.spec.tsx
+++ b/libs/catalog/src/components/Details/TabsContent/tests/Limits.spec.tsx
@@ -4,6 +4,7 @@ import { LimitsTab } from '../Limits/Limits';
 import styles from '../Limits/Limits.module.scss';
 
 vi.mock('@epam/ai-dial-ui-kit', () => ({
+  DIAL_KIT_ICON_STROKE: 1.5,
   DIAL_ICON_SIZE: { SM: 16, MD: 20, LG: 24 },
   ElementSize: { Small: 'small', Standard: 'standard' },
   ProgressBar: ({

--- a/libs/catalog/src/components/Favorites/FavoriteCard.tsx
+++ b/libs/catalog/src/components/Favorites/FavoriteCard.tsx
@@ -1,5 +1,10 @@
 import { mergeClasses } from '@epam/ai-dial-chat-shared';
-import { CardShell, DIAL_ICON_SIZE, ElementSize } from '@epam/ai-dial-ui-kit';
+import {
+  CardShell,
+  DIAL_ICON_SIZE,
+  DIAL_KIT_ICON_STROKE,
+  ElementSize,
+} from '@epam/ai-dial-ui-kit';
 import { IconCheck } from '@tabler/icons-react';
 import { FC, KeyboardEvent, MouseEvent, useCallback, useState } from 'react';
 import { AppIdentityColors } from '../../models/app-identity-styles';
@@ -115,6 +120,7 @@ export const FavoriteCard: FC<FavoriteCardProps> = ({
             styles.selectedCheck,
           )}
           aria-hidden
+          stroke={DIAL_KIT_ICON_STROKE}
         />
       )}
 

--- a/libs/catalog/src/components/Favorites/Favorites.tsx
+++ b/libs/catalog/src/components/Favorites/Favorites.tsx
@@ -3,6 +3,7 @@ import {
   ItemHeader,
   mergeClasses,
 } from '@epam/ai-dial-chat-shared';
+import { DIAL_KIT_ICON_STROKE } from '@epam/ai-dial-ui-kit';
 import { IconChevronLeft, IconChevronRight } from '@tabler/icons-react';
 import {
   FC,
@@ -422,7 +423,11 @@ export const Favorites: FC<FavoritesProps> = ({
                     styles.navBtn,
                   )}
                 >
-                  <IconChevronLeft size={14} className="rtl:scale-x-[-1]" />
+                  <IconChevronLeft
+                    size={14}
+                    className="rtl:scale-x-[-1]"
+                    stroke={DIAL_KIT_ICON_STROKE}
+                  />
                 </button>
                 <span
                   className={mergeClasses(
@@ -442,7 +447,11 @@ export const Favorites: FC<FavoritesProps> = ({
                     styles.navBtn,
                   )}
                 >
-                  <IconChevronRight size={14} className="rtl:scale-x-[-1]" />
+                  <IconChevronRight
+                    size={14}
+                    className="rtl:scale-x-[-1]"
+                    stroke={DIAL_KIT_ICON_STROKE}
+                  />
                 </button>
               </div>
             ) : undefined

--- a/libs/catalog/src/components/Filter/Filter.tsx
+++ b/libs/catalog/src/components/Filter/Filter.tsx
@@ -2,9 +2,10 @@ import { buildCssVars, mergeClasses } from '@epam/ai-dial-chat-shared';
 import {
   CheckboxBox,
   DIAL_ICON_SIZE,
+  DIAL_KIT_ICON_STROKE,
   Dropdown,
-  PrimaryButton,
   GhostButton,
+  PrimaryButton,
 } from '@epam/ai-dial-ui-kit';
 import { IconChevronDown, IconFilter } from '@tabler/icons-react';
 import {
@@ -394,7 +395,7 @@ export const Filter: FC<FilterProps> = ({
       >
         <IconFilter
           size={DIAL_ICON_SIZE.SM}
-          strokeWidth={1.8}
+          stroke={DIAL_KIT_ICON_STROKE}
           className={mergeClasses('shrink-0', styles.filterBtnFunnel)}
           aria-hidden
         />
@@ -408,7 +409,7 @@ export const Filter: FC<FilterProps> = ({
         </span>
         <IconChevronDown
           size={14}
-          strokeWidth={2.2}
+          stroke={DIAL_KIT_ICON_STROKE}
           className={mergeClasses(
             'shrink-0 transition-transform duration-150',
             styles.filterBtnChevron,

--- a/libs/catalog/src/components/Filter/tests/Filter.spec.tsx
+++ b/libs/catalog/src/components/Filter/tests/Filter.spec.tsx
@@ -25,6 +25,7 @@ vi.mock('../Filter.module.scss', () => ({
 }));
 
 vi.mock('@epam/ai-dial-ui-kit', () => ({
+  DIAL_KIT_ICON_STROKE: 1.5,
   DIAL_ICON_SIZE: { SM: 16 },
   /* Without htmlFor the real CheckboxBox is a decorative span hidden from AT. */
   CheckboxBox: ({

--- a/libs/catalog/src/components/ListView/ListView.tsx
+++ b/libs/catalog/src/components/ListView/ListView.tsx
@@ -46,6 +46,7 @@ export const ListView: FC<ListViewProps> = ({
   stickyHeaderTop,
   selectedItemId,
   credentialsBadgeLoggedOutLabel,
+  isReadonly = false,
 }) => {
   if (items.length === 0) {
     return (
@@ -151,7 +152,7 @@ export const ListView: FC<ListViewProps> = ({
     >
       <div className={mergeClasses('rounded-xl', styles.gridClip)}>
         <Grid<CatalogItem>
-          columnDefs={CATALOG_COLUMNS(type)}
+          columnDefs={CATALOG_COLUMNS(type, isReadonly)}
           rowData={windowedItems}
           getRowId={(r) => r.id}
           withoutHeaderBorders
@@ -169,6 +170,7 @@ export const ListView: FC<ListViewProps> = ({
               isFavoriteVisible,
               selectedItemId,
               credentialsBadgeLoggedOutLabel,
+              isReadonly,
             } satisfies GridContext,
             onCellClicked: onItemClick
               ? (event) => {

--- a/libs/catalog/src/components/ListView/Renders/NameCellRenderer.tsx
+++ b/libs/catalog/src/components/ListView/Renders/NameCellRenderer.tsx
@@ -3,7 +3,7 @@ import {
   ItemHeader,
   mergeClasses,
 } from '@epam/ai-dial-chat-shared';
-import { DIAL_ICON_SIZE } from '@epam/ai-dial-ui-kit';
+import { DIAL_ICON_SIZE, DIAL_KIT_ICON_STROKE } from '@epam/ai-dial-ui-kit';
 import { IconCheck } from '@tabler/icons-react';
 import type { ICellRendererParams } from 'ag-grid-community';
 import { FC } from 'react';
@@ -50,6 +50,7 @@ export const NameCellRenderer: FC<
               size={DIAL_ICON_SIZE.SM}
               className={mergeClasses('shrink-0', styles.selectedCheck)}
               aria-hidden
+              stroke={DIAL_KIT_ICON_STROKE}
             />
           ) : undefined
         }

--- a/libs/catalog/src/components/ListView/columns.ts
+++ b/libs/catalog/src/components/ListView/columns.ts
@@ -11,6 +11,7 @@ import { TagsCellRenderer } from './Renders/TagsCellRenderer';
 /** Column definitions for the catalog ag-grid list view. A stable module-level constant so ag-grid never sees a new array/closures on each render. */
 export const CATALOG_COLUMNS = (
   type: CatalogEntityType,
+  isReadonly = false,
 ): ColDef<CatalogItem>[] => {
   return [
     {
@@ -60,6 +61,7 @@ export const CATALOG_COLUMNS = (
       filter: false,
       sortable: false,
       resizable: false,
+      hide: isReadonly,
       headerClass: styles.favHeader,
       cellRenderer: StarCellRenderer,
     },

--- a/libs/catalog/src/components/ListView/tests/ListView.spec.tsx
+++ b/libs/catalog/src/components/ListView/tests/ListView.spec.tsx
@@ -6,6 +6,7 @@ import type { CatalogItem } from '../../../models/catalog-item';
 import { ListView } from '../ListView';
 
 vi.mock('@epam/ai-dial-ui-kit', () => ({
+  DIAL_KIT_ICON_STROKE: 1.5,
   DIAL_ICON_SIZE: { SM: 16, MD: 20, LG: 24 },
   mergeClasses: (...args: (string | undefined)[]) =>
     args.filter(Boolean).join(' '),

--- a/libs/catalog/src/components/StarToggleButton/StarToggleButton.tsx
+++ b/libs/catalog/src/components/StarToggleButton/StarToggleButton.tsx
@@ -1,8 +1,9 @@
 import { buildCssVars } from '@epam/ai-dial-chat-shared';
 import {
   DIAL_ICON_SIZE,
-  ToggleIconButton,
+  DIAL_KIT_ICON_STROKE,
   ElementSize,
+  ToggleIconButton,
 } from '@epam/ai-dial-ui-kit';
 import { IconStar, IconStarFilled } from '@tabler/icons-react';
 import { FC, MouseEvent } from 'react';
@@ -44,7 +45,7 @@ export const StarToggleButton: FC<StarToggleButtonProps> = ({
           className={styles.starFilledIcon}
         />
       ) : (
-        <IconStar size={DIAL_ICON_SIZE.SM} />
+        <IconStar size={DIAL_ICON_SIZE.SM} stroke={DIAL_KIT_ICON_STROKE} />
       )
     }
     aria-label={ariaLabel}

--- a/libs/catalog/src/components/Toolbar/Rows/TitleRow.tsx
+++ b/libs/catalog/src/components/Toolbar/Rows/TitleRow.tsx
@@ -4,11 +4,12 @@ import {
   ButtonDropdown,
   ButtonVariant,
   DIAL_ICON_SIZE,
+  DIAL_KIT_ICON_STROKE,
   DropdownItem,
+  ElementSize,
   Search,
   SegmentedControl,
   SegmentedControlItem,
-  ElementSize,
 } from '@epam/ai-dial-ui-kit';
 import { IconLayoutGrid, IconLayoutList } from '@tabler/icons-react';
 import { FC, useMemo } from 'react';
@@ -74,12 +75,24 @@ export const TitleRow: FC<TitleRowProps> = ({
     () => [
       {
         value: CatalogViewMode.Grid,
-        icon: <IconLayoutGrid size={DIAL_ICON_SIZE.SM} aria-hidden />,
+        icon: (
+          <IconLayoutGrid
+            size={DIAL_ICON_SIZE.SM}
+            aria-hidden
+            stroke={DIAL_KIT_ICON_STROKE}
+          />
+        ),
         'aria-label': gridViewLabel,
       },
       {
         value: CatalogViewMode.List,
-        icon: <IconLayoutList size={DIAL_ICON_SIZE.SM} aria-hidden />,
+        icon: (
+          <IconLayoutList
+            size={DIAL_ICON_SIZE.SM}
+            aria-hidden
+            stroke={DIAL_KIT_ICON_STROKE}
+          />
+        ),
         'aria-label': listViewLabel,
       },
     ],

--- a/libs/catalog/src/models/card-props.ts
+++ b/libs/catalog/src/models/card-props.ts
@@ -72,4 +72,10 @@ export interface CardProps {
   isSelected?: boolean;
   /** Accessible label for the logged-out warning icon on the entity avatar, and the text shown in its hover tooltip. Default: `'Authorize to use this toolset.'`. */
   credentialsBadgeLoggedOutLabel?: string;
+  /**
+   * Renders the card as a read-only browsing surface: no favorite star, no
+   * footer divider, and no "Featured" tag. The footer row is dropped entirely
+   * when the item has no folder path left to show. Default: false.
+   */
+  isReadonly?: boolean;
 }

--- a/libs/catalog/src/models/card-row-data.ts
+++ b/libs/catalog/src/models/card-row-data.ts
@@ -24,4 +24,6 @@ export interface CardRowData {
   selectedItemId?: string;
   /** Accessible label for the logged-out warning icon on the entity avatar, and the text shown in its hover tooltip. */
   credentialsBadgeLoggedOutLabel: string;
+  /** Renders every card read-only: no favorite star, no footer divider, and no "Featured" tag. */
+  isReadonly?: boolean;
 }

--- a/libs/catalog/src/models/catalog-props.ts
+++ b/libs/catalog/src/models/catalog-props.ts
@@ -301,6 +301,17 @@ export interface CatalogProps {
   onCreateClick?: () => void;
   /** Hides the "Create" button entirely, e.g. when rendering as a read-only picker. Default: false. */
   hideCreateButton?: boolean;
+  /**
+   * Renders the whole catalog as a read-only browsing surface. Browse cards
+   * lose their favorite star, footer divider, and "Featured" tag; the list
+   * view loses its "Favorite" column; the "Create" button and the favorites
+   * strip are not rendered; and the details panel withholds its favorite star
+   * and every mutating action (Share, Publish/Unpublish, Edit, Delete,
+   * "Remove from My List", "Revoke access", and the credentials Log in / Log
+   * out / manage button). The non-mutating actions — the primary "Use in
+   * chat" and Download — still render. Default: false.
+   */
+  isReadonly?: boolean;
   /** Hides the page heading (title row), e.g. when the host renders its own title outside the catalog. Default: false. */
   hidePageTitle?: boolean;
   /** Initial Browse view mode (grid or list). Default: `CatalogViewMode.Grid`. */

--- a/libs/catalog/src/models/grid-context.ts
+++ b/libs/catalog/src/models/grid-context.ts
@@ -15,4 +15,6 @@ export interface GridContext {
   selectedItemId?: string;
   /** Accessible label for the logged-out warning icon on the entity avatar, and the text shown in its hover tooltip. */
   credentialsBadgeLoggedOutLabel?: string;
+  /** Renders the list read-only: the "Favorite" column is dropped entirely. */
+  isReadonly?: boolean;
 }

--- a/libs/catalog/src/models/grid-props.ts
+++ b/libs/catalog/src/models/grid-props.ts
@@ -40,4 +40,6 @@ export interface CardGridProps {
   skeletonColor?: string;
   /** Background color of a skeleton placeholder card. Fallback: `--bg-layer-raised`. */
   skeletonCardBackground?: string;
+  /** Renders every card read-only: no favorite star, no footer divider, and no "Featured" tag. Default: false. */
+  isReadonly?: boolean;
 }

--- a/libs/catalog/src/models/item-details-props.ts
+++ b/libs/catalog/src/models/item-details-props.ts
@@ -459,6 +459,15 @@ export interface DetailsPanelProps {
   isDetailsLoading?: boolean;
   /** Called when the panel should close (close button or backdrop click). */
   onClose: () => void;
+  /**
+   * Renders the panel read-only: the favorite star and every action that
+   * mutates the item or the caller's relationship to it — Share,
+   * Publish/Unpublish, Edit, Delete, "Remove from My List", "Revoke access",
+   * and the credentials Log in / Log out / manage button — are withheld. The
+   * non-mutating actions (the primary "Use in chat" and Download) still
+   * render. Default: false.
+   */
+  isReadonly?: boolean;
   /** Called when the star/favorite button is toggled. */
   onToggleFavorite?: (id: string, isStarred: boolean) => void;
   /**

--- a/libs/catalog/src/models/list-props.ts
+++ b/libs/catalog/src/models/list-props.ts
@@ -73,4 +73,6 @@ export interface ListViewProps {
   selectedItemId?: string;
   /** Accessible label for the logged-out warning icon on the entity avatar, and the text shown in its hover tooltip. Default: `'Authorize to use this toolset.'`. */
   credentialsBadgeLoggedOutLabel?: string;
+  /** Renders the list read-only: the "Favorite" column is dropped entirely. Default: false. */
+  isReadonly?: boolean;
 }

--- a/libs/chat-shared/package.json
+++ b/libs/chat-shared/package.json
@@ -28,7 +28,7 @@
     "remark-math": "^6.0.0",
     "rehype-katex": "^7.0.1",
     "katex": "^0.16.22",
-    "@epam/ai-dial-ui-kit": "^0.14.0-dev.13"
+    "@epam/ai-dial-ui-kit": "^0.14.0-dev.15"
   },
   "dependencies": {
     "classnames": "2.5.1",

--- a/libs/chat-shared/src/components/CopyButton/CopyButton.tsx
+++ b/libs/chat-shared/src/components/CopyButton/CopyButton.tsx
@@ -1,5 +1,6 @@
 import {
   DIAL_ICON_SIZE,
+  DIAL_KIT_ICON_STROKE,
   ElementSize,
   NeutralButton,
   ToggleIconButton,
@@ -34,9 +35,19 @@ export const CopyIconButton: FC<CopyButtonProps> = ({
       size={size}
       icon={
         isCopied ? (
-          <IconCheck size={iconSize} stroke={1.5} aria-hidden />
+          <IconCheck
+            size={iconSize}
+            stroke={DIAL_KIT_ICON_STROKE}
+            aria-hidden
+          />
         ) : (
-          (iconCopy ?? <IconCopy size={iconSize} stroke={1.5} aria-hidden />)
+          (iconCopy ?? (
+            <IconCopy
+              size={iconSize}
+              stroke={DIAL_KIT_ICON_STROKE}
+              aria-hidden
+            />
+          ))
         )
       }
       aria-label={isCopied ? copiedLabel : (ariaLabel ?? copyLabel)}
@@ -61,9 +72,17 @@ export const CopyButton: FC<CopyButtonProps> = ({
       label={isCopied ? copiedLabel : copyLabel}
       iconBefore={
         isCopied ? (
-          <IconCheck size={DIAL_ICON_SIZE.SM} aria-hidden />
+          <IconCheck
+            size={DIAL_ICON_SIZE.SM}
+            aria-hidden
+            stroke={DIAL_KIT_ICON_STROKE}
+          />
         ) : (
-          <IconCopy size={DIAL_ICON_SIZE.SM} aria-hidden />
+          <IconCopy
+            size={DIAL_ICON_SIZE.SM}
+            aria-hidden
+            stroke={DIAL_KIT_ICON_STROKE}
+          />
         )
       }
       onClick={onClick}

--- a/libs/chat-shared/src/components/DeploymentIcon/tests/DeploymentIcon.spec.tsx
+++ b/libs/chat-shared/src/components/DeploymentIcon/tests/DeploymentIcon.spec.tsx
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { type DeploymentIconProps, DeploymentIcon } from '../DeploymentIcon';
 
 vi.mock('@epam/ai-dial-ui-kit', () => ({
+  DIAL_KIT_ICON_STROKE: 1.5,
   Tooltip: ({ children }: { children: ReactNode }) => <>{children}</>,
 }));
 

--- a/libs/chat-shared/src/components/MarkdownRenderer/CodeBlock/CodeBlock.tsx
+++ b/libs/chat-shared/src/components/MarkdownRenderer/CodeBlock/CodeBlock.tsx
@@ -1,5 +1,6 @@
 import {
   DIAL_ICON_SIZE,
+  DIAL_KIT_ICON_STROKE,
   ElementSize,
   GhostIconButton,
 } from '@epam/ai-dial-ui-kit';
@@ -137,7 +138,12 @@ export const MarkdownCodeBlock: FC<MarkdownCodeBlockProps> = memo(
             <div className="flex items-center gap-1">
               {!hideDownload && (
                 <GhostIconButton
-                  icon={<IconDownload size={DIAL_ICON_SIZE.SM} />}
+                  icon={
+                    <IconDownload
+                      size={DIAL_ICON_SIZE.SM}
+                      stroke={DIAL_KIT_ICON_STROKE}
+                    />
+                  }
                   aria-label={downloadLabel}
                   size={ElementSize.Small}
                   onClick={handleDownload}
@@ -150,9 +156,14 @@ export const MarkdownCodeBlock: FC<MarkdownCodeBlockProps> = memo(
                       size={DIAL_ICON_SIZE.SM}
                       className={styles.copiedIcon}
                       aria-hidden
+                      stroke={DIAL_KIT_ICON_STROKE}
                     />
                   ) : (
-                    <IconCopy size={DIAL_ICON_SIZE.SM} aria-hidden />
+                    <IconCopy
+                      size={DIAL_ICON_SIZE.SM}
+                      aria-hidden
+                      stroke={DIAL_KIT_ICON_STROKE}
+                    />
                   )
                 }
                 aria-label={copyLabel}

--- a/libs/chat-shared/src/components/MarkdownRenderer/MarkdownRenderer.tsx
+++ b/libs/chat-shared/src/components/MarkdownRenderer/MarkdownRenderer.tsx
@@ -316,7 +316,7 @@ const buildMarkdownComponents = (
     <th
       scope="col"
       className={mergeClasses(
-        'sticky top-0 z-[2] max-w-96 whitespace-normal break-words border-b px-3 py-2.5 text-start',
+        'sticky top-0 z-[2] max-w-96 whitespace-normal break-words px-3 py-2.5 text-start',
         tableStyles.rowDivider,
         tableStyles.tableHeaderCell,
         cn.tableHeaderFont ?? 'dial-tiny-lead-semi-text',
@@ -330,7 +330,7 @@ const buildMarkdownComponents = (
   td: ({ children }) => (
     <td
       className={mergeClasses(
-        'max-w-96 whitespace-normal border-b px-3 py-2.5 align-top [overflow-wrap:anywhere]',
+        'max-w-96 whitespace-normal px-3 py-2.5 align-top [overflow-wrap:anywhere]',
         tableStyles.rowDivider,
         cn.tableBodyCell,
         cn.tableCell,

--- a/libs/chat-shared/src/components/MarkdownRenderer/Table/MarkdownTable.module.scss
+++ b/libs/chat-shared/src/components/MarkdownRenderer/Table/MarkdownTable.module.scss
@@ -43,7 +43,10 @@ tbody .row:nth-child(even) td {
 }
 
 .rowDivider {
-  border-color: var(--cm-table-row-divider, var(--stroke-tertiary, #e0e6f0));
+  /* Dividers inside a table sit on the thin stroke (0.5px), one step below the
+     1px main stroke controls and standalone dividers use. */
+  border-block-end: 0.5px solid
+    var(--cm-table-row-divider, var(--stroke-tertiary, #e0e6f0));
 }
 
 tbody .row:hover td {

--- a/libs/chat-shared/src/components/MarkdownRenderer/tests/MarkdownRenderer.spec.tsx
+++ b/libs/chat-shared/src/components/MarkdownRenderer/tests/MarkdownRenderer.spec.tsx
@@ -133,10 +133,10 @@ describe('MarkdownRenderer', () => {
     expect(cell.className).toContain('custom-cell');
     expect(columnHeader.className).toContain('max-w-96');
     expect(columnHeader.className).toContain('whitespace-normal');
-    expect(columnHeader.className).toContain('border-b');
+    expect(columnHeader.className).toContain('rowDivider');
     expect(columnHeader.className).toContain('tableHeaderCell');
     expect(cell.className).toContain('max-w-96');
-    expect(cell.className).toContain('border-b');
+    expect(cell.className).toContain('rowDivider');
     expect(cell.className).toContain('align-top');
     expect(cell.className).toContain('custom-body-cell');
     expect(columnHeader.className).not.toContain('custom-body-cell');

--- a/libs/chat-shared/src/constants/icon.ts
+++ b/libs/chat-shared/src/constants/icon.ts
@@ -1,15 +1,15 @@
-import { DIAL_ICON_SIZE } from '@epam/ai-dial-ui-kit';
+import { DIAL_ICON_SIZE, DIAL_KIT_ICON_STROKE } from '@epam/ai-dial-ui-kit';
 
-/** Base props for medium-sized Tabler icons (MD size, stroke 1.5, `aria-hidden`). */
+/** Base props for medium-sized Tabler icons (MD size, icon stroke, `aria-hidden`). */
 export const BASE_MD_ICON_PROPS = {
   size: DIAL_ICON_SIZE.MD,
-  stroke: 1.5,
+  stroke: DIAL_KIT_ICON_STROKE,
   'aria-hidden': true,
 };
 
-/** Base props for large Tabler icons (LG size, stroke 1.5, `aria-hidden`). */
+/** Base props for large Tabler icons (LG size, icon stroke, `aria-hidden`). */
 export const BASE_LG_ICON_PROPS = {
   size: DIAL_ICON_SIZE.LG,
-  stroke: 1.5,
+  stroke: DIAL_KIT_ICON_STROKE,
   'aria-hidden': true,
 };

--- a/libs/chat-shared/src/utils/copy-to-clipboard.ts
+++ b/libs/chat-shared/src/utils/copy-to-clipboard.ts
@@ -119,9 +119,10 @@ export const markdownToRichTextHtml = (content: string): string =>
 
 /**
  * Copies markdown `content` to the clipboard as rich text, so pasting into a
- * rich-text target (Word, Gmail, Slack) keeps the formatting. Only the
- * `text/html` flavour is written — a plain-text target pastes nothing from
- * here. Falls back to {@link copyToClipboard}, and therefore to the raw
+ * rich-text target (Word, Gmail, Slack) keeps the formatting. Both the
+ * `text/html` and the `text/plain` flavour are written, so a plain-text
+ * target (Notepad, a terminal, a code editor) pastes the raw markdown instead
+ * of nothing. Falls back to {@link copyToClipboard}, and therefore to the raw
  * markdown, when the multi-format Clipboard API isn't available.
  */
 export const copyMarkdownAsRichText = (content: string): Promise<boolean> => {
@@ -141,13 +142,12 @@ export const copyMarkdownAsRichText = (content: string): Promise<boolean> => {
   }
 
   /*
-   * `text/html` is the only flavour offered on purpose. A target that sees both
-   * flavours may pick `text/plain` — which is exactly what this action is not
-   * for — and then the styling never arrives. The cost is that a plain-text
-   * target pastes nothing at all from here; `onCopyMarkdown` (plain
-   * {@link copyToClipboard}) is the action for those, so the two copy buttons
-   * do one job each. Do not add `text/plain` back without checking a rich
-   * target still honours the HTML.
+   * Both flavours ride along. A rich target picks `text/html` — that is the
+   * negotiation every editor implements, and the styling arrives as before —
+   * while a plain-text target, which can read nothing but `text/plain`, would
+   * otherwise paste an empty string. `onCopyMarkdown` still exists for the
+   * deliberate markdown-only copy; this action is simply no longer unusable
+   * outside a rich editor.
    *
    * Clipboard API must be called synchronously within the user-gesture
    * handler; do NOT await before calling it.
@@ -156,6 +156,7 @@ export const copyMarkdownAsRichText = (content: string): Promise<boolean> => {
     .write([
       new ClipboardItem({
         'text/html': new Blob([html], { type: 'text/html' }),
+        'text/plain': new Blob([content], { type: 'text/plain' }),
       }),
     ])
     .then(() => true)

--- a/libs/chat-shared/src/utils/tests/copy-to-clipboard.spec.ts
+++ b/libs/chat-shared/src/utils/tests/copy-to-clipboard.spec.ts
@@ -1,5 +1,8 @@
-import { describe, expect, it } from 'vitest';
-import { markdownToRichTextHtml } from '../copy-to-clipboard';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  copyMarkdownAsRichText,
+  markdownToRichTextHtml,
+} from '../copy-to-clipboard';
 
 const TABLE_MARKDOWN = [
   '| Year | Song |',
@@ -108,5 +111,94 @@ describe('markdownToRichTextHtml', () => {
     expect(html).not.toContain('<script');
     expect(html).toContain('Before');
     expect(html).toContain('After');
+  });
+});
+
+const originalClipboard = navigator.clipboard;
+const originalClipboardItem = globalThis.ClipboardItem;
+
+const setClipboard = (clipboard: unknown): void => {
+  Object.defineProperty(navigator, 'clipboard', {
+    value: clipboard,
+    configurable: true,
+  });
+};
+
+/** jsdom's `Blob` has no `text()`, so the bytes come back through `FileReader`. */
+const readBlob = (blob: Blob): Promise<string> =>
+  new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(String(reader.result));
+    reader.onerror = () => reject(reader.error);
+    reader.readAsText(blob);
+  });
+
+/** Reads back the flavours of the single `ClipboardItem` handed to `write`. */
+const writtenFlavours = async (
+  write: ReturnType<typeof vi.fn>,
+): Promise<Record<string, string>> => {
+  const [items] = write.mock.calls[0] as [ClipboardItem[]];
+  const item = items[0];
+  const entries = await Promise.all(
+    item.types.map(
+      async (type) => [type, await readBlob(await item.getType(type))] as const,
+    ),
+  );
+  return Object.fromEntries(entries);
+};
+
+describe('copyMarkdownAsRichText', () => {
+  beforeEach(() => {
+    /* jsdom ships no ClipboardItem, so the multi-format path needs a stand-in
+       that keeps its blobs readable. */
+    globalThis.ClipboardItem = class {
+      constructor(private readonly data: Record<string, Blob>) {}
+      get types(): string[] {
+        return Object.keys(this.data);
+      }
+      getType(type: string): Promise<Blob> {
+        return Promise.resolve(this.data[type]);
+      }
+    } as unknown as typeof ClipboardItem;
+  });
+
+  afterEach(() => {
+    setClipboard(originalClipboard);
+    globalThis.ClipboardItem = originalClipboardItem;
+  });
+
+  it('offers the rich flavour alongside the plain one a text editor reads', async () => {
+    const write = vi.fn(async () => undefined);
+    setClipboard({ write, writeText: vi.fn(async () => undefined) });
+
+    await expect(copyMarkdownAsRichText('# hi')).resolves.toBe(true);
+
+    const flavours = await writtenFlavours(write);
+    expect(Object.keys(flavours).sort()).toEqual(['text/html', 'text/plain']);
+    expect(flavours['text/html']).toContain('<h1 style="font-size:20px');
+    /* Plain-text targets get the markdown source — the alternative today is an
+       empty paste. */
+    expect(flavours['text/plain']).toBe('# hi');
+  });
+
+  it('falls back to the plain-text copy when the clipboard write is refused', async () => {
+    const writeText = vi.fn(async () => undefined);
+    setClipboard({
+      write: vi.fn(async () => {
+        throw new Error('denied');
+      }),
+      writeText,
+    });
+
+    await expect(copyMarkdownAsRichText('# hi')).resolves.toBe(true);
+    expect(writeText).toHaveBeenCalledWith('# hi');
+  });
+
+  it('falls back to the plain-text copy when the multi-format API is absent', async () => {
+    const writeText = vi.fn(async () => undefined);
+    setClipboard({ writeText });
+
+    await expect(copyMarkdownAsRichText('# hi')).resolves.toBe(true);
+    expect(writeText).toHaveBeenCalledWith('# hi');
   });
 });

--- a/libs/conversation-input/package.json
+++ b/libs/conversation-input/package.json
@@ -24,7 +24,7 @@
     "@tabler/icons-react": "^3.44.0",
     "react": "^19.0.0",
     "react-dom": "^19.2.6",
-    "@epam/ai-dial-ui-kit": "^0.14.0-dev.13"
+    "@epam/ai-dial-ui-kit": "^0.14.0-dev.15"
   },
   "dependencies": {
     "react-window": "^2.2.7"

--- a/libs/conversation-input/src/components/AddAttachmentButton/AddAttachmentButton.tsx
+++ b/libs/conversation-input/src/components/AddAttachmentButton/AddAttachmentButton.tsx
@@ -8,6 +8,7 @@ import {
 import {
   BASE_ICON_SIZE,
   DIAL_ICON_SIZE,
+  DIAL_KIT_ICON_STROKE,
   Dropdown,
   ElementSize,
   GhostIconButton,
@@ -158,6 +159,7 @@ export const AddAttachmentButton: FC<AddAttachmentButtonProps> = ({
                 style={cssVars}
                 className={styles.selectedToolIcon}
                 aria-hidden
+                stroke={DIAL_KIT_ICON_STROKE}
               />
             )}
           </span>
@@ -182,7 +184,13 @@ export const AddAttachmentButton: FC<AddAttachmentButtonProps> = ({
             {
               key: 'attach',
               label: attachLabel,
-              icon: <IconPaperclip size={BASE_ICON_SIZE} aria-hidden />,
+              icon: (
+                <IconPaperclip
+                  size={BASE_ICON_SIZE}
+                  aria-hidden
+                  stroke={DIAL_KIT_ICON_STROKE}
+                />
+              ),
               onClick: onAttachClick,
             },
           ]
@@ -193,7 +201,13 @@ export const AddAttachmentButton: FC<AddAttachmentButtonProps> = ({
             {
               key: 'tools',
               label: toolsMenuTitle,
-              icon: <IconTool size={BASE_ICON_SIZE} aria-hidden />,
+              icon: (
+                <IconTool
+                  size={BASE_ICON_SIZE}
+                  aria-hidden
+                  stroke={DIAL_KIT_ICON_STROKE}
+                />
+              ),
               onClick: isMobile
                 ? () => {
                     setIsToolsSheetOpen(true);
@@ -205,7 +219,7 @@ export const AddAttachmentButton: FC<AddAttachmentButtonProps> = ({
                     iconAfter: (
                       <IconChevronRight
                         size={BASE_ICON_SIZE}
-                        stroke={1.5}
+                        stroke={DIAL_KIT_ICON_STROKE}
                         style={cssVars}
                         className={mergeClasses(
                           'rtl:scale-x-[-1]',
@@ -226,7 +240,13 @@ export const AddAttachmentButton: FC<AddAttachmentButtonProps> = ({
             {
               key: 'prompts',
               label: promptsMenuTitle,
-              icon: <IconPrompt size={BASE_ICON_SIZE} aria-hidden />,
+              icon: (
+                <IconPrompt
+                  size={BASE_ICON_SIZE}
+                  aria-hidden
+                  stroke={DIAL_KIT_ICON_STROKE}
+                />
+              ),
               onClick: isMobile
                 ? () => {
                     setIsPromptsSheetOpen(true);
@@ -238,7 +258,7 @@ export const AddAttachmentButton: FC<AddAttachmentButtonProps> = ({
                     iconAfter: (
                       <IconChevronRight
                         size={BASE_ICON_SIZE}
-                        stroke={1.5}
+                        stroke={DIAL_KIT_ICON_STROKE}
                         style={cssVars}
                         className={mergeClasses(
                           'rtl:scale-x-[-1]',
@@ -269,11 +289,17 @@ export const AddAttachmentButton: FC<AddAttachmentButtonProps> = ({
             {
               key: 'chat-settings',
               label: chatSettings.menuItemLabel ?? 'Chat settings',
-              icon: <IconSettings size={BASE_ICON_SIZE} aria-hidden />,
+              icon: (
+                <IconSettings
+                  size={BASE_ICON_SIZE}
+                  aria-hidden
+                  stroke={DIAL_KIT_ICON_STROKE}
+                />
+              ),
               iconAfter: isMobile ? (
                 <IconChevronRight
                   size={BASE_ICON_SIZE}
-                  stroke={1.5}
+                  stroke={DIAL_KIT_ICON_STROKE}
                   style={cssVars}
                   className={mergeClasses(
                     'rtl:scale-x-[-1]',
@@ -316,7 +342,13 @@ export const AddAttachmentButton: FC<AddAttachmentButtonProps> = ({
       }
     >
       <GhostIconButton
-        icon={<IconPlus size={DIAL_ICON_SIZE.LG} aria-hidden />}
+        icon={
+          <IconPlus
+            size={DIAL_ICON_SIZE.LG}
+            aria-hidden
+            stroke={DIAL_KIT_ICON_STROKE}
+          />
+        }
         aria-label={addMenuTitle}
         tooltipProps={{ tooltip: addMenuTitle }}
         disabled={isDisabled}
@@ -329,7 +361,13 @@ export const AddAttachmentButton: FC<AddAttachmentButtonProps> = ({
       {isMobile ? (
         <>
           <GhostIconButton
-            icon={<IconPlus size={DIAL_ICON_SIZE.LG} aria-hidden />}
+            icon={
+              <IconPlus
+                size={DIAL_ICON_SIZE.LG}
+                aria-hidden
+                stroke={DIAL_KIT_ICON_STROKE}
+              />
+            }
             aria-label={addMenuTitle}
             size={ElementSize.Large}
             tooltipProps={{ tooltip: addMenuTitle }}

--- a/libs/conversation-input/src/components/BottomSheetShell/BottomSheetShell.tsx
+++ b/libs/conversation-input/src/components/BottomSheetShell/BottomSheetShell.tsx
@@ -1,9 +1,10 @@
 import { buildCssVars, mergeClasses } from '@epam/ai-dial-chat-shared';
 import {
-  DIAL_ICON_SIZE,
   CloseButton,
-  GhostIconButton,
+  DIAL_ICON_SIZE,
+  DIAL_KIT_ICON_STROKE,
   ElementSize,
+  GhostIconButton,
 } from '@epam/ai-dial-ui-kit';
 import { IconArrowLeft } from '@tabler/icons-react';
 import type { CSSProperties, FC, ReactNode } from 'react';
@@ -109,7 +110,7 @@ export const BottomSheetShell: FC<BottomSheetShellProps> = ({
                     icon={
                       <IconArrowLeft
                         size={DIAL_ICON_SIZE.LG}
-                        stroke={1.5}
+                        stroke={DIAL_KIT_ICON_STROKE}
                         className="rtl:scale-x-[-1]"
                       />
                     }

--- a/libs/conversation-input/src/components/EditMessageInput/EditMessageInput.tsx
+++ b/libs/conversation-input/src/components/EditMessageInput/EditMessageInput.tsx
@@ -2,6 +2,7 @@ import type { Attachment, DisplayAttachment } from '@epam/ai-dial-chat-shared';
 import { RequestStatus, mergeClasses } from '@epam/ai-dial-chat-shared';
 import {
   BASE_ICON_SIZE,
+  DIAL_KIT_ICON_STROKE,
   NeutralButton,
   PrimaryButton,
 } from '@epam/ai-dial-ui-kit';
@@ -119,7 +120,13 @@ export const EditMessageInput: FC<EditMessageInputProps> = ({
             {
               key: 'dial-fs',
               label: dialFileSystemLabel ?? 'DIAL file system',
-              icon: <IconFile size={BASE_ICON_SIZE} aria-hidden />,
+              icon: (
+                <IconFile
+                  size={BASE_ICON_SIZE}
+                  aria-hidden
+                  stroke={DIAL_KIT_ICON_STROKE}
+                />
+              ),
               onClick: onDialFileSystemClick,
             },
           ]

--- a/libs/conversation-input/src/components/Input/Buttons/SendButton.tsx
+++ b/libs/conversation-input/src/components/Input/Buttons/SendButton.tsx
@@ -1,4 +1,8 @@
-import { DIAL_ICON_SIZE, PrimaryIconButton } from '@epam/ai-dial-ui-kit';
+import {
+  DIAL_ICON_SIZE,
+  DIAL_KIT_ICON_STROKE,
+  PrimaryIconButton,
+} from '@epam/ai-dial-ui-kit';
 import { IconArrowNarrowRight } from '@tabler/icons-react';
 import { type FC } from 'react';
 
@@ -29,6 +33,7 @@ export const SendButton: FC<SendButtonProps> = ({
         <IconArrowNarrowRight
           size={DIAL_ICON_SIZE.LG}
           className="rtl:scale-x-[-1]"
+          stroke={DIAL_KIT_ICON_STROKE}
         />
       }
     />

--- a/libs/conversation-input/src/components/Input/Buttons/StopButton.tsx
+++ b/libs/conversation-input/src/components/Input/Buttons/StopButton.tsx
@@ -1,4 +1,8 @@
-import { DIAL_ICON_SIZE, StaticIconButton } from '@epam/ai-dial-ui-kit';
+import {
+  DIAL_ICON_SIZE,
+  DIAL_KIT_ICON_STROKE,
+  StaticIconButton,
+} from '@epam/ai-dial-ui-kit';
 import { IconPlaystationSquare } from '@tabler/icons-react';
 import { type FC } from 'react';
 
@@ -15,7 +19,12 @@ export const StopButton: FC<Props> = ({
 }) => {
   return (
     <StaticIconButton
-      icon={<IconPlaystationSquare size={DIAL_ICON_SIZE.LG} />}
+      icon={
+        <IconPlaystationSquare
+          size={DIAL_ICON_SIZE.LG}
+          stroke={DIAL_KIT_ICON_STROKE}
+        />
+      }
       onClick={() => onStop?.()}
       aria-label={ariaLabel}
     />

--- a/libs/conversation-input/src/components/Input/Input.tsx
+++ b/libs/conversation-input/src/components/Input/Input.tsx
@@ -10,6 +10,7 @@ import {
 import {
   BASE_ICON_SIZE,
   DIAL_ICON_SIZE,
+  DIAL_KIT_ICON_STROKE,
   GhostIconButton,
 } from '@epam/ai-dial-ui-kit';
 import { IconFile, IconMicrophone } from '@tabler/icons-react';
@@ -143,7 +144,13 @@ export const Input: FC<InputProps> = ({
             {
               key: 'dial-fs',
               label: dialFileSystemLabel ?? 'DIAL file system',
-              icon: <IconFile size={BASE_ICON_SIZE} aria-hidden />,
+              icon: (
+                <IconFile
+                  size={BASE_ICON_SIZE}
+                  aria-hidden
+                  stroke={DIAL_KIT_ICON_STROKE}
+                />
+              ),
               onClick: onDialFileSystemClick,
             },
           ]
@@ -566,7 +573,7 @@ export const Input: FC<InputProps> = ({
                 icon={
                   <IconMicrophone
                     size={DIAL_ICON_SIZE.LG}
-                    stroke={1.5}
+                    stroke={DIAL_KIT_ICON_STROKE}
                     aria-hidden
                   />
                 }

--- a/libs/conversation-input/src/components/Input/Input.tsx
+++ b/libs/conversation-input/src/components/Input/Input.tsx
@@ -11,7 +11,6 @@ import {
   BASE_ICON_SIZE,
   DIAL_ICON_SIZE,
   GhostIconButton,
-  StaticIconButton,
 } from '@epam/ai-dial-ui-kit';
 import { IconFile, IconMicrophone } from '@tabler/icons-react';
 import {

--- a/libs/conversation-input/src/components/Input/Input.tsx
+++ b/libs/conversation-input/src/components/Input/Input.tsx
@@ -10,6 +10,7 @@ import {
 import {
   BASE_ICON_SIZE,
   DIAL_ICON_SIZE,
+  GhostIconButton,
   StaticIconButton,
 } from '@epam/ai-dial-ui-kit';
 import { IconFile, IconMicrophone } from '@tabler/icons-react';
@@ -562,10 +563,16 @@ export const Input: FC<InputProps> = ({
             )}
 
             {shouldShowMicButton && (
-              <StaticIconButton
-                icon={<IconMicrophone size={DIAL_ICON_SIZE.LG} aria-hidden />}
+              <GhostIconButton
+                icon={
+                  <IconMicrophone
+                    size={DIAL_ICON_SIZE.LG}
+                    stroke={1.5}
+                    aria-hidden
+                  />
+                }
                 aria-label={micLabel}
-                className="size-8 flex-shrink-0"
+                className="size-[40px] flex-shrink-0"
                 onClick={startRecording}
                 disabled={isInputDisabled || isStreaming}
               />

--- a/libs/conversation-input/src/components/Input/ModelSelectorControl.tsx
+++ b/libs/conversation-input/src/components/Input/ModelSelectorControl.tsx
@@ -1,11 +1,12 @@
 import { DeploymentItem, mergeClasses } from '@epam/ai-dial-chat-shared';
 import {
   DIAL_ICON_SIZE,
-  Dropdown,
+  DIAL_KIT_ICON_STROKE,
   DialDropdownIcon,
-  Tooltip,
+  Dropdown,
   ElementSize,
   GhostIconButton,
+  Tooltip,
 } from '@epam/ai-dial-ui-kit';
 import { IconChevronDown } from '@tabler/icons-react';
 import { type CSSProperties, type FC, ReactNode, useState } from 'react';
@@ -84,6 +85,7 @@ export const ModelSelectorControl: FC<Props> = ({
       size={DIAL_ICON_SIZE.SM}
       className={styles.modelSelectorCaret}
       aria-hidden
+      stroke={DIAL_KIT_ICON_STROKE}
     />
   );
 

--- a/libs/conversation-input/src/components/ModelSelectorBottomSheet/ModelSelectorBottomSheet.tsx
+++ b/libs/conversation-input/src/components/ModelSelectorBottomSheet/ModelSelectorBottomSheet.tsx
@@ -6,9 +6,10 @@ import {
 import {
   Button,
   DIAL_ICON_SIZE,
-  Search,
+  DIAL_KIT_ICON_STROKE,
   ElementSize,
   Highlight,
+  Search,
 } from '@epam/ai-dial-ui-kit';
 import { IconCheck } from '@tabler/icons-react';
 import { type CSSProperties, type FC, useEffect, useState } from 'react';
@@ -98,6 +99,7 @@ const ModelRow = ({
                 size={DIAL_ICON_SIZE.SM}
                 className={styles.checkIcon}
                 aria-hidden
+                stroke={DIAL_KIT_ICON_STROKE}
               />
             )}
           </span>

--- a/libs/conversation-input/src/components/ToolsBottomSheet/ToolsBottomSheet.tsx
+++ b/libs/conversation-input/src/components/ToolsBottomSheet/ToolsBottomSheet.tsx
@@ -1,6 +1,10 @@
 import { buildCssVars, mergeClasses } from '@epam/ai-dial-chat-shared';
 import type { ToolMenuItem } from '@epam/ai-dial-chat-shared';
-import { BASE_ICON_SIZE, Button } from '@epam/ai-dial-ui-kit';
+import {
+  BASE_ICON_SIZE,
+  Button,
+  DIAL_KIT_ICON_STROKE,
+} from '@epam/ai-dial-ui-kit';
 import { IconCheck } from '@tabler/icons-react';
 import type { CSSProperties, FC } from 'react';
 import { BottomSheetShell } from '../BottomSheetShell/BottomSheetShell';
@@ -92,7 +96,11 @@ export const ToolsBottomSheet: FC<ToolsBottomSheetProps> = ({
                   <span
                     className={mergeClasses('ms-auto', styles.selectedIcon)}
                   >
-                    <IconCheck size={BASE_ICON_SIZE} aria-hidden />
+                    <IconCheck
+                      size={BASE_ICON_SIZE}
+                      aria-hidden
+                      stroke={DIAL_KIT_ICON_STROKE}
+                    />
                   </span>
                 ) : null
               }

--- a/libs/conversation-input/src/components/ToolsChips/ToolsChips.tsx
+++ b/libs/conversation-input/src/components/ToolsChips/ToolsChips.tsx
@@ -1,5 +1,6 @@
 import type { ToolMenuItem } from '@epam/ai-dial-chat-shared';
 import { buildCssVars, mergeClasses } from '@epam/ai-dial-chat-shared';
+import { DIAL_KIT_ICON_STROKE } from '@epam/ai-dial-ui-kit';
 import { IconX } from '@tabler/icons-react';
 import type { FC } from 'react';
 import styles from './ToolsChips.module.scss';
@@ -125,7 +126,7 @@ export const ToolsChips: FC<ToolsChipsProps> = ({
               'flex shrink-0 items-center rounded p-0.5 transition-colors',
             )}
           >
-            <IconX size={12} aria-hidden />
+            <IconX size={12} aria-hidden stroke={DIAL_KIT_ICON_STROKE} />
           </button>
         </div>
       ))}

--- a/libs/conversation-input/src/components/VoiceBar/VoiceBar.tsx
+++ b/libs/conversation-input/src/components/VoiceBar/VoiceBar.tsx
@@ -1,6 +1,7 @@
 import { mergeClasses } from '@epam/ai-dial-chat-shared';
 import {
   DIAL_ICON_SIZE,
+  DIAL_KIT_ICON_STROKE,
   ErrorText,
   GhostIconButton,
   PrimaryIconButton,
@@ -179,7 +180,13 @@ export const VoiceBar: FC<VoiceBarProps> = ({
   const controls = (
     <div className="flex flex-shrink-0 items-center justify-end gap-1">
       <GhostIconButton
-        icon={<IconX size={DIAL_ICON_SIZE.LG} aria-hidden />}
+        icon={
+          <IconX
+            size={DIAL_ICON_SIZE.LG}
+            aria-hidden
+            stroke={DIAL_KIT_ICON_STROKE}
+          />
+        }
         aria-label={discardLabel}
         onClick={onDiscard}
       />

--- a/libs/conversation-input/src/hooks/useModelSelector.tsx
+++ b/libs/conversation-input/src/hooks/useModelSelector.tsx
@@ -5,10 +5,11 @@ import {
 } from '@epam/ai-dial-chat-shared';
 import {
   DIAL_ICON_SIZE,
-  Search,
+  DIAL_KIT_ICON_STROKE,
   DropdownItem,
   ElementSize,
   Highlight,
+  Search,
 } from '@epam/ai-dial-ui-kit';
 import { IconCheck } from '@tabler/icons-react';
 import { type ReactNode, useMemo, useState } from 'react';
@@ -172,7 +173,7 @@ export const useModelSelector = ({
             {isSelected && (
               <IconCheck
                 size={DIAL_ICON_SIZE.SM}
-                stroke={2}
+                stroke={DIAL_KIT_ICON_STROKE}
                 className={selectedItemCheckClassName}
                 aria-hidden
               />

--- a/libs/conversation-messages/package.json
+++ b/libs/conversation-messages/package.json
@@ -24,7 +24,7 @@
     "react-markdown": "^10.1.0",
     "@epam/ai-dial-attachment-input": "*",
     "@epam/ai-dial-chat-shared": "*",
-    "@epam/ai-dial-ui-kit": "^0.14.0-dev.13"
+    "@epam/ai-dial-ui-kit": "^0.14.0-dev.15"
   },
   "nx": {
     "tags": [

--- a/libs/conversation-messages/src/components/MessageActions/MessageActions.tsx
+++ b/libs/conversation-messages/src/components/MessageActions/MessageActions.tsx
@@ -7,6 +7,7 @@ import {
 } from '@epam/ai-dial-chat-shared';
 import {
   DIAL_ICON_SIZE,
+  DIAL_KIT_ICON_STROKE,
   ElementSize,
   ToggleIconButton,
 } from '@epam/ai-dial-ui-kit';
@@ -89,7 +90,7 @@ export const MessageActions: FC<MessageActionsProps> = ({
                 <IconPencilMinus
                   size={DIAL_ICON_SIZE.SM}
                   aria-hidden
-                  stroke={1.5}
+                  stroke={DIAL_KIT_ICON_STROKE}
                 />
               }
               size={ElementSize.Small}
@@ -103,7 +104,11 @@ export const MessageActions: FC<MessageActionsProps> = ({
           {onDelete && (
             <ToggleIconButton
               icon={
-                <IconTrashX size={DIAL_ICON_SIZE.SM} aria-hidden stroke={1.5} />
+                <IconTrashX
+                  size={DIAL_ICON_SIZE.SM}
+                  aria-hidden
+                  stroke={DIAL_KIT_ICON_STROKE}
+                />
               }
               size={ElementSize.Small}
               aria-label={ariaLabels?.deleteMessage ?? 'Delete message'}
@@ -120,7 +125,7 @@ export const MessageActions: FC<MessageActionsProps> = ({
                 <IconRefresh
                   size={DIAL_ICON_SIZE.SM}
                   aria-hidden
-                  stroke={1.5}
+                  stroke={DIAL_KIT_ICON_STROKE}
                 />
               }
               size={ElementSize.Small}
@@ -152,7 +157,7 @@ export const MessageActions: FC<MessageActionsProps> = ({
                 <IconMarkdown
                   size={DIAL_ICON_SIZE.SM}
                   aria-hidden
-                  stroke={1.5}
+                  stroke={DIAL_KIT_ICON_STROKE}
                 />
               }
               copyLabel={tooltips?.copyMarkdown ?? 'Copy as Markdown'}
@@ -168,14 +173,13 @@ export const MessageActions: FC<MessageActionsProps> = ({
                   <IconThumbUpFilled
                     className={styles.activeRating}
                     size={DIAL_ICON_SIZE.SM}
-                    stroke={1.5}
                     aria-hidden
                   />
                 ) : (
                   <IconThumbUp
                     size={DIAL_ICON_SIZE.SM}
                     aria-hidden
-                    stroke={1.5}
+                    stroke={DIAL_KIT_ICON_STROKE}
                   />
                 )
               }
@@ -194,13 +198,12 @@ export const MessageActions: FC<MessageActionsProps> = ({
                     className={styles.activeRating}
                     size={DIAL_ICON_SIZE.SM}
                     aria-hidden
-                    stroke={1.5}
                   />
                 ) : (
                   <IconThumbDown
                     size={DIAL_ICON_SIZE.SM}
                     aria-hidden
-                    stroke={1.5}
+                    stroke={DIAL_KIT_ICON_STROKE}
                   />
                 )
               }

--- a/libs/conversation-messages/src/components/MessageBubble/MessageBubble.module.scss
+++ b/libs/conversation-messages/src/components/MessageBubble/MessageBubble.module.scss
@@ -17,7 +17,7 @@
   @apply pointer-events-none absolute inset-x-0 bottom-0 h-12;
   background: linear-gradient(
     to bottom,
-    var(--cm-bubble-fade-start, var(--shadow-xs-sm-2, #161b2d08)),
+    var(--cm-bubble-fade-start, var(--shadow-xs-2, #161b2d08)),
     var(--cm-bubble-user-bg, var(--bg-layer-sunken, #eef1f7))
   );
 }

--- a/libs/conversation-panel/package.json
+++ b/libs/conversation-panel/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "react-window": "^2.2.7",
-    "@epam/ai-dial-ui-kit": "^0.14.0-dev.13"
+    "@epam/ai-dial-ui-kit": "^0.14.0-dev.15"
   },
   "peerDependencies": {
     "react": "^19.0.0",

--- a/libs/conversation-panel/src/components/ConversationGroupHeader/ConversationGroupHeader.tsx
+++ b/libs/conversation-panel/src/components/ConversationGroupHeader/ConversationGroupHeader.tsx
@@ -84,15 +84,9 @@ export const ConversationGroupHeader: FC<ConversationGroupHeaderProps> = ({
       )}
     >
       {isExpanded ? (
-        <IconCaretDownFilled
-          stroke={0.5}
-          size={12}
-          className="shrink-0"
-          aria-hidden
-        />
+        <IconCaretDownFilled size={12} className="shrink-0" aria-hidden />
       ) : (
         <IconCaretRightFilled
-          stroke={0.5}
           size={12}
           className="shrink-0 rtl:scale-x-[-1]"
           aria-hidden

--- a/libs/conversation-panel/src/components/ConversationPanel/ConversationPanel.module.scss
+++ b/libs/conversation-panel/src/components/ConversationPanel/ConversationPanel.module.scss
@@ -6,7 +6,10 @@
   }
 
   &.itemActive {
-    background: var(--cp-item-active, var(--bg-layer-sunken, #eef1f7));
+    background: var(
+      --cp-item-active,
+      var(--bg-control-accent-alpha, #2764d90f)
+    );
     color: var(--cp-text, var(--text-primary, #161b2d));
   }
 }

--- a/libs/conversation-panel/src/components/ConversationPanel/tests/ConversationPanel.spec.tsx
+++ b/libs/conversation-panel/src/components/ConversationPanel/tests/ConversationPanel.spec.tsx
@@ -6,6 +6,7 @@ import { ConversationItem } from '../../../models/panel-props';
 import { ConversationPanel } from '../ConversationPanel';
 
 vi.mock('@epam/ai-dial-ui-kit', () => ({
+  DIAL_KIT_ICON_STROKE: 1.5,
   mergeClasses: (...args: (string | undefined | false | null)[]) =>
     args.filter(Boolean).join(' '),
   DIAL_ICON_SIZE: { SM: 16, LG: 24 },

--- a/libs/conversation-panel/src/components/ConversationRow/ConversationRow.tsx
+++ b/libs/conversation-panel/src/components/ConversationRow/ConversationRow.tsx
@@ -6,12 +6,13 @@ import {
 import {
   Button,
   DIAL_ICON_SIZE,
+  DIAL_KIT_ICON_STROKE,
   Dropdown,
+  ElementSize,
   GhostIconButton,
+  Highlight,
   Skeleton,
   SkeletonVariant,
-  ElementSize,
-  Highlight,
   type DropdownItem,
 } from '@epam/ai-dial-ui-kit';
 import { IconClock, IconDotsVertical } from '@tabler/icons-react';
@@ -168,7 +169,7 @@ export const ConversationRow: FC<ConversationRowProps> = ({
         taskBadgeClassName,
       )}
     >
-      <IconClock size={12} aria-hidden />
+      <IconClock size={12} aria-hidden stroke={DIAL_KIT_ICON_STROKE} />
       {item.taskBadgeLabel}
     </span>
   ) : undefined;
@@ -281,6 +282,7 @@ export const ConversationRow: FC<ConversationRowProps> = ({
                   size={DIAL_ICON_SIZE.SM}
                   className={styles.triggerIcon}
                   aria-hidden
+                  stroke={DIAL_KIT_ICON_STROKE}
                 />
               }
               size={ElementSize.Small}

--- a/libs/conversation-panel/src/components/ConversationRow/tests/ConversationRow.spec.tsx
+++ b/libs/conversation-panel/src/components/ConversationRow/tests/ConversationRow.spec.tsx
@@ -5,6 +5,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { ConversationRow } from '../ConversationRow';
 
 vi.mock('@epam/ai-dial-ui-kit', () => ({
+  DIAL_KIT_ICON_STROKE: 1.5,
   DIAL_ICON_SIZE: { SM: 16, MD: 20, LG: 24 },
   ElementSize: { Small: 'small', Standard: 'standard', Large: 'large' },
   SkeletonVariant: { Circular: 'circular' },

--- a/libs/conversation-panel/src/components/ImportExportQueue/ImportExportQueue.tsx
+++ b/libs/conversation-panel/src/components/ImportExportQueue/ImportExportQueue.tsx
@@ -9,8 +9,9 @@ import {
   ConfirmationPopup,
   ConfirmationPopupVariant,
   DIAL_ICON_SIZE,
-  EllipsisTooltip,
+  DIAL_KIT_ICON_STROKE,
   ElementSize,
+  EllipsisTooltip,
   GhostIconButton,
   ProgressBar,
 } from '@epam/ai-dial-ui-kit';
@@ -123,6 +124,7 @@ const JobRow: FC<JobRowProps> = ({
                 <IconRefresh
                   size={DIAL_ICON_SIZE.SM}
                   className={classes.textSecondary}
+                  stroke={DIAL_KIT_ICON_STROKE}
                 />
               }
               onClick={() => onRetry(job.id)}
@@ -140,6 +142,7 @@ const JobRow: FC<JobRowProps> = ({
               <IconX
                 size={DIAL_ICON_SIZE.SM}
                 className={classes.textSecondary}
+                stroke={DIAL_KIT_ICON_STROKE}
               />
             }
             onClick={() => onDismiss(job.id)}
@@ -255,11 +258,13 @@ export const ImportExportQueue: FC<ImportExportQueueProps> = memo(
                   <IconChevronUp
                     size={DIAL_ICON_SIZE.SM}
                     className={classes.textSecondary}
+                    stroke={DIAL_KIT_ICON_STROKE}
                   />
                 ) : (
                   <IconChevronDown
                     size={DIAL_ICON_SIZE.SM}
                     className={classes.textSecondary}
+                    stroke={DIAL_KIT_ICON_STROKE}
                   />
                 )
               }
@@ -273,6 +278,7 @@ export const ImportExportQueue: FC<ImportExportQueueProps> = memo(
                 <IconX
                   size={DIAL_ICON_SIZE.SM}
                   className={classes.textSecondary}
+                  stroke={DIAL_KIT_ICON_STROKE}
                 />
               }
               onClick={handleClose}

--- a/libs/conversation-panel/src/components/ImportExportQueue/tests/ImportExportQueue.spec.tsx
+++ b/libs/conversation-panel/src/components/ImportExportQueue/tests/ImportExportQueue.spec.tsx
@@ -14,6 +14,7 @@ import {
 } from '../ImportExportQueue';
 
 vi.mock('@epam/ai-dial-ui-kit', () => ({
+  DIAL_KIT_ICON_STROKE: 1.5,
   ProgressBar: ({
     value,
     'aria-label': ariaLabel,

--- a/libs/conversation-panel/src/components/NewChatButton/NewChatButton.tsx
+++ b/libs/conversation-panel/src/components/NewChatButton/NewChatButton.tsx
@@ -31,7 +31,7 @@ export const NewChatButton: FC<NewChatButtonProps> = memo(
           onClick={onClick}
           type="button"
           className={mergeClasses(
-            'flex h-[36px] w-full cursor-pointer items-center justify-center gap-2 rounded-full px-3 py-1 shadow-sm hover:shadow-xs active:shadow-xs',
+            'flex h-[36px] w-full cursor-pointer items-center justify-center gap-2 rounded-full px-3 py-1 shadow-chat-button hover:shadow-xs focus-visible:shadow-xs active:shadow-xs',
             styles.button,
           )}
         >

--- a/libs/conversation-panel/src/components/NewChatButton/NewChatButton.tsx
+++ b/libs/conversation-panel/src/components/NewChatButton/NewChatButton.tsx
@@ -1,4 +1,5 @@
 import { buildCssVars, mergeClasses } from '@epam/ai-dial-chat-shared';
+import { DIAL_KIT_ICON_STROKE } from '@epam/ai-dial-ui-kit';
 import { IconPlus } from '@tabler/icons-react';
 import { type FC, memo } from 'react';
 import type { NewChatButtonColors } from '../../models/panel-props';
@@ -35,7 +36,11 @@ export const NewChatButton: FC<NewChatButtonProps> = memo(
             styles.button,
           )}
         >
-          <IconPlus size={18} stroke={2} className="shrink-0" />
+          <IconPlus
+            size={18}
+            stroke={DIAL_KIT_ICON_STROKE}
+            className="shrink-0"
+          />
           <span className={labelClassName}>{label}</span>
         </button>
       </div>

--- a/libs/conversation-panel/src/components/RenameConversationPopup/RenameConversationPopup.tsx
+++ b/libs/conversation-panel/src/components/RenameConversationPopup/RenameConversationPopup.tsx
@@ -6,6 +6,7 @@ import {
 import {
   ButtonVariant,
   DIAL_ICON_SIZE,
+  DIAL_KIT_ICON_STROKE,
   GhostIconButton,
   Input,
   Popup,
@@ -167,7 +168,10 @@ export const RenameConversationPopup: FC<RenameConversationPopupProps> = memo(
                   isGenerating ? (
                     <Spinner size={DIAL_ICON_SIZE.MD} />
                   ) : (
-                    <IconSparkles size={DIAL_ICON_SIZE.MD} stroke={1.5} />
+                    <IconSparkles
+                      size={DIAL_ICON_SIZE.MD}
+                      stroke={DIAL_KIT_ICON_STROKE}
+                    />
                   )
                 }
               />

--- a/libs/conversation-panel/src/components/RenameConversationPopup/tests/RenameConversationPopup.spec.tsx
+++ b/libs/conversation-panel/src/components/RenameConversationPopup/tests/RenameConversationPopup.spec.tsx
@@ -19,6 +19,7 @@ import {
 } from '../RenameConversationPopup';
 
 vi.mock('@epam/ai-dial-ui-kit', () => ({
+  DIAL_KIT_ICON_STROKE: 1.5,
   PopupSize: { Sm: 'sm' },
   ButtonVariant: { Primary: 'primary', Neutral: 'neutral' },
   Popup: ({

--- a/libs/conversation-stages/package.json
+++ b/libs/conversation-stages/package.json
@@ -22,7 +22,7 @@
     "react": "^19.0.0",
     "@tabler/icons-react": "^3.0.0",
     "@epam/ai-dial-chat-shared": "*",
-    "@epam/ai-dial-ui-kit": "^0.14.0-dev.13"
+    "@epam/ai-dial-ui-kit": "^0.14.0-dev.15"
   },
   "nx": {
     "tags": [

--- a/libs/conversation-stages/src/components/CollapsedGroup/CollapsedGroup.tsx
+++ b/libs/conversation-stages/src/components/CollapsedGroup/CollapsedGroup.tsx
@@ -5,6 +5,7 @@ import {
 } from '@epam/ai-dial-chat-shared';
 import {
   DIAL_ICON_SIZE,
+  DIAL_KIT_ICON_STROKE,
   EllipsisTooltip,
   LinkButton,
   Spinner,
@@ -192,6 +193,7 @@ export const CollapsedGroup: FC<CollapsedGroupProps> = ({
           size={DIAL_ICON_SIZE.SM}
           className={styles.doneIcon}
           aria-hidden
+          stroke={DIAL_KIT_ICON_STROKE}
         />
         <span
           className={mergeClasses(
@@ -227,12 +229,17 @@ export const CollapsedGroup: FC<CollapsedGroupProps> = ({
         aria-expanded={isOpen}
         iconAfter={
           isOpen ? (
-            <IconChevronDown size={12} aria-hidden />
+            <IconChevronDown
+              size={12}
+              aria-hidden
+              stroke={DIAL_KIT_ICON_STROKE}
+            />
           ) : (
             <IconChevronRight
               size={12}
               className="rtl:scale-x-[-1]"
               aria-hidden
+              stroke={DIAL_KIT_ICON_STROKE}
             />
           )
         }

--- a/libs/conversation-stages/src/components/CollapsedGroup/tests/CollapsedGroup.spec.tsx
+++ b/libs/conversation-stages/src/components/CollapsedGroup/tests/CollapsedGroup.spec.tsx
@@ -5,6 +5,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { CollapsedGroup } from '../CollapsedGroup';
 
 vi.mock('@epam/ai-dial-ui-kit', () => ({
+  DIAL_KIT_ICON_STROKE: 1.5,
   DIAL_ICON_SIZE: { SM: 14, MD: 16 },
   Spinner: ({ ariaLabel }: { ariaLabel?: string }) => (
     <span role="status" aria-label={ariaLabel} />

--- a/libs/conversation-stages/src/components/StageIcon/StageIcon.tsx
+++ b/libs/conversation-stages/src/components/StageIcon/StageIcon.tsx
@@ -1,5 +1,9 @@
 import { StageStatus } from '@epam/ai-dial-chat-shared';
-import { DIAL_ICON_SIZE, Spinner } from '@epam/ai-dial-ui-kit';
+import {
+  DIAL_ICON_SIZE,
+  DIAL_KIT_ICON_STROKE,
+  Spinner,
+} from '@epam/ai-dial-ui-kit';
 import { IconAlertCircle, IconCheck } from '@tabler/icons-react';
 import { FC } from 'react';
 import styles from '../StagesPanel/StagesPanel.module.scss';
@@ -34,6 +38,7 @@ export const StageIcon: FC<StageIconProps> = ({
           size={DIAL_ICON_SIZE.MD}
           className={styles.iconError}
           aria-hidden
+          stroke={DIAL_KIT_ICON_STROKE}
         />
         <span className="sr-only">{failedLabel}</span>
       </>
@@ -45,6 +50,7 @@ export const StageIcon: FC<StageIconProps> = ({
       size={DIAL_ICON_SIZE.SM}
       className={styles.iconCompleted}
       aria-hidden
+      stroke={DIAL_KIT_ICON_STROKE}
     />
   );
 };

--- a/libs/conversation-stages/src/components/StageItem/StageItem.tsx
+++ b/libs/conversation-stages/src/components/StageItem/StageItem.tsx
@@ -1,6 +1,10 @@
 import type { Stage } from '@epam/ai-dial-chat-shared';
 import { mergeClasses, StageStatus } from '@epam/ai-dial-chat-shared';
-import { DIAL_ICON_SIZE, EllipsisTooltip } from '@epam/ai-dial-ui-kit';
+import {
+  DIAL_ICON_SIZE,
+  DIAL_KIT_ICON_STROKE,
+  EllipsisTooltip,
+} from '@epam/ai-dial-ui-kit';
 import { IconChevronDown, IconChevronRight } from '@tabler/icons-react';
 import { FC, useState } from 'react';
 import type {
@@ -93,12 +97,17 @@ export const StageItem: FC<StageItemProps> = ({
       {hasExpandableContent && (
         <span className={mergeClasses('flex-none', styles.iconSecondary)}>
           {isOpen ? (
-            <IconChevronDown size={DIAL_ICON_SIZE.SM} aria-hidden />
+            <IconChevronDown
+              size={DIAL_ICON_SIZE.SM}
+              aria-hidden
+              stroke={DIAL_KIT_ICON_STROKE}
+            />
           ) : (
             <IconChevronRight
               size={DIAL_ICON_SIZE.SM}
               className="rtl:scale-x-[-1]"
               aria-hidden
+              stroke={DIAL_KIT_ICON_STROKE}
             />
           )}
         </span>

--- a/libs/conversation-stages/src/components/StageItem/tests/StageItem.spec.tsx
+++ b/libs/conversation-stages/src/components/StageItem/tests/StageItem.spec.tsx
@@ -4,6 +4,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { StageItem } from '../StageItem';
 
 vi.mock('@epam/ai-dial-ui-kit', () => ({
+  DIAL_KIT_ICON_STROKE: 1.5,
   DIAL_ICON_SIZE: { SM: 14, MD: 16 },
   Spinner: ({ ariaLabel }: { ariaLabel?: string }) => (
     <span role="status" aria-label={ariaLabel} />

--- a/libs/conversation-stages/src/components/StageMarkdownContent/StageCodeBlock.tsx
+++ b/libs/conversation-stages/src/components/StageMarkdownContent/StageCodeBlock.tsx
@@ -1,8 +1,9 @@
 import { copyToClipboard, mergeClasses } from '@epam/ai-dial-chat-shared';
 import {
   DIAL_ICON_SIZE,
-  GhostIconButton,
+  DIAL_KIT_ICON_STROKE,
   ElementSize,
+  GhostIconButton,
 } from '@epam/ai-dial-ui-kit';
 import { IconCheck, IconCopy } from '@tabler/icons-react';
 import {
@@ -68,11 +69,13 @@ export const StageCodeBlock: FC<Props> = ({
             <IconCheck
               size={DIAL_ICON_SIZE.SM}
               className={styles.iconSecondary}
+              stroke={DIAL_KIT_ICON_STROKE}
             />
           ) : (
             <IconCopy
               size={DIAL_ICON_SIZE.SM}
               className={styles.iconSecondary}
+              stroke={DIAL_KIT_ICON_STROKE}
             />
           )
         }

--- a/libs/conversation-stages/src/components/StageMarkdownContent/tests/StageCodeBlock.spec.tsx
+++ b/libs/conversation-stages/src/components/StageMarkdownContent/tests/StageCodeBlock.spec.tsx
@@ -11,6 +11,7 @@ vi.mock('@epam/ai-dial-chat-shared', () => ({
 }));
 
 vi.mock('@epam/ai-dial-ui-kit', () => ({
+  DIAL_KIT_ICON_STROKE: 1.5,
   DIAL_ICON_SIZE: { SM: 16 },
   ElementSize: { Small: 'small' },
   GhostIconButton: ({

--- a/libs/conversation-stages/src/components/StagesPanel/StagesPanel.tsx
+++ b/libs/conversation-stages/src/components/StagesPanel/StagesPanel.tsx
@@ -3,7 +3,11 @@ import {
   mergeClasses,
   StageStatus,
 } from '@epam/ai-dial-chat-shared';
-import { DIAL_ICON_SIZE, EllipsisTooltip } from '@epam/ai-dial-ui-kit';
+import {
+  DIAL_ICON_SIZE,
+  DIAL_KIT_ICON_STROKE,
+  EllipsisTooltip,
+} from '@epam/ai-dial-ui-kit';
 import { IconChevronDown, IconChevronRight } from '@tabler/icons-react';
 import { FC, useState } from 'react';
 import { StageRow } from '../../models/stage-grouping';
@@ -108,12 +112,17 @@ const StageGroupRow: FC<StageGroupRowProps> = ({
         )}
         <span className={mergeClasses('flex-none', styles.iconSecondary)}>
           {isOpen ? (
-            <IconChevronDown size={DIAL_ICON_SIZE.SM} aria-hidden />
+            <IconChevronDown
+              size={DIAL_ICON_SIZE.SM}
+              aria-hidden
+              stroke={DIAL_KIT_ICON_STROKE}
+            />
           ) : (
             <IconChevronRight
               size={DIAL_ICON_SIZE.SM}
               className="rtl:scale-x-[-1]"
               aria-hidden
+              stroke={DIAL_KIT_ICON_STROKE}
             />
           )}
         </span>

--- a/libs/conversation-stages/src/components/StagesPanel/tests/StagesPanel.spec.tsx
+++ b/libs/conversation-stages/src/components/StagesPanel/tests/StagesPanel.spec.tsx
@@ -4,6 +4,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { StagesPanel } from '../StagesPanel';
 
 vi.mock('@epam/ai-dial-ui-kit', () => ({
+  DIAL_KIT_ICON_STROKE: 1.5,
   DIAL_ICON_SIZE: { SM: 14, MD: 16 },
   Spinner: ({ ariaLabel }: { ariaLabel?: string }) => (
     <span role="status" aria-label={ariaLabel} />

--- a/libs/deployment-creation-form/src/components/DeploymentLocalesField/DeploymentLocalesField.tsx
+++ b/libs/deployment-creation-form/src/components/DeploymentLocalesField/DeploymentLocalesField.tsx
@@ -4,6 +4,7 @@ import {
   ButtonVariant,
   DangerIconButton,
   DIAL_ICON_SIZE,
+  DIAL_KIT_ICON_STROKE,
   ElementSize,
   Input,
   LinkButton,
@@ -158,7 +159,13 @@ export const DeploymentLocalesField: FC<DeploymentLocalesFieldProps> = ({
       </span>
       <LinkButton
         label={editLabel}
-        iconBefore={<IconPencil size={DIAL_ICON_SIZE.SM} aria-hidden />}
+        iconBefore={
+          <IconPencil
+            size={DIAL_ICON_SIZE.SM}
+            aria-hidden
+            stroke={DIAL_KIT_ICON_STROKE}
+          />
+        }
         className="!px-0"
         onClick={handleOpen}
       />
@@ -195,7 +202,13 @@ export const DeploymentLocalesField: FC<DeploymentLocalesFieldProps> = ({
                   <DangerIconButton
                     appearance={ButtonAppearance.Ghost}
                     size={ElementSize.Small}
-                    icon={<IconTrashX size={DIAL_ICON_SIZE.SM} aria-hidden />}
+                    icon={
+                      <IconTrashX
+                        size={DIAL_ICON_SIZE.SM}
+                        aria-hidden
+                        stroke={DIAL_KIT_ICON_STROKE}
+                      />
+                    }
                     aria-label={`${deleteAriaLabel} ${index + 1}`}
                     onClick={() => handleRowDelete(entry.id)}
                   />
@@ -262,7 +275,13 @@ export const DeploymentLocalesField: FC<DeploymentLocalesFieldProps> = ({
           })}
           <LinkButton
             label={addLocaleLabel}
-            iconBefore={<IconPlus size={DIAL_ICON_SIZE.SM} aria-hidden />}
+            iconBefore={
+              <IconPlus
+                size={DIAL_ICON_SIZE.SM}
+                aria-hidden
+                stroke={DIAL_KIT_ICON_STROKE}
+              />
+            }
             className="self-start"
             onClick={handleAddRow}
             disabled={draftEntries.length >= availableLocaleOptions.length}

--- a/libs/navigation-panel/src/components/NavigationPanel/NavigationPanel.module.scss
+++ b/libs/navigation-panel/src/components/NavigationPanel/NavigationPanel.module.scss
@@ -31,7 +31,7 @@
 .itemActive {
   background: var(
     --np-item-selected-bg,
-    var(--bg-control-accent-alpha-hover, #2764d924)
+    var(--bg-control-accent-alpha, #2764d90f)
   );
   color: var(--np-item-active-text, var(--text-accent, #1d4ed8));
 }

--- a/libs/navigation-panel/src/components/NavigationPanel/NavigationPanel.tsx
+++ b/libs/navigation-panel/src/components/NavigationPanel/NavigationPanel.tsx
@@ -1,5 +1,9 @@
 import { buildCssVars, mergeClasses } from '@epam/ai-dial-chat-shared';
-import { DIAL_ICON_SIZE, IconButton } from '@epam/ai-dial-ui-kit';
+import {
+  DIAL_ICON_SIZE,
+  DIAL_KIT_ICON_STROKE,
+  IconButton,
+} from '@epam/ai-dial-ui-kit';
 import { Fragment, memo, useMemo, type FC, type ReactNode } from 'react';
 import type {
   NavigationLinkRenderer,
@@ -76,7 +80,12 @@ export const NavigationPanel: FC<NavigationPanelProps> = memo(
                 {renderLink(
                   item,
                   <IconButton
-                    icon={<item.icon size={DIAL_ICON_SIZE.LG} stroke={1.5} />}
+                    icon={
+                      <item.icon
+                        size={DIAL_ICON_SIZE.LG}
+                        stroke={DIAL_KIT_ICON_STROKE}
+                      />
+                    }
                     aria-label={item.label}
                     aria-current={item.isActive ? 'page' : undefined}
                     tooltipProps={{ tooltip: item.label }}

--- a/libs/navigation-panel/src/components/NavigationPanel/NavigationPanel.tsx
+++ b/libs/navigation-panel/src/components/NavigationPanel/NavigationPanel.tsx
@@ -52,7 +52,7 @@ export const NavigationPanel: FC<NavigationPanelProps> = memo(
         style={{ ...cssVars, ...railCssVars }}
         className={mergeClasses(
           styles.rail,
-          'relative z-10 flex h-full w-[60px] flex-col justify-between shadow-md',
+          'relative z-10 flex h-full w-[60px] flex-col justify-between shadow-sm',
           typography?.fontClassName,
           className,
         )}

--- a/libs/navigation-panel/src/components/NavigationPanel/tests/NavigationPanel.spec.tsx
+++ b/libs/navigation-panel/src/components/NavigationPanel/tests/NavigationPanel.spec.tsx
@@ -5,6 +5,7 @@ import type { NavigationPanelItem } from '../../../models/navigation-item';
 import { NavigationPanel } from '../NavigationPanel';
 
 vi.mock('@epam/ai-dial-ui-kit', () => ({
+  DIAL_KIT_ICON_STROKE: 1.5,
   DIAL_ICON_SIZE: { LG: 24 },
   IconButton: ({
     'aria-label': ariaLabel,

--- a/libs/navigation-panel/src/components/NavigationSheet/NavigationMenuPage.tsx
+++ b/libs/navigation-panel/src/components/NavigationSheet/NavigationMenuPage.tsx
@@ -1,4 +1,4 @@
-import { BASE_ICON_SIZE } from '@epam/ai-dial-ui-kit';
+import { BASE_ICON_SIZE, DIAL_KIT_ICON_STROKE } from '@epam/ai-dial-ui-kit';
 import { IconUser } from '@tabler/icons-react';
 import { memo, type FC, type ReactNode } from 'react';
 import { useSheetNavigation } from '../../hooks/useSheetNavigation';
@@ -74,7 +74,12 @@ export const NavigationMenuPage: FC<NavigationMenuPageProps> = memo(
               key={item.id}
               label={item.label}
               textClassName={textClassName}
-              icon={<item.icon size={BASE_ICON_SIZE} stroke={1.5} />}
+              icon={
+                <item.icon
+                  size={BASE_ICON_SIZE}
+                  stroke={DIAL_KIT_ICON_STROKE}
+                />
+              }
               onClick={() => handleSelectItem(item)}
             />
           ))}
@@ -82,7 +87,13 @@ export const NavigationMenuPage: FC<NavigationMenuPageProps> = memo(
             <SheetRow
               label={profileLabel}
               textClassName={textClassName}
-              icon={<IconUser size={BASE_ICON_SIZE} stroke={1.5} aria-hidden />}
+              icon={
+                <IconUser
+                  size={BASE_ICON_SIZE}
+                  stroke={DIAL_KIT_ICON_STROKE}
+                  aria-hidden
+                />
+              }
               onClick={handleOpenProfile}
             />
           )}

--- a/libs/navigation-panel/src/components/NavigationSheet/OptionListPage.tsx
+++ b/libs/navigation-panel/src/components/NavigationSheet/OptionListPage.tsx
@@ -1,4 +1,4 @@
-import { DIAL_ICON_SIZE } from '@epam/ai-dial-ui-kit';
+import { DIAL_ICON_SIZE, DIAL_KIT_ICON_STROKE } from '@epam/ai-dial-ui-kit';
 import { IconCheck } from '@tabler/icons-react';
 import { memo, type FC } from 'react';
 import { useSheetNavigation } from '../../hooks/useSheetNavigation';
@@ -31,7 +31,7 @@ export const OptionListPage: FC<OptionListPageProps> = memo(
               option.isActive ? (
                 <IconCheck
                   size={DIAL_ICON_SIZE.SM}
-                  stroke={2}
+                  stroke={DIAL_KIT_ICON_STROKE}
                   aria-hidden
                   className={styles.activeIcon}
                 />

--- a/libs/navigation-panel/src/components/NavigationSheet/ProfilePage.tsx
+++ b/libs/navigation-panel/src/components/NavigationSheet/ProfilePage.tsx
@@ -1,5 +1,9 @@
 import { mergeClasses } from '@epam/ai-dial-chat-shared';
-import { BASE_ICON_SIZE, EllipsisTooltip } from '@epam/ai-dial-ui-kit';
+import {
+  BASE_ICON_SIZE,
+  DIAL_KIT_ICON_STROKE,
+  EllipsisTooltip,
+} from '@epam/ai-dial-ui-kit';
 import { IconChevronRight, IconLogout } from '@tabler/icons-react';
 import { memo, type FC } from 'react';
 import { useSheetNavigation } from '../../hooks/useSheetNavigation';
@@ -73,7 +77,7 @@ export const ProfilePage: FC<ProfilePageProps> = memo(
                   trailing={
                     <IconChevronRight
                       size={BASE_ICON_SIZE}
-                      stroke={1.5}
+                      stroke={DIAL_KIT_ICON_STROKE}
                       aria-hidden
                       className={mergeClasses(
                         styles.rowIcon,
@@ -104,7 +108,13 @@ export const ProfilePage: FC<ProfilePageProps> = memo(
           <SheetRow
             label={logOutLabel}
             textClassName={textClassName}
-            icon={<IconLogout size={BASE_ICON_SIZE} stroke={1.5} aria-hidden />}
+            icon={
+              <IconLogout
+                size={BASE_ICON_SIZE}
+                stroke={DIAL_KIT_ICON_STROKE}
+                aria-hidden
+              />
+            }
             onClick={handleLogout}
           />
         </ul>

--- a/libs/navigation-panel/src/components/NavigationSheet/tests/NavigableBottomSheet.spec.tsx
+++ b/libs/navigation-panel/src/components/NavigationSheet/tests/NavigableBottomSheet.spec.tsx
@@ -5,6 +5,7 @@ import { useSheetNavigation } from '../../../hooks/useSheetNavigation';
 import { NavigableBottomSheet } from '../NavigableBottomSheet';
 
 vi.mock('@epam/ai-dial-ui-kit', () => ({
+  DIAL_KIT_ICON_STROKE: 1.5,
   DIAL_ICON_SIZE: { SM: 16, MD: 20, LG: 24 },
   ElementSize: { Standard: 'standard' },
   GhostIconButton: ({

--- a/libs/navigation-panel/src/components/NavigationSheet/tests/NavigationSheet.spec.tsx
+++ b/libs/navigation-panel/src/components/NavigationSheet/tests/NavigationSheet.spec.tsx
@@ -7,6 +7,7 @@ import type { NavigationUserProfile } from '../../../models/user-profile';
 import { NavigationSheet } from '../NavigationSheet';
 
 vi.mock('@epam/ai-dial-ui-kit', () => ({
+  DIAL_KIT_ICON_STROKE: 1.5,
   BASE_ICON_SIZE: 20,
   DIAL_ICON_SIZE: { SM: 16, MD: 20, LG: 24 },
   ElementSize: { Standard: 'standard' },

--- a/libs/navigation-panel/src/components/UserMenu/UserMenu.tsx
+++ b/libs/navigation-panel/src/components/UserMenu/UserMenu.tsx
@@ -1,10 +1,11 @@
 import { buildCssVars, mergeClasses } from '@epam/ai-dial-chat-shared';
 import {
   DIAL_ICON_SIZE,
-  EllipsisTooltip,
-  Tooltip,
+  DIAL_KIT_ICON_STROKE,
   Dropdown,
   DropdownItemType,
+  EllipsisTooltip,
+  Tooltip,
   type DropdownItem,
 } from '@epam/ai-dial-ui-kit';
 import { IconLogout, IconSettings } from '@tabler/icons-react';
@@ -93,7 +94,13 @@ export const UserMenu: FC<UserMenuProps> = memo(
                 label: (
                   <span className={labelClassName}>{labels.settings}</span>
                 ),
-                icon: <IconSettings size={DIAL_ICON_SIZE.SM} aria-hidden />,
+                icon: (
+                  <IconSettings
+                    size={DIAL_ICON_SIZE.SM}
+                    aria-hidden
+                    stroke={DIAL_KIT_ICON_STROKE}
+                  />
+                ),
                 onClick: onSettings,
               },
             ]
@@ -101,7 +108,13 @@ export const UserMenu: FC<UserMenuProps> = memo(
         {
           key: 'logout',
           label: <span className={labelClassName}>{labels.logOut}</span>,
-          icon: <IconLogout size={DIAL_ICON_SIZE.SM} aria-hidden />,
+          icon: (
+            <IconLogout
+              size={DIAL_ICON_SIZE.SM}
+              aria-hidden
+              stroke={DIAL_KIT_ICON_STROKE}
+            />
+          ),
           onClick: onLogout,
         },
       ];

--- a/libs/navigation-panel/src/components/UserMenu/tests/UserMenu.spec.tsx
+++ b/libs/navigation-panel/src/components/UserMenu/tests/UserMenu.spec.tsx
@@ -15,6 +15,7 @@ interface MockDropdownItem {
 /* The real Dropdown renders its items in a floating overlay on open; the mock
    renders them inline so assertions stay about content, not positioning. */
 vi.mock('@epam/ai-dial-ui-kit', () => ({
+  DIAL_KIT_ICON_STROKE: 1.5,
   DIAL_ICON_SIZE: { SM: 16 },
   DropdownItemType: { PlainText: 'plainText', Divider: 'divider' },
   Tooltip: ({ children }: { children: ReactNode }) => children,

--- a/libs/navigation-panel/src/components/common/MenuItemLabel.tsx
+++ b/libs/navigation-panel/src/components/common/MenuItemLabel.tsx
@@ -1,5 +1,5 @@
 import { mergeClasses } from '@epam/ai-dial-chat-shared';
-import { DIAL_ICON_SIZE } from '@epam/ai-dial-ui-kit';
+import { DIAL_ICON_SIZE, DIAL_KIT_ICON_STROKE } from '@epam/ai-dial-ui-kit';
 import { IconCheck } from '@tabler/icons-react';
 import { memo, type FC, type ReactNode } from 'react';
 import styles from './MenuPrimitives.module.scss';
@@ -40,6 +40,7 @@ export const MenuItemLabel: FC<MenuItemLabelProps> = memo(
             size={DIAL_ICON_SIZE.SM}
             aria-hidden
             className={styles.activeIcon}
+            stroke={DIAL_KIT_ICON_STROKE}
           />
         )}
       </span>

--- a/libs/prompt-editor/src/components/PromptFolderField/PromptFolderField.tsx
+++ b/libs/prompt-editor/src/components/PromptFolderField/PromptFolderField.tsx
@@ -1,6 +1,7 @@
 import { mergeClasses } from '@epam/ai-dial-chat-shared';
 import {
   DIAL_ICON_SIZE,
+  DIAL_KIT_ICON_STROKE,
   ElementSize,
   GhostIconButton,
   Input,
@@ -170,18 +171,36 @@ export const PromptFolderField: FC<PromptFolderFieldProps> = ({
         {actions != null && !disabled && (
           <>
             <GhostIconButton
-              icon={<IconFolderPlus size={DIAL_ICON_SIZE.SM} aria-hidden />}
+              icon={
+                <IconFolderPlus
+                  size={DIAL_ICON_SIZE.SM}
+                  aria-hidden
+                  stroke={DIAL_KIT_ICON_STROKE}
+                />
+              }
               aria-label={labels?.folderCreateLabel ?? 'Create folder'}
               onClick={openCreate}
             />
             <GhostIconButton
-              icon={<IconPencil size={DIAL_ICON_SIZE.SM} aria-hidden />}
+              icon={
+                <IconPencil
+                  size={DIAL_ICON_SIZE.SM}
+                  aria-hidden
+                  stroke={DIAL_KIT_ICON_STROKE}
+                />
+              }
               aria-label={labels?.folderRenameLabel ?? 'Rename folder'}
               disabled={isRootSelected}
               onClick={openRename}
             />
             <GhostIconButton
-              icon={<IconTrashX size={DIAL_ICON_SIZE.SM} aria-hidden />}
+              icon={
+                <IconTrashX
+                  size={DIAL_ICON_SIZE.SM}
+                  aria-hidden
+                  stroke={DIAL_KIT_ICON_STROKE}
+                />
+              }
               aria-label={labels?.folderDeleteLabel ?? 'Delete folder'}
               disabled={isRootSelected}
               onClick={openDelete}

--- a/libs/prompts/src/components/PromptParametersPopup/PromptParametersPopup.tsx
+++ b/libs/prompts/src/components/PromptParametersPopup/PromptParametersPopup.tsx
@@ -5,6 +5,7 @@ import {
   mergeClasses,
 } from '@epam/ai-dial-chat-shared';
 import {
+  DIAL_KIT_ICON_STROKE,
   GhostIconButton,
   NeutralButton,
   Popup,
@@ -71,7 +72,13 @@ export const PromptParametersPopup: FC<PromptParametersPopupProps> = ({
     <div className="flex items-center gap-2">
       {onBack != null && (
         <GhostIconButton
-          icon={<IconChevronLeft className="rtl:scale-x-[-1]" aria-hidden />}
+          icon={
+            <IconChevronLeft
+              className="rtl:scale-x-[-1]"
+              aria-hidden
+              stroke={DIAL_KIT_ICON_STROKE}
+            />
+          }
           aria-label={backLabel}
           onClick={onBack}
         />

--- a/libs/publish-panel/package.json
+++ b/libs/publish-panel/package.json
@@ -23,7 +23,7 @@
     "@tabler/icons-react": "^3.0.0",
     "@epam/ai-dial-chat-shared": "*",
     "@epam/ai-dial-ui-kit": "*",
-    "@epam/ai-dial-react-file-manager": "^0.2.0-dev.7"
+    "@epam/ai-dial-react-file-manager": "^0.2.0-dev.9"
   },
   "nx": {
     "tags": [

--- a/libs/publish-panel/src/components/PublishAccessRules/PublishAccessRules.tsx
+++ b/libs/publish-panel/src/components/PublishAccessRules/PublishAccessRules.tsx
@@ -2,6 +2,7 @@ import { buildCssVars, mergeClasses } from '@epam/ai-dial-chat-shared';
 import {
   ButtonVariant,
   DIAL_ICON_SIZE,
+  DIAL_KIT_ICON_STROKE,
   GhostButton,
   GhostIconButton,
   Notification,
@@ -306,7 +307,13 @@ export const PublishAccessRules: FC<PublishAccessRulesProps> = ({
                   {functionLabel(rule.function, functionLabels)}: {targetsText}
                 </span>
                 <GhostIconButton
-                  icon={<IconTrashX size={DIAL_ICON_SIZE.SM} aria-hidden />}
+                  icon={
+                    <IconTrashX
+                      size={DIAL_ICON_SIZE.SM}
+                      aria-hidden
+                      stroke={DIAL_KIT_ICON_STROKE}
+                    />
+                  }
                   aria-label={removeAriaLabel}
                   onClick={() => handleRemoveRule(index)}
                   disabled={disabled}
@@ -339,7 +346,13 @@ export const PublishAccessRules: FC<PublishAccessRulesProps> = ({
          */}
         <GhostButton
           label={addRuleLabel}
-          iconBefore={<IconPlus size={DIAL_ICON_SIZE.SM} aria-hidden />}
+          iconBefore={
+            <IconPlus
+              size={DIAL_ICON_SIZE.SM}
+              aria-hidden
+              stroke={DIAL_KIT_ICON_STROKE}
+            />
+          }
           onClick={handleOpenEditor}
           disabled={isAddDisabled}
         />

--- a/libs/publish-panel/src/components/PublishFoldersTree/PublishFoldersTree.tsx
+++ b/libs/publish-panel/src/components/PublishFoldersTree/PublishFoldersTree.tsx
@@ -6,6 +6,7 @@ import {
 } from '@epam/ai-dial-react-file-manager';
 import {
   DIAL_ICON_SIZE,
+  DIAL_KIT_ICON_STROKE,
   DropdownItem,
   GhostButton,
 } from '@epam/ai-dial-ui-kit';
@@ -207,7 +208,13 @@ export const PublishFoldersTree: FC<PublishFoldersTreeProps> = ({
       {
         key: 'add-child',
         label: addChildFolderLabel,
-        icon: <IconFolderPlus size={DIAL_ICON_SIZE.SM} aria-hidden />,
+        icon: (
+          <IconFolderPlus
+            size={DIAL_ICON_SIZE.SM}
+            aria-hidden
+            stroke={DIAL_KIT_ICON_STROKE}
+          />
+        ),
         onClick: () => beginCreatingFolder(childPath),
       },
     ];
@@ -215,7 +222,13 @@ export const PublishFoldersTree: FC<PublishFoldersTreeProps> = ({
       items.push({
         key: 'add-sibling',
         label: addSiblingFolderLabel,
-        icon: <IconPlus size={DIAL_ICON_SIZE.SM} aria-hidden />,
+        icon: (
+          <IconPlus
+            size={DIAL_ICON_SIZE.SM}
+            aria-hidden
+            stroke={DIAL_KIT_ICON_STROKE}
+          />
+        ),
         onClick: () => beginCreatingFolder(childPath.slice(0, -1)),
       });
     }
@@ -303,7 +316,13 @@ export const PublishFoldersTree: FC<PublishFoldersTreeProps> = ({
         <GhostButton
           onClick={handleStartCreatingFolder}
           label={createFolderLabel}
-          iconBefore={<IconPlus size={DIAL_ICON_SIZE.SM} aria-hidden />}
+          iconBefore={
+            <IconPlus
+              size={DIAL_ICON_SIZE.SM}
+              aria-hidden
+              stroke={DIAL_KIT_ICON_STROKE}
+            />
+          }
           disabled={disabled || isCreatingFolder}
         />
         {isCreatingFolder && (

--- a/libs/quotations/src/components/CitationCard/CitationCard.tsx
+++ b/libs/quotations/src/components/CitationCard/CitationCard.tsx
@@ -6,9 +6,10 @@ import {
   MIMEType,
 } from '@epam/ai-dial-chat-shared';
 import {
+  DIAL_KIT_ICON_STROKE,
+  ElementSize,
   EllipsisTooltip,
   GhostIconButton,
-  ElementSize,
   PrimaryButton,
 } from '@epam/ai-dial-ui-kit';
 import { IconChevronLeft, IconChevronRight } from '@tabler/icons-react';
@@ -153,7 +154,13 @@ export const CitationCard: FC<CitationCardProps> = ({
         {hasSwitcher && (
           <div className="flex shrink-0 items-center gap-1">
             <GhostIconButton
-              icon={<IconChevronLeft size={14} className="rtl:scale-x-[-1]" />}
+              icon={
+                <IconChevronLeft
+                  size={14}
+                  className="rtl:scale-x-[-1]"
+                  stroke={DIAL_KIT_ICON_STROKE}
+                />
+              }
               size={ElementSize.Small}
               aria-label={labels.previousCitation}
               onClick={() => onIndexChange((activeIndex - 1 + total) % total)}
@@ -162,7 +169,13 @@ export const CitationCard: FC<CitationCardProps> = ({
               {labels.formatSwitcherText(activeIndex + 1, total)}
             </span>
             <GhostIconButton
-              icon={<IconChevronRight size={14} className="rtl:scale-x-[-1]" />}
+              icon={
+                <IconChevronRight
+                  size={14}
+                  className="rtl:scale-x-[-1]"
+                  stroke={DIAL_KIT_ICON_STROKE}
+                />
+              }
               size={ElementSize.Small}
               aria-label={labels.nextCitation}
               onClick={() => onIndexChange((activeIndex + 1) % total)}

--- a/libs/quotations/src/components/CitationCard/CitationCard.tsx
+++ b/libs/quotations/src/components/CitationCard/CitationCard.tsx
@@ -56,6 +56,8 @@ export interface CitationCardTypography {
   titleClassName?: string;
   /** CSS class applied to the quoted excerpt. Defaults to `'dial-small-text'`. */
   quoteClassName?: string;
+  /** CSS class applied to bold spans inside the quoted excerpt. Defaults to `'dial-small-semi-text'` — the semibold step matching the default `quoteClassName`. */
+  quoteStrongClassName?: string;
   /** CSS class applied to the pagination switcher text. Defaults to `'dial-tiny-text'`. */
   switcherClassName?: string;
 }
@@ -101,7 +103,6 @@ export const CitationCard: FC<CitationCardProps> = ({
   const total = group.annotations.length;
   const annotation = group.annotations[activeIndex] ?? group.primaryAnnotation;
   const hasSwitcher = total > 1;
-  const groupHasTitle = group.annotations.some((a) => a.body?.title);
   const sourceContentType =
     group.primaryAnnotation.body?.source?.attachment?.type;
   const isWebLink =
@@ -113,6 +114,8 @@ export const CitationCard: FC<CitationCardProps> = ({
     typography?.sourceNameClassName ?? 'dial-tiny-text';
   const titleClassName = typography?.titleClassName ?? 'dial-body-semi-text';
   const quoteClassName = typography?.quoteClassName ?? 'dial-small-text';
+  const quoteStrongClassName =
+    typography?.quoteStrongClassName ?? 'dial-small-semi-text';
   const switcherClassName = typography?.switcherClassName ?? 'dial-tiny-text';
 
   const cssVars = buildCssVars({
@@ -170,29 +173,34 @@ export const CitationCard: FC<CitationCardProps> = ({
 
       {(annotation.body?.title || annotation.body?.quote || hasSwitcher) && (
         <div className="flex flex-col gap-3">
-          {(annotation.body?.title || (hasSwitcher && groupHasTitle)) && (
+          {annotation.body?.title && (
             <p
               className={mergeClasses(
                 titleClassName,
                 styles.title,
                 'break-words',
-                hasSwitcher && groupHasTitle && 'min-h-[1lh]',
               )}
             >
-              {annotation.body?.title}
+              {annotation.body.title}
             </p>
           )}
           {(annotation.body?.quote || hasSwitcher) && (
-            <div className={mergeClasses(hasSwitcher && 'min-h-[3lh]')}>
+            <div
+              className={mergeClasses(
+                quoteClassName,
+                styles.quote,
+                'line-clamp-6 break-words',
+                hasSwitcher && 'min-h-[3lh]',
+              )}
+            >
               {annotation.body?.quote && (
                 <MarkdownRenderer
                   content={annotation.body.quote}
                   classNames={{
-                    p: mergeClasses(
-                      quoteClassName,
-                      'line-clamp-6',
-                      styles.quote,
-                    ),
+                    p: mergeClasses(quoteClassName, styles.quote),
+                    ul: mergeClasses(quoteClassName, 'ps-3'),
+                    ol: mergeClasses(quoteClassName, 'ps-3'),
+                    strong: quoteStrongClassName,
                   }}
                 />
               )}

--- a/libs/scheduled-tasks/src/components/ScheduledTaskCard/ScheduledTaskCard.tsx
+++ b/libs/scheduled-tasks/src/components/ScheduledTaskCard/ScheduledTaskCard.tsx
@@ -2,6 +2,7 @@ import { buildCssVars, mergeClasses } from '@epam/ai-dial-chat-shared';
 import {
   CardShell,
   DIAL_ICON_SIZE,
+  DIAL_KIT_ICON_STROKE,
   FolderPath,
   Highlight,
 } from '@epam/ai-dial-ui-kit';
@@ -132,7 +133,11 @@ export const ScheduledTaskCard: FC<ScheduledTaskCardProps> = ({
                 styles.pausedLabel,
               )}
             >
-              <IconPlayerPause size={DIAL_ICON_SIZE.SM} aria-hidden />
+              <IconPlayerPause
+                size={DIAL_ICON_SIZE.SM}
+                aria-hidden
+                stroke={DIAL_KIT_ICON_STROKE}
+              />
               {pausedBadgeLabel}
             </span>
           ) : (

--- a/libs/scheduled-tasks/src/components/ScheduledTaskCard/tests/ScheduledTaskCard.spec.tsx
+++ b/libs/scheduled-tasks/src/components/ScheduledTaskCard/tests/ScheduledTaskCard.spec.tsx
@@ -6,6 +6,7 @@ import type { ScheduledTaskItem } from '../../../models/scheduled-task-item';
 import { ScheduledTaskCard } from '../ScheduledTaskCard';
 
 vi.mock('@epam/ai-dial-ui-kit', () => ({
+  DIAL_KIT_ICON_STROKE: 1.5,
   CardShell: ({
     children,
     ...rest

--- a/libs/scheduled-tasks/src/components/ScheduledTaskCardGrid/tests/ScheduledTaskCardGrid.spec.tsx
+++ b/libs/scheduled-tasks/src/components/ScheduledTaskCardGrid/tests/ScheduledTaskCardGrid.spec.tsx
@@ -6,6 +6,7 @@ import type { ScheduledTaskItem } from '../../../models/scheduled-task-item';
 import { ScheduledTaskCardGrid } from '../ScheduledTaskCardGrid';
 
 vi.mock('@epam/ai-dial-ui-kit', () => ({
+  DIAL_KIT_ICON_STROKE: 1.5,
   FolderPath: ({ segments }: { segments: string[] }) => (
     <>{segments.join(' / ')}</>
   ),

--- a/libs/scheduled-tasks/src/components/ScheduledTaskCardSkeleton/tests/ScheduledTaskCardSkeleton.spec.tsx
+++ b/libs/scheduled-tasks/src/components/ScheduledTaskCardSkeleton/tests/ScheduledTaskCardSkeleton.spec.tsx
@@ -4,6 +4,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { ScheduledTaskCardSkeleton } from '../ScheduledTaskCardSkeleton';
 
 vi.mock('@epam/ai-dial-ui-kit', () => ({
+  DIAL_KIT_ICON_STROKE: 1.5,
   // Read by @epam/ai-dial-chat-shared at module init, not by the component
   DIAL_ICON_SIZE: { SM: 16, MD: 20, LG: 24 },
   CardShell: ({

--- a/libs/scheduled-tasks/src/components/ScheduledTaskCreateForm/tests/ScheduledTaskCreateForm.spec.tsx
+++ b/libs/scheduled-tasks/src/components/ScheduledTaskCreateForm/tests/ScheduledTaskCreateForm.spec.tsx
@@ -10,6 +10,7 @@ import { ScheduledTaskRepeat } from '../../../types/scheduled-task-schedule';
 import { ScheduledTaskCreateForm } from '../ScheduledTaskCreateForm';
 
 vi.mock('@epam/ai-dial-ui-kit', () => ({
+  DIAL_KIT_ICON_STROKE: 1.5,
   Input: ({
     labelProps,
     value,

--- a/libs/scheduled-tasks/src/components/ScheduledTaskDetailView/ScheduledTaskDetailView.tsx
+++ b/libs/scheduled-tasks/src/components/ScheduledTaskDetailView/ScheduledTaskDetailView.tsx
@@ -6,10 +6,11 @@ import {
 import {
   ButtonVariant,
   DIAL_ICON_SIZE,
-  Spinner,
+  DIAL_KIT_ICON_STROKE,
   GhostButton,
   GhostIconButton,
   NeutralButton,
+  Spinner,
   Switch,
 } from '@epam/ai-dial-ui-kit';
 import {
@@ -128,6 +129,7 @@ export const ScheduledTaskDetailView: FC<ScheduledTaskDetailViewProps> = ({
                 size={DIAL_ICON_SIZE.LG}
                 className="rtl:scale-x-[-1]"
                 aria-hidden
+                stroke={DIAL_KIT_ICON_STROKE}
               />
             }
             aria-label={labels.backAriaLabel}
@@ -164,7 +166,13 @@ export const ScheduledTaskDetailView: FC<ScheduledTaskDetailViewProps> = ({
             <GhostButton
               variant={ButtonVariant.Danger}
               label={labels.deleteButtonLabel}
-              iconBefore={<IconTrashX size={DIAL_ICON_SIZE.SM} aria-hidden />}
+              iconBefore={
+                <IconTrashX
+                  size={DIAL_ICON_SIZE.SM}
+                  aria-hidden
+                  stroke={DIAL_KIT_ICON_STROKE}
+                />
+              }
               onClick={onDelete}
               disabled={isDeleting}
               className="shrink-0"
@@ -175,7 +183,11 @@ export const ScheduledTaskDetailView: FC<ScheduledTaskDetailViewProps> = ({
             <NeutralButton
               label={labels.editButtonLabel}
               iconBefore={
-                <IconPencilMinus size={DIAL_ICON_SIZE.SM} aria-hidden />
+                <IconPencilMinus
+                  size={DIAL_ICON_SIZE.SM}
+                  aria-hidden
+                  stroke={DIAL_KIT_ICON_STROKE}
+                />
               }
               onClick={onEdit}
               disabled={isDeleting}

--- a/libs/scheduled-tasks/src/components/ScheduledTaskDetailView/tests/ScheduledTaskDetailView.spec.tsx
+++ b/libs/scheduled-tasks/src/components/ScheduledTaskDetailView/tests/ScheduledTaskDetailView.spec.tsx
@@ -19,6 +19,7 @@ vi.mock('@epam/ai-dial-chat-shared', async (importOriginal) => {
 });
 
 vi.mock('@epam/ai-dial-ui-kit', () => ({
+  DIAL_KIT_ICON_STROKE: 1.5,
   DIAL_ICON_SIZE: { SM: 16, MD: 20, LG: 24 },
   ButtonVariant: { Primary: 'primary', Neutral: 'neutral', Danger: 'danger' },
   Switch: ({

--- a/libs/scheduled-tasks/src/components/ScheduledTaskRunHistoryList/ScheduledTaskRunHistoryList.tsx
+++ b/libs/scheduled-tasks/src/components/ScheduledTaskRunHistoryList/ScheduledTaskRunHistoryList.tsx
@@ -1,6 +1,7 @@
 import { buildCssVars, mergeClasses } from '@epam/ai-dial-chat-shared';
 import {
   DIAL_ICON_SIZE,
+  DIAL_KIT_ICON_STROKE,
   GhostButton,
   Skeleton,
   SkeletonVariant,
@@ -26,6 +27,7 @@ const RunStatusIcon: FC<{ status: ScheduledTaskRunStatus }> = ({ status }) => {
           size={DIAL_ICON_SIZE.SM}
           className={styles.successIcon}
           aria-hidden
+          stroke={DIAL_KIT_ICON_STROKE}
         />
       );
     case ScheduledTaskRunStatus.Error:
@@ -34,6 +36,7 @@ const RunStatusIcon: FC<{ status: ScheduledTaskRunStatus }> = ({ status }) => {
           size={DIAL_ICON_SIZE.SM}
           className={styles.errorIcon}
           aria-hidden
+          stroke={DIAL_KIT_ICON_STROKE}
         />
       );
     case ScheduledTaskRunStatus.InProgress:
@@ -48,6 +51,7 @@ const RunStatusIcon: FC<{ status: ScheduledTaskRunStatus }> = ({ status }) => {
           size={DIAL_ICON_SIZE.SM}
           className={styles.missedIcon}
           aria-hidden
+          stroke={DIAL_KIT_ICON_STROKE}
         />
       );
     default:
@@ -187,7 +191,7 @@ export const ScheduledTaskRunHistoryList: FC<
       >
         <IconClipboardX
           size={44}
-          stroke={1.5}
+          stroke={DIAL_KIT_ICON_STROKE}
           className={styles.subtitleText}
           aria-hidden
         />

--- a/libs/scheduled-tasks/src/components/ScheduledTaskRunHistoryList/tests/ScheduledTaskRunHistoryList.spec.tsx
+++ b/libs/scheduled-tasks/src/components/ScheduledTaskRunHistoryList/tests/ScheduledTaskRunHistoryList.spec.tsx
@@ -7,6 +7,7 @@ import { ScheduledTaskRunStatus } from '../../../types/scheduled-task-run-status
 import { ScheduledTaskRunHistoryList } from '../ScheduledTaskRunHistoryList';
 
 vi.mock('@epam/ai-dial-ui-kit', () => ({
+  DIAL_KIT_ICON_STROKE: 1.5,
   DIAL_ICON_SIZE: { SM: 16, MD: 20, LG: 24 },
   Spinner: () => <div role="progressbar" />,
   Skeleton: (props: Record<string, unknown>) => (

--- a/libs/scheduled-tasks/src/components/ScheduledTasks/ScheduledTasks.tsx
+++ b/libs/scheduled-tasks/src/components/ScheduledTasks/ScheduledTasks.tsx
@@ -8,6 +8,7 @@ import {
   ButtonDropdown,
   ButtonVariant,
   DIAL_ICON_SIZE,
+  DIAL_KIT_ICON_STROKE,
   ElementSize,
   GhostButton,
   PrimaryButton,
@@ -222,7 +223,13 @@ export const ScheduledTasks: FC<ScheduledTasksProps> = ({
 
         <PrimaryButton
           label={labels.createButtonLabel}
-          iconBefore={<IconPlus size={DIAL_ICON_SIZE.SM} aria-hidden />}
+          iconBefore={
+            <IconPlus
+              size={DIAL_ICON_SIZE.SM}
+              aria-hidden
+              stroke={DIAL_KIT_ICON_STROKE}
+            />
+          }
           onClick={onCreateClick}
           className="shrink-0"
         />

--- a/libs/settings-panel/package.json
+++ b/libs/settings-panel/package.json
@@ -19,7 +19,7 @@
   },
   "peerDependencies": {
     "@epam/ai-dial-chat-shared": "*",
-    "@epam/ai-dial-ui-kit": "^0.14.0-dev.13",
+    "@epam/ai-dial-ui-kit": "^0.14.0-dev.15",
     "@tabler/icons-react": "^3.44.0",
     "react": "^19.2.7"
   },

--- a/libs/share/src/components/AccessControl/AccessControl.tsx
+++ b/libs/share/src/components/AccessControl/AccessControl.tsx
@@ -1,5 +1,9 @@
 import { mergeClasses } from '@epam/ai-dial-chat-shared';
-import { DIAL_ICON_SIZE, Dropdown } from '@epam/ai-dial-ui-kit';
+import {
+  DIAL_ICON_SIZE,
+  DIAL_KIT_ICON_STROKE,
+  Dropdown,
+} from '@epam/ai-dial-ui-kit';
 import { IconCheck, IconChevronDown, IconWorld } from '@tabler/icons-react';
 import { FC, type KeyboardEvent, type RefObject } from 'react';
 import { ShareLinkAccess } from '../../types/share';
@@ -79,7 +83,11 @@ export const AccessControl: FC<AccessControlProps> = ({
           styles.linkIconBadge,
         )}
       >
-        <IconWorld size={DIAL_ICON_SIZE.MD} aria-hidden />
+        <IconWorld
+          size={DIAL_ICON_SIZE.MD}
+          aria-hidden
+          stroke={DIAL_KIT_ICON_STROKE}
+        />
       </span>
       <div className="min-w-0 flex-1">
         <p
@@ -148,7 +156,7 @@ export const AccessControl: FC<AccessControlProps> = ({
                     {isChecked && (
                       <IconCheck
                         size={DIAL_ICON_SIZE.SM}
-                        stroke={2}
+                        stroke={DIAL_KIT_ICON_STROKE}
                         className={styles.accessMenuItemCheck}
                         aria-hidden
                       />
@@ -183,7 +191,7 @@ export const AccessControl: FC<AccessControlProps> = ({
             </span>
             <IconChevronDown
               size={DIAL_ICON_SIZE.MD}
-              strokeWidth={2.2}
+              stroke={DIAL_KIT_ICON_STROKE}
               className={mergeClasses(
                 'shrink-0 transition-transform duration-150 rtl:scale-x-[-1]',
                 styles.accessTriggerChevron,

--- a/libs/share/src/components/LinkView/LinkView.tsx
+++ b/libs/share/src/components/LinkView/LinkView.tsx
@@ -1,5 +1,10 @@
 import { mergeClasses } from '@epam/ai-dial-chat-shared';
-import { DIAL_ICON_SIZE, GhostIconButton, Input } from '@epam/ai-dial-ui-kit';
+import {
+  DIAL_ICON_SIZE,
+  DIAL_KIT_ICON_STROKE,
+  GhostIconButton,
+  Input,
+} from '@epam/ai-dial-ui-kit';
 import { IconCheck, IconCopy } from '@tabler/icons-react';
 import { FC } from 'react';
 import styles from '../SharePopover/SharePopover.module.scss';
@@ -46,9 +51,17 @@ export const LinkView: FC<LinkViewProps> = ({
       <GhostIconButton
         icon={
           isCopied ? (
-            <IconCheck size={DIAL_ICON_SIZE.LG} aria-hidden />
+            <IconCheck
+              size={DIAL_ICON_SIZE.LG}
+              aria-hidden
+              stroke={DIAL_KIT_ICON_STROKE}
+            />
           ) : (
-            <IconCopy size={DIAL_ICON_SIZE.LG} aria-hidden />
+            <IconCopy
+              size={DIAL_ICON_SIZE.LG}
+              aria-hidden
+              stroke={DIAL_KIT_ICON_STROKE}
+            />
           )
         }
         aria-label={isCopied ? copiedButtonLabel : copyButtonLabel}

--- a/libs/share/src/components/SharePopover/SharePopoverHeader.tsx
+++ b/libs/share/src/components/SharePopover/SharePopoverHeader.tsx
@@ -1,5 +1,9 @@
 import { mergeClasses } from '@epam/ai-dial-chat-shared';
-import { DIAL_ICON_SIZE, GhostButton } from '@epam/ai-dial-ui-kit';
+import {
+  DIAL_ICON_SIZE,
+  DIAL_KIT_ICON_STROKE,
+  GhostButton,
+} from '@epam/ai-dial-ui-kit';
 import { IconLink, IconQrcode } from '@tabler/icons-react';
 import { FC } from 'react';
 import { SharePopoverView } from '../../types/share';
@@ -41,7 +45,13 @@ export const SharePopoverHeader: FC<SharePopoverHeaderProps> = ({
       <GhostButton
         id={QR_BUTTON_ID}
         label={qrButtonLabel}
-        iconBefore={<IconQrcode size={DIAL_ICON_SIZE.SM} aria-hidden />}
+        iconBefore={
+          <IconQrcode
+            size={DIAL_ICON_SIZE.SM}
+            aria-hidden
+            stroke={DIAL_KIT_ICON_STROKE}
+          />
+        }
         className="ms-auto"
         onClick={() => onViewChange(SharePopoverView.Qr)}
       />
@@ -49,7 +59,13 @@ export const SharePopoverHeader: FC<SharePopoverHeaderProps> = ({
       <GhostButton
         id={LINK_BUTTON_ID}
         label={linkLabel}
-        iconBefore={<IconLink size={DIAL_ICON_SIZE.SM} aria-hidden />}
+        iconBefore={
+          <IconLink
+            size={DIAL_ICON_SIZE.SM}
+            aria-hidden
+            stroke={DIAL_KIT_ICON_STROKE}
+          />
+        }
         className="ms-auto"
         onClick={() => onViewChange(SharePopoverView.Link)}
       />

--- a/libs/sidebar/src/components/SidebarPanel/SidebarPanel.tsx
+++ b/libs/sidebar/src/components/SidebarPanel/SidebarPanel.tsx
@@ -152,7 +152,7 @@ export const SidebarPanel: FC<SidebarPanelProps> = ({
             }
       }
       className={mergeClasses(
-        'h-full flex-shrink-0 gap-3 overflow-hidden shadow-md',
+        'h-full flex-shrink-0 gap-3 overflow-hidden shadow-sm',
         orientation === SidebarOrientation.Left &&
           '[clip-path:inset(-24px_-24px_-24px_0)] rtl:[clip-path:inset(-24px_0_-24px_-24px)]',
         !isResizing && 'transition-[width] duration-200 ease-in-out',

--- a/libs/sidebar/src/components/SidebarPanel/SidebarPanel.tsx
+++ b/libs/sidebar/src/components/SidebarPanel/SidebarPanel.tsx
@@ -1,6 +1,7 @@
 import { buildCssVars, mergeClasses } from '@epam/ai-dial-chat-shared';
 import {
   DIAL_ICON_SIZE,
+  DIAL_KIT_ICON_STROKE,
   DialConditionalResizableContainer,
   GhostIconButton,
   ResizableContainerSide,
@@ -135,7 +136,13 @@ export const SidebarPanel: FC<SidebarPanelProps> = ({
       : ResizableContainerSide.Right;
   const closeButton = onClose ? (
     <GhostIconButton
-      icon={<IconX size={DIAL_ICON_SIZE.LG} stroke={1.5} aria-hidden />}
+      icon={
+        <IconX
+          size={DIAL_ICON_SIZE.LG}
+          stroke={DIAL_KIT_ICON_STROKE}
+          aria-hidden
+        />
+      }
       aria-label={labels.closeLabel}
       tooltipProps={{ tooltip: labels.closeLabel }}
       onClick={onClose}

--- a/libs/sidebar/src/components/SidebarPanel/tests/SidebarPanel.spec.tsx
+++ b/libs/sidebar/src/components/SidebarPanel/tests/SidebarPanel.spec.tsx
@@ -5,6 +5,7 @@ import { SidebarOrientation } from '../../../types/orientation';
 import { SidebarPanel } from '../SidebarPanel';
 
 vi.mock('@epam/ai-dial-ui-kit', () => ({
+  DIAL_KIT_ICON_STROKE: 1.5,
   DIAL_ICON_SIZE: { LG: 24 },
   GhostIconButton: ({
     'aria-label': ariaLabel,

--- a/libs/skill-editor/package.json
+++ b/libs/skill-editor/package.json
@@ -20,7 +20,7 @@
   "peerDependencies": {
     "@epam/ai-dial-chat-shared": "*",
     "@epam/ai-dial-ui-kit": "*",
-    "@epam/ai-dial-react-file-manager": "^0.2.0-dev.7",
+    "@epam/ai-dial-react-file-manager": "^0.2.0-dev.9",
     "@tabler/icons-react": "^3.0.0",
     "react": "^19.0.0"
   },

--- a/libs/skill-editor/src/components/SkillEditor/SkillEditor.tsx
+++ b/libs/skill-editor/src/components/SkillEditor/SkillEditor.tsx
@@ -5,7 +5,7 @@ import {
   Accordion,
   CaptionText,
   DIAL_ICON_SIZE,
-  type DropdownItem,
+  DIAL_KIT_ICON_STROKE,
   EditorThemes,
   ErrorText,
   GhostButton,
@@ -15,6 +15,7 @@ import {
   PrimaryButton,
   Spinner,
   Textarea,
+  type DropdownItem,
 } from '@epam/ai-dial-ui-kit';
 import { IconPlus, IconTrashX } from '@tabler/icons-react';
 import {
@@ -234,6 +235,7 @@ export const SkillEditor: FC<SkillEditorProps> = ({
               size={DIAL_ICON_SIZE.SM}
               className={removeIconClassName}
               aria-hidden
+              stroke={DIAL_KIT_ICON_STROKE}
             />
           ),
           onClick: () => handleRemoveNode(item.path),
@@ -254,7 +256,9 @@ export const SkillEditor: FC<SkillEditorProps> = ({
         </span>
         <NeutralButton
           label={t.addUploadLabel ?? 'Upload from device'}
-          iconBefore={<IconPlus size={16} aria-hidden />}
+          iconBefore={
+            <IconPlus size={16} aria-hidden stroke={DIAL_KIT_ICON_STROKE} />
+          }
           onClick={() => {
             setDroppedFiles(undefined);
             setIsUploadDialogOpen(true);

--- a/libs/skill-editor/src/components/SkillEditor/tests/SkillEditor.spec.tsx
+++ b/libs/skill-editor/src/components/SkillEditor/tests/SkillEditor.spec.tsx
@@ -33,6 +33,7 @@ vi.mock('@epam/ai-dial-react-file-manager', async (importOriginal) => {
 });
 
 vi.mock('@epam/ai-dial-ui-kit', () => ({
+  DIAL_KIT_ICON_STROKE: 1.5,
   DIAL_ICON_SIZE: { LG: 24, MD: 20, SM: 16 },
   EditorThemes: { dark: 'dark', light: 'light' },
   Accordion: ({

--- a/libs/skill-editor/src/components/SkillEditor/tests/SkillEditorFiles.spec.tsx
+++ b/libs/skill-editor/src/components/SkillEditor/tests/SkillEditorFiles.spec.tsx
@@ -63,6 +63,7 @@ vi.mock('@epam/ai-dial-react-file-manager', async (importOriginal) => {
 });
 
 vi.mock('@epam/ai-dial-ui-kit', () => ({
+  DIAL_KIT_ICON_STROKE: 1.5,
   DIAL_ICON_SIZE: { LG: 24, MD: 20, SM: 16 },
   EditorThemes: { dark: 'dark', light: 'light' },
   Accordion: ({

--- a/libs/skill-editor/src/components/SkillFileDropOverlay/SkillFileDropOverlay.tsx
+++ b/libs/skill-editor/src/components/SkillFileDropOverlay/SkillFileDropOverlay.tsx
@@ -1,4 +1,5 @@
 import { mergeClasses } from '@epam/ai-dial-chat-shared';
+import { DIAL_KIT_ICON_STROKE } from '@epam/ai-dial-ui-kit';
 import { IconUpload } from '@tabler/icons-react';
 import type { FC } from 'react';
 import type { SkillEditorLabels } from '../../models/skill-editor-props';
@@ -32,7 +33,12 @@ export const SkillFileDropOverlay: FC<SkillFileDropOverlayProps> = ({
       )}
     >
       <div className="flex flex-col items-center text-center">
-        <IconUpload size={100} className="text-accent-primary" aria-hidden />
+        <IconUpload
+          size={100}
+          className="text-accent-primary"
+          aria-hidden
+          stroke={DIAL_KIT_ICON_STROKE}
+        />
         <span className="dial-h3-text mt-5">
           {t.dropOverlayTitle ?? 'Upload files'}
         </span>

--- a/libs/skill-editor/src/components/SkillFileUploadDialog/SkillFileUploadDialog.tsx
+++ b/libs/skill-editor/src/components/SkillFileUploadDialog/SkillFileUploadDialog.tsx
@@ -1,5 +1,6 @@
 import { formatFileSize } from '@epam/ai-dial-chat-shared';
 import {
+  DIAL_KIT_ICON_STROKE,
   ErrorText,
   FileDropzone,
   GhostButton,
@@ -252,7 +253,11 @@ export const SkillFileUploadDialog: FC<SkillFileUploadDialogProps> = ({
                   key={candidate.id}
                   className="flex items-center gap-2 rounded-lg border border-tertiary p-2"
                 >
-                  <IconFileText size={20} aria-hidden />
+                  <IconFileText
+                    size={20}
+                    aria-hidden
+                    stroke={DIAL_KIT_ICON_STROKE}
+                  />
                   <div className="flex min-w-0 flex-1 flex-col">
                     <span className="dial-small-text truncate">
                       {candidate.path}
@@ -271,7 +276,13 @@ export const SkillFileUploadDialog: FC<SkillFileUploadDialogProps> = ({
                     )}
                   </div>
                   <GhostIconButton
-                    icon={<IconTrashX size={16} aria-hidden />}
+                    icon={
+                      <IconTrashX
+                        size={16}
+                        aria-hidden
+                        stroke={DIAL_KIT_ICON_STROKE}
+                      />
+                    }
                     aria-label={
                       t.uploadRemoveCandidateLabel?.(candidate.path) ??
                       `Remove ${candidate.path}`

--- a/libs/skill-editor/src/components/SkillFileUploadDialog/tests/SkillFileUploadDialog.spec.tsx
+++ b/libs/skill-editor/src/components/SkillFileUploadDialog/tests/SkillFileUploadDialog.spec.tsx
@@ -11,6 +11,7 @@ import {
 import { SkillFileUploadDialog } from '../SkillFileUploadDialog';
 
 vi.mock('@epam/ai-dial-ui-kit', () => ({
+  DIAL_KIT_ICON_STROKE: 1.5,
   DIAL_ICON_SIZE: { LG: 24, MD: 20, SM: 16 },
   PopupSize: { Sm: 'sm', Md: 'md', Lg: 'lg' },
   Popup: ({

--- a/libs/source-panel/src/components/ConversationSourcesPanel/tests/ConversationSourcesPanel.spec.tsx
+++ b/libs/source-panel/src/components/ConversationSourcesPanel/tests/ConversationSourcesPanel.spec.tsx
@@ -39,6 +39,7 @@ vi.mock('@epam/ai-dial-sidebar', () => ({
 }));
 
 vi.mock('@epam/ai-dial-ui-kit', () => ({
+  DIAL_KIT_ICON_STROKE: 1.5,
   DIAL_ICON_SIZE: { LG: 24, SM: 16 },
   ElementSize: { Small: 'small' },
   mergeClasses: (...classes: (string | undefined)[]) =>

--- a/libs/source-panel/src/components/FilesSection/tests/FilesSection.spec.tsx
+++ b/libs/source-panel/src/components/FilesSection/tests/FilesSection.spec.tsx
@@ -5,6 +5,7 @@ import { describe, expect, it, vi } from 'vitest';
 import FilesSection from '../FilesSection';
 
 vi.mock('@epam/ai-dial-ui-kit', () => ({
+  DIAL_KIT_ICON_STROKE: 1.5,
   DIAL_ICON_SIZE: { SM: 16, MD: 20, LG: 24 },
   mergeClasses: (...classes: (string | undefined)[]) =>
     classes.filter(Boolean).join(' '),

--- a/libs/source-panel/src/components/SourcesSection/SourcesSection.tsx
+++ b/libs/source-panel/src/components/SourcesSection/SourcesSection.tsx
@@ -5,6 +5,7 @@ import {
 } from '@epam/ai-dial-chat-shared';
 import {
   DIAL_ICON_SIZE,
+  DIAL_KIT_ICON_STROKE,
   ElementSize,
   GhostIconButton,
   Highlight,
@@ -115,7 +116,11 @@ const SourcesSection: FC<SourcesSectionProps> = ({
               <GhostIconButton
                 size={ElementSize.Small}
                 icon={
-                  <IconCopy size={DIAL_ICON_SIZE.SM} stroke={1.5} aria-hidden />
+                  <IconCopy
+                    size={DIAL_ICON_SIZE.SM}
+                    stroke={DIAL_KIT_ICON_STROKE}
+                    aria-hidden
+                  />
                 }
                 aria-label={copyLabel}
                 onClick={() => void handleCopy(source.url)}

--- a/libs/source-panel/src/components/SourcesSection/tests/SourcesSection.spec.tsx
+++ b/libs/source-panel/src/components/SourcesSection/tests/SourcesSection.spec.tsx
@@ -5,6 +5,7 @@ import { QuotationSource } from '../../../models/quotation-source';
 import SourcesSection from '../SourcesSection';
 
 vi.mock('@epam/ai-dial-ui-kit', () => ({
+  DIAL_KIT_ICON_STROKE: 1.5,
   DIAL_ICON_SIZE: { SM: 16 },
   ElementSize: { Small: 'small' },
   mergeClasses: (...classes: (string | undefined)[]) =>

--- a/libs/starter-buttons/package.json
+++ b/libs/starter-buttons/package.json
@@ -21,7 +21,7 @@
     "@epam/ai-dial-chat-shared": "*",
     "@tabler/icons-react": "^3.44.0",
     "react": "^19.0.0",
-    "@epam/ai-dial-ui-kit": "^0.14.0-dev.13"
+    "@epam/ai-dial-ui-kit": "^0.14.0-dev.15"
   },
   "nx": {
     "tags": [

--- a/libs/starter-buttons/src/components/StarterButtons/StarterButtons.tsx
+++ b/libs/starter-buttons/src/components/StarterButtons/StarterButtons.tsx
@@ -1,9 +1,10 @@
 import { BASE_MD_ICON_PROPS } from '@epam/ai-dial-chat-shared';
 import type { DropdownItem } from '@epam/ai-dial-ui-kit';
 import {
+  ButtonAppearance,
+  DIAL_KIT_ICON_STROKE,
   Dropdown,
   NeutralButton,
-  ButtonAppearance,
   NeutralIconButton,
 } from '@epam/ai-dial-ui-kit';
 import { IconDots, IconDotsVertical } from '@tabler/icons-react';
@@ -150,9 +151,12 @@ export const StarterButtons: FC<StarterButtonsProps> = ({
                 appearance={ButtonAppearance.Outlined}
                 icon={
                   isMobile ? (
-                    <IconDots {...iconProps} />
+                    <IconDots {...iconProps} stroke={DIAL_KIT_ICON_STROKE} />
                   ) : (
-                    <IconDotsVertical {...iconProps} />
+                    <IconDotsVertical
+                      {...iconProps}
+                      stroke={DIAL_KIT_ICON_STROKE}
+                    />
                   )
                 }
                 aria-label={labels.overflow}

--- a/libs/usage-dashboard/package.json
+++ b/libs/usage-dashboard/package.json
@@ -20,7 +20,7 @@
   "peerDependencies": {
     "@epam/ai-dial-chat-api-client": "*",
     "@epam/ai-dial-chat-shared": "*",
-    "@epam/ai-dial-ui-kit": "^0.14.0-dev.13",
+    "@epam/ai-dial-ui-kit": "^0.14.0-dev.15",
     "@tabler/icons-react": "^3.44.0",
     "react": "^19.2.7"
   },

--- a/libs/usage-dashboard/src/components/ModelLimitsSection/ModelLimitsSection.module.scss
+++ b/libs/usage-dashboard/src/components/ModelLimitsSection/ModelLimitsSection.module.scss
@@ -15,12 +15,14 @@
 }
 
 .headerRow {
-  border-block-end: 1px solid
+  /* Dividers inside the table sit on the thin stroke (0.5px), one step below
+     the 1px main stroke controls and standalone dividers use. */
+  border-block-end: 0.5px solid
     var(--mls-row-divider, var(--stroke-tertiary, #e0e6f0));
 }
 
 .row {
-  border-block-start: 1px solid
+  border-block-start: 0.5px solid
     var(--mls-row-divider, var(--stroke-tertiary, #e0e6f0));
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "libs/*"
       ],
       "dependencies": {
-        "@epam/ai-dial-react-file-manager": "0.2.0-dev.7",
+        "@epam/ai-dial-react-file-manager": "0.2.0-dev.9",
         "@epam/ai-dial-react-pdf-highlighter": "0.2.0-dev.28",
         "@epam/ai-dial-shared": "0.48.0",
         "@epam/ai-dial-typescript-sdk": "0.1.0-dev.39",
@@ -470,7 +470,7 @@
       "license": "Apache-2.0",
       "peerDependencies": {
         "@epam/ai-dial-chat-shared": "*",
-        "@epam/ai-dial-react-file-manager": "^0.2.0-dev.7",
+        "@epam/ai-dial-react-file-manager": "^0.2.0-dev.9",
         "@epam/ai-dial-ui-kit": "*",
         "@tabler/icons-react": "^3.0.0",
         "react": "^19.0.0"
@@ -541,7 +541,7 @@
       "license": "Apache-2.0",
       "peerDependencies": {
         "@epam/ai-dial-chat-shared": "*",
-        "@epam/ai-dial-react-file-manager": "^0.2.0-dev.7",
+        "@epam/ai-dial-react-file-manager": "^0.2.0-dev.9",
         "@epam/ai-dial-ui-kit": "*",
         "@tabler/icons-react": "^3.0.0",
         "react": "^19.0.0"
@@ -2604,9 +2604,9 @@
       "link": true
     },
     "node_modules/@epam/ai-dial-react-file-manager": {
-      "version": "0.2.0-dev.7",
-      "resolved": "https://registry.npmjs.org/@epam/ai-dial-react-file-manager/-/ai-dial-react-file-manager-0.2.0-dev.7.tgz",
-      "integrity": "sha512-Vx6mI9qSn70RrTxRZ5pMBvHeNKZ4wtc3jL+zd7dWr+DqhwKNaRVLptpdIPLtITqYXQPTtRXDBEDOiUl447bXRA==",
+      "version": "0.2.0-dev.9",
+      "resolved": "https://registry.npmjs.org/@epam/ai-dial-react-file-manager/-/ai-dial-react-file-manager-0.2.0-dev.9.tgz",
+      "integrity": "sha512-HlCDrfShxWTEYrNIQIw0Ytp9isfx9CsNT09YxAf46YKzbS6uWbA1qTqtfIs1othtD9V402trB7MvMVqd8vclYg==",
       "license": "Apache-2.0",
       "dependencies": {
         "classnames": "^2.5.1",
@@ -2617,7 +2617,7 @@
         "npm": ">=10.7.0"
       },
       "peerDependencies": {
-        "@epam/ai-dial-ui-kit": "^0.14.0-dev.13",
+        "@epam/ai-dial-ui-kit": "^0.14.0-dev.15",
         "@tabler/icons-react": "^3.41.1",
         "ag-grid-community": "^35.2.1",
         "ag-grid-react": "^35.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@epam/ai-dial-react-pdf-highlighter": "0.2.0-dev.28",
         "@epam/ai-dial-shared": "0.48.0",
         "@epam/ai-dial-typescript-sdk": "0.1.0-dev.39",
-        "@epam/ai-dial-ui-kit": "^0.14.0-dev.13",
+        "@epam/ai-dial-ui-kit": "^0.14.0-dev.15",
         "@epam/ai-dial-visualizer-connector": "0.48.0",
         "@epam/pdf-highlighter-kit": "^0.0.18",
         "@mcp-ui/client": "^7.1.1",
@@ -206,7 +206,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@epam/ai-dial-chat-overlay": "*",
-        "@epam/ai-dial-ui-kit": "^0.14.0-dev.13"
+        "@epam/ai-dial-ui-kit": "^0.14.0-dev.15"
       }
     },
     "apps/mcp-app-sandbox": {
@@ -245,7 +245,7 @@
         "@epam/ai-dial-react-pdf-highlighter": "*",
         "@epam/ai-dial-shared": "0.48.0",
         "@epam/ai-dial-sidebar": "0.0.1",
-        "@epam/ai-dial-ui-kit": "^0.14.0-dev.13",
+        "@epam/ai-dial-ui-kit": "^0.14.0-dev.15",
         "@epam/ai-dial-visualizer-connector": "0.48.0",
         "@epam/pdf-highlighter-kit": ">=0.0.14",
         "@mcp-ui/client": "^7.1.1",
@@ -262,7 +262,7 @@
       "license": "Apache-2.0",
       "peerDependencies": {
         "@epam/ai-dial-chat-shared": "*",
-        "@epam/ai-dial-ui-kit": "^0.14.0-dev.13",
+        "@epam/ai-dial-ui-kit": "^0.14.0-dev.15",
         "@tabler/icons-react": "^3.44.0",
         "react": "^19.0.0"
       }
@@ -273,7 +273,7 @@
       "license": "Apache-2.0",
       "peerDependencies": {
         "@epam/ai-dial-chat-shared": "*",
-        "@epam/ai-dial-ui-kit": "^0.14.0-dev.13",
+        "@epam/ai-dial-ui-kit": "^0.14.0-dev.15",
         "@tabler/icons-react": "^3.44.0",
         "react": "^19.0.0"
       }
@@ -285,7 +285,7 @@
       "peerDependencies": {
         "@epam/ai-dial-chat-shared": "*",
         "@epam/ai-dial-publish-panel": "*",
-        "@epam/ai-dial-ui-kit": "^0.14.0-dev.13",
+        "@epam/ai-dial-ui-kit": "^0.14.0-dev.15",
         "@tabler/icons-react": "^3.0.0",
         "ag-grid-community": "35.3.0",
         "react": "^19.0.0"
@@ -349,7 +349,7 @@
         "unified": "^11.0.5"
       },
       "peerDependencies": {
-        "@epam/ai-dial-ui-kit": "^0.14.0-dev.13",
+        "@epam/ai-dial-ui-kit": "^0.14.0-dev.15",
         "@tabler/icons-react": "^3.44.0",
         "katex": "^0.16.22",
         "react": "^19.2.6",
@@ -372,7 +372,7 @@
       "peerDependencies": {
         "@epam/ai-dial-attachment-input": "*",
         "@epam/ai-dial-chat-shared": "*",
-        "@epam/ai-dial-ui-kit": "^0.14.0-dev.13",
+        "@epam/ai-dial-ui-kit": "^0.14.0-dev.15",
         "@tabler/icons-react": "^3.44.0",
         "react": "^19.0.0",
         "react-dom": "^19.2.6"
@@ -383,9 +383,9 @@
       "version": "0.0.1",
       "license": "Apache-2.0",
       "peerDependencies": {
+        "@epam/ai-dial-attachment-input": "*",
         "@epam/ai-dial-chat-shared": "*",
-        "@epam/ai-dial-conversation-input": "*",
-        "@epam/ai-dial-ui-kit": "^0.14.0-dev.13",
+        "@epam/ai-dial-ui-kit": "^0.14.0-dev.15",
         "@tabler/icons-react": "^3.0.0",
         "react": "^19.0.0",
         "react-markdown": "^10.1.0"
@@ -396,7 +396,7 @@
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@epam/ai-dial-ui-kit": "^0.14.0-dev.13",
+        "@epam/ai-dial-ui-kit": "^0.14.0-dev.15",
         "react-window": "^2.2.7"
       },
       "peerDependencies": {
@@ -412,7 +412,7 @@
       "license": "Apache-2.0",
       "peerDependencies": {
         "@epam/ai-dial-chat-shared": "*",
-        "@epam/ai-dial-ui-kit": "^0.14.0-dev.13",
+        "@epam/ai-dial-ui-kit": "^0.14.0-dev.15",
         "@tabler/icons-react": "^3.0.0",
         "react": "^19.0.0"
       }
@@ -507,7 +507,7 @@
       "license": "Apache-2.0",
       "peerDependencies": {
         "@epam/ai-dial-chat-shared": "*",
-        "@epam/ai-dial-ui-kit": "^0.14.0-dev.13",
+        "@epam/ai-dial-ui-kit": "^0.14.0-dev.15",
         "@tabler/icons-react": "^3.44.0",
         "react": "^19.2.7"
       }
@@ -552,8 +552,8 @@
       "version": "0.0.1",
       "license": "Apache-2.0",
       "peerDependencies": {
+        "@epam/ai-dial-attachment-input": "*",
         "@epam/ai-dial-chat-shared": "*",
-        "@epam/ai-dial-conversation-input": "*",
         "@epam/ai-dial-sidebar": "*",
         "@epam/ai-dial-ui-kit": "*",
         "@tabler/icons-react": "^3.0.0",
@@ -566,7 +566,7 @@
       "license": "Apache-2.0",
       "peerDependencies": {
         "@epam/ai-dial-chat-shared": "*",
-        "@epam/ai-dial-ui-kit": "^0.14.0-dev.13",
+        "@epam/ai-dial-ui-kit": "^0.14.0-dev.15",
         "@tabler/icons-react": "^3.44.0",
         "react": "^19.0.0"
       }
@@ -578,7 +578,7 @@
       "peerDependencies": {
         "@epam/ai-dial-chat-api-client": "*",
         "@epam/ai-dial-chat-shared": "*",
-        "@epam/ai-dial-ui-kit": "^0.14.0-dev.13",
+        "@epam/ai-dial-ui-kit": "^0.14.0-dev.15",
         "@tabler/icons-react": "^3.44.0",
         "react": "^19.2.7"
       }
@@ -2692,9 +2692,9 @@
       }
     },
     "node_modules/@epam/ai-dial-ui-kit": {
-      "version": "0.14.0-dev.13",
-      "resolved": "https://registry.npmjs.org/@epam/ai-dial-ui-kit/-/ai-dial-ui-kit-0.14.0-dev.13.tgz",
-      "integrity": "sha512-kcolJxIcLjNwCHQcLSqDtC1fSaw7/wERP8d5SCdp+gxU2S937OwtrjDWoenAt/BGS8eLPcy7XuOE+i8FquLDcw==",
+      "version": "0.14.0-dev.15",
+      "resolved": "https://registry.npmjs.org/@epam/ai-dial-ui-kit/-/ai-dial-ui-kit-0.14.0-dev.15.tgz",
+      "integrity": "sha512-UAf6C7UIDHC0QQ3AxKjoctluBxEHOZkfn7B6Tp80bRRcdhV4IPfoXoKbpcbpb+7ha9JML8F1Ahhr9dNqHoFdjA==",
       "license": "Apache-2.0",
       "dependencies": {
         "ag-grid-community": "^35.2.1",

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "@epam/ai-dial-react-pdf-highlighter": "0.2.0-dev.28",
     "@epam/ai-dial-shared": "0.48.0",
     "@epam/ai-dial-typescript-sdk": "0.1.0-dev.39",
-    "@epam/ai-dial-ui-kit": "^0.14.0-dev.13",
+    "@epam/ai-dial-ui-kit": "^0.14.0-dev.15",
     "@epam/ai-dial-visualizer-connector": "0.48.0",
     "@epam/pdf-highlighter-kit": "^0.0.18",
     "@mcp-ui/client": "^7.1.1",

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "webpack-node-externals": "^3.0.0"
   },
   "dependencies": {
-    "@epam/ai-dial-react-file-manager": "0.2.0-dev.7",
+    "@epam/ai-dial-react-file-manager": "0.2.0-dev.9",
     "@epam/ai-dial-react-pdf-highlighter": "0.2.0-dev.28",
     "@epam/ai-dial-shared": "0.48.0",
     "@epam/ai-dial-typescript-sdk": "0.1.0-dev.39",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -16,7 +16,7 @@ const shadowColors = {
   'xs-1': 'var(--shadow-xs-1, #2764D933)', // blue-500 alpha-20
   'xs-2': 'var(--shadow-xs-2, #161B2D08)', // grey-1000 alpha-3
   sm: 'var(--shadow-sm, #2764D914)', // blue-500 alpha-8
-  md: 'var(--shadow-md, #2764D90A)', // blue-500 alpha-4
+  md: 'var(--shadow-md, #2764D90F)', // blue-500 alpha-6
   lg: 'var(--shadow-lg, #2764D914)', // blue-500 alpha-8
 };
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -13,8 +13,9 @@ const backgroundsColors = {
 };
 
 const shadowColors = {
-  'xs-sm-1': 'var(--shadow-xs-sm-1, #2764D933)', // blue-500 alpha-20
-  'xs-sm-2': 'var(--shadow-xs-sm-2, #161B2D08)', // grey-1000 alpha-3
+  'xs-1': 'var(--shadow-xs-1, #2764D933)', // blue-500 alpha-20
+  'xs-2': 'var(--shadow-xs-2, #161B2D08)', // grey-1000 alpha-3
+  sm: 'var(--shadow-sm, #2764D914)', // blue-500 alpha-8
   md: 'var(--shadow-md, #2764D90A)', // blue-500 alpha-4
   lg: 'var(--shadow-lg, #2764D914)', // blue-500 alpha-8
 };
@@ -183,14 +184,9 @@ module.exports = {
         ...visualBgColors,
       },
       boxShadow: {
-        // xs — Button-Pressed; sm — Button-Default, Side Panel
-        xs: `0 1px 4px 0 ${shadowColors['xs-sm-1']}, 0 1px 2px 0 ${shadowColors['xs-sm-2']}`,
-        sm: `0 2px 12px 0 ${shadowColors['xs-sm-1']}, 0 2px 6px 0 ${shadowColors['xs-sm-2']}`,
-        /*
-         * md — Button-Hover, Card-Default, Input; lg — Card-Hover. Both are a
-         * single wide blue layer: the grey layer would only muddy it at this
-         * size.
-         */
+        xs: `0 1px 4px 0 ${shadowColors['xs-1']}, 0 1px 2px 0 ${shadowColors['xs-2']}`,
+        'chat-button': `0 2px 12px 0 ${shadowColors['xs-1']}, 0 2px 6px 0 ${shadowColors['xs-2']}`,
+        sm: `0 8px 10px 0 ${shadowColors.sm}`,
         md: `0 8px 24px 0 ${shadowColors.md}`,
         lg: `0 8px 44px 0 ${shadowColors.lg}`,
       },


### PR DESCRIPTION
## What

Two related UI fixes on this branch.

**Colors / button styling** (`02c1c65`)
- `Input`, `ConversationPanel`, and `NavigationPanel` color corrections.
- `useOpenAttachmentCanvas` adjustment with a covering spec.

**Citation card quote layout** (`8552798`)
- `line-clamp-6` moved from each markdown `<p>` to the quote block as a whole, so a markdown list inside a citation is bounded too instead of growing the card.
- Quote typography and color now reach the list and bold spans, which previously fell back to `MarkdownRenderer` defaults (16px `dial-body-paragraph-semi-text` inside 14px quote text).
- New `typography.quoteStrongClassName` (defaults to `dial-small-semi-text`) so the bold step stays in the same scale as `quoteClassName`.
- List indent inside the card reduced from the renderer's base `ps-5` to `ps-3`.
- The annotation title is rendered only when the active annotation actually has one. The previous placeholder (`hasSwitcher && groupHasTitle`) rendered an empty `<p class="min-h-[1lh]">`, leaving ~36px of dead space above the quote whenever a group mixed titled and untitled citations.

## Trade-off

Dropping the title placeholder means the card height can shift by ~36px when paging between a citation that has a title and one that does not. That reservation was the source of the visible gap; if stable height matters more, it can come back on the content container instead of as an empty paragraph.

## Verification

- `nx lint @epam/ai-dial-quotations` — pass
- `nx typecheck @epam/ai-dial-quotations` — pass
- `nx test @epam/ai-dial-quotations` — fails, and **fails identically on a clean tree** (all 8 spec files die at import with `TypeError: Cannot read properties of undefined (reading 'config')`); pre-existing, not from these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
