### PR TITLE
fix(chat): fix card detailed topic size (#5723, #6471)

### DIFF
--- a/apps/chat/src/components/Common/Modal.tsx
+++ b/apps/chat/src/components/Common/Modal.tsx
@@ -27,6 +27,8 @@ import { Spinner } from './Spinner';
 
 import { DialEllipsisTooltip } from '@epam/ai-dial-ui-kit';
 
+export const MODAL_CLOSE_BUTTON_WIDTH = 36;
+
 export interface Props extends FormHTMLAttributes<HTMLFormElement> {
   children: ReactNode | ReactNode[];
   portalId: string;

--- a/apps/chat/src/components/Common/OverflowContainer.tsx
+++ b/apps/chat/src/components/Common/OverflowContainer.tsx
@@ -9,6 +9,7 @@ import React, {
 import { useResizeObserver } from '@/src/hooks/useResizeObserver';
 
 const GAP_WIDTH = 8;
+const EDGE_SAFETY_MARGIN = 4;
 
 interface OverflowContainerProps<T> {
   items: T[];
@@ -16,6 +17,7 @@ interface OverflowContainerProps<T> {
   renderOverflow: (hiddenItems: T[]) => ReactNode;
   getKey: (item: T) => string | number;
   overflowIndicatorWidth?: number;
+  trailingReservedWidth?: number;
   className?: string;
   dataQA?: string;
 }
@@ -26,6 +28,7 @@ export function OverflowContainer<T>({
   renderOverflow,
   getKey,
   overflowIndicatorWidth = 50,
+  trailingReservedWidth = 0,
   className = 'flex w-full flex-nowrap items-center gap-1',
   dataQA,
 }: OverflowContainerProps<T>) {
@@ -39,7 +42,10 @@ export function OverflowContainer<T>({
     const container = containerRef.current;
     if (!container) return;
 
-    const containerWidth = container.offsetWidth;
+    const containerWidth = Math.max(
+      container.offsetWidth - trailingReservedWidth - EDGE_SAFETY_MARGIN,
+      0,
+    );
 
     let totalWidth = 0;
     for (let i = 0; i < items.length; i++) {
@@ -55,7 +61,7 @@ export function OverflowContainer<T>({
       return;
     }
 
-    const availableWidth = containerWidth - overflowIndicatorWidth;
+    const availableWidth = containerWidth - overflowIndicatorWidth - GAP_WIDTH;
     let occupiedWidth = 0;
     const newVisibleItems: T[] = [];
     const newHiddenItems: T[] = [];
@@ -81,7 +87,7 @@ export function OverflowContainer<T>({
 
     setVisibleItems(newVisibleItems);
     setHiddenItems(newHiddenItems);
-  }, [items, overflowIndicatorWidth]);
+  }, [items, overflowIndicatorWidth, trailingReservedWidth]);
 
   useResizeObserver(containerRef.current, recalculateItems);
   useLayoutEffect(() => {

--- a/apps/chat/src/components/Marketplace/EntityDetailsHeader.tsx
+++ b/apps/chat/src/components/Marketplace/EntityDetailsHeader.tsx
@@ -19,6 +19,7 @@ import { MarketplaceI18nKeys } from '@/src/constants/i18n';
 import { HeaderIconSizes } from '@/src/constants/marketplace';
 
 import { ModelIcon } from '@/src/components/Chatbar/ModelIcon';
+import { MODAL_CLOSE_BUTTON_WIDTH } from '@/src/components/Common/Modal';
 import { ShareIcon } from '@/src/components/Common/ShareIcon';
 import { MarketplaceEntityIndicator } from '@/src/components/Marketplace/MarketplaceEntityIndicator';
 
@@ -108,7 +109,11 @@ export function EntityHeader<T extends MarketplaceEntity>({
               {entity.topics && (
                 <TopicsList
                   topics={entity.topics}
-                  counterMarginRight={screenState === ScreenState.SM ? 18 : 0}
+                  trailingReservedWidth={
+                    screenState === ScreenState.SM
+                      ? MODAL_CLOSE_BUTTON_WIDTH
+                      : 0
+                  }
                 />
               )}
               <div className="flex max-w-full items-center gap-[2px] whitespace-nowrap">

--- a/apps/chat/src/components/Marketplace/MarketplaceEntityTopic.tsx
+++ b/apps/chat/src/components/Marketplace/MarketplaceEntityTopic.tsx
@@ -2,12 +2,23 @@ import classNames from 'classnames';
 
 import { getTopicColors } from '@/src/utils/app/style-helpers';
 
-import { DialEllipsisTooltip } from '@epam/ai-dial-ui-kit';
-
 interface Props {
   topic: string;
   className?: string;
+  /**
+   * Caps how wide the pill may grow before its label is truncated with an
+   * ellipsis. Without a cap a long topic is an indivisible atom that either
+   * fits whole or is pushed into the `+N` counter, leaving the row half empty.
+   *
+   * Truncation is done in plain CSS rather than with a tooltip component on
+   * purpose: the pill must contain a single text node, since e2e assertions
+   * read the topic name from this element's inner text.
+   */
   maxWidth?: number;
+  /**
+   * Suppresses the hover title holding the full topic name. Set it where the
+   * name is already shown in full, e.g. inside the `+N` counter's own tooltip.
+   */
   hideTooltip?: boolean;
 }
 
@@ -20,17 +31,14 @@ export const MarketplaceEntityTopic = ({
   return (
     <span
       className={classNames(
-        'shrink-0 items-center self-start text-nowrap rounded border border-accent-primary px-1.5 py-1 text-xs leading-3',
+        'shrink-0 items-center self-start overflow-hidden text-ellipsis text-nowrap rounded border border-accent-primary px-1.5 py-1 text-xs leading-3',
         className,
       )}
       style={{ ...getTopicColors(topic), maxWidth }}
+      {...(!hideTooltip && { title: topic })}
       data-qa="entity-topic"
     >
-      <DialEllipsisTooltip
-        text={topic}
-        hideTooltip={hideTooltip}
-        id="entity-topic-name"
-      />
+      {topic}
     </span>
   );
 };

--- a/apps/chat/src/components/Marketplace/MarketplaceEntityTopic.tsx
+++ b/apps/chat/src/components/Marketplace/MarketplaceEntityTopic.tsx
@@ -2,22 +2,35 @@ import classNames from 'classnames';
 
 import { getTopicColors } from '@/src/utils/app/style-helpers';
 
+import { DialEllipsisTooltip } from '@epam/ai-dial-ui-kit';
+
 interface Props {
   topic: string;
   className?: string;
+  maxWidth?: number;
+  hideTooltip?: boolean;
 }
 
-export const MarketplaceEntityTopic = ({ topic, className }: Props) => {
+export const MarketplaceEntityTopic = ({
+  topic,
+  className,
+  maxWidth,
+  hideTooltip,
+}: Props) => {
   return (
     <span
       className={classNames(
         'shrink-0 items-center self-start text-nowrap rounded border border-accent-primary px-1.5 py-1 text-xs leading-3',
         className,
       )}
-      style={getTopicColors(topic)}
+      style={{ ...getTopicColors(topic), maxWidth }}
       data-qa="entity-topic"
     >
-      {topic}
+      <DialEllipsisTooltip
+        text={topic}
+        hideTooltip={hideTooltip}
+        id="entity-topic-name"
+      />
     </span>
   );
 };

--- a/apps/chat/src/components/Marketplace/TopicsList.tsx
+++ b/apps/chat/src/components/Marketplace/TopicsList.tsx
@@ -7,15 +7,15 @@ import { MarketplaceEntityTopic } from './MarketplaceEntityTopic';
 
 interface TopicsListProps {
   topics: string[];
-  counterMarginRight?: number;
+  trailingReservedWidth?: number;
 }
 
-const COUNTER_WIDTH = 30;
+const COUNTER_WIDTH = 34;
 const getKey = (item: { topic: string }) => item.topic;
 
 export const TopicsList = ({
   topics,
-  counterMarginRight = 0,
+  trailingReservedWidth = 0,
 }: TopicsListProps) => {
   const items = topics.map((topic) => ({ topic }));
 
@@ -42,7 +42,8 @@ export const TopicsList = ({
     <OverflowContainer
       items={items}
       getKey={getKey}
-      overflowIndicatorWidth={COUNTER_WIDTH + counterMarginRight}
+      overflowIndicatorWidth={COUNTER_WIDTH}
+      trailingReservedWidth={trailingReservedWidth}
       renderItem={MarketplaceEntityTopic}
       renderOverflow={renderOverflow}
       className="flex w-full gap-2"

--- a/apps/chat/src/components/Marketplace/TopicsList.tsx
+++ b/apps/chat/src/components/Marketplace/TopicsList.tsx
@@ -11,7 +11,13 @@ interface TopicsListProps {
 }
 
 const COUNTER_WIDTH = 34;
+const TOPIC_MAX_WIDTH = 180;
+
 const getKey = (item: { topic: string }) => item.topic;
+
+const renderTopic = ({ topic }: { topic: string }) => (
+  <MarketplaceEntityTopic topic={topic} maxWidth={TOPIC_MAX_WIDTH} />
+);
 
 export const TopicsList = ({
   topics,
@@ -28,6 +34,7 @@ export const TopicsList = ({
             key={item.topic}
             topic={item.topic}
             className="max-w-full truncate"
+            hideTooltip
           />
         ))}
         placement="top"
@@ -44,7 +51,7 @@ export const TopicsList = ({
       getKey={getKey}
       overflowIndicatorWidth={COUNTER_WIDTH}
       trailingReservedWidth={trailingReservedWidth}
-      renderItem={MarketplaceEntityTopic}
+      renderItem={renderTopic}
       renderOverflow={renderOverflow}
       className="flex w-full gap-2"
       dataQA="entity-topics"


### PR DESCRIPTION
**Description:**

When the topic is long (~30 symbols) it's grouped under [+1] though it looks like there is enough space on the card or card detailed view
[Mobile] On card detailed view there could be a case when topic or [+1] is too close to 'x' button

Issues:

- Issue #5723
- Issue #6471

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
