### PR TITLE
fix: add possibility to control catalog tabs/topics externally

### DIFF
--- a/libs/catalog/README.md
+++ b/libs/catalog/README.md
@@ -89,6 +89,27 @@ render, as do search, sort, filters, tabs, and the details tabs.
 `Card`, `CardGrid`, `ListView`, and `DetailsPanel` each accept `isReadonly`
 directly too, for hosts composing their own layout instead of using `Catalog`.
 
+#### Controlling tabs and Topics options independently of `items`
+
+By default the entity-type tabs and the Topics filter's option list are both
+derived from `items` — the same list the grid renders. A host that narrows
+`items` for the grid (e.g. filtering by a selected category-tree node) would
+otherwise lose a tab, or a Topics option, for any entity type with zero
+matches in that narrowed set. Pass `tabs` and/or `topicOptions`, computed from
+a wider item set via the exported `buildCatalogTabs`/`getTopicOptions`
+helpers, to keep them stable while `items` stays narrowed:
+
+```tsx
+import { buildCatalogTabs, Catalog, getTopicOptions } from '@epam/ai-dial-catalog';
+
+<Catalog
+  items={itemsNarrowedByCategory}
+  tabs={buildCatalogTabs(allCatalogItems)}
+  topicOptions={getTopicOptions(allCatalogItems)}
+  favorites={favoriteItems}
+/>;
+```
+
 ### CardGrid
 
 Virtualized grid view of catalog cards.
