### PR TITLE
feat(chat): request offline usage consent when signing in to a toolset (Issue #8505)

### DIFF
--- a/apps/chat-api/src/external-services/dto/external-service.dto.ts
+++ b/apps/chat-api/src/external-services/dto/external-service.dto.ts
@@ -1,5 +1,12 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { IsEnum, IsNotEmpty, IsString, ValidateIf } from 'class-validator';
+import {
+  IsBoolean,
+  IsEnum,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  ValidateIf,
+} from 'class-validator';
 
 export enum ExternalServiceAuthType {
   None = 'NONE',
@@ -103,6 +110,24 @@ export class ExternalServiceSigninBodyDto {
   @IsString()
   @IsNotEmpty()
   redirectUri?: string;
+
+  /*
+   * Whether the user permits the application to use this credential while they
+   * are not present. Core records it on the credential and gates every
+   * on-behalf-of mint on it, so a credential signed in without it fails with
+   * `consent-required` the moment an application uses it in the background.
+   *
+   * Optional and defaulted by the caller, never by this DTO: standing consent
+   * has to be a choice the user actually made.
+   */
+  @ApiPropertyOptional({
+    description:
+      'Whether the user consents to the application using this credential while ' +
+      'they are offline. Required for on-behalf-of use (e.g. scheduled runs).',
+  })
+  @IsOptional()
+  @IsBoolean()
+  offlineUsageConsent?: boolean;
 }
 
 export class ExternalServiceLogoutBodyDto {

--- a/apps/chat-api/src/external-services/external-services.mapper.ts
+++ b/apps/chat-api/src/external-services/external-services.mapper.ts
@@ -59,6 +59,7 @@ export const toDialExternalServiceSigninBody = (
   apiKey: body.apiKey,
   code: body.code,
   redirectUri: body.redirectUri,
+  offlineUsageConsent: body.offlineUsageConsent,
 });
 
 export const toDialExternalServiceSignoutBody = (

--- a/apps/chat-api/src/external-services/tests/external-services.mapper.spec.ts
+++ b/apps/chat-api/src/external-services/tests/external-services.mapper.spec.ts
@@ -73,6 +73,46 @@ describe('toDialExternalServiceSigninBody', () => {
   });
 });
 
+describe('toDialExternalServiceSigninBody offline usage consent', () => {
+  /*
+   * Core gates every on-behalf-of mint on this flag, so an application that
+   * works in the background cannot use a credential signed in without it —
+   * the sign-in succeeds and the later mint fails with `consent-required`.
+   */
+  it('forwards the consent when the user granted it', () => {
+    const body = toDialExternalServiceSigninBody(APP_ID, SERVICE_ID, {
+      credentialsLevel: ExternalServiceCredentialsLevel.User,
+      authenticationType: ExternalServiceAuthType.OAuth,
+      code: 'auth-code',
+      redirectUri: 'https://chat.example.com/auth/toolset-signin',
+      offlineUsageConsent: true,
+    });
+
+    expect(body.offlineUsageConsent).toBe(true);
+  });
+
+  it('forwards a declined consent as false rather than dropping it', () => {
+    const body = toDialExternalServiceSigninBody(APP_ID, SERVICE_ID, {
+      credentialsLevel: ExternalServiceCredentialsLevel.User,
+      authenticationType: ExternalServiceAuthType.ApiKey,
+      apiKey: 'k',
+      offlineUsageConsent: false,
+    });
+
+    expect(body.offlineUsageConsent).toBe(false);
+  });
+
+  it('leaves it undefined when the caller did not ask — never granted by default', () => {
+    const body = toDialExternalServiceSigninBody(APP_ID, SERVICE_ID, {
+      credentialsLevel: ExternalServiceCredentialsLevel.User,
+      authenticationType: ExternalServiceAuthType.ApiKey,
+      apiKey: 'k',
+    });
+
+    expect(body.offlineUsageConsent).toBeUndefined();
+  });
+});
+
 describe('toDialExternalServiceSignoutBody', () => {
   it('maps the sign-out request with the reconstructed scope id as url', () => {
     expect(

--- a/apps/chat-api/src/toolsets/auth/tests/toolsets-auth.service.spec.ts
+++ b/apps/chat-api/src/toolsets/auth/tests/toolsets-auth.service.spec.ts
@@ -99,6 +99,54 @@ describe('ToolsetsAuthService', () => {
       expect(sentBody.code).toBeUndefined();
     });
 
+    /*
+     * Core gates every on-behalf-of mint on this flag, so a toolset signed in
+     * without it works interactively and still fails with `consent-required`
+     * the moment an application reaches for it in the background.
+     */
+    it('forwards offline usage consent, including an explicit decline', async () => {
+      for (const consent of [true, false] as const) {
+        const { service } = makeWriteService();
+        const signinSpy = vi
+          .spyOn(service['dialClient'].client, 'toolsetSignin')
+          .mockResolvedValue(mutationSdkOk);
+
+        await service.loginToolset('user1', 'token', id, {
+          url: id,
+          credentialsLevel: ToolsetCredentialsLevel.User,
+          authenticationType: ToolsetAuthType.ApiKey,
+          apiKey: 'secret-key',
+          offlineUsageConsent: consent,
+        });
+
+        const sentBody = signinSpy.mock.calls[0][0].body as Record<
+          string,
+          unknown
+        >;
+        expect(sentBody.offlineUsageConsent).toBe(consent);
+      }
+    });
+
+    it('leaves offline usage consent unset when the caller did not ask', async () => {
+      const { service } = makeWriteService();
+      const signinSpy = vi
+        .spyOn(service['dialClient'].client, 'toolsetSignin')
+        .mockResolvedValue(mutationSdkOk);
+
+      await service.loginToolset('user1', 'token', id, {
+        url: id,
+        credentialsLevel: ToolsetCredentialsLevel.User,
+        authenticationType: ToolsetAuthType.ApiKey,
+        apiKey: 'secret-key',
+      });
+
+      const sentBody = signinSpy.mock.calls[0][0].body as Record<
+        string,
+        unknown
+      >;
+      expect(sentBody.offlineUsageConsent).toBeUndefined();
+    });
+
     it('posts OAuth code + redirectUri to the signin endpoint', async () => {
       const { service } = makeWriteService();
       const signinSpy = vi

--- a/apps/chat-api/src/toolsets/dto/toolset-auth.dto.ts
+++ b/apps/chat-api/src/toolsets/dto/toolset-auth.dto.ts
@@ -1,5 +1,6 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import {
+  IsBoolean,
   IsEnum,
   IsNotEmpty,
   IsOptional,
@@ -74,6 +75,25 @@ export class ToolsetLoginBodyDto {
   @IsString()
   @IsNotEmpty()
   redirectUri?: string;
+
+  /*
+   * Whether the user permits an application to use this toolset credential
+   * while they are NOT present. DIAL Core records it on the credential and
+   * gates every on-behalf-of mint on it, so a toolset signed in without it
+   * works interactively and still fails with `consent-required` the moment an
+   * application reaches for it in the background.
+   *
+   * Optional and defaulted by the caller, never by this DTO: standing consent
+   * has to be a choice the user actually made.
+   */
+  @ApiPropertyOptional({
+    description:
+      'Whether the user consents to an application using this credential while ' +
+      'they are offline. Required for on-behalf-of use (e.g. scheduled runs).',
+  })
+  @IsOptional()
+  @IsBoolean()
+  offlineUsageConsent?: boolean;
 }
 
 export class ToolsetLogoutBodyDto {

--- a/apps/chat-api/src/toolsets/utils/toolset-mapper.util.ts
+++ b/apps/chat-api/src/toolsets/utils/toolset-mapper.util.ts
@@ -261,6 +261,8 @@ export const toDialToolsetSigninBody = (
   const base = {
     url: resolveToolsetLoginUrl(toolsetName),
     credentialsLevel: toDialCredentialsLevel(body.credentialsLevel),
+    // Forwarded exactly as sent, including an explicit `false`; never defaulted here.
+    offlineUsageConsent: body.offlineUsageConsent,
   };
 
   if (body.authenticationType === ToolsetAuthType.ApiKey) {

--- a/apps/chat/src/components/SigninInterruptDialog/SigninInterruptDialog.tsx
+++ b/apps/chat/src/components/SigninInterruptDialog/SigninInterruptDialog.tsx
@@ -7,6 +7,7 @@ import {
 } from '@epam/ai-dial-chat-hooks';
 import { OverlayFeature } from '@epam/ai-dial-chat-overlay';
 import {
+  Checkbox,
   DIAL_ICON_SIZE,
   Popup,
   Spinner,
@@ -178,6 +179,7 @@ const getResourceKey = (event: PendingSigninEvent): string =>
  * when a tool call or an application's external service needs fresh
  * credentials) and lets the user log in or decline each one.
  */
+
 const SigninInterruptDialog: FC = () => {
   const { t } = useTranslation();
   const { language } = useLanguage();
@@ -381,6 +383,15 @@ const SigninInterruptDialog: FC = () => {
     [reportEvent, setRowState, pendingEvents, infoByResourceKey, t],
   );
 
+  /*
+   * Standing permission for the application to use these credentials while the
+   * user is away; Core gates every on-behalf-of mint on it. Offered checked
+   * because the interrupt only appears when an application has said it needs to
+   * act for the user — but shown and declinable, never attached silently to the
+   * "Log in" click.
+   */
+  const [offlineUsageConsent, setOfflineUsageConsent] = useState(true);
+
   const handleDeclineAll = useCallback(() => {
     for (const event of pendingEvents) {
       void handleDecline(event.id);
@@ -493,6 +504,7 @@ const SigninInterruptDialog: FC = () => {
           apiKey: rowState.apiKey,
           oauthSettings: info.oauthSettings,
           forceStale: true,
+          offlineUsageConsent,
         });
         if (outcome.type === ExternalServiceLoginOutcomeType.Success) {
           await finishLogin(event, info);
@@ -516,7 +528,14 @@ const SigninInterruptDialog: FC = () => {
       };
       void run();
     },
-    [getRowState, loginExternalService, finishLogin, setRowState, t],
+    [
+      getRowState,
+      loginExternalService,
+      finishLogin,
+      setRowState,
+      t,
+      offlineUsageConsent,
+    ],
   );
 
   const handleLogin = useCallback(
@@ -591,6 +610,17 @@ const SigninInterruptDialog: FC = () => {
             );
           })}
         </div>
+        {pendingEvents.some(
+          (event) => event.kind === PendingSigninEventKind.ExternalService,
+        ) && (
+          <Checkbox
+            className="mt-2"
+            isSelected={offlineUsageConsent}
+            onChange={setOfflineUsageConsent}
+            labelProps={{ label: t(ToolsetSigninI18nKeys.OfflineUsageConsent) }}
+            caption={t(ToolsetSigninI18nKeys.OfflineUsageConsentHint)}
+          />
+        )}
       </div>
     </Popup>
   );

--- a/apps/chat/src/components/SigninInterruptDialog/SigninInterruptDialog.tsx
+++ b/apps/chat/src/components/SigninInterruptDialog/SigninInterruptDialog.tsx
@@ -450,6 +450,7 @@ const SigninInterruptDialog: FC = () => {
           apiKey: rowState.apiKey,
           oauthSettings: info.oauthSettings,
           forceStale: true,
+          offlineUsageConsent,
         });
         if (outcome.type === ToolsetLoginOutcomeType.Success) {
           await refetchToolsets();
@@ -481,6 +482,7 @@ const SigninInterruptDialog: FC = () => {
       finishLogin,
       setRowState,
       t,
+      offlineUsageConsent,
     ],
   );
 
@@ -610,17 +612,13 @@ const SigninInterruptDialog: FC = () => {
             );
           })}
         </div>
-        {pendingEvents.some(
-          (event) => event.kind === PendingSigninEventKind.ExternalService,
-        ) && (
-          <Checkbox
-            className="mt-2"
-            isSelected={offlineUsageConsent}
-            onChange={setOfflineUsageConsent}
-            labelProps={{ label: t(ToolsetSigninI18nKeys.OfflineUsageConsent) }}
-            caption={t(ToolsetSigninI18nKeys.OfflineUsageConsentHint)}
-          />
-        )}
+        <Checkbox
+          className="mt-2"
+          isSelected={offlineUsageConsent}
+          onChange={setOfflineUsageConsent}
+          labelProps={{ label: t(ToolsetSigninI18nKeys.OfflineUsageConsent) }}
+          caption={t(ToolsetSigninI18nKeys.OfflineUsageConsentHint)}
+        />
       </div>
     </Popup>
   );

--- a/apps/chat/src/constants/translation-keys.ts
+++ b/apps/chat/src/constants/translation-keys.ts
@@ -1067,6 +1067,8 @@ export enum ToolsetSigninI18nKeys {
   StatusLoginSuccess = 'toolsetSignin.statusLoginSuccess',
   StatusDeclineSuccess = 'toolsetSignin.statusDeclineSuccess',
   NoCredentialsRequired = 'toolsetSignin.noCredentialsRequired',
+  OfflineUsageConsent = 'toolsetSignin.offlineUsageConsent',
+  OfflineUsageConsentHint = 'toolsetSignin.offlineUsageConsentHint',
 }
 
 export enum ErrorBoundaryI18nKeys {

--- a/apps/chat/src/hooks/externalServices/tests/useExternalServiceLogin.spec.ts
+++ b/apps/chat/src/hooks/externalServices/tests/useExternalServiceLogin.spec.ts
@@ -157,6 +157,8 @@ describe('useExternalServiceLogin', () => {
         ROUTES.ToolsetSignIn,
         'USER',
         'external-service',
+        // Offline usage consent — undefined here because the caller did not ask for it.
+        undefined,
       );
       expect(outcome).toEqual({
         type: ExternalServiceLoginOutcomeType.Success,

--- a/apps/chat/src/hooks/externalServices/useExternalServiceLogin.ts
+++ b/apps/chat/src/hooks/externalServices/useExternalServiceLogin.ts
@@ -52,6 +52,13 @@ export interface ExternalServiceLoginParams {
   /** Required for `ExternalServiceAuthType.OAuth`. */
   oauthSettings?: ExternalServiceOAuthSettings;
   /**
+   * Whether the user agreed the application may use the credential while they
+   * are away. DIAL Core gates every on-behalf-of mint on it, so an application
+   * that works in the background cannot use a credential signed in without it.
+   * Absent means not granted — this is never defaulted on the user's behalf.
+   */
+  offlineUsageConsent?: boolean;
+  /**
    * Always logs out the target level first regardless of any cached status —
    * a Core-pushed `external-service/signin` event is proof credentials may
    * be stale even if a cached read still reports signed in. The signin
@@ -107,8 +114,14 @@ export const useExternalServiceLogin = (): {
     async (
       params: ExternalServiceLoginParams,
     ): Promise<ExternalServiceLoginOutcome> => {
-      const { appId, serviceId, credentialsLevel, oauthSettings, forceStale } =
-        params;
+      const {
+        appId,
+        serviceId,
+        credentialsLevel,
+        oauthSettings,
+        forceStale,
+        offlineUsageConsent,
+      } = params;
       /*
        * The shared OAuth popup/BroadcastChannel utilities (`utils/toolsets.ts`)
        * correlate a flow by a single opaque string id — this composite id is
@@ -154,6 +167,7 @@ export const useExternalServiceLogin = (): {
         ROUTES.ToolsetSignIn,
         toolsetLevel,
         OAuthResourceKind.ExternalService,
+        offlineUsageConsent,
       );
 
       if (initiation.type !== ToolsetOAuthInitiationResultType.Started) {
@@ -210,6 +224,7 @@ export const useExternalServiceLogin = (): {
         authenticationType,
         apiKey,
         forceStale,
+        offlineUsageConsent,
       } = params;
 
       try {
@@ -225,6 +240,7 @@ export const useExternalServiceLogin = (): {
           credentialsLevel,
           authenticationType,
           apiKey: apiKey?.trim(),
+          offlineUsageConsent,
         });
         return { type: ExternalServiceLoginOutcomeType.Success };
       } catch {

--- a/apps/chat/src/i18n/locales/en.json
+++ b/apps/chat/src/i18n/locales/en.json
@@ -1084,7 +1084,9 @@
     "errorRetry": "Retry",
     "statusLoginSuccess": "Login succeeded for {{name}}.",
     "statusDeclineSuccess": "Declined {{name}}.",
-    "noCredentialsRequired": "No credentials required"
+    "noCredentialsRequired": "No credentials required",
+    "offlineUsageConsent": "Allow offline use",
+    "offlineUsageConsentHint": "Required for scheduled and background runs."
   },
   "voiceRecording": {
     "micLabel": "Record voice message",

--- a/apps/chat/src/pages/ToolsetAuthCallback/ToolsetAuthCallback.tsx
+++ b/apps/chat/src/pages/ToolsetAuthCallback/ToolsetAuthCallback.tsx
@@ -70,6 +70,12 @@ const ToolsetAuthCallback: FC = () => {
           authenticationType: ExternalServiceAuthType.OAuth,
           code,
           redirectUri,
+          /*
+           * Decided before the redirect, carried through the popup's redirect
+           * state: the code exchange happens here, after the round-trip, so
+           * this is the only place the user's choice can still be submitted.
+           */
+          offlineUsageConsent: redirectState.offlineUsageConsent,
         });
         return null;
       }

--- a/apps/chat/src/pages/ToolsetAuthCallback/ToolsetAuthCallback.tsx
+++ b/apps/chat/src/pages/ToolsetAuthCallback/ToolsetAuthCallback.tsx
@@ -93,6 +93,8 @@ const ToolsetAuthCallback: FC = () => {
           ToolsetAuthTypes.OAuth as ToolsetLoginBodyDto['authenticationType'],
         code,
         redirectUri,
+        /* Decided before the redirect; the exchange happens here — see the external-service branch. */
+        offlineUsageConsent: redirectState.offlineUsageConsent,
       };
       await loginToolset(redirectState.toolsetId, body);
       return null;

--- a/apps/chat/src/server-api/external-services.ts
+++ b/apps/chat/src/server-api/external-services.ts
@@ -43,6 +43,8 @@ export interface ExternalServiceSigninBodyDto {
   apiKey?: string;
   code?: string;
   redirectUri?: string;
+  /** Permit the application to use this credential while the user is away — see the BFF DTO. */
+  offlineUsageConsent?: boolean;
 }
 
 export interface ExternalServiceLogoutBodyDto {

--- a/libs/chat-api-client/src/generated/src/models/index.ts
+++ b/libs/chat-api-client/src/generated/src/models/index.ts
@@ -6569,6 +6569,12 @@ export interface ToolsetLoginBodyDto {
    * @memberof ToolsetLoginBodyDto
    */
   redirectUri?: string;
+  /**
+   * Whether the user consents to an application using this credential while they are offline. Required for on-behalf-of use (e.g. scheduled runs).
+   * @type {boolean}
+   * @memberof ToolsetLoginBodyDto
+   */
+  offlineUsageConsent?: boolean;
 }
 
 /**

--- a/libs/chat-hooks/src/oauth/models.ts
+++ b/libs/chat-hooks/src/oauth/models.ts
@@ -47,6 +47,13 @@ export interface ToolsetRedirectState {
    * require structurally.
    */
   resourceKind?: OAuthResourceKind;
+  /**
+   * Whether the user agreed the application may use the resulting credential
+   * while they are away. Carried through the popup because the choice is made
+   * before the redirect and the code exchange happens after it — the callback
+   * route has no other way to learn it. Absent means "not granted".
+   */
+  offlineUsageConsent?: boolean;
 }
 
 export type ToolsetOAuthInitiationResult =

--- a/libs/chat-hooks/src/oauth/popup.ts
+++ b/libs/chat-hooks/src/oauth/popup.ts
@@ -122,6 +122,7 @@ export const initiateOAuthLogin = (
   toolsetId: string,
   callbackPath: string,
   credentialsLevel: ToolsetCredentialsLevel = ToolsetCredentialsLevel.User,
+  offlineUsageConsent?: boolean,
 ): ToolsetOAuthInitiationResult => {
   const redirectUri = getToolsetRedirectUri(callbackPath);
   const state = generateUUID();
@@ -138,5 +139,7 @@ export const initiateOAuthLogin = (
     toolsetId,
     credentialsLevel,
     redirectUri,
+    OAuthResourceKind.Toolset,
+    offlineUsageConsent,
   );
 };

--- a/libs/chat-hooks/src/oauth/popup.ts
+++ b/libs/chat-hooks/src/oauth/popup.ts
@@ -32,6 +32,7 @@ const writeRedirectStateAndNavigate = (
   credentialsLevel: ToolsetCredentialsLevel,
   redirectUri: string,
   resourceKind: OAuthResourceKind = OAuthResourceKind.Toolset,
+  offlineUsageConsent?: boolean,
 ): ToolsetOAuthInitiationResult => {
   const redirectState: ToolsetRedirectState = {
     toolsetId,
@@ -39,6 +40,7 @@ const writeRedirectStateAndNavigate = (
     redirectUri,
     state,
     resourceKind,
+    offlineUsageConsent,
   };
   popup.sessionStorage.setItem(
     TOOLSET_REDIRECT_STATE_KEY,
@@ -84,6 +86,7 @@ export const navigateToolsetOAuthPopup = (
   callbackPath: string,
   credentialsLevel: ToolsetCredentialsLevel = ToolsetCredentialsLevel.User,
   resourceKind: OAuthResourceKind = OAuthResourceKind.Toolset,
+  offlineUsageConsent?: boolean,
 ): ToolsetOAuthInitiationResult => {
   const redirectUri = getToolsetRedirectUri(callbackPath);
   const state = generateUUID();
@@ -100,6 +103,7 @@ export const navigateToolsetOAuthPopup = (
     credentialsLevel,
     redirectUri,
     resourceKind,
+    offlineUsageConsent,
   );
 };
 

--- a/libs/chat-hooks/src/oauth/useToolsetLogin/tests/useToolsetLogin.spec.ts
+++ b/libs/chat-hooks/src/oauth/useToolsetLogin/tests/useToolsetLogin.spec.ts
@@ -8,6 +8,7 @@ import {
   openToolsetOAuthPopup,
 } from '../../popup';
 import {
+  OAuthResourceKind,
   ToolsetAuthTypes,
   ToolsetCredentialsLevel,
   ToolsetOAuthInitiationResultType,
@@ -232,6 +233,8 @@ describe('useToolsetLogin', () => {
         TOOLSET_ID,
         '/some/other/callback',
         ToolsetCredentialsLevel.User,
+        // Offline usage consent — undefined here because the caller did not ask for it.
+        undefined,
       );
       expect(waitForToolsetOAuthResult).toHaveBeenCalledWith(
         expect.anything(),
@@ -271,6 +274,8 @@ describe('useToolsetLogin', () => {
         TOOLSET_ID,
         CALLBACK_PATH,
         ToolsetCredentialsLevel.User,
+        OAuthResourceKind.Toolset,
+        undefined,
       );
       expect(initiateOAuthLogin).not.toHaveBeenCalled();
       expect(outcome).toEqual({ type: ToolsetLoginOutcomeType.Success });

--- a/libs/chat-hooks/src/oauth/useToolsetLogin/useToolsetLogin.ts
+++ b/libs/chat-hooks/src/oauth/useToolsetLogin/useToolsetLogin.ts
@@ -13,6 +13,7 @@ import {
   openToolsetOAuthPopup,
 } from '../popup';
 import {
+  OAuthResourceKind,
   ToolsetAuthStatus,
   ToolsetAuthTypes,
   ToolsetCredentialsLevel,
@@ -60,6 +61,13 @@ export interface ToolsetLoginParams {
    * status may be stale even when it still reads `SIGNED_IN`.
    */
   forceStale?: boolean;
+  /**
+   * Whether the user agreed an application may use this credential while they
+   * are away. DIAL Core gates every on-behalf-of mint on it, so a toolset
+   * signed in without it works interactively and still fails with
+   * `consent-required` in the background. Absent means not granted.
+   */
+  offlineUsageConsent?: boolean;
 }
 
 /** Parameters for {@link useToolsetLogin}. */
@@ -127,7 +135,13 @@ export const useToolsetLogin = ({
 
   const loginWithOAuth = useCallback(
     async (params: ToolsetLoginParams): Promise<ToolsetLoginOutcome> => {
-      const { toolsetId, credentialsLevel, oauthSettings, forceStale } = params;
+      const {
+        toolsetId,
+        credentialsLevel,
+        oauthSettings,
+        forceStale,
+        offlineUsageConsent,
+      } = params;
       const authSettings: ToolsetOAuthSettings = {
         clientId: oauthSettings?.clientId,
         authorizationEndpoint: oauthSettings?.authorizationEndpoint,
@@ -164,6 +178,8 @@ export const useToolsetLogin = ({
               toolsetId,
               callbackPath,
               credentialsLevel,
+              OAuthResourceKind.Toolset,
+              offlineUsageConsent,
             );
           })()
         : initiateOAuthLogin(
@@ -171,6 +187,7 @@ export const useToolsetLogin = ({
             toolsetId,
             callbackPath,
             credentialsLevel,
+            offlineUsageConsent,
           );
 
       if (initiation.type === ToolsetOAuthInitiationResultType.Blocked) {
@@ -237,6 +254,7 @@ export const useToolsetLogin = ({
         apiKey,
         isCurrentlyFailed,
         forceStale,
+        offlineUsageConsent,
       } = params;
 
       try {
@@ -250,6 +268,7 @@ export const useToolsetLogin = ({
           authenticationType:
             authenticationType as ToolsetLoginBodyDto['authenticationType'],
           apiKey: apiKey?.trim(),
+          offlineUsageConsent,
         };
         await loginToolset(toolsetId, body);
         emitToolsetLoginSuccess<ToolsetCredentialsLevel>({


### PR DESCRIPTION
**Description:**

> **Stacked on #8506.** A cross-fork PR can only target a branch in this repository, so this one is opened against `development` and **its diff currently includes #8506's commit**. Review only the second commit (`feat(chat): extend offline usage consent to toolset sign-in`); once #8506 merges, this diff reduces to that commit alone.

Same defect as #8504, on the toolset half of the same Core contract. `offlineUsageConsent` is a field of DIAL Core's shared `ResourceSignInRequest`, which backs `POST /v1/ops/toolset/signin` (`ResourceCredentialsController`) exactly as it backs external-service sign-in. Chat set it on neither, so a toolset signed in from Chat works while the user watches and fails with `consent-required` the moment an application reaches for it in the background.

The sign-in interrupt's consent checkbox now covers both kinds, so a dialog listing a toolset and an external service asks once and applies the answer to both — it is the same question about the same kind of permission.

`initiateOAuthLogin` gains the parameter alongside `navigateToolsetOAuthPopup`, because the toolset flow uses the former when no pre-emptive logout is needed and the latter when one is; both persist the choice in the popup's redirect state so the callback can submit it after the round-trip. Missing either would silently drop consent on one of the two paths.

As in #8506, nothing is defaulted server-side: the DTO leaves it `undefined` and the mapper forwards exactly what the caller sent, including an explicit `false`.

**One thing worth a reviewer's attention:** the frontend toolset path submits through the generated API client, whose `ToolsetLoginBodyDto` needed the new optional field. `npm run openapi` is blocked by a pre-existing, unrelated bug in `app-config.service.ts` (already noted in `apps/chat/src/server-api/external-services.ts`), so this PR adds the field to the generated model by hand, matching what regeneration would emit from the BFF DTO's `@ApiPropertyOptional`. Worth regenerating once that bug is fixed.

Two `useToolsetLogin` specs asserted exact argument lists for the popup helpers and were updated for the new trailing parameter.

**Verification:** `chat-api` 168 files / 2786 tests pass, oauth hooks 90/90, `SigninInterruptDialog` 9/9, eslint and prettier clean, and `nx run-many --target=typecheck --projects=@epam/chat,@epam/ai-dial-chat-hooks` passes. Not exercised against a live DIAL deployment.

Issues:

- Issue #8505

**UI changes**

None beyond #8506 — the same checkbox now also applies to toolset rows in the sign-in interrupt dialog.

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`
- [x] the pull request name ends with `(Issue #<TICKET_ID>)`
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs