### PR TITLE
fix(publish): stop masking Core errors and percent-encode resource paths

### DIFF
--- a/apps/chat-api/src/publish/publish-rules.service.ts
+++ b/apps/chat-api/src/publish/publish-rules.service.ts
@@ -54,7 +54,12 @@ export class PublishRulesService {
       throw new BadGatewayException('Failed to reach DIAL Core');
     }
 
-    if (result.error) {
+    /*
+     * `openapi-fetch` short-circuits on an empty response body and returns
+     * `{ error: undefined }` without reading it, even for a non-2xx status —
+     * see the matching guard comment in `publish.service.ts`.
+     */
+    if (!result.response.ok || result.error != null) {
       return mapDialHttpStatus(
         result.response.status,
         `get publish rules for "${folderPath}"`,

--- a/apps/chat-api/src/publish/publish.service.ts
+++ b/apps/chat-api/src/publish/publish.service.ts
@@ -11,6 +11,7 @@ import {
   mapDialHttpStatus,
 } from '../common/dial/dial-error.mapper';
 import { getBearerAuthHeaders } from '../common/utils/auth-header';
+import { encodeDialResourcePath } from '../common/utils/encode-dial-path';
 import { safeDecodeURIComponent } from '../common/utils/uri';
 import { withCachedDialRequest } from '../dial/cached-dial-request.helper';
 import { DialClientService } from '../dial/dial-client.service';
@@ -104,7 +105,15 @@ export class PublishService {
     author: string,
     rules?: PublishRuleDto[],
   ): Promise<PublishResultDto> {
-    const sourceUrl = entityId;
+    /*
+     * `entityId` arrives as plain, unencoded text (e.g. a prompt path can
+     * end in a literal space, `prompts/{bucket}/test space`) — DIAL Core
+     * rejects resource urls containing raw spaces/special characters, so
+     * `sourceUrl` must be percent-encoded per segment before it is sent to
+     * Core, exactly as `conversation-publish.service.ts` already does for
+     * conversations.
+     */
+    const sourceUrl = encodeDialResourcePath(entityId);
     const publicTargetFolder = getPublicTargetFolder(folderPath);
     const targetUrl = getPublishedTargetUrl(
       getResourceTypePrefix(sourceUrl),
@@ -136,7 +145,14 @@ export class PublishService {
       throw new BadGatewayException('Failed to publish to DIAL Core');
     }
 
-    if (result.error) {
+    /*
+     * `openapi-fetch` short-circuits on an empty response body (e.g. a
+     * `Content-Length: 0` error response) and returns `{ error: undefined }`
+     * without reading the body, even for a non-2xx status — so `result.error`
+     * alone cannot be trusted to detect failure (see the same guard in
+     * `models.service.ts` and `files-listing.service.ts`).
+     */
+    if (!result.response.ok || result.error != null) {
       return mapDialHttpStatus(
         result.response.status,
         `publish ${entityType} "${entityId}"`,
@@ -198,7 +214,8 @@ export class PublishService {
     version: string | undefined,
     author: string,
   ): Promise<UnpublishResultDto> {
-    const sourceUrl = entityId;
+    /* See the matching `sourceUrl` encoding comment in `publish` above. */
+    const sourceUrl = encodeDialResourcePath(entityId);
     const publicTargetFolder = getPublicTargetFolder(folderPath);
     const targetUrl = getPublishedTargetUrl(
       getResourceTypePrefix(sourceUrl),
@@ -237,7 +254,8 @@ export class PublishService {
       );
     }
 
-    if (result.error) {
+    /* See the matching `openapi-fetch` empty-body guard comment in `publish` above. */
+    if (!result.response.ok || result.error != null) {
       return mapDialHttpStatus(
         result.response.status,
         `unpublish ${entityType} "${entityId}"`,

--- a/apps/chat-api/src/publish/tests/publish-rules.service.spec.ts
+++ b/apps/chat-api/src/publish/tests/publish-rules.service.spec.ts
@@ -4,10 +4,18 @@ import type { DialClientService } from '../../dial/dial-client.service';
 import { PublishRulesService } from '../publish-rules.service';
 
 const okResponse = (data: unknown) =>
-  ({ data, response: {} as Response }) as never;
+  ({ data, response: { ok: true, status: 200 } as Response }) as never;
 
 const errResponse = (status: number) =>
-  ({ error: {}, response: { status } as Response }) as never;
+  ({ error: {}, response: { ok: false, status } as Response }) as never;
+
+/*
+ * `openapi-fetch` short-circuits on an empty response body and returns
+ * `{ error: undefined }` without reading it, even for a non-2xx status — see
+ * the matching guard comment in `publish.service.ts`.
+ */
+const emptyBodyErrResponse = (status: number) =>
+  ({ response: { ok: false, status } as Response }) as never;
 
 const makeService = () => {
   const dialClient = {
@@ -114,6 +122,17 @@ describe('PublishRulesService', () => {
       const { service, dialClient } = makeService();
       vi.spyOn(dialClient.client, 'getPublicationRules').mockRejectedValue(
         new Error('boom'),
+      );
+
+      await expect(
+        service.getRules('token-abc', 'Organization/Data Science'),
+      ).rejects.toBeInstanceOf(BadGatewayException);
+    });
+
+    it('maps a Core 500 with an empty response body to BadGatewayException instead of reporting success', async () => {
+      const { service, dialClient } = makeService();
+      vi.spyOn(dialClient.client, 'getPublicationRules').mockResolvedValue(
+        emptyBodyErrResponse(500),
       );
 
       await expect(

--- a/apps/chat-api/src/publish/tests/publish.service.spec.ts
+++ b/apps/chat-api/src/publish/tests/publish.service.spec.ts
@@ -9,10 +9,18 @@ import { PublishService } from '../publish.service';
 const TEST_BUCKET = 'bucket-123';
 
 const okResponse = (data: unknown) =>
-  ({ data, response: {} as Response }) as never;
+  ({ data, response: { ok: true, status: 200 } as Response }) as never;
 
 const errResponse = (status: number) =>
-  ({ error: {}, response: { status } as Response }) as never;
+  ({ error: {}, response: { ok: false, status } as Response }) as never;
+
+/*
+ * `openapi-fetch` short-circuits on an empty response body and returns
+ * `{ error: undefined }` without reading it, even for a non-2xx status — see
+ * the matching guard comment in `publish.service.ts`.
+ */
+const emptyBodyErrResponse = (status: number) =>
+  ({ response: { ok: false, status } as Response }) as never;
 
 const makeCacheManager = () => ({
   get: vi.fn(),
@@ -233,9 +241,9 @@ describe('PublishService', () => {
           resources: [
             {
               action: 'ADD',
-              sourceUrl: 'applications/bucket-123/My App Name__0.0.1',
+              sourceUrl: 'applications/bucket-123/My%20App%20Name__0.0.1',
               targetUrl:
-                'applications/public/DK%20Test%20with%20nested/Level%201/My App Name__0.0.1',
+                'applications/public/DK%20Test%20with%20nested/Level%201/My%20App%20Name__0.0.1',
             },
           ],
           displayAuthor: 'Test User',
@@ -266,7 +274,7 @@ describe('PublishService', () => {
             targetFolder: 'public/',
             resources: [
               expect.objectContaining({
-                targetUrl: 'applications/public/My App Name__0.0.1',
+                targetUrl: 'applications/public/My%20App%20Name__0.0.1',
               }),
             ],
           }),
@@ -357,6 +365,36 @@ describe('PublishService', () => {
       );
     });
 
+    it('percent-encodes a raw space in a versionless prompt name in both sourceUrl and targetUrl', async () => {
+      const { service, dialClient } = makeService();
+      vi.spyOn(dialClient.client, 'createPublication').mockResolvedValue(
+        okResponse({}),
+      );
+
+      await service.publish(
+        'token-abc',
+        TEST_BUCKET,
+        CatalogEntityType.Prompt,
+        'prompts/bucket-123/test space',
+        '01folder',
+        undefined,
+        'Test User',
+      );
+
+      expect(dialClient.client.createPublication).toHaveBeenCalledWith(
+        expect.objectContaining({
+          body: expect.objectContaining({
+            resources: [
+              expect.objectContaining({
+                sourceUrl: 'prompts/bucket-123/test%20space',
+                targetUrl: 'prompts/public/01folder/test%20space',
+              }),
+            ],
+          }),
+        }),
+      );
+    });
+
     it('maps a Core 403 to ForbiddenException', async () => {
       const { service, dialClient } = makeService();
       vi.spyOn(dialClient.client, 'createPublication').mockResolvedValue(
@@ -393,6 +431,26 @@ describe('PublishService', () => {
           'Test User',
         ),
       ).rejects.toBeInstanceOf(BadGatewayException);
+    });
+
+    it('maps a Core 500 with an empty response body to BadGatewayException instead of reporting success', async () => {
+      const { service, dialClient, cacheManager } = makeService();
+      vi.spyOn(dialClient.client, 'createPublication').mockResolvedValue(
+        emptyBodyErrResponse(500),
+      );
+
+      await expect(
+        service.publish(
+          'token-abc',
+          TEST_BUCKET,
+          CatalogEntityType.Toolset,
+          'toolsets/bucket-123/tool-abc123__1.2.0',
+          'Organization/Data Science',
+          '1.2.0',
+          'Test User',
+        ),
+      ).rejects.toBeInstanceOf(BadGatewayException);
+      expect(cacheManager.del).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/chat-api/src/publish/tests/unpublish.service.spec.ts
+++ b/apps/chat-api/src/publish/tests/unpublish.service.spec.ts
@@ -13,10 +13,18 @@ const TEST_BUCKET = 'bucket-123';
 const TOOLSET_ID = 'toolsets/bucket-123/tool-abc123__1.2.0';
 
 const okResponse = (data: unknown) =>
-  ({ data, response: {} as Response }) as never;
+  ({ data, response: { ok: true, status: 200 } as Response }) as never;
 
 const errResponse = (status: number) =>
-  ({ error: {}, response: { status } as Response }) as never;
+  ({ error: {}, response: { ok: false, status } as Response }) as never;
+
+/*
+ * `openapi-fetch` short-circuits on an empty response body and returns
+ * `{ error: undefined }` without reading it, even for a non-2xx status — see
+ * the matching guard comment in `publish.service.ts`.
+ */
+const emptyBodyErrResponse = (status: number) =>
+  ({ response: { ok: false, status } as Response }) as never;
 
 const makeCacheManager = () => ({
   get: vi.fn(),
@@ -271,6 +279,26 @@ describe('PublishService.unpublish', () => {
         'Test User',
       ),
     ).rejects.toBeInstanceOf(expected);
+    expect(cacheManager.del).not.toHaveBeenCalled();
+  });
+
+  it('maps a Core 500 with an empty response body to BadGatewayException instead of reporting success', async () => {
+    const { service, dialClient, cacheManager } = makeService();
+    vi.spyOn(dialClient.client, 'createPublication').mockResolvedValue(
+      emptyBodyErrResponse(500),
+    );
+
+    await expect(
+      service.unpublish(
+        'token-abc',
+        TEST_BUCKET,
+        CatalogEntityType.Toolset,
+        TOOLSET_ID,
+        'Organization/Data Science',
+        '1.2.0',
+        'Test User',
+      ),
+    ).rejects.toBeInstanceOf(BadGatewayException);
     expect(cacheManager.del).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## Summary
- `openapi-fetch` short-circuits on an empty response body and returns `{ error: undefined }` even for a non-2xx status, so a DIAL Core 500 with no body was silently reported as a successful publish/unpublish/publish-rules read. Both `publish.service.ts` and `publish-rules.service.ts` now also guard on `!result.response.ok`, matching the pattern already used in `models.service.ts`/`files-listing.service.ts`.
- `entityId` was used raw as `sourceUrl`/`targetUrl` when publishing/unpublishing a catalog entity (Toolset/Application/Prompt/Skill). A resource name containing a space or other special character (e.g. a prompt named "test space") produced a malformed, un-percent-encoded resource url that Core rejects. `sourceUrl` is now built via `encodeDialResourcePath`, the same helper `conversation-publish.service.ts` already used for conversations.

## Test plan
- [x] `nx test chat-api` — all 199 tests pass, including new regression tests for the empty-body-500 guard and for percent-encoding a raw space in a prompt name
- [x] `nx lint chat-api`
- [x] `nx build chat-api`