### PR TITLE
fix(chat-api): accept a full URL in auth provider host variables

### DIFF
--- a/apps/chat-api/.env.template
+++ b/apps/chat-api/.env.template
@@ -25,6 +25,10 @@ AUTH_POST_LOGOUT_REDIRECT_URI=http://localhost:4207
 # See apps/chat-api/README.md "Auth provider environment variables" for the
 # full field list per provider (Auth0, Azure AD, Azure B2C, GitLab, Google,
 # Keycloak, PingID, Cognito, Okta).
+#
+# Every AUTH_*_HOST value accepts either a bare host (HTTPS is assumed) or a
+# full http(s) URL, so a provider reachable only over plain HTTP can be
+# configured as, for example, http://keycloak.internal:8080/realms/dial.
 
 # Auth0
 AUTH_AUTH0_CLIENT_ID=your-client-id
@@ -61,6 +65,7 @@ AUTH_AUTH0_HOST=your-tenant.auth0.com
 # AUTH_KEYCLOAK_CLIENT_ID=your-client-id
 # AUTH_KEYCLOAK_SECRET=<client-secret>
 # AUTH_KEYCLOAK_HOST=keycloak.example.com/realms/dial
+# Or a full URL: AUTH_KEYCLOAK_HOST=http://keycloak.internal:8080/realms/dial
 
 # If an OIDC provider uses a certificate issued by a private CA, mount the
 # PEM-encoded CA bundle into the container and set this path before startup.

--- a/apps/chat-api/README.md
+++ b/apps/chat-api/README.md
@@ -229,6 +229,13 @@ Alongside the encrypted session cookie, the BFF can optionally authenticate requ
 
 Each identity provider is configured through its own set of discrete environment variables, following the `AUTH_{PROVIDER_TYPE}_{FIELD_NAME}` convention. A provider is registered only when its `CLIENT_ID` variable is set; an unconfigured provider is silently skipped. If `CLIENT_ID` is set but another field that provider requires is missing, the application fails to boot with an error naming the missing variable. The provider's `id` (used in `/api/v1/auth/login/<id>` and in the `/api/v1/auth/providers` response) is fixed in code and cannot be overridden. Only one instance of each provider type is supported.
 
+Every `AUTH_{PROVIDER_TYPE}_HOST` variable (`AUTH_AUTH0_HOST`, `AUTH_GITLAB_HOST`, `AUTH_KEYCLOAK_HOST`, `AUTH_PING_ID_HOST`, `AUTH_COGNITO_HOST`) accepts either form:
+
+- a bare host, optionally with a path — `keycloak.example.com/realms/dial` — in which case HTTPS is assumed and `https://` is prepended;
+- a full URL whose scheme is used as given — `http://keycloak.internal:8080/realms/dial` — which is how a provider reachable only over plain HTTP (an in-cluster Keycloak, a local test instance) is configured.
+
+A trailing slash is normalised away. A scheme other than `http` or `https` fails boot with an error naming the variable.
+
 **Auth0** (`id: auth0`)
 
 | Variable                      | Required | Default                               |

--- a/apps/chat-api/src/auth/providers/provider-builders.ts
+++ b/apps/chat-api/src/auth/providers/provider-builders.ts
@@ -38,6 +38,32 @@ const requireField = (
   return value;
 };
 
