### PR TITLE
fix(chat): support all mime types (#8553)

### DIFF
--- a/libs/attachment-input/src/utils/attachment.ts
+++ b/libs/attachment-input/src/utils/attachment.ts
@@ -60,17 +60,26 @@ const WILDCARD_TYPE_LABELS: Record<string, string> = {
   '*': 'All files',
 };
 
+const MIME_TYPE_LABEL_OVERRIDES: Record<string, string> = {
+  'image/jpeg': 'JPEG',
+};
+
 /** Converts an array of MIME type strings (including wildcards) into a comma-separated human-readable label string. */
 export const mimeTypesToExtensionLabels = (
   types: string[],
   wildcardLabels: Record<string, string> = WILDCARD_TYPE_LABELS,
 ): string => {
   const labels = types.map((type) => {
-    if (type.endsWith('/*')) {
-      const major = type.slice(0, -2);
+    const normalizedType = type.toLowerCase().split(';')[0].trim();
+    if (normalizedType.endsWith('/*')) {
+      const major = normalizedType.slice(0, -2);
       return wildcardLabels[major] ?? `${major} files`;
     }
-    const subtype = type.split('/')[1];
+    const labelOverride = MIME_TYPE_LABEL_OVERRIDES[normalizedType];
+    if (labelOverride) return labelOverride;
+    const extension = MIME_TYPE_EXT_MAP[normalizedType];
+    if (extension) return extension.toUpperCase();
+    const subtype = normalizedType.split('/')[1];
     return subtype != null ? subtype.toUpperCase() : type.toUpperCase();
   });
   return labels.join(', ');

--- a/libs/attachment-input/src/utils/tests/attachment-mime.spec.ts
+++ b/libs/attachment-input/src/utils/tests/attachment-mime.spec.ts
@@ -8,6 +8,17 @@ describe('mimeTypesToExtensionLabels', () => {
     expect(mimeTypesToExtensionLabels(['image/jpeg'])).toBe('JPEG');
   });
 
+  it('converts common vendor and structured MIME types to extension labels', () => {
+    expect(
+      mimeTypesToExtensionLabels([
+        'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+        'application/vnd.amazon.ebook',
+        'application/epub+zip',
+        'font/woff2',
+      ]),
+    ).toBe('DOCX, AZW, EPUB, WOFF2');
+  });
+
   it('converts wildcard MIME types to human-readable group labels', () => {
     expect(mimeTypesToExtensionLabels(['image/*'])).toBe('Image files');
     expect(mimeTypesToExtensionLabels(['audio/*'])).toBe('Audio files');

--- a/libs/chat-shared/src/constants/mime-types.ts
+++ b/libs/chat-shared/src/constants/mime-types.ts
@@ -1,45 +1,118 @@
-/** Maps MIME types to canonical file extensions. */
+/**
+ * Maps common MIME types to canonical file extensions.
+ *
+ * The standard entries follow MDN's common media types table. Project-specific
+ * aliases are retained for MIME values produced by existing integrations.
+ * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/MIME_types/Common_types
+ */
 export const MIME_TYPE_EXT_MAP: Record<string, string> = {
   // Text
-  'text/markdown': 'md',
-  'text/plain': 'txt',
+  'text/calendar': 'ics',
+  'text/css': 'css',
+  'text/csv': 'csv',
   'text/html': 'html',
   'text/javascript': 'js',
-  'text/typescript': 'ts',
   'text/jsx': 'jsx',
+  'text/markdown': 'md',
+  'text/plain': 'txt',
   'text/tsx': 'tsx',
-  'text/x-sql': 'sql',
+  'text/typescript': 'ts',
+  'text/xml': 'xml',
   'text/x-php': 'php',
   'text/x-rustsrc': 'rs',
+  'text/x-sql': 'sql',
   'text/x-vue': 'vue',
 
   // Application
-  'application/json': 'json',
-  'application/pdf': 'pdf',
+  'application/epub+zip': 'epub',
+  'application/gzip': 'gz',
+  'application/java-archive': 'jar',
   'application/javascript': 'js',
+  'application/json': 'json',
+  'application/ld+json': 'jsonld',
+  'application/manifest+json': 'webmanifest',
+  'application/msword': 'doc',
+  'application/octet-stream': 'bin',
+  'application/ogg': 'ogx',
+  'application/pdf': 'pdf',
+  'application/rtf': 'rtf',
+  'application/sql': 'sql',
   'application/typescript': 'ts',
   'application/xhtml+xml': 'xhtml',
-  'application/gzip': 'gz',
-  'application/x-tar': 'tar',
-  'application/x-zip-compressed': 'zip',
-  'application/x-rar-compressed': 'rar',
-  'application/x-7z-compressed': '7z',
-  'application/x-php': 'php',
-  'application/x-rust': 'rs',
-  'application/sql': 'sql',
-  'application/msword': 'doc',
-  'application/vnd.ms-word': 'doc',
+  'application/xml': 'xml',
+  'application/vnd.amazon.ebook': 'azw',
+  'application/vnd.apple.installer+xml': 'mpkg',
   'application/vnd.ms-excel': 'xls',
+  'application/vnd.ms-fontobject': 'eot',
   'application/vnd.ms-powerpoint': 'ppt',
-  'application/vnd.openxmlformats-officedocument.wordprocessingml.document':
-    'docx',
-  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': 'xlsx',
+  'application/vnd.ms-word': 'doc',
+  'application/vnd.mozilla.xul+xml': 'xul',
+  'application/vnd.oasis.opendocument.presentation': 'odp',
+  'application/vnd.oasis.opendocument.spreadsheet': 'ods',
+  'application/vnd.oasis.opendocument.text': 'odt',
   'application/vnd.openxmlformats-officedocument.presentationml.presentation':
     'pptx',
+  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': 'xlsx',
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document':
+    'docx',
+  'application/vnd.rar': 'rar',
+  'application/vnd.visio': 'vsd',
+  'application/x-7z-compressed': '7z',
+  'application/x-abiword': 'abw',
+  'application/x-bzip': 'bz',
+  'application/x-bzip2': 'bz2',
+  'application/x-cdf': 'cda',
+  'application/x-csh': 'csh',
+  'application/x-freearc': 'arc',
+  'application/x-gzip': 'gz',
+  'application/x-httpd-php': 'php',
+  'application/x-php': 'php',
+  'application/x-rar-compressed': 'rar',
+  'application/x-rust': 'rs',
+  'application/x-sh': 'sh',
+  'application/x-tar': 'tar',
+  'application/x-zip-compressed': 'zip',
+  'application/zip': 'zip',
+
+  // Audio
+  'audio/3gpp': '3gp',
+  'audio/3gpp2': '3g2',
+  'audio/aac': 'aac',
+  'audio/midi': 'midi',
+  'audio/mp4': 'm4a',
+  'audio/mpeg': 'mp3',
+  'audio/ogg': 'oga',
+  'audio/wav': 'wav',
+  'audio/webm': 'weba',
+  'audio/x-midi': 'midi',
+
+  // Fonts
+  'font/otf': 'otf',
+  'font/ttf': 'ttf',
+  'font/woff': 'woff',
+  'font/woff2': 'woff2',
 
   // Images
+  'image/apng': 'apng',
+  'image/avif': 'avif',
+  'image/bmp': 'bmp',
+  'image/gif': 'gif',
   'image/jpeg': 'jpg',
+  'image/png': 'png',
   'image/svg+xml': 'svg',
+  'image/tiff': 'tiff',
+  'image/vnd.microsoft.icon': 'ico',
+  'image/webp': 'webp',
+
+  // Video
+  'video/3gpp': '3gp',
+  'video/3gpp2': '3g2',
+  'video/mp2t': 'ts',
+  'video/mp4': 'mp4',
+  'video/mpeg': 'mpeg',
+  'video/ogg': 'ogv',
+  'video/webm': 'webm',
+  'video/x-msvideo': 'avi',
 };
 
 /** MIME type wildcard that matches any content type. */

--- a/openspec/specs/attachment-input-lib/spec.md
+++ b/openspec/specs/attachment-input-lib/spec.md
@@ -79,6 +79,10 @@ The following utility functions SHALL be exported from `libs/attachment-input/sr
 
 The `useClipboardPaste` and `useLazyImageLoad` hooks (with `LazyImageLoadStatus`) SHALL be exported alongside them.
 
+`mimeTypesToExtensionLabels(types, wildcardLabels?)` SHALL return one comma-separated string. For each concrete MIME value, it SHALL normalize case and ignore MIME parameters, use the uppercased extension from `MIME_TYPE_EXT_MAP` when the normalized value is known, preserve the established `image/jpeg` → `JPEG` label, and otherwise fall back to the uppercased subtype. Wildcards SHALL retain their human-readable group-label behavior.
+
+`MIME_TYPE_EXT_MAP` SHALL cover the 78 unique MIME values in MDN's [Common media types](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/MIME_types/Common_types) table as retrieved on 2026-09-02, choosing one canonical extension when multiple extensions share one MIME value. Existing project-specific aliases MAY remain in addition to that baseline.
+
 #### Scenario: isMimeTypeAllowed returns correct result
 - **WHEN** `isMimeTypeAllowed` is called with a MIME type and an allowlist array
 - **THEN** it returns `true` if the MIME type matches an allowed entry, `false` otherwise
@@ -89,7 +93,11 @@ The `useClipboardPaste` and `useLazyImageLoad` hooks (with `LazyImageLoadStatus`
 
 #### Scenario: mimeTypesToExtensionLabels converts MIME types
 - **WHEN** `mimeTypesToExtensionLabels` is called with an array of MIME type strings
-- **THEN** it returns an array of human-readable extension label strings
+- **THEN** it returns one comma-separated string of human-readable extension labels
+
+#### Scenario: Structured MIME types use canonical extension labels
+- **WHEN** `mimeTypesToExtensionLabels` is called with `['application/vnd.openxmlformats-officedocument.wordprocessingml.document', 'application/vnd.amazon.ebook', 'application/epub+zip', 'font/woff2']`
+- **THEN** it returns `"DOCX, AZW, EPUB, WOFF2"`
 
 ### Requirement: Upload constants exported from new lib
 The upload constraint constants (e.g. `MAX_UPLOADS_PER_MINUTE`) from `libs/conversation-input/src/constants/upload.ts` SHALL be exported from `libs/attachment-input/src/index.ts`.

--- a/openspec/specs/attachment-unsupported-type-error/spec.md
+++ b/openspec/specs/attachment-unsupported-type-error/spec.md
@@ -20,7 +20,7 @@ After processing a batch of added files (from file picker, drag-and-drop, or cli
 
 When the failure reason is that the deployment accepts **no** attachment types at all, the pair `attachments.noAttachmentsAllowed.title` / `.message` ("Attachments not supported" / "This model does not support file attachments.") SHALL be used instead, with no `{{formats}}` interpolation — listing zero accepted formats would produce an empty sentence.
 
-The `formats` list is produced by the pure `mimeTypesToExtensionLabels(types: string[], wildcardLabels?: Record<string, string>): string` utility exported from `@epam/ai-dial-attachment-input`, which converts MIME entries to uppercase extension labels (e.g. `image/jpeg` → `JPEG`, `application/pdf` → `PDF`, `text/csv` → `CSV`) and maps a `<major>/*` wildcard through a label table (`image/*` → `Image files`, `audio/*` → `Audio files`, `video/*` → `Video files`, `text/*` → `Text files`, `*/*` → `All files`), falling back to `<major> files` for an unlisted major type. A host may override that table through the second argument.
+The `formats` list is produced by the pure `mimeTypesToExtensionLabels(types: string[], wildcardLabels?: Record<string, string>): string` utility exported from `@epam/ai-dial-attachment-input`. For a concrete MIME value, the utility normalizes case and ignores MIME parameters, resolves known values through `MIME_TYPE_EXT_MAP`, and renders the mapped extension in uppercase (e.g. `application/vnd.openxmlformats-officedocument.wordprocessingml.document` → `DOCX`, `application/pdf` → `PDF`, `text/csv` → `CSV`). The established `image/jpeg` → `JPEG` label is preserved; an unknown concrete MIME falls back to its uppercased subtype. A `<major>/*` wildcard is mapped through a label table (`image/*` → `Image files`, `audio/*` → `Audio files`, `video/*` → `Video files`, `text/*` → `Text files`, `*/*` → `All files`), falling back to `<major> files` for an unlisted major type. A host may override that wildcard table through the second argument.
 
 **i18n keys:**
 - `attachments.unsupportedType.title`
@@ -54,6 +54,11 @@ The `formats` list is produced by the pure `mimeTypesToExtensionLabels(types: st
 
 - **WHEN** the deployment's `inputAttachmentTypes` is `['image/*']` and the user picks `photo.png` (MIME `image/png`)
 - **THEN** the file passes validation and `onUploadAttachment` is called normally
+
+#### Scenario: Structured MIME entry is readable in an error notification
+
+- **WHEN** validation fails for a deployment whose `inputAttachmentTypes` contains `application/vnd.openxmlformats-officedocument.wordprocessingml.document`
+- **THEN** the notification body lists `DOCX`, not the raw MIME subtype
 
 #### Scenario: Global wildcard accepts any file
 

--- a/openspec/specs/catalog-item-details-fetch/spec.md
+++ b/openspec/specs/catalog-item-details-fetch/spec.md
@@ -276,7 +276,7 @@ layout without physical-direction overrides. No new React state or memoisation i
 
 ### Requirement: Input/Output modalities render as friendly labels, and internal-only capability flags are hidden
 
-`apps/chat/src/utils/map-entity-details-to-catalog.ts` SHALL render a model's and application's
+`libs/chat-hooks/src/catalog/map-entity-details-to-catalog.ts` SHALL render a model's and application's
 `inputAttachmentTypes`/`outputAttachmentTypes` (surfaced as `ModelSpecification.inputTypes`/
 `outputTypes` and `AgentConfiguration.inputAttachmentTypes`/`outputAttachmentTypes`) as
 human-readable labels via `mimeTypesToExtensionLabels` (`@epam/ai-dial-attachment-input`) rather
@@ -284,7 +284,10 @@ than the raw MIME type strings DIAL Core returns. A wildcard major type (`image/
 `video/*`, `text/*`) SHALL render as `"<Major> files"` (e.g. `"Image files"`); the catch-all
 wildcard `*/*` SHALL render as `"All files"` rather than falling through to the generic
 `"<major> files"` template (which would otherwise render the nonsensical `"* files"`); a
-concrete MIME type (e.g. `application/pdf`) SHALL render as its uppercased subtype (`"PDF"`).
+known concrete MIME type SHALL render as its uppercased extension from `MIME_TYPE_EXT_MAP`
+(e.g. `application/pdf` → `"PDF"` and
+`application/vnd.openxmlformats-officedocument.wordprocessingml.document` → `"DOCX"`), while
+an unknown concrete MIME type SHALL fall back to its uppercased subtype.
 The `Specification` section's row labels for these two fields SHALL use the i18n keys
 `catalog.details.modelSpecification.inputModalities` / `.outputModalities`
 (`CatalogI18nKeys.DetailsModelInputModalities` / `DetailsModelOutputModalities`), replacing the
@@ -319,10 +322,15 @@ tool calls`, `Reasoning efforts` (model only), and `Configuration schema` (appli
 - **WHEN** a model's `input_attachment_types` is `["*/*"]`
 - **THEN** the Input modalities row renders `"All files"`, not `"* files"`
 
-#### Scenario: A concrete MIME type renders as its uppercased subtype
+#### Scenario: A known concrete MIME type renders as its extension label
 
 - **WHEN** an application's `input_attachment_types` is `["application/pdf"]`
 - **THEN** the `Configuration` section's Input attachments row renders `"PDF"`
+
+#### Scenario: A structured vendor MIME type does not render as a raw subtype
+
+- **WHEN** a model's `input_attachment_types` is `["application/vnd.openxmlformats-officedocument.wordprocessingml.document"]`
+- **THEN** the `Specification` section's Input modalities row renders `"DOCX"`
 
 #### Scenario: Toolset Capabilities section never renders
 


### PR DESCRIPTION
**Description:**

Fix unreadable attachment type labels produced from `inputAttachmentTypes`.
Previously, structured or vendor-specific MIME types such as `application/vnd.openxmlformats-officedocument.wordprocessingml.document` were displayed as raw uppercased MIME subtypes. They are now resolved to concise extension labels such as DOCX.

Changes
• Expanded `MIME_TYPE_EXT_MAP` to cover all 78 unique MIME types from MDN’s common media types table while retaining existing project-specific aliases.
• Updated `mimeTypesToExtensionLabels` to:
  ◦ resolve known MIME types through the shared map;
  ◦ normalize casing and ignore MIME parameters;
  ◦ preserve existing wildcard labels such as Image files;
  ◦ preserve the existing image/jpeg → JPEG output;
  ◦ fall back to the uppercased subtype for unknown MIME types.

Issues:

- https://github.com/epam/ai-dial-chat/issues/8553


**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [X] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
