### PR TITLE
fix(chat): add possibility for host to control catalog columns visibility

### DIFF
--- a/libs/catalog/README.md
+++ b/libs/catalog/README.md
@@ -549,9 +549,9 @@ for that.
 The list view's optional columns — `folder`, `tags`, and `favorite` — each
 have a built-in default rule (`folder` hides for `CatalogEntityType.Model`;
 `tags` and `favorite` are always shown). `columnVisibility` replaces any of
-these per column, given the active tab's `type` and its `items`; columns left
-out of the map keep their default. `favorite`'s resolved visibility is
-additionally combined (AND) with `isReadonly`.
+these per column, given the active tab's `type`; columns left out of the map
+keep their default. `favorite`'s resolved visibility is additionally combined
+(AND) with `isReadonly`.
 
 ```tsx
 <Catalog

--- a/libs/catalog/README.md
+++ b/libs/catalog/README.md
@@ -539,7 +539,9 @@ lib knowing why. All three default to **visible** when omitted.
 `isFavoriteVisible` is the same family for the favorite star: returning `false`
 for an item hides the star in the browse grid, the list view, the favorites
 strip, and the details panel, and makes that item non-favoritable. It defaults
-to **visible** when omitted, so a predicate can only narrow visibility.
+to **visible** when omitted, so a predicate can only narrow visibility. When
+every item in the active list-view tab is hidden this way, the list view also
+drops its "Favorite" column header, the same as it does under `isReadonly`.
 
 ```tsx
 <Catalog

--- a/libs/catalog/README.md
+++ b/libs/catalog/README.md
@@ -539,9 +539,36 @@ lib knowing why. All three default to **visible** when omitted.
 `isFavoriteVisible` is the same family for the favorite star: returning `false`
 for an item hides the star in the browse grid, the list view, the favorites
 strip, and the details panel, and makes that item non-favoritable. It defaults
