### PR TITLE
feat(chat): allow block markup in the legacy announcement banner

### DIFF
--- a/apps/chat-api/.env.template
+++ b/apps/chat-api/.env.template
@@ -111,9 +111,15 @@ DEFAULT_DEPLOYMENT="deployment_id"
 # are only visible in the server log — there is no UI feedback.
 # ANNOUNCEMENTS=[{"title":"We have upgraded to DIAL 1.43 🎉","description":"Check what's new:","link":{"label":"Changelog","href":"https://your-site.example.com/changelog"}}]
 
-# Legacy single-line announcement banner, still supported. Rendered centered, with the
-# same sanitization and content-keyed dismissal. Ignored when ANNOUNCEMENT_TITLE or
-# ANNOUNCEMENT_DESCRIPTION is set. Unset/empty hides the banner.
+# Legacy announcement banner, still supported. Rendered centered, with the same
+# content-keyed dismissal. Ignored when ANNOUNCEMENT_TITLE or ANNOUNCEMENT_DESCRIPTION
+# is set. Unset/empty hides the banner.
+#
+# It is not truncated to one line and accepts <p> and <u> on top of the description's
+# inline tags, so a multi-paragraph message renders as stacked centered lines. Anything
+# else is stripped: style attributes go, and unlike the description no target/rel is
+# added for you, so write target="_blank" rel="noreferrer" on links that leave the page.
+# Links are underlined by the app.
 # ANNOUNCEMENT_HTML_MESSAGE=Welcome to <a href="https://your-site.example.com">DIAL</a>!
 
 # Operator-authored HTML message shown in the footer of the chat input area (desktop) and

--- a/apps/chat-api/README.md
+++ b/apps/chat-api/README.md
@@ -210,7 +210,7 @@ Banner dismissal is content-keyed and persists in the browser's `localStorage`: 
 
 | Variable                    | Default | Description                                                                                                                                                                                                                                                      |
 | --------------------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `ANNOUNCEMENT_HTML_MESSAGE` | —       | Deprecated. Renders the legacy single-line, centered banner, with the same sanitization and content-keyed dismissal as the structured form. Ignored when `ANNOUNCEMENT_TITLE` or `ANNOUNCEMENT_DESCRIPTION` is set. Use the structured pair for new deployments. |
+| `ANNOUNCEMENT_HTML_MESSAGE` | —       | Deprecated. Renders the legacy centered banner with the same content-keyed dismissal as the structured form. Unlike the description, it is not truncated and accepts `<p>` and `<u>` on top of the inline set (`<a>`, `<b>`, `<strong>`, `<em>`, `<br>`, `<span>`), so a multi-paragraph message renders as stacked centered lines. `style` attributes are stripped — links are underlined by the app — and `target`/`rel` are not added for you, so author them yourself. Ignored when `ANNOUNCEMENT_TITLE` or `ANNOUNCEMENT_DESCRIPTION` is set. Use the structured pair for new deployments. |
 
 #### Header bearer-token authentication
 

--- a/apps/chat-api/src/app-config/config-registry/config-registry.constants.ts
+++ b/apps/chat-api/src/app-config/config-registry/config-registry.constants.ts
@@ -105,7 +105,7 @@ export const CONFIG_DEFINITIONS: ConfigDefinition[] = [
     defaultValue: null,
     critical: false,
     description:
-      'Operator-authored HTML announcement message shown in a dismissible top-of-app banner. Null/empty hides the banner. Sourced from ANNOUNCEMENT_HTML_MESSAGE.',
+      'Operator-authored HTML announcement message shown in a dismissible top-of-app banner. Passed through verbatim and sanitized client-side to <a>, <b>, <strong>, <em>, <u>, <br>, <span>, <p>; style attributes are stripped. Null/empty hides the banner. Sourced from ANNOUNCEMENT_HTML_MESSAGE.',
     owner: 'chat-team',
     envVar: 'ANNOUNCEMENT_HTML_MESSAGE',
   },

--- a/apps/chat/src/components/AnnouncementBanner/AnnouncementBanner.tsx
+++ b/apps/chat/src/components/AnnouncementBanner/AnnouncementBanner.tsx
@@ -2,6 +2,7 @@ import {
   hasAnnouncementContent,
   hasStructuredAnnouncement,
   sanitizeAnnouncementHtml,
+  sanitizeAnnouncementMessageHtml,
   type AnnouncementContent,
 } from '@epam/ai-dial-chat-hooks';
 import { mergeClasses } from '@epam/ai-dial-chat-shared';
@@ -66,7 +67,7 @@ const AnnouncementBanner: FC<Props> = ({ className }) => {
   const sanitizedHtml = useMemo(
     () =>
       shouldRender && !isStructured && announcementHtml
-        ? sanitizeAnnouncementHtml(announcementHtml)
+        ? sanitizeAnnouncementMessageHtml(announcementHtml)
         : '',
     [shouldRender, isStructured, announcementHtml],
   );
@@ -146,8 +147,12 @@ const AnnouncementBanner: FC<Props> = ({ className }) => {
       )}
     >
       <div className="flex min-w-0 flex-1 items-center justify-center gap-3">
