### PR TITLE
fix(chat): persist conversation stages

### DIFF
--- a/apps/chat/src/pages/Conversation/Conversation.tsx
+++ b/apps/chat/src/pages/Conversation/Conversation.tsx
@@ -285,6 +285,7 @@ export const ConversationPage: FC<Props> = ({ onDuplicateReadonly }) => {
     startStream,
     handleStop,
     resumeIfAwaitingGeneration,
+    restoreBufferedGeneration,
     isStreaming,
     canStopStreaming,
   } = useConversationStream({
@@ -356,8 +357,9 @@ export const ConversationPage: FC<Props> = ({ onDuplicateReadonly }) => {
         setIsFetching(true);
       }
       try {
-        const result: Conversation =
+        const loadedConversation: Conversation =
           initialData ?? ((await apiGetConversation(id)) as Conversation);
+        const result = restoreBufferedGeneration(id, loadedConversation);
         if (result.name) {
           updateConversationTitle(id, result.name);
         }
@@ -453,6 +455,7 @@ export const ConversationPage: FC<Props> = ({ onDuplicateReadonly }) => {
       restoreToolConfiguration,
       startStream,
       resumeIfAwaitingGeneration,
+      restoreBufferedGeneration,
       updateConversationTitle,
       getGeneration,
       showErrorNotification,

--- a/libs/chat-hooks/README.md
+++ b/libs/chat-hooks/README.md
@@ -456,7 +456,7 @@ Also exports `DEFAULT_MAX_ARCHIVE_BYTES`, `EXPORT_APP_NAME` and `formatQuotedNam
 
 ### useConversationStream
 
-Owns completion-streaming state — per-conversation-path streaming/stoppable tracking, stale-chunk rejection, reload-after-complete, and hard-refresh resume detection — driven entirely through an injected `ConversationStreamTransport`. The library never hardcodes an `/api` path, CSRF handling, or a `server-api` import; the host implements the transport against its own BFF/generated-client calls.
+Owns completion-streaming state — per-conversation-path streaming/stoppable tracking, cross-navigation live-message buffering, stale-chunk rejection, reload-after-complete, and hard-refresh resume detection — driven entirely through an injected `ConversationStreamTransport`. The library never hardcodes an `/api` path, CSRF handling, or a `server-api` import; the host implements the transport against its own BFF/generated-client calls.
 
 ```tsx
 import {
@@ -509,7 +509,7 @@ const ChatPage = ({
 
 `ConversationStreamTransport` has four methods the host implements: `streamCompletion(path, message, model, options, customContent?, generationId?, mode?, messageIndex?, clientChannelId?)`, `stopCompletion({ generationId, path })`, `watchConversation(path, signal)`, and `getConversation(conversationId, signal?)`.
 
-**Returns** (`UseConversationStreamResult`): `{ startStream, handleStop, resumeIfAwaitingGeneration, isStreaming, canStopStreaming }`. `resumeIfAwaitingGeneration(conversationId, conversation)` detects a hard-refresh-mid-generation conversation and watches for its resolution.
+**Returns** (`UseConversationStreamResult`): `{ startStream, handleStop, resumeIfAwaitingGeneration, restoreBufferedGeneration, isStreaming, canStopStreaming }`. `restoreBufferedGeneration(conversationId, conversation)` reapplies the full in-memory assistant message accumulated by an active stream when the host reloads that conversation during navigation; this includes text and merged `custom_content.stages` received before and while the conversation was hidden. `resumeIfAwaitingGeneration(conversationId, conversation)` detects a hard-refresh-mid-generation conversation and watches for its resolution.
 
 Also exports the standalone `getConversationPath` (strips a conversation id's bucket segment and decodes it) and `isAwaitingGenerationResume` (the placeholder-detection predicate the hook is built on) for hosts that need the same checks outside the hook.
 

--- a/libs/chat-hooks/src/conversation/useConversationStream/tests/useConversationStream.spec.ts
+++ b/libs/chat-hooks/src/conversation/useConversationStream/tests/useConversationStream.spec.ts
@@ -32,6 +32,7 @@ const makeConversation = (
 const useHookHarness = ({
   transport,
   conversationId,
+  initialConversation,
   ...rest
 }: {
   transport: ConversationStreamTransport;
@@ -39,9 +40,10 @@ const useHookHarness = ({
   onStopError?: (error: Error) => void;
   overlay?: ConversationStreamOverlayNotifier;
   channel?: ConversationStreamChannel;
+  initialConversation?: Conversation;
 }) => {
   const [conversation, setConversation] = useState<Conversation | null>(
-    makeConversation(),
+    initialConversation ?? makeConversation(),
   );
   const conversationRef = useRef<Conversation | null>(conversation);
   conversationRef.current = conversation;
@@ -190,6 +192,162 @@ describe('useConversationStream', () => {
 
     rerender({ conversationId: 'bucket/convB' });
     expect(result.current.stream.isStreaming).toBe(false);
+  });
+
+  it('restores stages accumulated before and during background navigation', async () => {
+    const initialConversation = makeConversation({
+      messages: [
+        {
+          role: MessageRole.User,
+          content: 'Use a tool',
+          timestamp: '2026-01-01T00:00:00.000Z',
+        },
+        {
+          role: MessageRole.Assistant,
+          content: '',
+          timestamp: '2026-01-01T00:00:01.000Z',
+        },
+      ],
+    });
+    const { result, rerender } = renderHook(
+      (props: { conversationId: string }) =>
+        useHookHarness({
+          transport,
+          conversationId: props.conversationId,
+          initialConversation,
+        }),
+      { initialProps: { conversationId: 'bucket/convA' } },
+    );
+
+    await act(async () => {
+      result.current.stream.startStream(
+        'bucket/convA',
+        'Use a tool',
+        1,
+        'gpt-4o',
+        undefined,
+        'gen-1',
+      );
+      await Promise.resolve();
+    });
+
+    act(() => {
+      capturedOptions?.onChunk({
+        id: 'chunk-1',
+        object: 'chat.completion.chunk',
+        choices: [
+          {
+            delta: {
+              custom_content: {
+                stages: [
+                  {
+                    index: 0,
+                    name: 'Calling ',
+                    status: null,
+                    content: 'first ',
+                  },
+                ],
+              },
+            },
+            finish_reason: null,
+            index: 0,
+          },
+        ],
+      });
+    });
+
+    rerender({ conversationId: 'bucket/convB' });
+    act(() => {
+      capturedOptions?.onChunk({
+        id: 'chunk-2',
+        object: 'chat.completion.chunk',
+        choices: [
+          {
+            delta: {
+              custom_content: {
+                stages: [
+                  {
+                    index: 0,
+                    name: 'tool',
+                    status: null,
+                    content: 'second',
+                  },
+                ],
+              },
+            },
+            finish_reason: null,
+            index: 0,
+          },
+        ],
+      });
+    });
+
+    const reloadedPlaceholder = makeConversation({
+      messages: initialConversation.messages.map((message) => ({ ...message })),
+    });
+    const restored = result.current.stream.restoreBufferedGeneration(
+      'bucket/convA',
+      reloadedPlaceholder,
+    );
+
+    expect(restored.messages[1].custom_content?.stages).toEqual([
+      {
+        index: 0,
+        name: 'Calling tool',
+        status: null,
+        content: 'first second',
+      },
+    ]);
+
+    rerender({ conversationId: 'bucket/convA' });
+    act(() => {
+      capturedOptions?.onChunk({
+        id: 'chunk-3',
+        object: 'chat.completion.chunk',
+        choices: [
+          {
+            delta: {
+              custom_content: {
+                stages: [
+                  {
+                    index: 0,
+                    name: '',
+                    status: null,
+                    content: ' third',
+                  },
+                ],
+              },
+            },
+            finish_reason: null,
+            index: 0,
+          },
+        ],
+      });
+    });
+
+    expect(
+      result.current.conversation?.messages[1].custom_content?.stages,
+    ).toEqual([
+      {
+        index: 0,
+        name: 'Calling tool',
+        status: null,
+        content: 'first second third',
+      },
+    ]);
+
+    await act(async () => {
+      await capturedOptions?.onComplete();
+    });
+    const afterCompletion = makeConversation({
+      messages: reloadedPlaceholder.messages,
+    });
+    expect(
+      result.current.stream.restoreBufferedGeneration(
+        'bucket/convA',
+        afterCompletion,
+      ),
+    ).toBe(afterCompletion);
   });
 
   it('does not reload the displayed conversation when a different conversation completes', async () => {

--- a/libs/chat-hooks/src/conversation/useConversationStream/useConversationStream.ts
+++ b/libs/chat-hooks/src/conversation/useConversationStream/useConversationStream.ts
@@ -2,6 +2,7 @@ import { SendCompletionDtoModeEnum } from '@epam/ai-dial-chat-api-client';
 import {
   type Conversation,
   generateUUID,
+  type Message,
   type MessageCustomContent,
   type StreamChunk,
 } from '@epam/ai-dial-chat-shared';
@@ -131,14 +132,60 @@ export interface UseConversationStreamResult {
     currentConversationId: string,
     conversation: Conversation,
   ) => void;
+  /** Restores the accumulated live assistant message when its conversation is loaded again before completion. */
+  restoreBufferedGeneration: (
+    currentConversationId: string,
+    conversation: Conversation,
+  ) => Conversation;
   isStreaming: boolean;
   canStopStreaming: boolean;
 }
 
+interface BufferedGeneration {
+  generationId: string;
+  messageIndex: number;
+  message: Message;
+}
+
+const mergeBufferedMessage = (
+  current: Message,
+  buffered: Message,
+): Message => ({
+  ...current,
+  ...buffered,
+  ...((current.custom_content || buffered.custom_content) && {
+    custom_content: {
+      ...current.custom_content,
+      ...buffered.custom_content,
+    },
+  }),
+});
+
+const restoreBufferedMessage = (
+  conversation: Conversation,
+  buffered: BufferedGeneration,
+): Conversation => {
+  if (buffered.messageIndex > conversation.messages.length) {
+    return conversation;
+  }
+
+  const messages = [...conversation.messages];
+  if (buffered.messageIndex === messages.length) {
+    messages.push(buffered.message);
+  } else {
+    messages[buffered.messageIndex] = mergeBufferedMessage(
+      messages[buffered.messageIndex],
+      buffered.message,
+    );
+  }
+  return { ...conversation, messages };
+};
+
 /**
  * Owns completion-streaming state: per-path streaming/stoppable tracking,
- * stale-chunk rejection, reload-after-complete, backend-driven stop, and
- * hard-refresh resume detection — all driven through the injected
+ * stale-chunk rejection, cross-navigation live-message buffering,
+ * reload-after-complete, backend-driven stop, and hard-refresh resume
+ * detection — all driven through the injected
  * `transport`/`generation`/`channel`/`overlay` capabilities rather than any
  * app context or `server-api` import.
  */
@@ -162,6 +209,9 @@ export const useConversationStream = ({
   const activeGenerationIdRef = useRef<string | null>(null);
   const activeGenerationPathRef = useRef<string | null>(null);
   const resumingPathsRef = useRef<Set<string>>(new Set());
+  const bufferedGenerationsRef = useRef<Map<string, BufferedGeneration>>(
+    new Map(),
+  );
   /* Generation ids stopped by the user — onComplete emits notifyStopGenerating's
    * counterpart (nothing) instead of notifyGenerationEnd for these. */
   const stoppedGenerationIdsRef = useRef<Set<string>>(new Set());
@@ -237,6 +287,16 @@ export const useConversationStream = ({
       }
 
       const controller = startGeneration(conversationPath, genId);
+      const initialMessage = conversationRef.current?.messages[messageIndex];
+      if (initialMessage) {
+        bufferedGenerationsRef.current.set(conversationPath, {
+          generationId: genId,
+          messageIndex,
+          message: initialMessage,
+        });
+      } else {
+        bufferedGenerationsRef.current.delete(conversationPath);
+      }
       addStreamingPath(conversationPath);
       overlay?.notifyGenerationStart?.();
 
@@ -250,26 +310,46 @@ export const useConversationStream = ({
         signal: controller.signal,
         onChunk: (chunk) => {
           /*
-           * Drop stale chunks (a newer generation replaced this one) and
-           * chunks for a conversation the user is no longer viewing — the
-           * backend persists them, so the correct chat reloads them later.
+           * Drop stale chunks from a superseded generation. Background chunks
+           * still update the per-path buffer, so returning before the backend's
+           * terminal save restores the complete live message.
            */
           if (activeGenerationIdRef.current !== genId) return;
+
+          const buffered = bufferedGenerationsRef.current.get(conversationPath);
+          if (buffered?.generationId === genId) {
+            const updated = applyChunkToMessages([buffered.message], 0, chunk);
+            if (updated) buffered.message = updated[0];
+          }
+
           if (!isPathDisplayed(conversationPath)) return;
           setConversation((prev) => {
             if (!prev) return prev;
-            const updatedMessages = applyChunkToMessages(
-              prev.messages,
-              messageIndex,
-              chunk,
-            );
-            if (!updatedMessages) return prev;
-            const next = { ...prev, messages: updatedMessages };
+            const currentBuffer =
+              bufferedGenerationsRef.current.get(conversationPath);
+            let next: Conversation;
+            if (currentBuffer?.generationId === genId) {
+              next = restoreBufferedMessage(prev, currentBuffer);
+            } else {
+              const updatedMessages = applyChunkToMessages(
+                prev.messages,
+                messageIndex,
+                chunk,
+              );
+              if (!updatedMessages) return prev;
+              next = { ...prev, messages: updatedMessages };
+            }
             conversationRef.current = next;
             return next;
           });
         },
         onComplete: async () => {
+          if (
+            bufferedGenerationsRef.current.get(conversationPath)
+              ?.generationId === genId
+          ) {
+            bufferedGenerationsRef.current.delete(conversationPath);
+          }
           removeStreamingPath(conversationPath);
           if (activeGenerationIdRef.current === genId) {
             activeGenerationIdRef.current = null;
@@ -309,6 +389,11 @@ export const useConversationStream = ({
           }
         },
         onError: (error: Error) => {
+          const currentBuffer =
+            bufferedGenerationsRef.current.get(conversationPath);
+          const buffered =
+            currentBuffer?.generationId === genId ? currentBuffer : undefined;
+          if (buffered) bufferedGenerationsRef.current.delete(conversationPath);
           removeStreamingPath(conversationPath);
           if (activeGenerationIdRef.current === genId) {
             activeGenerationIdRef.current = null;
@@ -319,9 +404,13 @@ export const useConversationStream = ({
           if (!isPathDisplayed(conversationPath)) return;
           setConversation((prev) => {
             if (!prev) return prev;
+            const restored =
+              buffered?.generationId === genId
+                ? restoreBufferedMessage(prev, buffered)
+                : prev;
             const updated = {
-              ...prev,
-              messages: prev.messages.map((m, index) =>
+              ...restored,
+              messages: restored.messages.map((m, index) =>
                 index === messageIndex
                   ? { ...m, streamErrorMessage: error.message }
                   : m,
@@ -376,6 +465,20 @@ export const useConversationStream = ({
       overlay,
       transport,
     ],
+  );
+
+  const restoreBufferedGeneration = useCallback(
+    (
+      currentConversationId: string,
+      conversation: Conversation,
+    ): Conversation => {
+      const conversationPath = getConversationPath(currentConversationId);
+      const buffered = bufferedGenerationsRef.current.get(conversationPath);
+      return buffered
+        ? restoreBufferedMessage(conversation, buffered)
+        : conversation;
+    },
+    [],
   );
 
   const handleStop = useCallback(() => {
@@ -539,6 +642,7 @@ export const useConversationStream = ({
     startStream,
     handleStop,
     resumeIfAwaitingGeneration,
+    restoreBufferedGeneration,
     isStreaming,
     canStopStreaming,
   };

--- a/openspec/specs/app-level-generation-manager/spec.md
+++ b/openspec/specs/app-level-generation-manager/spec.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-Frontend ownership of the streaming-generation UI: an app-level context that keeps a stream alive across conversation navigation, plus the per-conversation guards that keep chunks, reloads, stop, and the streaming indicator scoped to the displayed conversation.
+Frontend ownership of the streaming-generation UI: an app-level context that keeps a stream alive across conversation navigation, plus per-generation buffering and per-conversation guards that keep chunks, reloads, stop, and the streaming indicator scoped to the displayed conversation.
 
 ## Requirements
 
@@ -55,6 +55,29 @@ Because the conversation page is not remounted between conversations, `useConver
 
 - **WHEN** the user returns to a conversation whose stream is still active
 - **THEN** subsequent chunks render live again because the path matches
+
+### Requirement: Active generation content survives conversation navigation
+
+`useConversationStream` SHALL keep an in-memory, per-path snapshot of the assistant message for every stream it started. Every accepted chunk SHALL update that snapshot even while another conversation is displayed; it SHALL NOT update the foreground conversation in that case. The snapshot SHALL accumulate the same text and `custom_content` fields as normal live rendering, including all stage updates merged by index.
+
+The hook SHALL expose `restoreBufferedGeneration(conversationId, conversation)`. When `ConversationPage` loads a conversation, it SHALL call this function before rendering or deciding whether to auto-start/resume generation. If the path has an active buffered snapshot, the snapshot SHALL replace the corresponding persisted start-state placeholder (or be appended at its recorded index when the start-state save has not landed yet). Server-provided message fields that are absent from the live snapshot SHALL be preserved. The buffer SHALL be discarded when the stream completes or errors; terminal state continues to come from the backend's saved conversation.
+
+This buffer is navigation-scoped, not durable persistence: a hard refresh still follows the existing awaiting-generation watch flow and waits for the backend's terminal save.
+
+#### Scenario: Returning before completion restores earlier stages
+
+- **WHEN** conversation A receives stage chunks, the user opens conversation B, more stage chunks arrive for A, and the user returns to A before generation completes
+- **THEN** A renders the complete accumulated stage list, including chunks received both before and during the navigation, and later stage chunks continue from that accumulated state
+
+#### Scenario: Background chunks do not modify the foreground conversation
+
+- **WHEN** conversation A receives chunks while conversation B is displayed
+- **THEN** A's buffered snapshot is updated and B's messages remain unchanged
+
+#### Scenario: Terminal state replaces the navigation buffer
+
+- **WHEN** the stream completes or errors
+- **THEN** its in-memory snapshot is discarded and the backend-saved terminal conversation remains the source of truth
 
 ### Requirement: Auto-start on load is idempotent
 

--- a/openspec/specs/chat-hooks-conversation-stream/spec.md
+++ b/openspec/specs/chat-hooks-conversation-stream/spec.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-Reusable hook exported by `@epam/ai-dial-chat-hooks` that drives completion streaming exclusively through an injected transport, with per-path streaming state, stale-chunk rejection, reload-after-complete semantics, and awaiting-generation resume detection.
+Reusable hook exported by `@epam/ai-dial-chat-hooks` that drives completion streaming exclusively through an injected transport, with per-path streaming state and live-message buffering, stale-chunk rejection, reload-after-complete semantics, and awaiting-generation resume detection.
 
 ## Requirements
 
@@ -42,8 +42,30 @@ match the currently active generation for that path.
 #### Scenario: Chunk for a non-displayed conversation is dropped
 - **WHEN** a chunk arrives for a conversation path that is not the
   currently displayed `conversationId`
-- **THEN** the chunk is not applied to conversation state, but streaming
-  continues to be tracked for that path
+- **THEN** the chunk is not applied to the displayed conversation state, but
+  it is accumulated in that path's live-message buffer and streaming continues
+  to be tracked for the path
+
+### Requirement: Buffered live message can be restored after navigation
+The hook SHALL accumulate accepted chunks into a per-path assistant-message
+snapshot, including merged `custom_content.stages`, regardless of whether the
+path is displayed. It SHALL expose
+`restoreBufferedGeneration(conversationId, conversation)`, which returns the
+conversation unchanged when no buffer exists and otherwise restores the
+buffered message at its recorded index. Completion and error callbacks SHALL
+clear the buffer because the backend's terminal save is then authoritative.
+
+#### Scenario: Earlier and background stages are restored
+- **WHEN** stage chunks arrive before and while their conversation is hidden
+  and the host reloads that conversation before completion
+- **THEN** `restoreBufferedGeneration` returns it with every accumulated stage
+  update, rather than only updates received after the conversation became
+  visible again
+
+#### Scenario: Completed generation no longer uses its buffer
+- **WHEN** the transport signals completion or error for a generation
+- **THEN** a later `restoreBufferedGeneration` call does not restore that
+  generation's in-memory snapshot
 
 ### Requirement: Reload-after-complete, never trust the local stream
 On stream completion, the hook SHALL reload the conversation through


### PR DESCRIPTION
**Description:**

Fixes agent execution stages disappearing when users navigate to another conversation and return while the response is still being generated.

**Root Cause**

The backend persists an empty assistant placeholder when generation starts and saves the fully assembled message only when generation finishes or terminates.
Meanwhile, `useConversationStream` ignored chunks belonging to a conversation that was not currently displayed. When the user returned, the frontend loaded the persisted placeholder, so previously received stages were unavailable. Only newly arriving stage chunks were rendered.

Changes
• Added an in-memory, per-conversation buffer for active assistant messages.
• Accumulate `text` and `custom_content` updates, including stages, while the conversation is in the background.
• Restore the buffered message when the user returns to the conversation.
• Continue merging subsequent chunks into the complete accumulated stage history.
• Clear the buffer on completion or error, leaving the backend-persisted terminal message as the source of truth.

**Checklist:**

- [X] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [X] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
