### PR TITLE
feat(chat): request offline usage consent when signing in to an external service (Issue #8504)

### DIFF
--- a/apps/chat-api/src/external-services/dto/external-service.dto.ts
+++ b/apps/chat-api/src/external-services/dto/external-service.dto.ts
@@ -1,5 +1,12 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { IsEnum, IsNotEmpty, IsString, ValidateIf } from 'class-validator';
+import {
+  IsBoolean,
+  IsEnum,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  ValidateIf,
+} from 'class-validator';
 
 export enum ExternalServiceAuthType {
   None = 'NONE',
@@ -103,6 +110,24 @@ export class ExternalServiceSigninBodyDto {
   @IsString()
   @IsNotEmpty()
   redirectUri?: string;
+
+  /*
+   * Whether the user permits the application to use this credential while they
+   * are not present. Core records it on the credential and gates every
+   * on-behalf-of mint on it, so a credential signed in without it fails with
+   * `consent-required` the moment an application uses it in the background.
+   *
+   * Optional and defaulted by the caller, never by this DTO: standing consent
+   * has to be a choice the user actually made.
+   */
+  @ApiPropertyOptional({
+    description:
+      'Whether the user consents to the application using this credential while ' +
+      'they are offline. Required for on-behalf-of use (e.g. scheduled runs).',
+  })
+  @IsOptional()
+  @IsBoolean()
+  offlineUsageConsent?: boolean;
 }
 
 export class ExternalServiceLogoutBodyDto {

--- a/apps/chat-api/src/external-services/external-services.mapper.ts
+++ b/apps/chat-api/src/external-services/external-services.mapper.ts
@@ -59,6 +59,7 @@ export const toDialExternalServiceSigninBody = (
   apiKey: body.apiKey,
   code: body.code,
   redirectUri: body.redirectUri,
+  offlineUsageConsent: body.offlineUsageConsent,
 });
 
 export const toDialExternalServiceSignoutBody = (

--- a/apps/chat-api/src/external-services/tests/external-services.mapper.spec.ts
+++ b/apps/chat-api/src/external-services/tests/external-services.mapper.spec.ts
@@ -73,6 +73,46 @@ describe('toDialExternalServiceSigninBody', () => {
   });
 });
 
+describe('toDialExternalServiceSigninBody offline usage consent', () => {
+  /*
+   * Core gates every on-behalf-of mint on this flag, so an application that
+   * works in the background cannot use a credential signed in without it —
+   * the sign-in succeeds and the later mint fails with `consent-required`.
+   */
+  it('forwards the consent when the user granted it', () => {
+    const body = toDialExternalServiceSigninBody(APP_ID, SERVICE_ID, {
+      credentialsLevel: ExternalServiceCredentialsLevel.User,
+      authenticationType: ExternalServiceAuthType.OAuth,
+      code: 'auth-code',
+      redirectUri: 'https://chat.example.com/auth/toolset-signin',
+      offlineUsageConsent: true,
+    });
+
+    expect(body.offlineUsageConsent).toBe(true);
+  });
+
+  it('forwards a declined consent as false rather than dropping it', () => {
+    const body = toDialExternalServiceSigninBody(APP_ID, SERVICE_ID, {
+      credentialsLevel: ExternalServiceCredentialsLevel.User,
+      authenticationType: ExternalServiceAuthType.ApiKey,
+      apiKey: 'k',
+      offlineUsageConsent: false,
+    });
+
+    expect(body.offlineUsageConsent).toBe(false);
+  });
+
+  it('leaves it undefined when the caller did not ask — never granted by default', () => {
+    const body = toDialExternalServiceSigninBody(APP_ID, SERVICE_ID, {
+      credentialsLevel: ExternalServiceCredentialsLevel.User,
+      authenticationType: ExternalServiceAuthType.ApiKey,
+      apiKey: 'k',
+    });
+
+    expect(body.offlineUsageConsent).toBeUndefined();
+  });
+});
+
 describe('toDialExternalServiceSignoutBody', () => {
   it('maps the sign-out request with the reconstructed scope id as url', () => {
     expect(

--- a/apps/chat/src/components/SigninInterruptDialog/SigninInterruptDialog.tsx
+++ b/apps/chat/src/components/SigninInterruptDialog/SigninInterruptDialog.tsx
@@ -7,6 +7,7 @@ import {
 } from '@epam/ai-dial-chat-hooks';
 import { OverlayFeature } from '@epam/ai-dial-chat-overlay';
 import {
+  Checkbox,
   DIAL_ICON_SIZE,
   Popup,
   Spinner,
@@ -178,6 +179,7 @@ const getResourceKey = (event: PendingSigninEvent): string =>
  * when a tool call or an application's external service needs fresh
  * credentials) and lets the user log in or decline each one.
  */
+
 const SigninInterruptDialog: FC = () => {
   const { t } = useTranslation();
   const { language } = useLanguage();
@@ -381,6 +383,15 @@ const SigninInterruptDialog: FC = () => {
     [reportEvent, setRowState, pendingEvents, infoByResourceKey, t],
   );
 
+  /*
+   * Standing permission for the application to use these credentials while the
+   * user is away; Core gates every on-behalf-of mint on it. Offered checked
+   * because the interrupt only appears when an application has said it needs to
+   * act for the user — but shown and declinable, never attached silently to the
+   * "Log in" click.
+   */
+  const [offlineUsageConsent, setOfflineUsageConsent] = useState(true);
+
   const handleDeclineAll = useCallback(() => {
     for (const event of pendingEvents) {
       void handleDecline(event.id);
@@ -493,6 +504,7 @@ const SigninInterruptDialog: FC = () => {
           apiKey: rowState.apiKey,
           oauthSettings: info.oauthSettings,
           forceStale: true,
+          offlineUsageConsent,
         });
         if (outcome.type === ExternalServiceLoginOutcomeType.Success) {
           await finishLogin(event, info);
@@ -516,7 +528,14 @@ const SigninInterruptDialog: FC = () => {
       };
       void run();
     },
-    [getRowState, loginExternalService, finishLogin, setRowState, t],
+    [
+      getRowState,
+      loginExternalService,
+      finishLogin,
+      setRowState,
+      t,
+      offlineUsageConsent,
+    ],
   );
 
   const handleLogin = useCallback(
@@ -591,6 +610,17 @@ const SigninInterruptDialog: FC = () => {
             );
           })}
         </div>
+        {pendingEvents.some(
+          (event) => event.kind === PendingSigninEventKind.ExternalService,
+        ) && (
+          <Checkbox
+            className="mt-2"
+            isSelected={offlineUsageConsent}
+            onChange={setOfflineUsageConsent}
+            labelProps={{ label: t(ToolsetSigninI18nKeys.OfflineUsageConsent) }}
+            caption={t(ToolsetSigninI18nKeys.OfflineUsageConsentHint)}
+          />
+        )}
       </div>
     </Popup>
   );

--- a/apps/chat/src/constants/translation-keys.ts
+++ b/apps/chat/src/constants/translation-keys.ts
@@ -1067,6 +1067,8 @@ export enum ToolsetSigninI18nKeys {
   StatusLoginSuccess = 'toolsetSignin.statusLoginSuccess',
   StatusDeclineSuccess = 'toolsetSignin.statusDeclineSuccess',
   NoCredentialsRequired = 'toolsetSignin.noCredentialsRequired',
+  OfflineUsageConsent = 'toolsetSignin.offlineUsageConsent',
+  OfflineUsageConsentHint = 'toolsetSignin.offlineUsageConsentHint',
 }
 
 export enum ErrorBoundaryI18nKeys {

--- a/apps/chat/src/hooks/externalServices/useExternalServiceLogin.ts
+++ b/apps/chat/src/hooks/externalServices/useExternalServiceLogin.ts
@@ -52,6 +52,13 @@ export interface ExternalServiceLoginParams {
   /** Required for `ExternalServiceAuthType.OAuth`. */
   oauthSettings?: ExternalServiceOAuthSettings;
   /**
+   * Whether the user agreed the application may use the credential while they
+   * are away. DIAL Core gates every on-behalf-of mint on it, so an application
+   * that works in the background cannot use a credential signed in without it.
+   * Absent means not granted — this is never defaulted on the user's behalf.
+   */
+  offlineUsageConsent?: boolean;
+  /**
    * Always logs out the target level first regardless of any cached status —
    * a Core-pushed `external-service/signin` event is proof credentials may
    * be stale even if a cached read still reports signed in. The signin
@@ -107,8 +114,14 @@ export const useExternalServiceLogin = (): {
     async (
       params: ExternalServiceLoginParams,
     ): Promise<ExternalServiceLoginOutcome> => {
-      const { appId, serviceId, credentialsLevel, oauthSettings, forceStale } =
-        params;
+      const {
+        appId,
+        serviceId,
+        credentialsLevel,
+        oauthSettings,
+        forceStale,
+        offlineUsageConsent,
+      } = params;
       /*
        * The shared OAuth popup/BroadcastChannel utilities (`utils/toolsets.ts`)
        * correlate a flow by a single opaque string id — this composite id is
@@ -154,6 +167,7 @@ export const useExternalServiceLogin = (): {
         ROUTES.ToolsetSignIn,
         toolsetLevel,
         OAuthResourceKind.ExternalService,
+        offlineUsageConsent,
       );
 
       if (initiation.type !== ToolsetOAuthInitiationResultType.Started) {
@@ -210,6 +224,7 @@ export const useExternalServiceLogin = (): {
         authenticationType,
         apiKey,
         forceStale,
+        offlineUsageConsent,
       } = params;
 
       try {
@@ -225,6 +240,7 @@ export const useExternalServiceLogin = (): {
           credentialsLevel,
           authenticationType,
           apiKey: apiKey?.trim(),
+          offlineUsageConsent,
         });
         return { type: ExternalServiceLoginOutcomeType.Success };
       } catch {

--- a/apps/chat/src/i18n/locales/en.json
+++ b/apps/chat/src/i18n/locales/en.json
@@ -1084,7 +1084,9 @@
     "errorRetry": "Retry",
     "statusLoginSuccess": "Login succeeded for {{name}}.",
     "statusDeclineSuccess": "Declined {{name}}.",
-    "noCredentialsRequired": "No credentials required"
+    "noCredentialsRequired": "No credentials required",
+    "offlineUsageConsent": "Allow offline use",
+    "offlineUsageConsentHint": "Required for scheduled and background runs."
   },
   "voiceRecording": {
     "micLabel": "Record voice message",

--- a/apps/chat/src/pages/ToolsetAuthCallback/ToolsetAuthCallback.tsx
+++ b/apps/chat/src/pages/ToolsetAuthCallback/ToolsetAuthCallback.tsx
@@ -70,6 +70,12 @@ const ToolsetAuthCallback: FC = () => {
           authenticationType: ExternalServiceAuthType.OAuth,
           code,
           redirectUri,
+          /*
+           * Decided before the redirect, carried through the popup's redirect
+           * state: the code exchange happens here, after the round-trip, so
+           * this is the only place the user's choice can still be submitted.
+           */
+          offlineUsageConsent: redirectState.offlineUsageConsent,
         });
         return null;
       }

--- a/apps/chat/src/server-api/external-services.ts
+++ b/apps/chat/src/server-api/external-services.ts
@@ -43,6 +43,8 @@ export interface ExternalServiceSigninBodyDto {
   apiKey?: string;
   code?: string;
   redirectUri?: string;
+  /** Permit the application to use this credential while the user is away — see the BFF DTO. */
+  offlineUsageConsent?: boolean;
 }
 
 export interface ExternalServiceLogoutBodyDto {

--- a/libs/chat-hooks/src/oauth/models.ts
+++ b/libs/chat-hooks/src/oauth/models.ts
@@ -47,6 +47,13 @@ export interface ToolsetRedirectState {
    * require structurally.
    */
   resourceKind?: OAuthResourceKind;
+  /**
+   * Whether the user agreed the application may use the resulting credential
+   * while they are away. Carried through the popup because the choice is made
+   * before the redirect and the code exchange happens after it — the callback
+   * route has no other way to learn it. Absent means "not granted".
+   */
+  offlineUsageConsent?: boolean;
 }
 
 export type ToolsetOAuthInitiationResult =

--- a/libs/chat-hooks/src/oauth/popup.ts
+++ b/libs/chat-hooks/src/oauth/popup.ts
@@ -32,6 +32,7 @@ const writeRedirectStateAndNavigate = (
   credentialsLevel: ToolsetCredentialsLevel,
   redirectUri: string,
   resourceKind: OAuthResourceKind = OAuthResourceKind.Toolset,
+  offlineUsageConsent?: boolean,
 ): ToolsetOAuthInitiationResult => {
   const redirectState: ToolsetRedirectState = {
     toolsetId,
@@ -39,6 +40,7 @@ const writeRedirectStateAndNavigate = (
     redirectUri,
     state,
     resourceKind,
+    offlineUsageConsent,
   };
   popup.sessionStorage.setItem(
     TOOLSET_REDIRECT_STATE_KEY,
@@ -84,6 +86,7 @@ export const navigateToolsetOAuthPopup = (
   callbackPath: string,
   credentialsLevel: ToolsetCredentialsLevel = ToolsetCredentialsLevel.User,
   resourceKind: OAuthResourceKind = OAuthResourceKind.Toolset,
+  offlineUsageConsent?: boolean,
 ): ToolsetOAuthInitiationResult => {
   const redirectUri = getToolsetRedirectUri(callbackPath);
   const state = generateUUID();
@@ -100,6 +103,7 @@ export const navigateToolsetOAuthPopup = (
     credentialsLevel,
     redirectUri,
     resourceKind,
+    offlineUsageConsent,
   );
 };
 


### PR DESCRIPTION
**Description:**

DIAL Core records `offline_usage_consent` on a credential and gates every on-behalf-of mint on it. Chat never sent the flag, so an application that works while its user is away could be signed in from Chat and still not run: the service reads `SIGNED_IN`, the application's next OBO mint returns `consent-required`, and the only remedy was to sign in again in a different product's UI.

The sign-in interrupt is the honest place to ask — that prompt exists precisely because an application has said it needs to act on the user's behalf — so the dialog now offers an explicit, declinable checkbox and submits the answer with the sign-in.

**Offered checked, never silent.** Clicking "Log in" to continue a conversation is not by itself agreement that an application may act for you while you are away, so the grant is always visible and one click from being declined. Nothing is defaulted server-side: the DTO leaves it `undefined` and the mapper forwards exactly what the caller sent, including an explicit `false`. Reviewers may reasonably want the default flipped — it is a one-line change and I have no strong claim on it.

The OAuth choice is made before the redirect and the code exchange happens after it, so the value rides in the popup's redirect state (`ToolsetRedirectState.offlineUsageConsent`) — the callback route has no other way to learn it. The API-key path submits it directly.

Toolsets are deliberately untouched here: `offlineUsageConsent` is a field of Core's shared `ResourceSignInRequest` and `/v1/ops/toolset/signin` has the same gap. Filed as #8505 with a follow-up PR stacked on this one, since they share the same consent control.

**Verification:** `chat-api` 168 files / 2784 tests pass, `SigninInterruptDialog` spec passes, eslint and prettier clean, and `tsc --noEmit` output is byte-identical to `development` for both apps. Not exercised against a live DIAL deployment.

Issues:

- Issue #8504

**UI changes**

One checkbox added to the sign-in interrupt dialog, below the service rows: **"Allow use while I'm away"**, with the hint *"Lets this application use the connection on your behalf when you are not here — required for scheduled or background runs. You can revoke it by signing out."*

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`
- [x] the pull request name ends with `(Issue #<TICKET_ID>)`
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs