### PR TITLE
fix(chat): keep isolated view active after navigating to the created conversation

### DIFF
--- a/apps/chat/src/context/IsolatedModelViewContext.tsx
+++ b/apps/chat/src/context/IsolatedModelViewContext.tsx
@@ -15,7 +15,6 @@ import {
   useRef,
   useState,
 } from 'react';
-import { useLocation } from 'react-router';
 import { useDeployments } from './DeploymentsContext';
 import { useUiFeatures } from './UiFeaturesContext';
 
@@ -48,15 +47,24 @@ export const IsolatedModelViewProvider = ({
 }: {
   children: ReactNode;
 }) => {
-  const { search } = useLocation();
   const { items, isLoading: isDeploymentsLoading } = useDeployments();
   const { applyIsolatedViewOverride } = useUiFeatures();
   const appliedOverrideRef = useRef(false);
 
-  const modelId = useMemo(() => {
-    const params = new URLSearchParams(search);
+  /*
+   * TODO: remove in next release. Captured once via a lazy initializer, not
+   * re-derived from `useLocation().search` on every render: the first
+   * message navigates away from `/?isolated-model-id=...` to
+   * `/conversations/<id>`, which has no such param. Isolated view must stay
+   * active for the rest of the tab's lifetime (matching the old SSR
+   * feature's per-page-load, not per-navigation, evaluation) — a reactive
+   * read would drop `isActive` back to `false` the moment that navigation
+   * happens, snapping every hidden surface back into view.
+   */
+  const [modelId] = useState(() => {
+    const params = new URLSearchParams(window.location.search);
     return params.get(ISOLATED_MODEL_ID_QUERY_PARAM) || null;
-  }, [search]);
+  });
 
   const resolvedDeployment = useMemo(
     () => (modelId ? findDeploymentByIdOrReference(items, modelId) : null),

--- a/apps/chat/src/context/tests/IsolatedModelViewContext.spec.tsx
+++ b/apps/chat/src/context/tests/IsolatedModelViewContext.spec.tsx
@@ -2,21 +2,16 @@
 import { OverlayFeature } from '@epam/ai-dial-chat-overlay';
 import { renderHook } from '@testing-library/react';
 import type { ReactNode } from 'react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   IsolatedModelViewProvider,
   useIsolatedModelView,
 } from '../IsolatedModelViewContext';
 
 const contextMocks = vi.hoisted(() => ({
-  search: '' as string,
   items: [] as { id: string; reference?: string }[],
   isLoading: false,
   applyIsolatedViewOverride: vi.fn(),
-}));
-
-vi.mock('react-router', () => ({
-  useLocation: () => ({ search: contextMocks.search }),
 }));
 
 vi.mock('../DeploymentsContext', () => ({
@@ -36,16 +31,24 @@ const wrapper = ({ children }: { children: ReactNode }) => (
   <IsolatedModelViewProvider>{children}</IsolatedModelViewProvider>
 );
 
+const setUrl = (pathOrSearch: string) => {
+  const url = pathOrSearch.startsWith('/') ? pathOrSearch : `/${pathOrSearch}`;
+  window.history.pushState({}, '', url);
+};
+
 describe('IsolatedModelViewContext', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    contextMocks.search = '';
     contextMocks.items = [];
     contextMocks.isLoading = false;
+    setUrl('');
+  });
+
+  afterEach(() => {
+    setUrl('');
   });
 
   it('is inactive when the query param is absent', () => {
-    contextMocks.search = '';
     const { result } = renderHook(() => useIsolatedModelView(), { wrapper });
 
     expect(result.current).toEqual({
@@ -57,7 +60,7 @@ describe('IsolatedModelViewContext', () => {
   });
 
   it('applies the forced feature set immediately, before deployments finish loading', () => {
-    contextMocks.search = '?isolated-model-id=gpt-4';
+    setUrl('?isolated-model-id=gpt-4');
     contextMocks.items = [];
     contextMocks.isLoading = true;
     const { result } = renderHook(() => useIsolatedModelView(), { wrapper });
@@ -80,7 +83,7 @@ describe('IsolatedModelViewContext', () => {
   });
 
   it('resolves the deployment once deployments finish loading', () => {
-    contextMocks.search = '?isolated-model-id=gpt-4';
+    setUrl('?isolated-model-id=gpt-4');
     contextMocks.items = [{ id: 'gpt-4' }];
     contextMocks.isLoading = false;
     const { result } = renderHook(() => useIsolatedModelView(), { wrapper });
@@ -93,7 +96,7 @@ describe('IsolatedModelViewContext', () => {
   });
 
   it('reports not-found once deployments have finished loading with no match, but still applies the override', () => {
-    contextMocks.search = '?isolated-model-id=unknown-model';
+    setUrl('?isolated-model-id=unknown-model');
     contextMocks.items = [{ id: 'gpt-4' }];
     contextMocks.isLoading = false;
     const { result } = renderHook(() => useIsolatedModelView(), { wrapper });
@@ -104,6 +107,30 @@ describe('IsolatedModelViewContext', () => {
       resolvedDeploymentId: null,
     });
     expect(contextMocks.applyIsolatedViewOverride).toHaveBeenCalledOnce();
+  });
+
+  /*
+   * Regression test: after the first message, the app navigates away from
+   * `/?isolated-model-id=...` to `/conversations/<id>`, which carries no
+   * such param. Isolated view must stay active for the rest of the tab's
+   * lifetime rather than re-reading the (now-changed) URL and snapping every
+   * hidden surface (navigation, announcement banner, etc.) back into view.
+   */
+  it('stays active after the URL changes away from the isolated-model-id param', () => {
+    setUrl('?isolated-model-id=gpt-4');
+    contextMocks.items = [{ id: 'gpt-4' }];
+    contextMocks.isLoading = false;
+    const { result, rerender } = renderHook(() => useIsolatedModelView(), {
+      wrapper,
+    });
+
+    expect(result.current.isActive).toBe(true);
+
+    setUrl('/conversations/some-id');
+    rerender();
+
+    expect(result.current.isActive).toBe(true);
+    expect(result.current.resolvedDeploymentId).toBe('gpt-4');
   });
 
   it('throws when used outside the provider', () => {


### PR DESCRIPTION
## Summary
- Follow-up to #8546 (already merged into `development`). During manual verification, after sending the first message the app navigates from `/?isolated-model-id=...` to `/conversations/<id>` — a URL with no such param — which snapped `isActive` back to `false` and un-hid navigation, the "old interface"/announcement banner, and every other surface the isolated view had forced off.
- Root cause: `IsolatedModelViewContext` re-derived `modelId` reactively from `useLocation().search` on every render.
- Fix: capture it once via a lazy `useState` initializer instead, so isolated view stays active for the rest of the tab's lifetime (matching the old feature's per-page-load, not per-navigation, evaluation).
- Added a regression test asserting `isActive` stays `true` after the URL changes away from the param.

## Test plan
- [x] New regression test in `IsolatedModelViewContext.spec.tsx`: `stays active after the URL changes away from the isolated-model-id param`
- [x] `npx tsc --noEmit -p apps/chat/tsconfig.app.json` — clean
- [x] `npm run test:file` for the touched context/route spec files — green
- [x] Manually confirmed by the requester (screenshot showed nav/banner reappearing after first message; issue reproduced and fixed)

Note: `nx lint`/`verify:changed` could not be run in this session — an unrelated stray worktree (`.worktrees/fix-quickapps-iframe-local-network-access`) currently breaks the nx project graph with duplicate project names; reproduced the same false positive on an untouched file to confirm it's unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)