-        <span
-          className="dial-small-paragraph-semi-text text-center"
+        {/* A div, not a span: the legacy message may contain <p> blocks, which
+            are invalid inside a span and get reparented by the browser. Links
+            are underlined here rather than via operator-authored style
+            attributes, which the sanitizer strips. */}
+        <div
+          className="dial-small-paragraph-semi-text text-center [&>p+p]:mt-1 [&_a]:underline"
           // eslint-disable-next-line react/no-danger -- HTML is sanitized by DOMPurify before use
           dangerouslySetInnerHTML={{ __html: sanitizedHtml }}
         />

--- a/apps/chat/src/components/AnnouncementBanner/tests/AnnouncementBanner.spec.tsx
+++ b/apps/chat/src/components/AnnouncementBanner/tests/AnnouncementBanner.spec.tsx
@@ -314,10 +314,48 @@ describe('AnnouncementBanner — legacy layout', () => {
     mockAppConfigState.announcementHtml = 'Welcome!';
     render(<AnnouncementBanner />);
 
-    expect(screen.getByText('Welcome!').className).toContain(
-      'dial-small-paragraph-semi-text',
-    );
+    const content = screen.getByText('Welcome!');
+    expect(content.className).toContain('dial-small-paragraph-semi-text');
+    /* Links are underlined here, not by operator-authored style attributes,
+       which the sanitizer strips. */
+    expect(content.className).toContain('[&_a]:underline');
     expect(screen.getByRole('region').className).toContain('justify-center');
+  });
+
+  it('keeps each <p> of a multi-paragraph message as its own line', () => {
+    mockAppConfigState.announcementHtml =
+      '<p>Upgraded to 1.47</p> <p>Prefer the old interface?</p>';
+    render(<AnnouncementBanner />);
+
+    const paragraphs = screen.getAllByRole('paragraph');
+    expect(paragraphs).toHaveLength(2);
+    expect(paragraphs[0].textContent).toBe('Upgraded to 1.47');
+    expect(paragraphs[1].textContent).toBe('Prefer the old interface?');
+  });
+
+  it('keeps <u> in the legacy message', () => {
+    mockAppConfigState.announcementHtml = '<p><u>Read this</u></p>';
+    render(<AnnouncementBanner />);
+
+    expect(screen.getByText('Read this').tagName).toBe('U');
+  });
+
+  it('strips operator-authored style attributes from the legacy message', () => {
+    mockAppConfigState.announcementHtml =
+      '<a href="https://dialx.ai" style="text-decoration: underline;">ChangeLog</a>';
+    render(<AnnouncementBanner />);
+
+    expect(screen.getByText('ChangeLog').getAttribute('style')).toBeNull();
+  });
+
+  it('keeps a legacy link opening in a new tab with the opener severed', () => {
+    mockAppConfigState.announcementHtml =
+      '<a href="https://dialx.ai" target="_blank" rel="noreferrer">ChangeLog</a>';
+    render(<AnnouncementBanner />);
+
+    const link = screen.getByText('ChangeLog');
+    expect(link.getAttribute('target')).toBe('_blank');
+    expect(link.getAttribute('rel')).toBe('noopener noreferrer');
   });
 });
 