+const stripTrailingSlashes = (value: string): string =>
+  value.replace(/\/+$/, '');
+
+const URL_SCHEME_PATTERN = /^([a-z][a-z0-9+.-]*):\/\//i;
+
+/*
+ * Accepts either a bare host (optionally with a path, e.g.
+ * `keycloak.example.com/realms/dial`) or a full http(s) URL. A bare host is
+ * assumed to be served over HTTPS; an explicit scheme is always preserved, so
+ * self-hosted providers reachable only over plain HTTP can be configured.
+ */
+const resolveIssuerFromHost = (
+  providerLabel: string,
+  envVarName: string,
+  value: string | undefined,
+): string => {
+  const raw = requireField(providerLabel, envVarName, value).trim();
+  const scheme = URL_SCHEME_PATTERN.exec(raw)?.[1]?.toLowerCase();
+  if (scheme && scheme !== 'http' && scheme !== 'https') {
+    throw new Error(
+      `${providerLabel} ${envVarName} must be a bare host or an http(s) URL, but uses the "${scheme}" scheme`,
+    );
+  }
+  return stripTrailingSlashes(scheme ? raw : `https://${raw}`);
+};
+
 const resolveAdminRoles = (
   providerRoles: string[] | undefined,
   appWideRoles: string[] | undefined,
@@ -69,7 +95,11 @@ const buildAuth0Config = (
     'AUTH_AUTH0_SECRET',
     env.AUTH_AUTH0_SECRET,
   );
-  providerConfig.issuer = `https://${requireField('Auth0', 'AUTH_AUTH0_HOST', env.AUTH_AUTH0_HOST)}/`;
+  providerConfig.issuer = `${resolveIssuerFromHost(
+    'Auth0',
+    'AUTH_AUTH0_HOST',
+    env.AUTH_AUTH0_HOST,
+  )}/`;
   providerConfig.audience = env.AUTH_AUTH0_AUDIENCE;
   providerConfig.label = env.AUTH_AUTH0_NAME ?? DEFAULT_PROVIDER_LABEL[id];
   providerConfig.scope = env.AUTH_AUTH0_SCOPE ?? DEFAULT_SCOPE[id];
@@ -176,7 +206,11 @@ const buildGitLabConfig = (
     'AUTH_GITLAB_SECRET',
     env.AUTH_GITLAB_SECRET,
   );
-  providerConfig.issuer = `https://${requireField('GitLab', 'AUTH_GITLAB_HOST', env.AUTH_GITLAB_HOST)}`;
+  providerConfig.issuer = resolveIssuerFromHost(
+    'GitLab',
+    'AUTH_GITLAB_HOST',
+    env.AUTH_GITLAB_HOST,
+  );
   providerConfig.label = env.AUTH_GITLAB_NAME ?? DEFAULT_PROVIDER_LABEL[id];
   providerConfig.scope = env.AUTH_GITLAB_SCOPE ?? DEFAULT_SCOPE[id];
   providerConfig.adminRoles = resolveAdminRoles(
@@ -228,7 +262,11 @@ const buildKeycloakConfig = (
     'AUTH_KEYCLOAK_SECRET',
     env.AUTH_KEYCLOAK_SECRET,
   );
-  providerConfig.issuer = `https://${requireField('Keycloak', 'AUTH_KEYCLOAK_HOST', env.AUTH_KEYCLOAK_HOST)}`;
+  providerConfig.issuer = resolveIssuerFromHost(
+    'Keycloak',
+    'AUTH_KEYCLOAK_HOST',
+    env.AUTH_KEYCLOAK_HOST,
+  );
   providerConfig.label = env.AUTH_KEYCLOAK_NAME ?? DEFAULT_PROVIDER_LABEL[id];
   providerConfig.scope = env.AUTH_KEYCLOAK_SCOPE ?? DEFAULT_SCOPE[id];
   providerConfig.adminRoles = resolveAdminRoles(
@@ -257,7 +295,11 @@ const buildPingIdConfig = (
     'AUTH_PING_ID_SECRET',
     env.AUTH_PING_ID_SECRET,
   );
-  providerConfig.issuer = `https://${requireField('PingID', 'AUTH_PING_ID_HOST', env.AUTH_PING_ID_HOST)}`;
+  providerConfig.issuer = resolveIssuerFromHost(
+    'PingID',
+    'AUTH_PING_ID_HOST',
+    env.AUTH_PING_ID_HOST,
+  );
   providerConfig.label = env.AUTH_PING_ID_NAME ?? DEFAULT_PROVIDER_LABEL[id];
   providerConfig.scope = env.AUTH_PING_ID_SCOPE ?? DEFAULT_SCOPE[id];
   providerConfig.adminRoles = resolveAdminRoles(
@@ -286,7 +328,11 @@ const buildCognitoConfig = (
     'AUTH_COGNITO_SECRET',
     env.AUTH_COGNITO_SECRET,
   );
-  providerConfig.issuer = `https://${requireField('Cognito', 'AUTH_COGNITO_HOST', env.AUTH_COGNITO_HOST)}`;
+  providerConfig.issuer = resolveIssuerFromHost(
+    'Cognito',
+    'AUTH_COGNITO_HOST',
+    env.AUTH_COGNITO_HOST,
+  );
   providerConfig.label = env.AUTH_COGNITO_NAME ?? DEFAULT_PROVIDER_LABEL[id];
   providerConfig.scope = env.AUTH_COGNITO_SCOPE ?? DEFAULT_SCOPE[id];
   providerConfig.adminRoles = resolveAdminRoles(

--- a/apps/chat-api/src/auth/providers/provider-registry.service.spec.ts
+++ b/apps/chat-api/src/auth/providers/provider-registry.service.spec.ts
@@ -312,6 +312,75 @@ describe('ProviderRegistryService', () => {
     });
   });
 
+  describe('issuer derivation from host variables', () => {
+    const issuerOf = async (env: Record<string, unknown>, id: string) => {
+      const module = await buildModule(env);
+      await module.init();
+      return module.get(ProviderRegistryService).getProvider(id).config.issuer;
+    };
+
+    it('prefixes https:// when the host carries no scheme', async () => {
+      await expect(issuerOf(KEYCLOAK_ENV, 'keycloak')).resolves.toBe(
+        'https://keycloak.example.com/realms/test',
+      );
+    });
+
+    it('preserves an explicit https:// URL instead of prefixing it again', async () => {
+      await expect(
+        issuerOf(
+          {
+            ...KEYCLOAK_ENV,
+            AUTH_KEYCLOAK_HOST: 'https://keycloak.example.com/realms/test',
+          },
+          'keycloak',
+        ),
+      ).resolves.toBe('https://keycloak.example.com/realms/test');
+    });
+
+    it('preserves an explicit http:// URL for a provider without TLS', async () => {
+      await expect(
+        issuerOf(
+          {
+            ...KEYCLOAK_ENV,
+            AUTH_KEYCLOAK_HOST: 'http://keycloak.internal:8080/realms/test',
+          },
+          'keycloak',
+        ),
+      ).resolves.toBe('http://keycloak.internal:8080/realms/test');
+    });
+
+    it('strips a trailing slash from the configured URL', async () => {
+      await expect(
+        issuerOf(
+          {
+            ...KEYCLOAK_ENV,
+            AUTH_KEYCLOAK_HOST: 'https://keycloak.example.com/realms/test/',
+          },
+          'keycloak',
+        ),
+      ).resolves.toBe('https://keycloak.example.com/realms/test');
+    });
+
+    it('keeps exactly one trailing slash on the Auth0 issuer given a full URL', async () => {
+      await expect(
+        issuerOf(
+          { ...AUTH0_ENV, AUTH_AUTH0_HOST: 'https://tenant.auth0.com/' },
+          'auth0',
+        ),
+      ).resolves.toBe('https://tenant.auth0.com/');
+    });
+
+    it('fails boot when the host uses a non-http(s) scheme', async () => {
+      const module = await buildModule({
+        ...KEYCLOAK_ENV,
+        AUTH_KEYCLOAK_HOST: 'ftp://keycloak.example.com/realms/test',
+      });
+      await expect(module.init()).rejects.toThrow(
+        /AUTH_KEYCLOAK_HOST must be a bare host or an http/,
+      );
+    });
+  });
+
   describe('header-token auth config validation', () => {
     it('boots successfully when the feature is disabled (default) and no allowlist is set', async () => {
       const module = await buildModule({});

--- a/openspec/specs/auth-provider-env-config/spec.md
+++ b/openspec/specs/auth-provider-env-config/spec.md
@@ -22,7 +22,7 @@ The system SHALL read each provider's configuration from discrete environment va
 #### Scenario: Auth0 configured via discrete variables
 
 - **WHEN** `AUTH_AUTH0_CLIENT_ID`, `AUTH_AUTH0_SECRET`, and `AUTH_AUTH0_HOST` are set
-- **THEN** the system registers an `auth0` provider using those values, deriving the OIDC issuer as `https://${AUTH_AUTH0_HOST}/`
+- **THEN** the system registers an `auth0` provider using those values, deriving the OIDC issuer from `AUTH_AUTH0_HOST` with a trailing slash (`https://tenant.auth0.com/` for `AUTH_AUTH0_HOST=tenant.auth0.com`)
 
 ### Requirement: The legacy AUTH_PROVIDERS variable is no longer supported
 
@@ -65,15 +65,32 @@ When a provider's `CLIENT_ID` variable is set but another field required for tha
 
 The system SHALL derive each provider's OIDC issuer URL as follows, matching the reference app's documented formulas:
 
-- Auth0: `https://${AUTH_AUTH0_HOST}/`
+- Auth0: `${resolved AUTH_AUTH0_HOST}/`
 - Azure AD: `https://login.microsoftonline.com/${AUTH_AZURE_AD_TENANT_ID}/v2.0`
 - Azure B2C: `AUTH_AZURE_B2C_ISSUER` if set; otherwise `https://${AUTH_AZURE_B2C_TENANT_ID}.b2clogin.com/${AUTH_AZURE_B2C_TENANT_ID}.onmicrosoft.com/${AUTH_AZURE_B2C_USER_FLOW}/v2.0`
-- GitLab: `https://${AUTH_GITLAB_HOST}`
+- GitLab: resolved `AUTH_GITLAB_HOST`
 - Google: the fixed constant `https://accounts.google.com` (no host variable)
-- Keycloak: `https://${AUTH_KEYCLOAK_HOST}`
-- PingID: `https://${AUTH_PING_ID_HOST}`
-- Cognito: `https://${AUTH_COGNITO_HOST}`
+- Keycloak: resolved `AUTH_KEYCLOAK_HOST`
+- PingID: resolved `AUTH_PING_ID_HOST`
+- Cognito: resolved `AUTH_COGNITO_HOST`
 - Okta: `AUTH_OKTA_ISSUER` directly
+
+A host variable is "resolved" by taking its value as given when it already carries an `http://` or `https://` scheme, and by prepending `https://` when it does not; trailing slashes are stripped from the result. A host variable whose value carries any other scheme SHALL fail application boot with an error naming that variable.
+
+#### Scenario: Bare host is assumed to be HTTPS
+
+- **WHEN** `AUTH_KEYCLOAK_HOST=keycloak.example.com/realms/dial`
+- **THEN** the derived issuer is `https://keycloak.example.com/realms/dial`
+
+#### Scenario: Explicit scheme in a host variable is preserved
+
+- **WHEN** `AUTH_KEYCLOAK_HOST=http://keycloak.internal:8080/realms/dial`
+- **THEN** the derived issuer is exactly `http://keycloak.internal:8080/realms/dial`, with no `https://` prefix added
+
+#### Scenario: Unsupported scheme in a host variable fails boot
+
+- **WHEN** `AUTH_KEYCLOAK_HOST=ftp://keycloak.example.com/realms/dial`
+- **THEN** application boot fails with an error naming `AUTH_KEYCLOAK_HOST`
 
 #### Scenario: Azure B2C falls back to the tenant/user-flow formula
 


### PR DESCRIPTION
The AUTH_{PROVIDER}_HOST variables inherited the reference frontend's convention of carrying a bare host, so the issuer builders prepended a hardcoded https:// scheme. That made a provider reachable only over plain HTTP (an in-cluster Keycloak, a local test instance) impossible to configure.

Route Auth0, GitLab, Keycloak, PingID and Cognito through a shared resolveIssuerFromHost helper: a value with an explicit http:// or https:// scheme is used as given, a bare host still gets https:// prepended, trailing slashes are normalised, and any other scheme fails boot with an error naming the variable.

Update apps/chat-api/README.md, .env.template and the auth-provider-env-config spec to document both accepted forms.

**Description:**

<SHORT_DESCRIPTION>

Issues:

- Issue #<TICKET_ID>

**UI changes**

<Please, provide Screenshots or Figma links>

**Checklist:**

- [ ] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [ ] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