-to **visible** when omitted, so a predicate can only narrow visibility. When
-every item in the active list-view tab is hidden this way, the list view also
-drops its "Favorite" column header, the same as it does under `isReadonly`.
+to **visible** when omitted, so a predicate can only narrow visibility. It
+only ever gates the star on individual rows — it has no effect on whether the
+list view's "Favorite" column itself is shown; see `columnVisibility` below
+for that.
+
+### Overriding which list-view columns show per tab
+
+The list view's optional columns — `folder`, `tags`, and `favorite` — each
+have a built-in default rule (`folder` hides for `CatalogEntityType.Model`;
+`tags` and `favorite` are always shown). `columnVisibility` replaces any of
+these per column, given the active tab's `type` and its `items`; columns left
+out of the map keep their default. `favorite`'s resolved visibility is
+additionally combined (AND) with `isReadonly`.
+
+```tsx
+<Catalog
+  items={items}
+  favorites={favorites}
+  // The star itself is still gated per-row by isFavoriteVisible — this only
+  // decides whether the list view's "Favorite" column exists at all.
+  columnVisibility={{
+    favorite: (type) => type !== CatalogEntityType.Model,
+    // Also drop Tags for Skills — this app's skills carry no topics.
+    tags: (type) => type !== CatalogEntityType.Skill,
+  }}
+/>
+```
+
+This only affects the list view's table — the Browse grid's cards are
+unaffected, since they don't render these as columns.
 
 ```tsx
 <Catalog

--- a/libs/catalog/src/components/Catalog/Catalog.tsx
+++ b/libs/catalog/src/components/Catalog/Catalog.tsx
@@ -34,6 +34,7 @@ export const Catalog: FC<CatalogProps> = ({
   browseHeaderRenderer,
   onToggleFavorite,
   isFavoriteVisible,
+  columnVisibility,
   onUseInChat,
   isPrimaryActionVisible,
   onShare,
@@ -536,6 +537,7 @@ export const Catalog: FC<CatalogProps> = ({
                 emptyStateTitle={emptyTitle}
                 onToggleFavorite={onToggleFavorite}
                 isFavoriteVisible={isFavoriteVisible}
+                columnVisibility={columnVisibility}
                 onItemClick={onCardClick ?? handleOpenDetails}
                 stickyHeaderTop={0}
                 selectedItemId={selectedItemId}

--- a/libs/catalog/src/components/ListView/ListView.tsx
+++ b/libs/catalog/src/components/ListView/ListView.tsx
@@ -153,7 +153,7 @@ export const ListView: FC<ListViewProps> = ({
     >
       <div className={mergeClasses('rounded-xl', styles.gridClip)}>
         <Grid<CatalogItem>
-          columnDefs={CATALOG_COLUMNS(type, isReadonly, items, columnVisibility)}
+          columnDefs={CATALOG_COLUMNS(type, isReadonly, columnVisibility)}
           rowData={windowedItems}
           getRowId={(r) => r.id}
           withoutHeaderBorders

--- a/libs/catalog/src/components/ListView/ListView.tsx
+++ b/libs/catalog/src/components/ListView/ListView.tsx
@@ -47,6 +47,7 @@ export const ListView: FC<ListViewProps> = ({
   selectedItemId,
   credentialsBadgeLoggedOutLabel,
   isReadonly = false,
+  columnVisibility,
 }) => {
   if (items.length === 0) {
     return (
@@ -152,7 +153,7 @@ export const ListView: FC<ListViewProps> = ({
     >
       <div className={mergeClasses('rounded-xl', styles.gridClip)}>
         <Grid<CatalogItem>
-          columnDefs={CATALOG_COLUMNS(type, isReadonly, items, isFavoriteVisible)}
+          columnDefs={CATALOG_COLUMNS(type, isReadonly, items, columnVisibility)}
           rowData={windowedItems}
           getRowId={(r) => r.id}
           withoutHeaderBorders

--- a/libs/catalog/src/components/ListView/ListView.tsx
+++ b/libs/catalog/src/components/ListView/ListView.tsx
@@ -152,7 +152,7 @@ export const ListView: FC<ListViewProps> = ({
     >
       <div className={mergeClasses('rounded-xl', styles.gridClip)}>
         <Grid<CatalogItem>
-          columnDefs={CATALOG_COLUMNS(type, isReadonly)}
+          columnDefs={CATALOG_COLUMNS(type, isReadonly, items, isFavoriteVisible)}
           rowData={windowedItems}
           getRowId={(r) => r.id}
           withoutHeaderBorders

--- a/libs/catalog/src/components/ListView/columns.ts
+++ b/libs/catalog/src/components/ListView/columns.ts
@@ -13,15 +13,11 @@ export type ListViewColumnKey = 'folder' | 'tags' | 'favorite';
 
 /**
  * Per-column rule resolving whether an optional `ListView` column renders for
- * the active tab, given its entity `type` and the (unwindowed) `items`
- * currently shown in that tab. Overrides the column's built-in default rule;
- * omitted keys keep their default.
+ * the active tab, given its entity `type`. Overrides the column's built-in
+ * default rule; omitted keys keep their default.
  */
 export type ListViewColumnVisibility = Partial<
-  Record<
-    ListViewColumnKey,
-    (type: CatalogEntityType, items: CatalogItem[]) => boolean
-  >
+  Record<ListViewColumnKey, (type: CatalogEntityType) => boolean>
 >;
 
 /**
@@ -44,14 +40,13 @@ const defaultColumnVisibility: Required<ListViewColumnVisibility> = {
  */
 export const resolveColumnVisibility = (
   type: CatalogEntityType,
-  items: CatalogItem[],
   columnVisibility?: ListViewColumnVisibility,
 ): Record<ListViewColumnKey, boolean> => {
   const keys: ListViewColumnKey[] = ['folder', 'tags', 'favorite'];
   return Object.fromEntries(
     keys.map((key) => [
       key,
-      (columnVisibility?.[key] ?? defaultColumnVisibility[key])(type, items),
+      (columnVisibility?.[key] ?? defaultColumnVisibility[key])(type),
     ]),
   ) as Record<ListViewColumnKey, boolean>;
 };
@@ -60,10 +55,9 @@ export const resolveColumnVisibility = (
 export const CATALOG_COLUMNS = (
   type: CatalogEntityType,
   isReadonly = false,
-  items: CatalogItem[] = [],
   columnVisibility?: ListViewColumnVisibility,
 ): ColDef<CatalogItem>[] => {
-  const visibility = resolveColumnVisibility(type, items, columnVisibility);
+  const visibility = resolveColumnVisibility(type, columnVisibility);
 
   return [
     {

--- a/libs/catalog/src/components/ListView/columns.ts
+++ b/libs/catalog/src/components/ListView/columns.ts
@@ -12,6 +12,8 @@ import { TagsCellRenderer } from './Renders/TagsCellRenderer';
 export const CATALOG_COLUMNS = (
   type: CatalogEntityType,
   isReadonly = false,
+  items: CatalogItem[] = [],
+  isFavoriteVisible?: (item: CatalogItem) => boolean,
 ): ColDef<CatalogItem>[] => {
   return [
     {
@@ -61,7 +63,16 @@ export const CATALOG_COLUMNS = (
       filter: false,
       sortable: false,
       resizable: false,
-      hide: isReadonly,
+      /**
+       * Also hidden when nothing in the active tab is favoritable at all
+       * (e.g. a pure-Models tab), so the header doesn't sit above an empty
+       * column. `.some` rather than `.every` keeps the column when only some
+       * rows lack a star.
+       */
+      hide:
+        isReadonly ||
+        (items.length > 0 &&
+          !items.some((item) => isFavoriteVisible?.(item) ?? true)),
       headerClass: styles.favHeader,
       cellRenderer: StarCellRenderer,
     },

--- a/libs/catalog/src/components/ListView/columns.ts
+++ b/libs/catalog/src/components/ListView/columns.ts
@@ -8,13 +8,63 @@ import { NameCellRenderer } from './Renders/NameCellRenderer';
 import { StarCellRenderer } from './Renders/StarCellRenderer';
 import { TagsCellRenderer } from './Renders/TagsCellRenderer';
 
+/** The optional built-in `ListView` columns a host can independently show or hide per entity type. */
+export type ListViewColumnKey = 'folder' | 'tags' | 'favorite';
+
+/**
+ * Per-column rule resolving whether an optional `ListView` column renders for
+ * the active tab, given its entity `type` and the (unwindowed) `items`
+ * currently shown in that tab. Overrides the column's built-in default rule;
+ * omitted keys keep their default.
+ */
+export type ListViewColumnVisibility = Partial<
+  Record<
+    ListViewColumnKey,
+    (type: CatalogEntityType, items: CatalogItem[]) => boolean
+  >
+>;
+
+/**
+ * Built-in default visibility rules, one per optional column. Independent of
+ * `isFavoriteVisible` (which only gates the star on individual rows) — a
+ * host that wants the "Favorite" column itself hidden for a tab (e.g.
+ * Models) does so explicitly via `columnVisibility.favorite`, not by an
+ * automatic aggregate over `isFavoriteVisible`.
+ */
+const defaultColumnVisibility: Required<ListViewColumnVisibility> = {
+  folder: (type) => type !== CatalogEntityType.Model,
+  tags: () => true,
+  favorite: () => true,
+};
+
+/**
+ * Resolves whether each optional `ListView` column renders for the active
+ * tab, applying `columnVisibility` overrides on top of the built-in
+ * defaults. Used by `CATALOG_COLUMNS` to compute each column's `ColDef.hide`.
+ */
+export const resolveColumnVisibility = (
+  type: CatalogEntityType,
+  items: CatalogItem[],
+  columnVisibility?: ListViewColumnVisibility,
+): Record<ListViewColumnKey, boolean> => {
+  const keys: ListViewColumnKey[] = ['folder', 'tags', 'favorite'];
+  return Object.fromEntries(
+    keys.map((key) => [
+      key,
+      (columnVisibility?.[key] ?? defaultColumnVisibility[key])(type, items),
+    ]),
+  ) as Record<ListViewColumnKey, boolean>;
+};
+
 /** Column definitions for the catalog ag-grid list view. A stable module-level constant so ag-grid never sees a new array/closures on each render. */
 export const CATALOG_COLUMNS = (
   type: CatalogEntityType,
   isReadonly = false,
   items: CatalogItem[] = [],
-  isFavoriteVisible?: (item: CatalogItem) => boolean,
+  columnVisibility?: ListViewColumnVisibility,
 ): ColDef<CatalogItem>[] => {
+  const visibility = resolveColumnVisibility(type, items, columnVisibility);
+
   return [
     {
       headerName: 'Name',
@@ -41,7 +91,7 @@ export const CATALOG_COLUMNS = (
       width: 170,
       minWidth: 170,
       filter: false,
-      hide: type === CatalogEntityType.Model,
+      hide: !visibility.folder,
       cellRenderer: FolderCellRenderer,
       valueGetter: (p) => p.data?.folder,
     },
@@ -52,6 +102,7 @@ export const CATALOG_COLUMNS = (
       minWidth: 230,
       filter: false,
       sortable: false,
+      hide: !visibility.tags,
       cellRenderer: TagsCellRenderer,
       valueGetter: (p) => p.data?.topics,
     },
@@ -63,16 +114,7 @@ export const CATALOG_COLUMNS = (
       filter: false,
       sortable: false,
       resizable: false,
-      /**
-       * Also hidden when nothing in the active tab is favoritable at all
-       * (e.g. a pure-Models tab), so the header doesn't sit above an empty
-       * column. `.some` rather than `.every` keeps the column when only some
-       * rows lack a star.
-       */
-      hide:
-        isReadonly ||
-        (items.length > 0 &&
-          !items.some((item) => isFavoriteVisible?.(item) ?? true)),
+      hide: isReadonly || !visibility.favorite,
       headerClass: styles.favHeader,
       cellRenderer: StarCellRenderer,
     },

--- a/libs/catalog/src/components/ListView/tests/columns.spec.ts
+++ b/libs/catalog/src/components/ListView/tests/columns.spec.ts
@@ -1,5 +1,6 @@
 import { CatalogEntityType } from '@epam/ai-dial-chat-shared';
 import { describe, expect, it } from 'vitest';
+import { CatalogItem } from '../../../models/catalog-item';
 import { CATALOG_COLUMNS } from '../columns';
 
 describe('CATALOG_COLUMNS', () => {
@@ -40,6 +41,29 @@ describe('CATALOG_COLUMNS', () => {
 
     expect(folderOf(CatalogEntityType.Prompt)?.hide).toBe(false);
     expect(folderOf(CatalogEntityType.Model)?.hide).toBe(true);
+  });
+
+  it('hides the Favorite column when no item in the active tab is favoritable', () => {
+    const items = [
+      { id: '1', type: CatalogEntityType.Model },
+      { id: '2', type: CatalogEntityType.Model },
+    ] as CatalogItem[];
+
+    const hidden = CATALOG_COLUMNS(
+      CatalogEntityType.Model,
+      false,
+      items,
+      () => false,
+    ).find((c) => c.field === 'isStarred');
+    expect(hidden?.hide).toBe(true);
+
+    const visible = CATALOG_COLUMNS(
+      CatalogEntityType.Model,
+      false,
+      items,
+      (item) => item.id === '2',
+    ).find((c) => c.field === 'isStarred');
+    expect(visible?.hide).toBeFalsy();
   });
 
   it('disables sorting on Type and Tags, but not on Name and Folder', () => {

--- a/libs/catalog/src/components/ListView/tests/columns.spec.ts
+++ b/libs/catalog/src/components/ListView/tests/columns.spec.ts
@@ -43,27 +43,32 @@ describe('CATALOG_COLUMNS', () => {
     expect(folderOf(CatalogEntityType.Model)?.hide).toBe(true);
   });
 
-  it('hides the Favorite column when no item in the active tab is favoritable', () => {
-    const items = [
-      { id: '1', type: CatalogEntityType.Model },
-      { id: '2', type: CatalogEntityType.Model },
-    ] as CatalogItem[];
+  it('shows the Favorite column by default, independent of isFavoriteVisible', () => {
+    const favColumn = CATALOG_COLUMNS(CatalogEntityType.Model).find(
+      (c) => c.field === 'isStarred',
+    );
+    expect(favColumn?.hide).toBeFalsy();
+  });
 
-    const hidden = CATALOG_COLUMNS(
-      CatalogEntityType.Model,
+  it('lets columnVisibility hide the Favorite column for a tab', () => {
+    const items = [{ id: '1', type: CatalogEntityType.Model }] as CatalogItem[];
+
+    const hiddenFavorite = CATALOG_COLUMNS(CatalogEntityType.Model, false, items, {
+      favorite: (type) => type !== CatalogEntityType.Model,
+    }).find((c) => c.field === 'isStarred');
+    expect(hiddenFavorite?.hide).toBe(true);
+  });
+
+  it("lets columnVisibility override the Folder column's default rule", () => {
+    const items = [{ id: '1', type: CatalogEntityType.Prompt }] as CatalogItem[];
+
+    const forcedHiddenFolder = CATALOG_COLUMNS(
+      CatalogEntityType.Prompt,
       false,
       items,
-      () => false,
-    ).find((c) => c.field === 'isStarred');
-    expect(hidden?.hide).toBe(true);
-
-    const visible = CATALOG_COLUMNS(
-      CatalogEntityType.Model,
-      false,
-      items,
-      (item) => item.id === '2',
-    ).find((c) => c.field === 'isStarred');
-    expect(visible?.hide).toBeFalsy();
+      { folder: () => false },
+    ).find((c) => c.field === 'folder');
+    expect(forcedHiddenFolder?.hide).toBe(true);
   });
 
   it('disables sorting on Type and Tags, but not on Name and Folder', () => {

--- a/libs/catalog/src/components/ListView/tests/columns.spec.ts
+++ b/libs/catalog/src/components/ListView/tests/columns.spec.ts
@@ -1,6 +1,5 @@
 import { CatalogEntityType } from '@epam/ai-dial-chat-shared';
 import { describe, expect, it } from 'vitest';
-import { CatalogItem } from '../../../models/catalog-item';
 import { CATALOG_COLUMNS } from '../columns';
 
 describe('CATALOG_COLUMNS', () => {
@@ -51,23 +50,16 @@ describe('CATALOG_COLUMNS', () => {
   });
 
   it('lets columnVisibility hide the Favorite column for a tab', () => {
-    const items = [{ id: '1', type: CatalogEntityType.Model }] as CatalogItem[];
-
-    const hiddenFavorite = CATALOG_COLUMNS(CatalogEntityType.Model, false, items, {
+    const hiddenFavorite = CATALOG_COLUMNS(CatalogEntityType.Model, false, {
       favorite: (type) => type !== CatalogEntityType.Model,
     }).find((c) => c.field === 'isStarred');
     expect(hiddenFavorite?.hide).toBe(true);
   });
 
   it("lets columnVisibility override the Folder column's default rule", () => {
-    const items = [{ id: '1', type: CatalogEntityType.Prompt }] as CatalogItem[];
-
-    const forcedHiddenFolder = CATALOG_COLUMNS(
-      CatalogEntityType.Prompt,
-      false,
-      items,
-      { folder: () => false },
-    ).find((c) => c.field === 'folder');
+    const forcedHiddenFolder = CATALOG_COLUMNS(CatalogEntityType.Prompt, false, {
+      folder: () => false,
+    }).find((c) => c.field === 'folder');
     expect(forcedHiddenFolder?.hide).toBe(true);
   });
 

--- a/libs/catalog/src/index.ts
+++ b/libs/catalog/src/index.ts
@@ -122,6 +122,10 @@ export type {
   ListViewStyles,
   ListViewTypography,
 } from './models/list-props';
+export type {
+  ListViewColumnKey,
+  ListViewColumnVisibility,
+} from './components/ListView/columns';
 
 export { FavoriteCard } from './components/Favorites/FavoriteCard';
 export type { FavoriteCardProps } from './components/Favorites/FavoriteCard';

--- a/libs/catalog/src/models/catalog-props.ts
+++ b/libs/catalog/src/models/catalog-props.ts
@@ -8,6 +8,7 @@ import type {
 } from '@epam/ai-dial-publish-panel';
 import { DropdownItem, TabModel } from '@epam/ai-dial-ui-kit';
 import type { ReactNode } from 'react';
+import type { ListViewColumnVisibility } from '../components/ListView/columns';
 import type { CatalogSortKey } from '../types/sort';
 import type { CredentialsLevel } from '../types/toolset-auth';
 import type { CatalogViewMode } from '../types/view-mode';
@@ -118,6 +119,18 @@ export interface CatalogProps {
    * can only ever narrow visibility, never widen it.
    */
   isFavoriteVisible?: (item: CatalogItem) => boolean;
+  /**
+   * Per-column overrides for whether an optional `ListView` column (`folder`,
+   * `tags`, `favorite`) renders for the active tab, given its entity type and
+   * the items currently shown in it. Independent of `isFavoriteVisible`
+   * (which only gates the star on individual rows, in the browse grid and
+   * cards too, not the column). Replaces that column's built-in default rule
+   * — e.g. `folder` normally hides for `CatalogEntityType.Model`; columns
+   * omitted from this map keep their default. `favorite` is additionally
+   * combined (AND) with `isReadonly`. No effect on the Browse grid/cards,
+   * only the list view's table.
+   */
+  columnVisibility?: ListViewColumnVisibility;
   /** Called when the "Use in chat" button is clicked in the details panel. */
   onUseInChat?: (item: CatalogItem) => void;
   /** Controls whether the primary action button is shown for an item. */

--- a/libs/catalog/src/models/catalog-props.ts
+++ b/libs/catalog/src/models/catalog-props.ts
@@ -121,14 +121,14 @@ export interface CatalogProps {
   isFavoriteVisible?: (item: CatalogItem) => boolean;
   /**
    * Per-column overrides for whether an optional `ListView` column (`folder`,
-   * `tags`, `favorite`) renders for the active tab, given its entity type and
-   * the items currently shown in it. Independent of `isFavoriteVisible`
-   * (which only gates the star on individual rows, in the browse grid and
-   * cards too, not the column). Replaces that column's built-in default rule
-   * — e.g. `folder` normally hides for `CatalogEntityType.Model`; columns
-   * omitted from this map keep their default. `favorite` is additionally
-   * combined (AND) with `isReadonly`. No effect on the Browse grid/cards,
-   * only the list view's table.
+   * `tags`, `favorite`) renders for the active tab, given its entity type.
+   * Independent of `isFavoriteVisible` (which only gates the star on
+   * individual rows, in the browse grid and cards too, not the column).
+   * Replaces that column's built-in default rule — e.g. `folder` normally
+   * hides for `CatalogEntityType.Model`; columns omitted from this map keep
+   * their default. `favorite` is additionally combined (AND) with
+   * `isReadonly`. No effect on the Browse grid/cards, only the list view's
+   * table.
    */
   columnVisibility?: ListViewColumnVisibility;
   /** Called when the "Use in chat" button is clicked in the details panel. */

--- a/libs/catalog/src/models/list-props.ts
+++ b/libs/catalog/src/models/list-props.ts
@@ -78,10 +78,10 @@ export interface ListViewProps {
   isReadonly?: boolean;
   /**
    * Per-column overrides for whether an optional column (`folder`, `tags`,
-   * `favorite`) renders for the active tab, given its entity `type` and the
-   * items shown in it. Independent of `isFavoriteVisible` (which only gates
-   * the star on individual rows, not the column). Replaces that column's
-   * built-in default rule; columns omitted from this map keep their default.
+   * `favorite`) renders for the active tab, given its entity `type`.
+   * Independent of `isFavoriteVisible` (which only gates the star on
+   * individual rows, not the column). Replaces that column's built-in
+   * default rule; columns omitted from this map keep their default.
    * `favorite` is additionally combined (AND) with `isReadonly`.
    */
   columnVisibility?: ListViewColumnVisibility;

--- a/libs/catalog/src/models/list-props.ts
+++ b/libs/catalog/src/models/list-props.ts
@@ -1,4 +1,5 @@
 import type { CatalogEntityType } from '@epam/ai-dial-chat-shared';
+import type { ListViewColumnVisibility } from '../components/ListView/columns';
 import { CatalogItem } from './catalog-item';
 /** Typography class overrides for `ListView` cells. */
 export interface ListViewTypography {
@@ -75,4 +76,13 @@ export interface ListViewProps {
   credentialsBadgeLoggedOutLabel?: string;
   /** Renders the list read-only: the "Favorite" column is dropped entirely. Default: false. */
   isReadonly?: boolean;
+  /**
+   * Per-column overrides for whether an optional column (`folder`, `tags`,
+   * `favorite`) renders for the active tab, given its entity `type` and the
+   * items shown in it. Independent of `isFavoriteVisible` (which only gates
+   * the star on individual rows, not the column). Replaces that column's
+   * built-in default rule; columns omitted from this map keep their default.
+   * `favorite` is additionally combined (AND) with `isReadonly`.
+   */
+  columnVisibility?: ListViewColumnVisibility;
 }


### PR DESCRIPTION
**Description:**

<SHORT_DESCRIPTION>

Issues:

- Issue #<TICKET_ID>

**UI changes**

<Please, provide Screenshots or Figma links>

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
