### PR TITLE
fix(chat-api): guard against an empty publish response body

### DIFF
--- a/apps/chat-api/src/publish/publish.service.ts
+++ b/apps/chat-api/src/publish/publish.service.ts
@@ -148,6 +148,13 @@ export class PublishService {
 
     await this.cacheManager.del(historyCacheKey(entityType, entityId));
 
+    /*
+     * Core returns 200 with no parseable body for some auto-approved
+     * publications (observed for a resource published for the first time),
+     * leaving `result.data` undefined even though the request succeeded —
+     * fall back to what the caller already supplied rather than reading off
+     * a body that may not exist.
+     */
     const publication = result.data;
     this.logger.debug(
       `Published ${entityType} "${entityId}" to "${folderPath}"`,
@@ -158,10 +165,10 @@ export class PublishService {
       entityType,
       folderPath,
       version: publicationVersion,
-      publishedAt: publication.createdAt
+      publishedAt: publication?.createdAt
         ? new Date(publication.createdAt).toISOString()
         : new Date().toISOString(),
-      publishedBy: publication.author ?? publication.displayAuthor ?? '',
+      publishedBy: publication?.author ?? publication?.displayAuthor ?? author,
     };
   }
 
@@ -242,6 +249,7 @@ export class PublishService {
 
     await this.cacheManager.del(historyCacheKey(entityType, entityId));
 
+    /* See the matching comment in `publish` above: `result.data` can be undefined. */
     const publication = result.data;
     this.logger.debug(
       `Requested unpublish of ${entityType} "${entityId}" from "${folderPath}"`,
@@ -252,10 +260,10 @@ export class PublishService {
       entityType,
       folderPath,
       version: publicationVersion,
-      requestedAt: publication.createdAt
+      requestedAt: publication?.createdAt
         ? new Date(publication.createdAt).toISOString()
         : new Date().toISOString(),
-      requestedBy: publication.author ?? publication.displayAuthor ?? '',
+      requestedBy: publication?.author ?? publication?.displayAuthor ?? author,
     };
   }
 

--- a/apps/chat-api/src/publish/tests/publish.service.spec.ts
+++ b/apps/chat-api/src/publish/tests/publish.service.spec.ts
@@ -88,6 +88,26 @@ describe('PublishService', () => {
       );
     });
 
+    it('falls back to the caller-supplied author and the current time when Core returns no parseable publication body', async () => {
+      const { service, dialClient } = makeService();
+      vi.spyOn(dialClient.client, 'createPublication').mockResolvedValue(
+        okResponse(undefined),
+      );
+
+      const result = await service.publish(
+        'token-abc',
+        TEST_BUCKET,
+        CatalogEntityType.Toolset,
+        'toolsets/bucket-123/tool-abc123__1.2.0',
+        'Organization/Data Science',
+        undefined,
+        'Test User',
+      );
+
+      expect(result.publishedBy).toBe('Test User');
+      expect(new Date(result.publishedAt).toString()).not.toBe('Invalid Date');
+    });
+
     it('publishes an unversioned skill using only its leaf name in the publication title and targetUrl', async () => {
       const { service, dialClient } = makeService();
       vi.spyOn(dialClient.client, 'createPublication').mockResolvedValue(

--- a/apps/chat-api/src/publish/tests/unpublish.service.spec.ts
+++ b/apps/chat-api/src/publish/tests/unpublish.service.spec.ts
@@ -90,6 +90,26 @@ describe('PublishService.unpublish', () => {
     );
   });
 
+  it('falls back to the caller-supplied author and the current time when Core returns no parseable publication body', async () => {
+    const { service, dialClient } = makeService();
+    vi.spyOn(dialClient.client, 'createPublication').mockResolvedValue(
+      okResponse(undefined),
+    );
+
+    const result = await service.unpublish(
+      'token-abc',
+      TEST_BUCKET,
+      CatalogEntityType.Toolset,
+      TOOLSET_ID,
+      'Organization/Data Science',
+      '1.2.0',
+      'Test User',
+    );
+
+    expect(result.requestedBy).toBe('Test User');
+    expect(new Date(result.requestedAt).toString()).not.toBe('Invalid Date');
+  });
+
   /*
    * The whole point of `getPublishedTargetUrl`: a DELETE resource whose
    * `targetUrl` does not match the published copy removes nothing, and Core


### PR DESCRIPTION
## Summary
- Publishing a catalog entity for the first time returned 500: `Cannot read properties of undefined (reading 'createdAt')` at `PublishService.publish`.
- Root cause: DIAL Core's `createPublication` can respond `200` with no parseable body for some auto-approved publications (reproduced against a newly-created prompt on release-1.0/UAT). `PublishService.publish`/`unpublish` read `result.data.createdAt`/`.author` without guarding against `result.data` being `undefined`.
- Fix: fall back to the caller-supplied `author` and the current time when the response body is missing, in both `publish` and `unpublish` (same pattern, same risk).
- Reproduced on both `development` and `release-1.0` (identical file on both branches) — this PR targets `development`; will backport to `release-1.0` separately.

## Test plan
- [x] Added regression tests for `publish` and `unpublish` covering `createPublication` resolving with `data: undefined`
- [x] `npm run test:file -- apps/chat-api/src/publish/tests/publish.service.spec.ts apps/chat-api/src/publish/tests/unpublish.service.spec.ts`
- [x] `nx run chat-api:lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)