### PR TITLE
fix: Fix extension calcilate for ooxml files, Issue #8492

### DIFF
--- a/libs/attachment-canvas/src/utils/download.ts
+++ b/libs/attachment-canvas/src/utils/download.ts
@@ -8,7 +8,20 @@ import type { AttachmentCanvasContent } from '../models/attachment-canvas';
 import {
   AttachmentContentType,
   AttachmentErrorType,
+  OoxmlFileType,
 } from '../types/attachment-canvas';
+
+/* `content.url` for `Ooxml` is a blob URL created while resolving the preview
+ * (see `resolveOoxmlCanvasContent`), so it never carries the original file's
+ * extension. Fall back to the MIME type implied by `content.format`. */
+const OOXML_MIME_TYPES: Record<OoxmlFileType, string> = {
+  [OoxmlFileType.Docx]:
+    'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  [OoxmlFileType.Xlsx]:
+    'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  [OoxmlFileType.Pptx]:
+    'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+};
 
 /** Returns true if the given canvas content can be downloaded. */
 export const isDownloadable = (content: AttachmentCanvasContent): boolean => {
@@ -59,7 +72,7 @@ const getContentUrlAndMimeType = (
     case AttachmentContentType.Pdf:
       return { url: content.url, mimeType: MIMEType.PDF };
     case AttachmentContentType.Ooxml:
-      return { url: content.url, mimeType: undefined };
+      return { url: content.url, mimeType: OOXML_MIME_TYPES[content.format] };
     case AttachmentContentType.Html:
       return { url: content.url, mimeType: MIMEType.HTML };
     case AttachmentContentType.Unsupported:

--- a/libs/attachment-canvas/src/utils/tests/download.spec.ts
+++ b/libs/attachment-canvas/src/utils/tests/download.spec.ts
@@ -50,12 +50,31 @@ describe('OOXML download', () => {
     expect(mockTriggerBlobDownload).not.toHaveBeenCalled();
   });
 
-  it('falls back to a default file name when none is supplied', () => {
+  it('falls back to a default file name with the format extension when none is supplied', () => {
     downloadAttachmentContent(ooxmlContent());
 
     expect(mockTriggerAnchorDownload).toHaveBeenCalledWith(
       'blob:office-url',
-      'attachment',
+      'attachment.docx',
     );
   });
+
+  it.each([
+    [OoxmlFileType.Docx, 'docx'],
+    [OoxmlFileType.Xlsx, 'xlsx'],
+    [OoxmlFileType.Pptx, 'pptx'],
+  ])(
+    'appends .%s to a title with no extension, even though the content url is an extensionless blob url',
+    (format, ext) => {
+      downloadAttachmentContent(
+        ooxmlContent(format),
+        'Thermo Fisher Scientific - 10-K Risk Factors & Governance Briefing',
+      );
+
+      expect(mockTriggerAnchorDownload).toHaveBeenCalledWith(
+        'blob:office-url',
+        `Thermo Fisher Scientific - 10-K Risk Factors & Governance Briefing.${ext}`,
+      );
+    },
+  );
 });

--- a/openspec/specs/canvas/spec.md
+++ b/openspec/specs/canvas/spec.md
@@ -692,7 +692,7 @@ When the registry is empty or no entry matches, `openFileCanvas` behaves exactly
 | `Image` | `content.url` | — |
 | `Audio` | `content.url` | `content.mimeType` |
 | `Pdf` | `content.url` | `MIMEType.PDF` (`'application/pdf'`) |
-| `Ooxml` | `content.url` | — |
+| `Ooxml` | `content.url` | MIME type for `content.format` (`docx`/`xlsx`/`pptx`) |
 | `Html` | `content.url` | `MIMEType.HTML` (`'text/html'`) |
 | `Unsupported`, `Error` | `content.url` | — |
 | `PlainText`, `Code` | — | `MIMEType.Plain` (`'text/plain'`) |


### PR DESCRIPTION
**Description:**

One more fix for files download when name doesn't have extension

title - how it's download (first one)
<img width="1915" height="1035" alt="image" src="https://github.com/user-attachments/assets/b589a5ed-8a39-484d-b83a-e0566d766ff4" />

<img width="1919" height="1006" alt="image" src="https://github.com/user-attachments/assets/953feb2e-2601-41a7-b177-864507dd753f" />

Issues:

- Issue #8492

**UI changes**


**Checklist:**

- [X] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [X] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [X] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