@@ -540,7 +561,12 @@ import type {
 ## Utilities
 
 ```tsx
-import { filterCatalogItems, sortCatalogItems } from '@epam/ai-dial-catalog';
+import {
+  buildCatalogTabs,
+  filterCatalogItems,
+  getTopicOptions,
+  sortCatalogItems,
+} from '@epam/ai-dial-catalog';
 
 /*
  * Matches an item's `name`, `description`, or `type` — case-insensitive.
@@ -549,4 +575,13 @@ import { filterCatalogItems, sortCatalogItems } from '@epam/ai-dial-catalog';
  */
 const filtered = filterCatalogItems(items, 'gpt');
 const sorted = sortCatalogItems(filtered, CatalogSortKey.NameAZ);
+
+/*
+ * Derives the entity-type tabs / Topics filter options that `Catalog` would
+ * compute internally from `items`. Use these to feed `Catalog`'s `tabs` /
+ * `topicOptions` props from a wider item set — see "Controlling tabs and
+ * Topics options independently of `items`" above.
+ */
+const tabs = buildCatalogTabs(items);
+const topicOptions = getTopicOptions(items);
 ```

--- a/libs/catalog/src/components/Catalog/Catalog.tsx
+++ b/libs/catalog/src/components/Catalog/Catalog.tsx
@@ -11,6 +11,7 @@ import {
   filterByMyApp,
   filterByTopics,
   filterCatalogItems,
+  getTopicOptions,
 } from '../../utils/catalog-filter';
 import { sortCatalogItems } from '../../utils/catalog-sort';
 import { buildCatalogTabs } from '../../utils/catalog-tabs';
@@ -26,6 +27,8 @@ import { CreateButton } from './CreateButton';
 /** Root catalog component: entity browsing with tabs, search, sort, filter, favorites strip, and details panel. */
 export const Catalog: FC<CatalogProps> = ({
   items,
+  tabs: controlledTabs,
+  topicOptions: controlledTopicOptions,
   favorites,
   titles,
   onToggleFavorite,
@@ -174,13 +177,13 @@ export const Catalog: FC<CatalogProps> = ({
   );
 
   const allFilterValues = useMemo(
-    () => new Set(filteredItems.flatMap((item) => item.topics)),
-    [filteredItems],
+    () => controlledTopicOptions ?? getTopicOptions(filteredItems),
+    [controlledTopicOptions, filteredItems],
   );
 
   const tabs = useMemo(
-    () => buildCatalogTabs(filteredItems, titles?.tabLabels),
-    [filteredItems, titles?.tabLabels],
+    () => controlledTabs ?? buildCatalogTabs(filteredItems, titles?.tabLabels),
+    [controlledTabs, filteredItems, titles?.tabLabels],
   );
 
   const firstTabId = tabs[0]?.id ?? '';

--- a/libs/catalog/src/components/Catalog/tests/Catalog.spec.tsx
+++ b/libs/catalog/src/components/Catalog/tests/Catalog.spec.tsx
@@ -6,6 +6,8 @@ import { describe, expect, it, vi } from 'vitest';
 import type { CatalogItem } from '../../../models/catalog-item';
 import { CatalogSortKey } from '../../../types/sort';
 import { CatalogViewMode } from '../../../types/view-mode';
+import { getTopicOptions } from '../../../utils/catalog-filter';
+import { buildCatalogTabs } from '../../../utils/catalog-tabs';
 import { Catalog } from '../Catalog';
 
 vi.mock('@epam/ai-dial-ui-kit', () => ({
@@ -730,6 +732,66 @@ describe('Catalog', () => {
         .getByRole('tab', { name: /Prompts/i })
         .getAttribute('aria-selected'),
     ).toBe('true');
+  });
+
+  it('renders the controlled tabs prop instead of tabs derived from items, keeping the grid limited to items', () => {
+    const wideTabs = buildCatalogTabs([
+      makeItem('1', 'Claude', { type: CatalogEntityType.Agent }),
+      makeItem('2', 'GPT', { type: CatalogEntityType.Model }),
+      makeItem('3', 'My Prompt', { type: CatalogEntityType.Prompt }),
+    ]);
+
+    render(
+      <Catalog
+        items={[makeItem('1', 'Claude', { type: CatalogEntityType.Agent })]}
+        tabs={wideTabs}
+        favorites={[]}
+        activeTab={CatalogEntityType.Agent}
+      />,
+    );
+
+    expect(screen.getByRole('tab', { name: /Models/i })).toBeTruthy();
+    expect(screen.getByRole('tab', { name: /Agents/i })).toBeTruthy();
+    expect(screen.getByRole('tab', { name: /Prompts/i })).toBeTruthy();
+    expect(
+      screen.getByRole('grid', { name: 'catalog grid' }).textContent,
+    ).toContain('1 items');
+  });
+
+  it('renders the controlled topicOptions prop instead of options derived from items', () => {
+    const wideTopicOptions = getTopicOptions([
+      makeItem('1', 'Claude', { topics: ['Free'] }),
+      makeItem('2', 'GPT', { topics: ['Paid'] }),
+    ]);
+
+    render(
+      <Catalog
+        items={[makeItem('1', 'Claude', { topics: ['Free'] })]}
+        topicOptions={wideTopicOptions}
+        favorites={[]}
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: 'Free' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Paid' })).toBeTruthy();
+  });
+
+  it('falls back to deriving tabs and Topics options from items when tabs/topicOptions are omitted', () => {
+    render(
+      <Catalog
+        items={[
+          makeItem('1', 'Claude', {
+            type: CatalogEntityType.Agent,
+            topics: ['Free'],
+          }),
+        ]}
+        favorites={[]}
+      />,
+    );
+
+    expect(screen.getByRole('tab', { name: /Agents/i })).toBeTruthy();
+    expect(screen.queryByRole('tab', { name: /Models/i })).toBeNull();
+    expect(screen.getByRole('button', { name: 'Free' })).toBeTruthy();
   });
 
   it('calls onActiveTabChange with the clicked tab id', async () => {

--- a/libs/catalog/src/index.ts
+++ b/libs/catalog/src/index.ts
@@ -70,8 +70,9 @@ export type {
   OverviewSpec,
 } from './models/item-overview';
 // Utils
-export { filterCatalogItems } from './utils/catalog-filter';
+export { filterCatalogItems, getTopicOptions } from './utils/catalog-filter';
 export { sortCatalogItems } from './utils/catalog-sort';
+export { buildCatalogTabs } from './utils/catalog-tabs';
 export { useFavColumns } from './utils/use-fav-columns';
 export {
   getCredentialsBadgeState,

--- a/libs/catalog/src/models/catalog-props.ts
+++ b/libs/catalog/src/models/catalog-props.ts
@@ -6,7 +6,7 @@ import type {
   PublishHistoryEntry,
   PublishPanelLabels,
 } from '@epam/ai-dial-publish-panel';
-import { DropdownItem } from '@epam/ai-dial-ui-kit';
+import { DropdownItem, TabModel } from '@epam/ai-dial-ui-kit';
 import type { ReactNode } from 'react';
 import type { CatalogSortKey } from '../types/sort';
 import type { CredentialsLevel } from '../types/toolset-auth';
@@ -68,8 +68,31 @@ export interface CatalogTitles {
 
 /** Props for Catalog. */
 export interface CatalogProps {
-  /** Items to display in the Browse section. */
+  /**
+   * Items to display in the Browse section's grid/list. Also drives the
+   * default entity-type tabs and Topics filter options when `tabs`/
+   * `topicOptions` are omitted.
+   */
   items: CatalogItem[];
+  /**
+   * Externally-controlled entity-type tab list. When omitted, `Catalog`
+   * derives tabs internally from `items` via `buildCatalogTabs`.
+   *
+   * Lets a host compute tabs from a wider item set than `items` — e.g. so a
+   * host that narrows `items` for grid display (by a category-tree
+   * selection) doesn't lose a tab for a type with zero matches in that
+   * narrowed set.
+   */
+  tabs?: TabModel[];
+  /**
+   * Externally-controlled set of available Topics filter options. When
+   * omitted, `Catalog` derives them internally from `items` via
+   * `getTopicOptions`.
+   *
+   * Lets a host compute the option set from a wider item set than `items`,
+   * for the same reason as `tabs`.
+   */
+  topicOptions?: Set<string>;
   /** Items to display in the Favorites section. */
   favorites: CatalogItem[];
   /** Grouped text labels for headings and actions. */

--- a/libs/catalog/src/utils/catalog-filter.spec.ts
+++ b/libs/catalog/src/utils/catalog-filter.spec.ts
@@ -1,7 +1,7 @@
 import { CatalogEntityType } from '@epam/ai-dial-chat-shared';
 import { describe, expect, it } from 'vitest';
 import type { CatalogItem } from '../models/catalog-item';
-import { filterCatalogItems } from './catalog-filter';
+import { filterCatalogItems, getTopicOptions } from './catalog-filter';
 
 const makeItem = (
   overrides: Partial<CatalogItem> & Pick<CatalogItem, 'id' | 'name'>,
@@ -64,5 +64,20 @@ describe('filterCatalogItems', () => {
       makeItem({ id: '2', name: 'Claude' }),
     ];
     expect(filterCatalogItems(items, 'xyzzy-no-match')).toHaveLength(0);
+  });
+});
+
+describe('getTopicOptions', () => {
+  it('returns the distinct set of topics across items', () => {
+    const items = [
+      makeItem({ id: '1', name: 'GPT-4', topics: ['Free', 'Text'] }),
+      makeItem({ id: '2', name: 'Claude', topics: ['Paid', 'Text'] }),
+    ];
+    expect(getTopicOptions(items)).toEqual(new Set(['Free', 'Text', 'Paid']));
+  });
+
+  it('returns an empty set when no items have topics', () => {
+    const items = [makeItem({ id: '1', name: 'GPT-4' })];
+    expect(getTopicOptions(items)).toEqual(new Set());
   });
 });

--- a/libs/catalog/src/utils/catalog-filter.ts
+++ b/libs/catalog/src/utils/catalog-filter.ts
@@ -30,6 +30,10 @@ export const filterByTopics = (
 export const filterByMyApp = (items: CatalogItem[]): CatalogItem[] =>
   items.filter((item) => item.isMyApp === true);
 
+/** Derives the set of distinct topic values present across `items`. */
+export const getTopicOptions = (items: CatalogItem[]): Set<string> =>
+  new Set(items.flatMap((item) => item.topics));
+
 /**
  * Returns a filtered array of items whose name, description, or type includes the query.
  * Case-insensitive and ignores leading/trailing whitespace.

--- a/openspec/specs/catalog-prompt-entity-type/spec.md
+++ b/openspec/specs/catalog-prompt-entity-type/spec.md
@@ -36,7 +36,7 @@ The lib MUST NOT branch on `Prompt` to reach any host-owned fact. It MUST NOT im
 
 `buildCatalogTabs` (`libs/catalog/src/utils/catalog-tabs.ts`) SHALL add `Prompt` to `DEFAULT_TAB_LABELS` with the English default `'Prompts'`, and to `TAB_ORDER` immediately after `CatalogEntityType.Skill`, as the last entry.
 
-Tab derivation behaviour is unchanged: a tab appears only when at least one item of that type is present in `items`, and a host-supplied `tabLabels[CatalogEntityType.Prompt]` overrides the English default.
+Tab derivation behaviour of `buildCatalogTabs` is unchanged: a tab appears only when at least one item of that type is present in the items it is given, and a host-supplied `tabLabels[CatalogEntityType.Prompt]` overrides the English default. `Catalog` uses that helper when `tabs` is omitted; a host-supplied `tabs` list is rendered as-is and is not re-filtered against `items`.
 
 #### Scenario: Prompts tab appears when prompt items are present
 

--- a/openspec/specs/catalog-sort-filter-persistence/spec.md
+++ b/openspec/specs/catalog-sort-filter-persistence/spec.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-Persisting the catalog's sort key and topic filter, and reconciling them into the controlled `Catalog` component.
+Persisting the catalog's sort key and topic filter, and reconciling them into the controlled `Catalog` component. Also the optional host-supplied Topics option set so a host can keep filter checkboxes that would disappear if `Catalog` derived them only from a narrowed `items` set.
 
 ## Requirements
 
@@ -47,6 +47,33 @@ RTL impact: none (no new layout).
 
 - **WHEN** the user checks a topic in the "From" filter dropdown and clicks Apply, and `onFilterTopicsChange` is supplied
 - **THEN** `onFilterTopicsChange` is called with a `Set<string>` containing the checked topic(s)
+
+---
+
+### Requirement: Catalog accepts a host-supplied Topics option set
+
+`CatalogProps` SHALL include an optional `topicOptions?: Set<string>`.
+
+When `topicOptions` is supplied, `Catalog` SHALL use it as the Topics filter checkbox values (`filterValues`) and SHALL NOT derive options from `items`. When omitted, `Catalog` SHALL derive them via `getTopicOptions` on non-hidden `items`.
+
+`topicOptions` controls only which topics are listed. The selected filter remains `filterTopics` / `onFilterTopicsChange` (or Catalog's internal filter state when those are omitted). A listed option with no matching item in the current `items` set is still shown; applying it may empty the Browse grid.
+
+`@epam/ai-dial-catalog` SHALL export `getTopicOptions` so a host can compute the option set from a wider item set than it passes as `items`, for the same reason as the host-supplied `tabs` list.
+
+`Catalog` SHALL NOT read storage, routes, translations, or feature flags to decide the Topics options.
+
+i18n keys needed: none. RTL/accessibility: the existing Filter dropdown already handles layout direction and checkbox labelling. Feature flag: none.
+
+#### Scenario: Host topicOptions include topics absent from current items
+
+- **WHEN** `Catalog` is rendered with items whose topics are only `['Free']`, and `topicOptions` computed via `getTopicOptions` from a wider set that also includes `'Paid'`
+- **THEN** the Topics filter lists both `Free` and `Paid`
+
+#### Scenario: Omitted topicOptions are still derived from items
+
+- **WHEN** `Catalog` is rendered with an item whose topics are `['Free']` and no `topicOptions` prop
+- **THEN** the Topics filter lists `Free`
+- **AND** it does not list topics that are absent from `items`
 
 ---
 

--- a/openspec/specs/catalog-tab-persistence/spec.md
+++ b/openspec/specs/catalog-tab-persistence/spec.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-Persisting the catalog's active tab selection and reconciling it into the controlled `Catalog` component.
+Persisting the catalog's active tab selection and reconciling it into the controlled `Catalog` component. Also the optional host-supplied tab list so a host can keep entity-type tabs that would disappear if `Catalog` derived them only from a narrowed `items` set.
 
 ## Requirements
 
@@ -13,13 +13,13 @@ Persisting the catalog's active tab selection and reconciling it into the contro
 - `activeTab?: string`
 - `onActiveTabChange?: (tabId: string) => void`
 
-`Catalog` (`libs/catalog/src/components/Catalog/Catalog.tsx`) SHALL use `props.activeTab ?? internalActiveTab` so it remains fully functional when the props are omitted (uncontrolled, current behavior unchanged: defaults to the first tab returned by `buildCatalogTabs`). When `onActiveTabChange` is supplied, `Catalog` SHALL call it on every tab-switch interaction in addition to updating its own internal fallback state.
+`Catalog` (`libs/catalog/src/components/Catalog/Catalog.tsx`) SHALL use `props.activeTab ?? internalActiveTab` so it remains fully functional when the props are omitted (uncontrolled, current behavior unchanged: defaults to the first tab of the resolved tab list — `tabs` when supplied, otherwise `buildCatalogTabs` on non-hidden `items`). When `onActiveTabChange` is supplied, `Catalog` SHALL call it on every tab-switch interaction in addition to updating its own internal fallback state.
 
 `Catalog` SHALL NOT read or write `localStorage`, `sessionStorage`, `URLSearchParams`, or any routing API to determine or persist the active tab — it remains host-agnostic per AGENTS.md §Library isolation.
 
 State owner: `Catalog`'s existing internal `activeTab` state remains the fallback owner when uncontrolled; `CatalogView` (via `useCatalogActiveTabPreference`, see below) is the owner when controlled.
 
-Memoisation: no new memoisation is required in `Catalog` beyond the existing `useMemo` for `tabs`.
+Memoisation: no new memoisation is required in `Catalog` beyond the existing `useMemo` for the resolved tab list.
 
 i18n keys needed: none (no new user-visible strings).
 
@@ -30,17 +30,50 @@ Accessibility: none — the existing `Tabs` component's `activeTabId`/`onTabChan
 #### Scenario: Uncontrolled Catalog behaves exactly as before
 
 - **WHEN** `Catalog` is rendered without `activeTab` or `onActiveTabChange`
-- **THEN** it defaults to the first tab id returned by `buildCatalogTabs` and tab switching works entirely from internal state, as it does today
+- **THEN** it defaults to the first tab id of the resolved tab list and tab switching works entirely from internal state, as it does today
 
 #### Scenario: Controlled activeTab overrides internal state
 
-- **WHEN** `Catalog` is rendered with `activeTab="skill"` and a `Skill` tab is present in `buildCatalogTabs`'s output
+- **WHEN** `Catalog` is rendered with `activeTab="skill"` and a `Skill` tab is present in the resolved tab list
 - **THEN** the Skill tab is shown as active regardless of any internal default
 
 #### Scenario: Switching tabs calls onActiveTabChange
 
 - **WHEN** the user clicks the "Agents" tab and `onActiveTabChange` is supplied
 - **THEN** `onActiveTabChange` is called with the Agent tab's id
+
+---
+
+### Requirement: Catalog accepts a host-supplied tab list
+
+`CatalogProps` SHALL include an optional `tabs?: TabModel[]` (`TabModel` from `@epam/ai-dial-ui-kit`).
+
+When `tabs` is supplied, `Catalog` SHALL render that list as the entity-type tab row and SHALL NOT call `buildCatalogTabs` on `items`. The Browse grid/list SHALL still be limited to the `items` prop: a host tab with no matching item type is shown, but its panel is empty.
+
+When `tabs` is omitted, `Catalog` SHALL derive the tab row from non-hidden `items` via `buildCatalogTabs(filteredItems, titles?.tabLabels)`. Host-supplied `titles.tabLabels` apply only on this default path; they SHALL NOT relabel a host-supplied `tabs` list.
+
+`@epam/ai-dial-catalog` SHALL export `buildCatalogTabs` so a host can compute tabs from a wider item set than it passes as `items` — for example after a category-tree selection that leaves one entity type with zero matches in the narrowed set.
+
+`Catalog` SHALL NOT read storage, routes, translations, or feature flags to decide the tab list.
+
+i18n keys needed: none. RTL/accessibility: the existing `Tabs` component already handles layout direction and ARIA tab semantics. Feature flag: none.
+
+#### Scenario: Host tabs survive a narrowed items list
+
+- **WHEN** `Catalog` is rendered with `items` containing only an Agent, and `tabs` computed via `buildCatalogTabs` from a wider set that also includes Model and Prompt items
+- **THEN** the tab row includes Models, Agents, and Prompts
+- **AND** the Browse grid still contains only the Agent item
+
+#### Scenario: Omitted tabs are still derived from items
+
+- **WHEN** `Catalog` is rendered with only an Agent item and no `tabs` prop
+- **THEN** the tab row includes Agents
+- **AND** it does not include Models, Prompts, or any other type absent from `items`
+
+#### Scenario: Host tabs are not relabelled by titles.tabLabels
+
+- **WHEN** `Catalog` is rendered with a host-supplied `tabs` list whose Agent label is `'Agents'` and `titles.tabLabels = { AGENT: 'Агенты' }`
+- **THEN** the Agents tab still shows `'Agents'`
 
 ---
 

--- a/openspec/specs/skill-catalog-listing/spec.md
+++ b/openspec/specs/skill-catalog-listing/spec.md
@@ -17,7 +17,7 @@ This is an overlay feature key, not an `ENABLED_FEATURES` / `ENABLED_FEATURES_RO
 #### Scenario: Feature disabled
 
 - **WHEN** `OverlayFeature.Skills` is not enabled
-- **THEN** no skill item enters `catalogItems`, `buildCatalogTabs` derives no Skills tab, and the catalog renders exactly as it does without this change
+- **THEN** no skill item enters `catalogItems`, the catalog's default tab derivation (`buildCatalogTabs` on those items, used when `tabs` is omitted) includes no Skills tab, and the catalog renders exactly as it does without this change
 
 #### Scenario: Feature enabled with at least one skill
 
@@ -69,7 +69,7 @@ The decision remains at the app edge through `CatalogItem.isEditable` and `Catal
 
 When the skills context reports a non-null `error`, `CatalogView` SHALL surface it once through the existing notification path (`useOperationNotification`) using the i18n key `catalog.skillsLoadError`, and SHALL continue rendering every other catalog item.
 
-An empty listing is not an error: with no skills present, `buildCatalogTabs` simply derives no Skills tab, and no notification is raised.
+An empty listing is not an error: with no skills present, the catalog's default tab derivation (`buildCatalogTabs` on those items) simply includes no Skills tab, and no notification is raised.
 
 #### Scenario: Listing error notifies and degrades
 


### PR DESCRIPTION
**Description:**

<SHORT_DESCRIPTION>

Issues:

- Issue #<TICKET_ID>

**UI changes**

<Please, provide Screenshots or Figma links>

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
