### PR TITLE
fix(catalog): fix card description font size to 14/24

### DIFF
--- a/libs/catalog/src/components/CardGrid/Card.tsx
+++ b/libs/catalog/src/components/CardGrid/Card.tsx
@@ -56,9 +56,8 @@ export const Card: FC<CardProps> = ({
   }, [item.id, initialIsStarred]);
 
   const descriptionClassName =
-    cardStyles?.typography?.descriptionClassName ?? 'dial-small-text';
-  const descriptionSizeClassName =
-    cardStyles?.typography?.descriptionSizeClassName ?? 'dial-tiny-text';
+    cardStyles?.typography?.descriptionClassName ??
+    'dial-small-paragraph-text';
 
   const featuredChipClassName = cardStyles?.typography?.featuredChipClassName;
   const folderLabelClassName =
@@ -171,7 +170,6 @@ export const Card: FC<CardProps> = ({
            * lines. `2lh` tracks whichever typography class is applied.
            */
           'line-clamp-2 min-h-[2lh] break-words',
-          descriptionSizeClassName,
           styles.description,
         )}
       >

--- a/libs/catalog/src/models/card-props.ts
+++ b/libs/catalog/src/models/card-props.ts
@@ -6,10 +6,8 @@ export interface CardTypography {
   nameClassName?: string;
   /** Typography class applied to the version text. Default: `'dial-tiny-text'`. */
   versionClassName?: string;
-  /** Typography class applied to the description text. Default: `'dial-small-text'`. */
+  /** Typography class applied to the description text. Default: `'dial-small-paragraph-text'`. */
   descriptionClassName?: string;
-  /** Typography class applied to the last-used text. Default: `'dial-tiny-text'`. */
-  descriptionSizeClassName?: string;
   /** Typography class applied to the featured chip label. Default: `'dial-tiny-lead-semi-text'`. */
   featuredChipClassName?: string;
   /** Typography class applied to folder path separator labels. Default: `'dial-tiny-text'`. */


### PR DESCRIPTION
## Summary
- The description paragraph in the catalog `Card` component had two conflicting default typography classes applied to the same element (`dial-small-text` + `dial-tiny-text`); the second one won the CSS cascade, rendering the text at 12px/16px instead of the intended 14px/24px.
- Replaced both with the single correct ai-dial-ui-kit class `dial-small-paragraph-text` (14px / line-height 24px), and removed the now-redundant `descriptionSizeClassName` prop from `CardTypography` (it had no consumers in this repo and only existed to apply the conflicting second class).

## Test plan
- [x] `npx tsc -p libs/catalog/tsconfig.lib.json --noEmit` — no errors from changed files
- [ ] Visually verify catalog/marketplace card descriptions render at 14px/24px in the app

🤖 Generated with [Claude Code](https://claude.com/claude-code)