### PR TITLE
fix(chat): correct displayed execution duration

### DIFF
--- a/libs/conversation-stages/README.md
+++ b/libs/conversation-stages/README.md
@@ -69,6 +69,12 @@ import { CollapsedGroup } from '@epam/ai-dial-conversation-stages';
 inner `StagesPanel`, so the group and the panel it wraps are themed from one
 place.
 
+When finished stage names include duration metadata with a start timestamp,
+such as `(7.18s, Start: 11:21:38, End: 11:21:45)`, the summary reports the
+elapsed union of those intervals. Parallel stages therefore contribute time
+only once. For legacy duration-only names such as `[3.99s]`, it falls back to
+summing the available durations.
+
 ## Types
 
 ```tsx

--- a/libs/conversation-stages/src/components/CollapsedGroup/CollapsedGroup.tsx
+++ b/libs/conversation-stages/src/components/CollapsedGroup/CollapsedGroup.tsx
@@ -18,9 +18,9 @@ import {
 import { FC, useEffect, useRef, useState } from 'react';
 import type { CollapsedGroupProps } from '../../models/collapsed-group';
 import {
+  calculateStagesDurationSeconds,
   cleanStageName,
   formatTotalDuration,
-  parseDurationSeconds,
 } from '../../utils/stage-name';
 import { findLiveStage, stagePosition } from '../../utils/stage-progress';
 import { StagesPanel } from '../StagesPanel/StagesPanel';
@@ -106,10 +106,9 @@ export const CollapsedGroup: FC<CollapsedGroupProps> = ({
   }
 
   const hasFailed = stages.some((s) => s.status === StageStatus.Failed);
-  const totalSeconds = stages.reduce((sum, stage) => {
-    const { durationLabel } = cleanStageName(stage.name);
-    return sum + (parseDurationSeconds(durationLabel) ?? 0);
-  }, 0);
+  const totalSeconds = calculateStagesDurationSeconds(
+    stages.map((stage) => stage.name),
+  );
   const totalDurationLabel =
     totalSeconds > 0 ? formatTotalDuration(totalSeconds) : undefined;
 

--- a/libs/conversation-stages/src/components/CollapsedGroup/tests/CollapsedGroup.spec.tsx
+++ b/libs/conversation-stages/src/components/CollapsedGroup/tests/CollapsedGroup.spec.tsx
@@ -96,6 +96,22 @@ describe('CollapsedGroup — collapsed states', () => {
     expect(screen.getByText(/1 failed/)).toBeTruthy();
   });
 
+  it('shows elapsed time without double-counting parallel stages', () => {
+    render(
+      <CollapsedGroup
+        stages={[
+          completed(0, 'Tool A (40s, Start: 11:21:00, End: 11:21:40)'),
+          completed(1, 'Tool B (40s, Start: 11:21:00, End: 11:21:40)'),
+          completed(2, 'Tool C (40s, Start: 11:21:00, End: 11:21:40)'),
+        ]}
+        isStreaming={false}
+      />,
+    );
+
+    expect(screen.getByText('40.0s')).toBeTruthy();
+    expect(screen.queryByText('2m 0s')).toBeNull();
+  });
+
   it('is expanded by default while running, showing progress through the live step', () => {
     render(
       <CollapsedGroup

--- a/libs/conversation-stages/src/components/StagesPanel/StagesPanel.tsx
+++ b/libs/conversation-stages/src/components/StagesPanel/StagesPanel.tsx
@@ -18,9 +18,8 @@ import type {
 } from '../../models/stages-props';
 import { groupStagesByName } from '../../utils/stage-grouping';
 import {
-  cleanStageName,
+  calculateStagesDurationSeconds,
   formatTotalDuration,
-  parseDurationSeconds,
 } from '../../utils/stage-name';
 import { findLiveStage } from '../../utils/stage-progress';
 import { StageIcon } from '../StageIcon/StageIcon';
@@ -53,10 +52,9 @@ const StageGroupRow: FC<StageGroupRowProps> = ({
   const [isOpen, setIsOpen] = useState(false);
 
   const hasFailed = row.attempts?.some((a) => a.status === StageStatus.Failed);
-  const totalSeconds = (row.attempts || []).reduce((sum, attempt) => {
-    const { durationLabel } = cleanStageName(attempt.name);
-    return sum + (parseDurationSeconds(durationLabel) ?? 0);
-  }, 0);
+  const totalSeconds = calculateStagesDurationSeconds(
+    (row.attempts || []).map((attempt) => attempt.name),
+  );
   const totalDurationLabel =
     totalSeconds > 0 ? formatTotalDuration(totalSeconds) : undefined;
 

--- a/libs/conversation-stages/src/components/StagesPanel/tests/StagesPanel.spec.tsx
+++ b/libs/conversation-stages/src/components/StagesPanel/tests/StagesPanel.spec.tsx
@@ -238,4 +238,27 @@ describe('StagesPanel', () => {
     expect(screen.getByText('Attempt 2')).toBeTruthy();
     expect(screen.getByText('Attempt 3')).toBeTruthy();
   });
+
+  it('does not double-count overlapping attempts in a collapsed stage row', () => {
+    render(
+      <StagesPanel
+        stages={[
+          {
+            index: 0,
+            name: 'Search (40s, Start: 11:21:00, End: 11:21:40)',
+            status: StageStatus.Completed,
+          },
+          {
+            index: 1,
+            name: 'Search (40s, Start: 11:21:00, End: 11:21:40)',
+            status: StageStatus.Completed,
+          },
+        ]}
+        isStreaming={false}
+      />,
+    );
+
+    expect(screen.getByText('40.0s')).toBeTruthy();
+    expect(screen.queryByText('1m 20s')).toBeNull();
+  });
 });

--- a/libs/conversation-stages/src/utils/stage-name.ts
+++ b/libs/conversation-stages/src/utils/stage-name.ts
@@ -10,8 +10,22 @@ const BRACKET_GROUP_RE = /[([][^()[\]]*[)\]]/g;
 /** Seconds-style duration (e.g. `3.99s`) inside an already-isolated bracket group. */
 const DURATION_INNER_RE = /(\d+(?:\.\d+)?)\s*s\b/;
 
+/** Start time emitted alongside a stage duration (e.g. `Start: 11:21:38`). */
+const START_TIME_INNER_RE =
+  /\bStart:\s*(\d{1,2}):([0-5]\d):([0-5]\d(?:\.\d+)?)\b/i;
+
 /** A colon at the very end of the (already duration-stripped) string. */
 const TRAILING_COLON_RE = /:\s*$/;
+
+const SECONDS_PER_DAY = 24 * 60 * 60;
+const SECONDS_PER_HALF_DAY = SECONDS_PER_DAY / 2;
+
+interface DurationMetadata {
+  durationLabel: string;
+  groupIndex: number;
+  groupLength: number;
+  startTimeSeconds?: number;
+}
 
 /** Result of cleaning a raw backend stage name for display. */
 interface CleanedStageName {
@@ -21,31 +35,47 @@ interface CleanedStageName {
   durationLabel?: string;
 }
 
-/** Strips an embedded duration bracket group (e.g. `(7.18s, ...)`) and a trailing colon from a raw backend stage name. */
-export const cleanStageName = (rawName: string): CleanedStageName => {
-  const safeRawName = rawName ?? '';
+const parseStartTimeSeconds = (inner: string): number | undefined => {
+  const match = START_TIME_INNER_RE.exec(inner);
+  if (!match) return undefined;
+
+  const hours = Number(match[1]);
+  if (hours > 23) return undefined;
+
+  return hours * 60 * 60 + Number(match[2]) * 60 + Number(match[3]);
+};
+
+const extractDurationMetadata = (
+  rawName: string,
+): DurationMetadata | undefined => {
   BRACKET_GROUP_RE.lastIndex = 0;
   let groupMatch: RegExpExecArray | null;
-  let durationMatch: RegExpExecArray | null = null;
-  let groupIndex = -1;
-  let groupLength = 0;
 
-  while ((groupMatch = BRACKET_GROUP_RE.exec(safeRawName))) {
+  while ((groupMatch = BRACKET_GROUP_RE.exec(rawName))) {
     const inner = groupMatch[0].slice(1, -1);
-    const innerMatch = DURATION_INNER_RE.exec(inner);
-    if (innerMatch) {
-      durationMatch = innerMatch;
-      groupIndex = groupMatch.index;
-      groupLength = groupMatch[0].length;
-      break;
+    const durationMatch = DURATION_INNER_RE.exec(inner);
+    if (durationMatch) {
+      return {
+        durationLabel: `${durationMatch[1]}s`,
+        groupIndex: groupMatch.index,
+        groupLength: groupMatch[0].length,
+        startTimeSeconds: parseStartTimeSeconds(inner),
+      };
     }
   }
 
-  const withoutDuration =
-    durationMatch && groupIndex >= 0
-      ? safeRawName.slice(0, groupIndex) +
-        safeRawName.slice(groupIndex + groupLength)
-      : safeRawName;
+  return undefined;
+};
+
+/** Strips an embedded duration bracket group (e.g. `(7.18s, ...)`) and a trailing colon from a raw backend stage name. */
+export const cleanStageName = (rawName: string): CleanedStageName => {
+  const safeRawName = rawName ?? '';
+  const metadata = extractDurationMetadata(safeRawName);
+
+  const withoutDuration = metadata
+    ? safeRawName.slice(0, metadata.groupIndex) +
+      safeRawName.slice(metadata.groupIndex + metadata.groupLength)
+    : safeRawName;
 
   const name = withoutDuration
     .replace(TRAILING_COLON_RE, '')
@@ -54,7 +84,7 @@ export const cleanStageName = (rawName: string): CleanedStageName => {
 
   return {
     name,
-    durationLabel: durationMatch ? `${durationMatch[1]}s` : undefined,
+    durationLabel: metadata?.durationLabel,
   };
 };
 
@@ -79,4 +109,68 @@ export const parseDurationSeconds = (
   if (!durationLabel) return undefined;
   const match = /^(\d+(?:\.\d+)?)s$/.exec(durationLabel);
   return match ? parseFloat(match[1]) : undefined;
+};
+
+/** Returns the elapsed duration represented by stage names, without double-counting overlapping timed stages. */
+export const calculateStagesDurationSeconds = (
+  stageNames: string[],
+): number => {
+  const timings = stageNames.flatMap((stageName) => {
+    const metadata = extractDurationMetadata(stageName ?? '');
+    const durationSeconds = parseDurationSeconds(metadata?.durationLabel);
+
+    return durationSeconds == null
+      ? []
+      : [{ durationSeconds, startTimeSeconds: metadata?.startTimeSeconds }];
+  });
+
+  if (timings.length === 0) return 0;
+
+  if (timings.some(({ startTimeSeconds }) => startTimeSeconds == null)) {
+    return timings.reduce(
+      (sum, { durationSeconds }) => sum + durationSeconds,
+      0,
+    );
+  }
+
+  /*
+   * Time-of-day values carry no date. Preserve stage order and unwrap only a
+   * large backward jump; a global min/max check cannot distinguish a real
+   * midnight rollover from a wide, forward-moving range within one day.
+   */
+  let dayOffset = 0;
+  let previousStart: number | undefined;
+  const intervals = timings
+    .flatMap(({ durationSeconds, startTimeSeconds }) => {
+      if (startTimeSeconds == null) return [];
+
+      let normalizedStart = startTimeSeconds + dayOffset;
+      if (
+        previousStart != null &&
+        previousStart - normalizedStart > SECONDS_PER_HALF_DAY
+      ) {
+        dayOffset += SECONDS_PER_DAY;
+        normalizedStart += SECONDS_PER_DAY;
+      }
+      previousStart = normalizedStart;
+
+      return { start: normalizedStart, end: normalizedStart + durationSeconds };
+    })
+    .sort((a, b) => a.start - b.start);
+
+  let totalSeconds = 0;
+  let currentStart = intervals[0].start;
+  let currentEnd = intervals[0].end;
+
+  for (const interval of intervals.slice(1)) {
+    if (interval.start <= currentEnd) {
+      currentEnd = Math.max(currentEnd, interval.end);
+    } else {
+      totalSeconds += currentEnd - currentStart;
+      currentStart = interval.start;
+      currentEnd = interval.end;
+    }
+  }
+
+  return totalSeconds + currentEnd - currentStart;
 };

--- a/libs/conversation-stages/src/utils/tests/stage-name.spec.ts
+++ b/libs/conversation-stages/src/utils/tests/stage-name.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  calculateStagesDurationSeconds,
   cleanStageName,
   formatTotalDuration,
   isIdentifierLike,
@@ -128,5 +129,56 @@ describe('parseDurationSeconds', () => {
   it('returns undefined for an absent or malformed label', () => {
     expect(parseDurationSeconds(undefined)).toBeUndefined();
     expect(parseDurationSeconds('not-a-duration')).toBeUndefined();
+  });
+});
+
+describe('calculateStagesDurationSeconds', () => {
+  it('counts parallel stages once', () => {
+    expect(
+      calculateStagesDurationSeconds([
+        'Tool A (40s, Start: 11:21:00, End: 11:21:40)',
+        'Tool B (40s, Start: 11:21:00, End: 11:21:40)',
+        'Tool C (40s, Start: 11:21:00, End: 11:21:40)',
+      ]),
+    ).toBe(40);
+  });
+
+  it('counts the union of partially overlapping and sequential stages', () => {
+    expect(
+      calculateStagesDurationSeconds([
+        'Tool A (20s, Start: 11:21:00, End: 11:21:20)',
+        'Tool B (20s, Start: 11:21:10, End: 11:21:30)',
+        'Tool C (10s, Start: 11:21:40, End: 11:21:50)',
+      ]),
+    ).toBe(40);
+  });
+
+  it('normalizes stages that overlap across midnight', () => {
+    expect(
+      calculateStagesDurationSeconds([
+        'Tool A (20s, Start: 23:59:50, End: 00:00:10)',
+        'Tool B (10s, Start: 00:00:05, End: 00:00:15)',
+      ]),
+    ).toBe(25);
+  });
+
+  it('does not infer a midnight rollover from a wide same-day time range', () => {
+    expect(
+      calculateStagesDurationSeconds([
+        'Tool A (1.00s, Start: 00:00:00, End: 00:00:01)',
+        'Tool B (3.00s, Start: 11:59:59, End: 12:00:02)',
+        'Tool C (4.00s, Start: 12:00:00, End: 12:00:04)',
+        'Tool D (1.00s, Start: 23:59:59, End: 00:00:00)',
+      ]),
+    ).toBe(7);
+  });
+
+  it('falls back to summing durations when a stage has no start timestamp', () => {
+    expect(
+      calculateStagesDurationSeconds([
+        'Tool A (40s, Start: 11:21:00, End: 11:21:40)',
+        'Legacy tool [40s]',
+      ]),
+    ).toBe(80);
   });
 });

--- a/openspec/specs/stage-visualization/spec.md
+++ b/openspec/specs/stage-visualization/spec.md
@@ -132,6 +132,44 @@ When `colors` is provided, `StagesPanel` SHALL apply values as CSS custom proper
 
 ---
 
+### Requirement: Finished stage summaries report elapsed execution time
+
+`CollapsedGroup` and collapsed repeated-stage rows in `StagesPanel` SHALL show the elapsed execution time represented by parseable duration metadata in stage names. When every duration-bearing stage also has a valid `Start: HH:mm:ss` timestamp, each stage SHALL be treated as the interval from its start timestamp through its declared duration, and overlapping intervals SHALL contribute to the total only once. A backward jump of more than 12 hours between consecutive stage start timestamps SHALL be treated as a midnight rollover; a wide but forward-moving range within one day SHALL remain on the same day.
+
+If any duration-bearing stage lacks a valid start timestamp, the components SHALL preserve compatibility with duration-only stage names by summing all parseable durations. If no duration can be parsed, no total-duration label SHALL be shown.
+
+#### Scenario: Fully parallel stages contribute time once
+
+- **WHEN** three finished stages each declare a duration of 40 seconds and the same start timestamp
+- **THEN** the finished summary shows `40.0s`, not `2m 0s`
+
+#### Scenario: Partially overlapping stages contribute their interval union
+
+- **WHEN** one 20-second stage starts at `11:21:00`, another 20-second stage starts at `11:21:10`, and a separate 10-second stage starts at `11:21:40`
+- **THEN** the finished summary shows `40.0s`
+
+#### Scenario: Duration-only metadata uses the compatibility fallback
+
+- **WHEN** two finished stages declare `[40s]` without start timestamps
+- **THEN** the finished summary shows their summed duration of `1m 20s`
+
+#### Scenario: Overlapping stages can span midnight
+
+- **WHEN** a 20-second stage starts at `23:59:50` and a 10-second stage starts at `00:00:05`
+- **THEN** the finished summary shows `25.0s`
+
+#### Scenario: A wide same-day range does not imply a midnight rollover
+
+- **WHEN** ordered stages start at `00:00:00`, `11:59:59`, `12:00:00`, and `23:59:59`, with the middle two intervals overlapping across noon
+- **THEN** the middle intervals remain on the same day and the finished summary shows `7.0s`
+
+#### Scenario: Stages without durations omit the total
+
+- **WHEN** none of the finished stage names contains parseable duration metadata
+- **THEN** no total-duration label is rendered
+
+---
+
 ### Requirement: `StagesPanel` is rendered above assistant message bubbles that have stages
 
 In `ConversationView.tsx`, a `messageHasStages` utility SHALL check `message.custom_content?.stages?.length > 0`. For each assistant message where this returns `true`, a `StagesPanel` SHALL be rendered immediately above the corresponding `MessageBubble`. The `isStreaming` prop SHALL be `true` only for the last message while `isAssistantTyping` is `true`.


### PR DESCRIPTION
**Description:**

Fix the displayed execution duration for model responses that run multiple tool calls in parallel.

Previously, `CollapsedGroup` and collapsed repeated-stage rows summed every stage duration. This significantly overstated elapsed time when stages overlapped—for example, three parallel 40-second calls were displayed as 2 minutes instead of 40 seconds.

**Checklist:**

- [X] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [X] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
