### PR TITLE
fix(chat): fix default locale (#8368)

### DIFF
--- a/apps/chat/src/utils/app/__tests__/marketplace-localization.test.ts
+++ b/apps/chat/src/utils/app/__tests__/marketplace-localization.test.ts
@@ -40,10 +40,18 @@ describe('marketplace-localization', () => {
       );
     });
 
-    it('returns an empty string when the primary locale is missing', () => {
+    it('falls back to the first available locale when the primary locale is missing', () => {
       LocalesService.setAvailableLocales(['de', 'en']);
 
-      expect(getLocalizedEntityIdName({ en: 'My App' })).toBe('');
+      expect(getLocalizedEntityIdName({ en: 'My App' })).toBe('My App');
+    });
+
+    it('falls back to the first available locale when neither the primary nor DEFAULT_LOCAL is present', () => {
+      LocalesService.setAvailableLocales(['de', 'en']);
+
+      expect(
+        getLocalizedEntityIdName({ fr: 'Mon App', it: 'La Mia App' }),
+      ).toBe('Mon App');
     });
 
     it('returns an empty string for an undefined name', () => {
@@ -114,10 +122,16 @@ describe('marketplace-localization', () => {
       expect(parseLocalizedField('de', { en: 'My App' })).toBe('My App');
     });
 
-    it('returns an empty string when nothing matches', () => {
+    it('falls back to the first available locale when nothing matches', () => {
       LocalesService.setAvailableLocales(['ar', 'en']);
 
-      expect(parseLocalizedField('de', { fr: 'Mon App' })).toBe('');
+      expect(parseLocalizedField('de', { fr: 'Mon App' })).toBe('Mon App');
+    });
+
+    it('returns an empty string when the field is an empty object', () => {
+      LocalesService.setAvailableLocales(['ar', 'en']);
+
+      expect(parseLocalizedField('de', {})).toBe('');
     });
 
     describe('strict', () => {

--- a/apps/chat/src/utils/app/marketplace-localization.ts
+++ b/apps/chat/src/utils/app/marketplace-localization.ts
@@ -25,7 +25,11 @@ export const parseLocalizedField = (
   }
 
   return (
-    field?.[locale] ?? field?.[primaryLocale] ?? field?.[DEFAULT_LOCAL] ?? ''
+    field?.[locale] ??
+    field?.[primaryLocale] ??
+    field?.[DEFAULT_LOCAL] ??
+    Object.values(field ?? {})[0] ??
+    ''
   );
 };
 
@@ -50,7 +54,11 @@ export const getLocalizedEntityIdName = (
 ): string => {
   if (typeof name === 'string') return name;
 
-  return name?.[LocalesService.getPrimaryLocale()] ?? '';
+  return (
+    name?.[LocalesService.getPrimaryLocale()] ??
+    Object.values(name ?? {})[0] ??
+    ''
+  );
 };
 
 export const updateLocalizedEntityIdName = (


### PR DESCRIPTION
**Description:**

[Locales]: select first locale as default if default is not configured for app/toolset

Issues:

- Issue #8368

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
