### PR TITLE
fix(chat): add possibility to override catalog 'Browse' header

### DIFF
--- a/libs/catalog/README.md
+++ b/libs/catalog/README.md
@@ -110,6 +110,26 @@ import { buildCatalogTabs, Catalog, getTopicOptions } from '@epam/ai-dial-catalo
 />;
 ```
 
+#### Overriding the Browse heading
+
+By default the Browse section's heading is the plain text label
+`titles.browseTitle` (default `'Browse'`) rendered next to the item count. Pass
+`browseHeading` to replace that whole slot with any node — e.g. a clickable
+breadcrumb — instead. When supplied, the item count is not rendered alongside
+it, so include it in the node if needed; the host owns click handling and
+visual composition entirely, since the lib has no notion of the underlying
+navigation (a category tree, etc.).
+
+```tsx
+<Catalog
+  items={itemsNarrowedByCategory}
+  favorites={favoriteItems}
+  browseHeading={
+    <Breadcrumb segments={selectedPath} onSegmentClick={handleJumpToSegment} />
+  }
+/>;
+```
+
 ### CardGrid
 
 Virtualized grid view of catalog cards.

--- a/libs/catalog/README.md
+++ b/libs/catalog/README.md
@@ -114,7 +114,7 @@ import { buildCatalogTabs, Catalog, getTopicOptions } from '@epam/ai-dial-catalo
 
 By default the Browse section's heading is the plain text label
 `titles.browseTitle` (default `'Browse'`) rendered next to the item count. Pass
-`browseHeading` to replace that whole slot with any node — e.g. a clickable
+`browseHeaderRenderer` to replace that whole slot with any node — e.g. a clickable
 breadcrumb — instead. When supplied, the item count is not rendered alongside
 it, so include it in the node if needed; the host owns click handling and
 visual composition entirely, since the lib has no notion of the underlying
@@ -124,7 +124,7 @@ navigation (a category tree, etc.).
 <Catalog
   items={itemsNarrowedByCategory}
   favorites={favoriteItems}
-  browseHeading={
+  browseHeaderRenderer={
     <Breadcrumb segments={selectedPath} onSegmentClick={handleJumpToSegment} />
   }
 />;

--- a/libs/catalog/src/components/Catalog/Catalog.tsx
+++ b/libs/catalog/src/components/Catalog/Catalog.tsx
@@ -31,7 +31,7 @@ export const Catalog: FC<CatalogProps> = ({
   topicOptions: controlledTopicOptions,
   favorites,
   titles,
-  browseHeading,
+  browseHeaderRenderer,
   onToggleFavorite,
   isFavoriteVisible,
   onUseInChat,
@@ -462,7 +462,7 @@ export const Catalog: FC<CatalogProps> = ({
             query={query}
             onQueryChange={setQuery}
             title={browseTitle}
-            browseHeading={browseHeading}
+            browseHeaderRenderer={browseHeaderRenderer}
             searchPlaceholder={searchPlaceholder}
             gridViewLabel={gridViewLabel}
             listViewLabel={listViewLabel}

--- a/libs/catalog/src/components/Catalog/Catalog.tsx
+++ b/libs/catalog/src/components/Catalog/Catalog.tsx
@@ -31,6 +31,7 @@ export const Catalog: FC<CatalogProps> = ({
   topicOptions: controlledTopicOptions,
   favorites,
   titles,
+  browseHeading,
   onToggleFavorite,
   isFavoriteVisible,
   onUseInChat,
@@ -461,6 +462,7 @@ export const Catalog: FC<CatalogProps> = ({
             query={query}
             onQueryChange={setQuery}
             title={browseTitle}
+            browseHeading={browseHeading}
             searchPlaceholder={searchPlaceholder}
             gridViewLabel={gridViewLabel}
             listViewLabel={listViewLabel}

--- a/libs/catalog/src/components/Toolbar/Rows/TitleRow.tsx
+++ b/libs/catalog/src/components/Toolbar/Rows/TitleRow.tsx
@@ -12,7 +12,7 @@ import {
   SegmentedControlItem,
 } from '@epam/ai-dial-ui-kit';
 import { IconLayoutGrid, IconLayoutList } from '@tabler/icons-react';
-import { FC, useMemo } from 'react';
+import { FC, ReactNode, useMemo } from 'react';
 import { ToolbarStyles } from '../../../models/toolbar-props';
 import { CatalogViewMode } from '../../../types/view-mode';
 import { Filter } from '../../Filter/Filter';
@@ -23,6 +23,7 @@ interface TitleRowProps {
   viewMode: CatalogViewMode;
   onViewModeChange: (mode: CatalogViewMode) => void;
   title?: string;
+  browseHeading?: ReactNode;
   styles?: ToolbarStyles;
   query: string;
   onQueryChange: (q: string) => void;
@@ -48,6 +49,7 @@ export const TitleRow: FC<TitleRowProps> = ({
   viewMode,
   onViewModeChange,
   title = 'Browse',
+  browseHeading,
   styles: browseStyles,
   query,
   onQueryChange,
@@ -109,18 +111,20 @@ export const TitleRow: FC<TitleRowProps> = ({
     <div className="flex flex-col gap-3">
       {/* Row 1: title | view toggle | divider | sort */}
       <div className="flex items-center gap-2">
-        <ItemHeader
-          title={title}
-          postfix={totalCount}
-          titleClassName={titleClassName}
-          postfixClassName={countClassName}
-          className="shrink-0"
-          shouldTruncateTitle={false}
-          colors={{
-            title: browseStyles?.colors?.titleText,
-            count: browseStyles?.colors?.countText,
-          }}
-        />
+        {browseHeading ?? (
+          <ItemHeader
+            title={title}
+            postfix={totalCount}
+            titleClassName={titleClassName}
+            postfixClassName={countClassName}
+            className="shrink-0"
+            shouldTruncateTitle={false}
+            colors={{
+              title: browseStyles?.colors?.titleText,
+              count: browseStyles?.colors?.countText,
+            }}
+          />
+        )}
 
         <div className="ms-auto flex items-center gap-2">
           <SegmentedControl

--- a/libs/catalog/src/components/Toolbar/Rows/TitleRow.tsx
+++ b/libs/catalog/src/components/Toolbar/Rows/TitleRow.tsx
@@ -23,7 +23,7 @@ interface TitleRowProps {
   viewMode: CatalogViewMode;
   onViewModeChange: (mode: CatalogViewMode) => void;
   title?: string;
-  browseHeading?: ReactNode;
+  browseHeaderRenderer?: ReactNode;
   styles?: ToolbarStyles;
   query: string;
   onQueryChange: (q: string) => void;
@@ -49,7 +49,7 @@ export const TitleRow: FC<TitleRowProps> = ({
   viewMode,
   onViewModeChange,
   title = 'Browse',
-  browseHeading,
+  browseHeaderRenderer,
   styles: browseStyles,
   query,
   onQueryChange,
@@ -111,7 +111,7 @@ export const TitleRow: FC<TitleRowProps> = ({
     <div className="flex flex-col gap-3">
       {/* Row 1: title | view toggle | divider | sort */}
       <div className="flex items-center gap-2">
-        {browseHeading ?? (
+        {browseHeaderRenderer ?? (
           <ItemHeader
             title={title}
             postfix={totalCount}

--- a/libs/catalog/src/components/Toolbar/tests/Toolbar.spec.tsx
+++ b/libs/catalog/src/components/Toolbar/tests/Toolbar.spec.tsx
@@ -88,4 +88,15 @@ describe('Toolbar', () => {
     renderToolbar({ title: 'Browse' });
     expect(screen.getByText('Browse')).toBeTruthy();
   });
+
+  it('renders browseHeading instead of the title/count when provided', () => {
+    renderToolbar({
+      title: 'Browse',
+      totalCount: 5,
+      browseHeading: <nav aria-label="breadcrumb">All entities &gt; Org</nav>,
+    });
+
+    expect(screen.getByLabelText('breadcrumb')).toBeTruthy();
+    expect(screen.queryByText('Browse')).toBeNull();
+  });
 });

--- a/libs/catalog/src/components/Toolbar/tests/Toolbar.spec.tsx
+++ b/libs/catalog/src/components/Toolbar/tests/Toolbar.spec.tsx
@@ -89,11 +89,11 @@ describe('Toolbar', () => {
     expect(screen.getByText('Browse')).toBeTruthy();
   });
 
-  it('renders browseHeading instead of the title/count when provided', () => {
+  it('renders browseHeaderRenderer instead of the title/count when provided', () => {
     renderToolbar({
       title: 'Browse',
       totalCount: 5,
-      browseHeading: <nav aria-label="breadcrumb">All entities &gt; Org</nav>,
+      browseHeaderRenderer: <nav aria-label="breadcrumb">All entities &gt; Org</nav>,
     });
 
     expect(screen.getByLabelText('breadcrumb')).toBeTruthy();

--- a/libs/catalog/src/models/catalog-props.ts
+++ b/libs/catalog/src/models/catalog-props.ts
@@ -97,6 +97,13 @@ export interface CatalogProps {
   favorites: CatalogItem[];
   /** Grouped text labels for headings and actions. */
   titles?: CatalogTitles;
+  /**
+   * Renders in place of the Browse section's heading (`titles.browseTitle`)
+   * when supplied, e.g. so a host can render a clickable breadcrumb instead
+   * of a plain text label. The item count normally shown next to the heading
+   * is not rendered alongside it — include it in the supplied node if needed.
+   */
+  browseHeading?: ReactNode;
   /** Whether catalog data is loading (reserved for future loading state). */
   isLoading?: boolean;
   /** Error to display if data loading failed (reserved for future error state). */

--- a/libs/catalog/src/models/catalog-props.ts
+++ b/libs/catalog/src/models/catalog-props.ts
@@ -103,7 +103,7 @@ export interface CatalogProps {
    * of a plain text label. The item count normally shown next to the heading
    * is not rendered alongside it — include it in the supplied node if needed.
    */
-  browseHeading?: ReactNode;
+  browseHeaderRenderer?: ReactNode;
   /** Whether catalog data is loading (reserved for future loading state). */
   isLoading?: boolean;
   /** Error to display if data loading failed (reserved for future error state). */

--- a/libs/catalog/src/models/toolbar-props.ts
+++ b/libs/catalog/src/models/toolbar-props.ts
@@ -1,4 +1,5 @@
 import { DropdownItem } from '@epam/ai-dial-ui-kit';
+import type { ReactNode } from 'react';
 import { CatalogViewMode } from '../types/view-mode';
 
 /** Typography class overrides for `Toolbar`. */
@@ -45,6 +46,12 @@ export interface ToolbarProps {
   onQueryChange: (q: string) => void;
   /** Section heading text. Default: 'Browse'. */
   title?: string;
+  /**
+   * Renders in place of the `title`/`totalCount` heading when supplied, e.g.
+   * so a host can render a clickable breadcrumb instead of a plain text
+   * label.
+   */
+  browseHeading?: ReactNode;
   /** Search input placeholder. Default: 'Search models, tools, agents…'. */
   searchPlaceholder?: string;
   /** Accessible label for switching to grid view. Default: 'Grid view'. */

--- a/libs/catalog/src/models/toolbar-props.ts
+++ b/libs/catalog/src/models/toolbar-props.ts
@@ -51,7 +51,7 @@ export interface ToolbarProps {
    * so a host can render a clickable breadcrumb instead of a plain text
    * label.
    */
-  browseHeading?: ReactNode;
+  browseHeaderRenderer?: ReactNode;
   /** Search input placeholder. Default: 'Search models, tools, agents…'. */
   searchPlaceholder?: string;
   /** Accessible label for switching to grid view. Default: 'Grid view'. */


### PR DESCRIPTION
**Description:**

add possibility to override catalog 'Browse' header

Issues:

- Issue #<TICKET_ID>

**UI changes**

<Please, provide Screenshots or Figma links>

**Checklist:**

- [ ] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [ ] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