@@ -443,6 +481,17 @@ describe('AnnouncementBanner — sanitization', () => {
     const link = screen.getByText('click');
     expect(link.tagName).toBe('A');
     expect(link.getAttribute('href')).toBeNull();
+  });
+
+  it('strips block-level markup from the description, which is one line', () => {
+    mockAppConfigState.announcementTitle = 'DIAL 1.47';
+    mockAppConfigState.announcementDescription = '<p>Check the changelog</p>';
+    render(<AnnouncementBanner />);
+
+    /* The structured layout truncates to a single line, so <p> stays out of
+       its allowlist even though the legacy banner accepts it. */
+    expect(screen.getAllByRole('paragraph')).toHaveLength(1);
+    expect(screen.getByText('Check the changelog').tagName).toBe('SPAN');
   });
 
   it('preserves an allowed description link with a safe href', () => {

--- a/libs/chat-hooks/README.md
+++ b/libs/chat-hooks/README.md
@@ -1785,13 +1785,16 @@ const { starters, propertyKey, description } = getStartersFromSchema(
 );
 ```
 
-### sanitizeAnnouncementHtml / hasStructuredAnnouncement / hasAnnouncementContent / buildAnnouncementSignature
+### sanitizeAnnouncementHtml / sanitizeAnnouncementMessageHtml / hasStructuredAnnouncement / hasAnnouncementContent / buildAnnouncementSignature
 
-Announcement-banner helpers: sanitizes operator-supplied HTML to an allowed tag/attribute set, checks whether structured (`title`/`description`) or any content is present, and builds the content-keyed signature used to track dismissal.
+Announcement-banner helpers: sanitize operator-supplied HTML, check whether structured (`title`/`description`) or any content is present, and build the content-keyed signature used to track dismissal.
+
+The two sanitizers differ in the tags they keep, because the two banner layouts differ. `sanitizeAnnouncementHtml` is for the structured `description`, which renders as one truncating line, so it keeps inline markup only — `a`, `b`, `strong`, `em`, `br`, `span`. `sanitizeAnnouncementMessageHtml` is for the legacy `html` message, a free-standing block, so it additionally keeps `u` and `p`. Both keep `href`, `target` and `rel` on links, drop everything else including `style`, and force `rel="noopener noreferrer"` on any link that already carries `target="_blank"`.
 
 ```ts
 import {
   hasAnnouncementContent,
+  sanitizeAnnouncementMessageHtml,
   type AnnouncementContent,
 } from '@epam/ai-dial-chat-hooks';
 
@@ -1802,6 +1805,9 @@ const content: AnnouncementContent = {
 };
 
 hasAnnouncementContent(content); // true
+
+sanitizeAnnouncementMessageHtml('<p>Upgraded to <strong>1.47</strong></p>');
+// '<p>Upgraded to <strong>1.47</strong></p>'
 ```
 
 ### sanitizeFooterHtml / formatAppVersion

--- a/libs/chat-hooks/src/conversation/announcement-message.ts
+++ b/libs/chat-hooks/src/conversation/announcement-message.ts
@@ -4,9 +4,28 @@ import DOMPurify, { type Config } from 'dompurify';
  * Kept in lockstep with ANNOUNCEMENT_ALLOWED_TAGS in
  * apps/chat-api/src/app-config/html-sanitizer.ts. Widening one side without
  * the other means the server returns markup this pass silently strips.
+ *
+ * Inline-only by design: the structured banner renders the description as a
+ * single truncating line, so block-level markup has nowhere to go.
  */
 const ANNOUNCEMENT_HTML_SANITIZE_OPTIONS: Config = {
   ALLOWED_TAGS: ['a', 'b', 'strong', 'em', 'br', 'span'],
+  ALLOWED_ATTR: ['href', 'target', 'rel'],
+};
+
+/*
+ * The legacy ANNOUNCEMENT_HTML_MESSAGE banner is a free-standing block rather
+ * than a truncated line, so it additionally accepts `p` — operators routinely
+ * author multi-paragraph announcements — and `u`. `style` stays out on
+ * purpose: the banner underlines its own links, and letting operator CSS
+ * through would put arbitrary positioning inside app chrome.
+ *
+ * This field is sanitized on the client only. The backend passes it through
+ * verbatim so that `buildAnnouncementSignature` keeps producing the byte-for-byte
+ * value older builds stored for dismissal.
+ */
+const ANNOUNCEMENT_MESSAGE_SANITIZE_OPTIONS: Config = {
+  ALLOWED_TAGS: ['a', 'b', 'strong', 'em', 'u', 'br', 'span', 'p'],
   ALLOWED_ATTR: ['href', 'target', 'rel'],
 };
 
@@ -23,9 +42,17 @@ DOMPurify.addHook('afterSanitizeAttributes', (node) => {
   }
 });
 
-/** Sanitizes announcement HTML to the allowed tag/attribute set. */
+/** Sanitizes announcement HTML to the allowed inline tag/attribute set. */
 export const sanitizeAnnouncementHtml = (html: string): string =>
   DOMPurify.sanitize(html, ANNOUNCEMENT_HTML_SANITIZE_OPTIONS) as string;
+
+/**
+ * Sanitizes the legacy `ANNOUNCEMENT_HTML_MESSAGE` banner, which permits the
+ * block-level markup the inline pass strips. See
+ * `ANNOUNCEMENT_MESSAGE_SANITIZE_OPTIONS` for why the two lists differ.
+ */
+export const sanitizeAnnouncementMessageHtml = (html: string): string =>
+  DOMPurify.sanitize(html, ANNOUNCEMENT_MESSAGE_SANITIZE_OPTIONS) as string;
 
 const isNonEmpty = (value: string | null): value is string =>
   typeof value === 'string' && value.length > 0;


### PR DESCRIPTION
ANNOUNCEMENT_HTML_MESSAGE is a free-standing block rather than a truncated line, so a multi-paragraph message is a normal thing for an operator to author. The single sanitizer shared with the structured description kept inline tags only, silently flattening every <p> into one run-on line.

Split the client pass in two: sanitizeAnnouncementHtml stays inline-only for the description, which still truncates to one line, and a new sanitizeAnnouncementMessageHtml additionally keeps <p> and <u> for the legacy field. The banner renders it in a div (a <p> inside a span is reparented by the browser) with stacked paragraphs and underlined links, so the underline operators reach for via a style attribute now comes from the app — style itself stays stripped rather than letting operator CSS into app chrome.

**Description:**

<SHORT_DESCRIPTION>

Issues:

- Issue #<TICKET_ID>

**UI changes**

<Please, provide Screenshots or Figma links>

**Checklist:**

- [ ] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [ ] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
