### PR TITLE
fix(chat-api): remove rate limiting on all endpoints

### DIFF
--- a/apps/chat-api/src/app-config/app-config.controller.ts
+++ b/apps/chat-api/src/app-config/app-config.controller.ts
@@ -1,6 +1,5 @@
 import { Controller, Get, Query, Req, UseGuards } from '@nestjs/common';
 import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
-import { Throttle } from '@nestjs/throttler';
 import type { Request } from 'express';
 import { OptionalSessionGuard } from '../auth/session/optional-session.guard';
 import type { SessionUser } from '../auth/session/session.types';
@@ -23,13 +22,11 @@ export class AppConfigController {
   @Get()
   @Public()
   @UseGuards(OptionalSessionGuard)
-  @Throttle({ default: { limit: 60, ttl: 60_000 } })
   @ApiOperation({
     summary: 'Get client-safe application configuration and feature flags',
   })
   @ApiResponse({ status: 200, type: ClientConfigResponseDtoClass })
   @ApiResponse({ status: 400, description: 'Missing or invalid appId' })
-  @ApiResponse({ status: 429, description: 'Too Many Requests' })
   async getClientConfig(
     @Query() query: GetClientConfigDto,
     @Req() req: Request,

--- a/apps/chat-api/src/app-config/tests/app-config.controller.spec.ts
+++ b/apps/chat-api/src/app-config/tests/app-config.controller.spec.ts
@@ -4,7 +4,6 @@ import {
   VersioningType,
 } from '@nestjs/common';
 import { Test } from '@nestjs/testing';
-import { ThrottlerModule } from '@nestjs/throttler';
 import request from 'supertest';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { OptionalSessionGuard } from '../../auth/session/optional-session.guard';
@@ -55,7 +54,6 @@ async function buildApp(
   mockService: ReturnType<typeof makeApp>['mockService'],
 ): Promise<INestApplication> {
   const module = await Test.createTestingModule({
-    imports: [ThrottlerModule.forRoot([{ ttl: 60_000, limit: 60 }])],
     controllers: [AppConfigController],
     providers: [{ provide: AppConfigService, useValue: mockService }],
   })

--- a/apps/chat-api/src/app/app.module.ts
+++ b/apps/chat-api/src/app/app.module.ts
@@ -1,9 +1,8 @@
 import { CacheModule } from '@nestjs/cache-manager';
 import { Module } from '@nestjs/common';
 import { ConfigModule, ConfigService } from '@nestjs/config';
-import { APP_GUARD, APP_INTERCEPTOR } from '@nestjs/core';
+import { APP_INTERCEPTOR } from '@nestjs/core';
 import { ServeStaticModule } from '@nestjs/serve-static';
-import { ThrottlerModule, ThrottlerGuard } from '@nestjs/throttler';
 import { AppConfigModule } from '../app-config/app-config.module';
 import { ApplicationSchemasModule } from '../application-schemas/application-schemas.module';
 import { ApplicationsModule } from '../applications/applications.module';
@@ -48,12 +47,6 @@ import { createServeStaticOptions } from './static-assets';
       ttl: 5 * 60 * 1000, // 5 minutes in milliseconds
       max: 100, // Maximum number of items in cache
     }),
-    ThrottlerModule.forRoot([
-      {
-        ttl: 60000, // 60 seconds
-        limit: 100, // 100 requests per minute
-      },
-    ]),
     ServeStaticModule.forRootAsync({
       inject: [ConfigService],
       useFactory: (configService: ConfigService<EnvironmentVariables, true>) =>
@@ -88,10 +81,6 @@ import { createServeStaticOptions } from './static-assets';
   ],
   controllers: [AppController, HealthController],
   providers: [
-    {
-      provide: APP_GUARD,
-      useClass: ThrottlerGuard,
-    },
     {
       provide: APP_INTERCEPTOR,
       useClass: MetricsInterceptor,

--- a/apps/chat-api/src/application-schemas/application-schemas.controller.ts
+++ b/apps/chat-api/src/application-schemas/application-schemas.controller.ts
@@ -1,6 +1,5 @@
 import { Controller, Get, Param, Req } from '@nestjs/common';
 import { ApiOperation, ApiParam, ApiResponse, ApiTags } from '@nestjs/swagger';
-import { Throttle } from '@nestjs/throttler';
 import type { Request } from 'express';
 import type { SessionUser } from '../auth/session/session.types';
 import { ApplicationSchemasService } from './application-schemas.service';
@@ -17,7 +16,6 @@ export class ApplicationSchemasController {
   ) {}
 
   @Get()
-  @Throttle({ default: { limit: 60, ttl: 60000 } })
   @ApiOperation({
     operationId: 'listApplicationSchemas',
     summary: 'List application type schemas',
@@ -38,7 +36,6 @@ export class ApplicationSchemasController {
     status: 403,
     description: 'Caller lacks permission to list application schemas',
   })
-  @ApiResponse({ status: 429, description: 'Rate limit exceeded' })
   @ApiResponse({
     status: 502,
     description: 'DIAL Core returned an error response',
@@ -53,7 +50,6 @@ export class ApplicationSchemasController {
   }
 
   @Get(':id')
-  @Throttle({ default: { limit: 60, ttl: 60000 } })
   @ApiOperation({
     operationId: 'getApplicationSchema',
     summary: 'Get application type schema by id',
@@ -81,7 +77,6 @@ export class ApplicationSchemasController {
     description: 'Caller lacks permission to access this schema',
   })
   @ApiResponse({ status: 404, description: 'Schema not found' })
-  @ApiResponse({ status: 429, description: 'Rate limit exceeded' })
   @ApiResponse({
     status: 502,
     description: 'DIAL Core returned an error response',

--- a/apps/chat-api/src/applications/applications.controller.ts
+++ b/apps/chat-api/src/applications/applications.controller.ts
@@ -11,7 +11,6 @@ import {
   Req,
 } from '@nestjs/common';
 import { ApiBody, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
-import { Throttle } from '@nestjs/throttler';
 import type { Request } from 'express';
 import type { SessionUser } from '../auth/session/session.types';
 import { ApplicationsService } from './applications.service';
@@ -32,7 +31,6 @@ export class ApplicationsController {
   constructor(private readonly applicationsService: ApplicationsService) {}
 
   @Get()
-  @Throttle({ default: { limit: 60, ttl: 60000 } })
   @Header('Cache-Control', 'private, max-age=30')
   @ApiOperation({
     operationId: 'listApplications',
@@ -55,7 +53,6 @@ export class ApplicationsController {
     status: 403,
     description: 'Caller lacks permission to list applications',
   })
-  @ApiResponse({ status: 429, description: 'Rate limit exceeded' })
   @ApiResponse({
     status: 502,
     description: 'DIAL Core returned an error response',
@@ -71,7 +68,6 @@ export class ApplicationsController {
 
   @Post()
   @HttpCode(201)
-  @Throttle({ default: { limit: 10, ttl: 60000 } })
   @ApiOperation({
     operationId: 'createApplication',
     summary: 'Create a new application',
@@ -94,7 +90,6 @@ export class ApplicationsController {
     description: 'Not authenticated — valid session cookie required',
   })
   @ApiResponse({ status: 409, description: 'Application name already taken' })
-  @ApiResponse({ status: 429, description: 'Rate limit exceeded' })
   @ApiResponse({
     status: 503,
     description: 'DIAL Core is unavailable or timed out',
@@ -109,7 +104,6 @@ export class ApplicationsController {
 
   @Patch(':applicationName')
   @HttpCode(200)
-  @Throttle({ default: { limit: 10, ttl: 60000 } })
   @ApiOperation({
     operationId: 'updateApplication',
     summary: 'Update an application',
@@ -135,7 +129,6 @@ export class ApplicationsController {
   })
   @ApiResponse({ status: 403, description: 'Caller lacks permission' })
   @ApiResponse({ status: 404, description: 'Application not found' })
-  @ApiResponse({ status: 429, description: 'Rate limit exceeded' })
   @ApiResponse({
     status: 502,
     description: 'DIAL Core returned an error response',
@@ -160,7 +153,6 @@ export class ApplicationsController {
 
   @Delete(':applicationName')
   @HttpCode(204)
-  @Throttle({ default: { limit: 10, ttl: 60000 } })
   @ApiOperation({
     operationId: 'deleteApplication',
     summary: 'Delete an application',
@@ -176,7 +168,6 @@ export class ApplicationsController {
   })
   @ApiResponse({ status: 403, description: 'Caller lacks permission' })
   @ApiResponse({ status: 404, description: 'Application not found' })
-  @ApiResponse({ status: 429, description: 'Rate limit exceeded' })
   @ApiResponse({
     status: 502,
     description: 'DIAL Core returned an error response',

--- a/apps/chat-api/src/auth/auth.controller.ts
+++ b/apps/chat-api/src/auth/auth.controller.ts
@@ -21,7 +21,6 @@ import {
   ApiSecurity,
   ApiTags,
 } from '@nestjs/swagger';
-import { Throttle } from '@nestjs/throttler';
 import type { Request, Response } from 'express';
 import { decodeJwt } from 'jose';
 import { generators, type AuthorizationParameters } from 'openid-client';
@@ -84,7 +83,6 @@ export class AuthController {
 
   @Get('providers')
   @Public()
-  @Throttle({ default: { limit: 30, ttl: 60000 } })
   @ApiOperation({ summary: 'List configured identity providers' })
   @ApiResponse({
     status: 200,
@@ -97,7 +95,6 @@ export class AuthController {
 
   @Get('login/:providerId')
   @Public()
-  @Throttle({ default: { limit: 10, ttl: 60000 } })
   @ApiOperation({ summary: 'Start OIDC login flow' })
   @ApiParam({
     name: 'providerId',
@@ -181,7 +178,6 @@ export class AuthController {
 
   @Get('callback/:providerId')
   @Public()
-  @Throttle({ default: { limit: 10, ttl: 60000 } })
   @ApiOperation({ summary: 'OIDC authorization callback' })
   @ApiParam({
     name: 'providerId',
@@ -404,7 +400,6 @@ export class AuthController {
 
   @Post('logout')
   @Public()
-  @Throttle({ default: { limit: 10, ttl: 60000 } })
   @ApiOperation({ summary: 'Log out and clear session cookie' })
   @ApiResponse({ status: 302, description: 'Redirect after logout' })
   @ApiResponse({
@@ -503,7 +498,6 @@ export class AuthController {
   @Get('me')
   @ApiCookieAuth('session')
   @ApiSecurity('bearer')
-  @Throttle({ default: { limit: 60, ttl: 60000 } })
   @ApiOperation({ summary: 'Get current user profile' })
   @ApiResponse({
     status: 200,

--- a/apps/chat-api/src/client-channel/client-channel.controller.ts
+++ b/apps/chat-api/src/client-channel/client-channel.controller.ts
@@ -10,7 +10,6 @@ import {
   UseGuards,
 } from '@nestjs/common';
 import { ApiHeader, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
-import { Throttle } from '@nestjs/throttler';
 import type { Request, Response } from 'express';
 import { FeatureKey } from '../app-config/feature-flags/feature-key.enum';
 import { FeatureGuard } from '../app-config/feature-flags/feature.guard';
@@ -36,7 +35,6 @@ export class ClientChannelController {
   @UseGuards(FeatureGuard)
   @RequireFeature(FeatureKey.LiveChatInteraction)
   @HttpCode(200)
-  @Throttle({ default: { limit: 10, ttl: 60000 } })
   @ApiOperation({
     operationId: 'subscribeClientChannel',
     summary: 'Subscribe to the DIAL Core client channel',
@@ -139,7 +137,6 @@ export class ClientChannelController {
   @UseGuards(FeatureGuard)
   @RequireFeature(FeatureKey.LiveChatInteraction)
   @HttpCode(200)
-  @Throttle({ default: { limit: 30, ttl: 60000 } })
   @ApiOperation({
     operationId: 'reportClientChannel',
     summary: 'Report an RPC response on the client channel',
@@ -163,7 +160,6 @@ export class ClientChannelController {
     status: 403,
     description: 'The liveChatInteraction feature is not enabled for this user',
   })
-  @ApiResponse({ status: 429, description: 'Rate limit exceeded' })
   @ApiResponse({
     status: 502,
     description: 'DIAL Core returned an error response',
@@ -186,7 +182,6 @@ export class ClientChannelController {
    */
   @Post('unsubscribe')
   @HttpCode(200)
-  @Throttle({ default: { limit: 30, ttl: 60000 } })
   @ApiOperation({
     operationId: 'unsubscribeClientChannel',
     summary: 'Unsubscribe from the client channel',

--- a/apps/chat-api/src/conversations/conversation-publish.controller.ts
+++ b/apps/chat-api/src/conversations/conversation-publish.controller.ts
@@ -8,7 +8,6 @@ import {
   Req,
 } from '@nestjs/common';
 import { ApiBody, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
-import { Throttle } from '@nestjs/throttler';
 import type { Request } from 'express';
 import type { SessionUser } from '../auth/session/session.types';
 import { getUserDisplayName } from '../common/utils/user-display-name';
@@ -37,7 +36,6 @@ export class ConversationPublishController {
 
   @Post('publish')
   @HttpCode(201)
-  @Throttle({ default: { limit: 10, ttl: 60000 } })
   @ApiOperation({
     operationId: 'publishConversation',
     summary: 'Publish a conversation to an Organization folder',
@@ -66,7 +64,6 @@ export class ConversationPublishController {
     description: 'Caller lacks write access to the target folder',
   })
   @ApiResponse({ status: 404, description: 'Conversation not found' })
-  @ApiResponse({ status: 429, description: 'Rate limit exceeded' })
   @ApiResponse({
     status: 502,
     description: 'DIAL Core returned an error response',
@@ -93,7 +90,6 @@ export class ConversationPublishController {
 
   @Post('unpublish')
   @HttpCode(200)
-  @Throttle({ default: { limit: 10, ttl: 60000 } })
   @ApiOperation({
     operationId: 'unpublishConversation',
     summary: 'Request removal of a published conversation from a folder',
@@ -124,7 +120,6 @@ export class ConversationPublishController {
     description: 'Caller lacks write access to the target folder',
   })
   @ApiResponse({ status: 404, description: 'Conversation not found' })
-  @ApiResponse({ status: 429, description: 'Rate limit exceeded' })
   @ApiResponse({
     status: 502,
     description: 'DIAL Core returned an error response',
@@ -150,7 +145,6 @@ export class ConversationPublishController {
 
   @Get('publish-history')
   @HttpCode(200)
-  @Throttle({ default: { limit: 60, ttl: 60000 } })
   @ApiOperation({
     operationId: 'getConversationPublishHistory',
     summary: 'Get publish history for a conversation',
@@ -169,7 +163,6 @@ export class ConversationPublishController {
     status: 401,
     description: 'Not authenticated — valid session cookie required',
   })
-  @ApiResponse({ status: 429, description: 'Rate limit exceeded' })
   @ApiResponse({
     status: 502,
     description: 'DIAL Core returned an error response',

--- a/apps/chat-api/src/conversations/conversation.controller.ts
+++ b/apps/chat-api/src/conversations/conversation.controller.ts
@@ -15,7 +15,6 @@ import {
   Res,
 } from '@nestjs/common';
 import { ApiHeader, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
-import { Throttle } from '@nestjs/throttler';
 import type { Request, Response } from 'express';
 import type { SessionUser } from '../auth/session/session.types';
 import {
@@ -66,7 +65,6 @@ export class ConversationController {
 
   @Post()
   @HttpCode(201)
-  @Throttle({ default: { limit: 20, ttl: 60000 } })
   @ApiOperation({
     summary: 'Create a new conversation',
     description:
@@ -98,7 +96,6 @@ export class ConversationController {
   }
 
   @Get('list')
-  @Throttle({ default: { limit: 300, ttl: 60000 } })
   @ApiOperation({
     summary: 'List conversations',
     description:
@@ -127,7 +124,6 @@ export class ConversationController {
   }
 
   @Get('metadata')
-  @Throttle({ default: { limit: 300, ttl: 60000 } })
   @ApiOperation({ summary: 'Get metadata for a conversation' })
   @ApiResponse({
     status: 200,
@@ -153,7 +149,6 @@ export class ConversationController {
   }
 
   @Get()
-  @Throttle({ default: { limit: 600, ttl: 60000 } })
   @ApiOperation({ summary: 'Get a conversation by path' })
   @ApiResponse({
     status: 200,
@@ -198,7 +193,6 @@ export class ConversationController {
 
   @Post('completions')
   @HttpCode(200)
-  @Throttle({ default: { limit: 100, ttl: 60000 } })
   @ApiOperation({
     summary: 'Stream a chat completion',
     description:
@@ -231,7 +225,6 @@ export class ConversationController {
     status: 409,
     description: 'Another generation is already active for this conversation',
   })
-  @ApiResponse({ status: 429, description: 'Rate limit exceeded' })
   @ApiResponse({ status: 502, description: 'DIAL Core error' })
   @ApiResponse({ status: 503, description: 'DIAL Core unreachable' })
   async streamCompletion(
@@ -272,7 +265,6 @@ export class ConversationController {
   }
 
   @Post('completions/stop')
-  @Throttle({ default: { limit: 60, ttl: 60000 } })
   @ApiOperation({ summary: 'Stop an active generation' })
   @ApiResponse({ status: 204, description: 'Generation stopped successfully' })
   @ApiResponse({ status: 401, description: 'Not authenticated' })
@@ -302,7 +294,6 @@ export class ConversationController {
 
   @Post('watch')
   @HttpCode(200)
-  @Throttle({ default: { limit: 20, ttl: 60000 } })
   @ApiOperation({
     operationId: 'watchConversation',
     summary: 'Subscribe to conversation resource updates via SSE',
@@ -380,7 +371,6 @@ export class ConversationController {
   }
 
   @Patch()
-  @Throttle({ default: { limit: 20, ttl: 60000 } })
   @ApiOperation({ summary: 'Rename a conversation by path' })
   @ApiResponse({
     status: 200,
@@ -411,7 +401,6 @@ export class ConversationController {
 
   @Post('generate-title')
   @HttpCode(200)
-  @Throttle({ default: { limit: 5, ttl: 60000 } })
   @ApiOperation({
     operationId: 'generateConversationTitle',
     summary: 'Generate an LLM-based title suggestion for a conversation',
@@ -437,7 +426,6 @@ export class ConversationController {
     description: 'Not authorized to use the configured utility model',
   })
   @ApiResponse({ status: 404, description: 'Conversation not found' })
-  @ApiResponse({ status: 429, description: 'Rate limit exceeded' })
   @ApiResponse({ status: 502, description: 'LLM title generation failed' })
   @ApiResponse({
     status: 503,
@@ -457,7 +445,6 @@ export class ConversationController {
   }
 
   @Post('duplicate')
-  @Throttle({ default: { limit: 20, ttl: 60000 } })
   @ApiOperation({
     summary: "Duplicate a conversation into the user's own bucket",
   })
@@ -485,7 +472,6 @@ export class ConversationController {
 
   @Post('deletions')
   @HttpCode(200)
-  @Throttle({ default: { limit: 5, ttl: 60000 } })
   @ApiOperation({
     operationId: 'deleteConversations',
     summary: 'Delete selected conversations',
@@ -503,7 +489,6 @@ export class ConversationController {
       'ids is empty, exceeds 100, contains non-strings, or body is missing',
   })
   @ApiResponse({ status: 401, description: 'Not authenticated' })
-  @ApiResponse({ status: 429, description: 'Rate limit exceeded' })
   @ApiResponse({ status: 500, description: 'Unexpected internal error' })
   deleteConversations(
     @Req() req: Request,
@@ -515,7 +500,6 @@ export class ConversationController {
 
   @Post('deletions/all')
   @HttpCode(200)
-  @Throttle({ default: { limit: 2, ttl: 60000 } })
   @ApiOperation({
     operationId: 'deleteAllConversations',
     summary: 'Delete all conversations in the user bucket',
@@ -532,7 +516,6 @@ export class ConversationController {
     description: 'confirm is missing, false, or non-boolean',
   })
   @ApiResponse({ status: 401, description: 'Not authenticated' })
-  @ApiResponse({ status: 429, description: 'Rate limit exceeded' })
   @ApiResponse({
     status: 502,
     description: 'DIAL Core metadata listing failed (bucket unreadable)',

--- a/apps/chat-api/src/deployments/deployments.controller.ts
+++ b/apps/chat-api/src/deployments/deployments.controller.ts
@@ -8,7 +8,6 @@ import {
   Res,
 } from '@nestjs/common';
 import { ApiOperation, ApiQuery, ApiResponse, ApiTags } from '@nestjs/swagger';
-import { Throttle } from '@nestjs/throttler';
 import type { Request, Response } from 'express';
 import type { SessionUser } from '../auth/session/session.types';
 import { DeploymentLimitsResponseDto } from '../openapi/openapi-response.dto';
@@ -25,7 +24,6 @@ export class DeploymentsController {
   constructor(private readonly deploymentsService: DeploymentsService) {}
 
   @Get()
-  @Throttle({ default: { limit: 60, ttl: 60000 } })
   @ApiOperation({
     operationId: 'listDeployments',
     summary: 'List deployments by interface type',
@@ -52,7 +50,6 @@ export class DeploymentsController {
     description: 'Not authenticated — valid session cookie required',
   })
   @ApiResponse({ status: 403, description: 'Caller lacks permission' })
-  @ApiResponse({ status: 429, description: 'Rate limit exceeded' })
   @ApiResponse({
     status: 502,
     description: 'DIAL Core returned an error response',
@@ -113,7 +110,6 @@ export class DeploymentsController {
   }
 
   @Get(':deployment/limits')
-  @Throttle({ default: { limit: 60, ttl: 60000 } })
   @Header('Cache-Control', 'private, no-store')
   @ApiOperation({
     operationId: 'getDeploymentLimits',
@@ -141,7 +137,6 @@ export class DeploymentsController {
     status: 404,
     description: 'Deployment limits not found',
   })
-  @ApiResponse({ status: 429, description: 'Rate limit exceeded' })
   @ApiResponse({ status: 500, description: 'Internal server error' })
   @ApiResponse({
     status: 502,
@@ -157,7 +152,6 @@ export class DeploymentsController {
   }
 
   @Get(':deployment/details')
-  @Throttle({ default: { limit: 60, ttl: 60000 } })
   @Header('Cache-Control', 'private, no-store')
   @ApiOperation({
     operationId: 'getDeploymentDetails',
@@ -177,7 +171,6 @@ export class DeploymentsController {
     description: 'Not authenticated — valid session cookie required',
   })
   @ApiResponse({ status: 404, description: 'Deployment not found' })
-  @ApiResponse({ status: 429, description: 'Rate limit exceeded' })
   @ApiResponse({
     status: 502,
     description: 'DIAL Core returned an error response',

--- a/apps/chat-api/src/deployments/user-limits.controller.ts
+++ b/apps/chat-api/src/deployments/user-limits.controller.ts
@@ -1,6 +1,5 @@
 import { Controller, Get, Header, Req } from '@nestjs/common';
 import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
-import { Throttle } from '@nestjs/throttler';
 import type { Request } from 'express';
 import type { SessionUser } from '../auth/session/session.types';
 import { UserLimitStatsResponseDto } from '../openapi/openapi-response.dto';
@@ -18,7 +17,6 @@ export class UserLimitsController {
   constructor(private readonly deploymentsService: DeploymentsService) {}
 
   @Get('limits')
-  @Throttle({ default: { limit: 60, ttl: 60000 } })
   @Header('Cache-Control', 'private, no-store')
   @ApiOperation({
     operationId: 'getUserLimits',
@@ -37,7 +35,6 @@ export class UserLimitsController {
     status: 401,
     description: 'Not authenticated — valid session cookie required',
   })
-  @ApiResponse({ status: 429, description: 'Rate limit exceeded' })
   @ApiResponse({ status: 500, description: 'Internal server error' })
   @ApiResponse({
     status: 502,
@@ -53,7 +50,6 @@ export class UserLimitsController {
   }
 
   @Get('usage')
-  @Throttle({ default: { limit: 60, ttl: 60000 } })
   @Header('Cache-Control', 'private, no-store')
   @ApiOperation({
     operationId: 'getUserUsage',
@@ -72,7 +68,6 @@ export class UserLimitsController {
     status: 401,
     description: 'Not authenticated — valid session cookie required',
   })
-  @ApiResponse({ status: 429, description: 'Rate limit exceeded' })
   @ApiResponse({ status: 500, description: 'Internal server error' })
   @ApiResponse({
     status: 502,

--- a/apps/chat-api/src/external-services/external-services.controller.ts
+++ b/apps/chat-api/src/external-services/external-services.controller.ts
@@ -9,7 +9,6 @@ import {
   UseGuards,
 } from '@nestjs/common';
 import { ApiBody, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
-import { Throttle } from '@nestjs/throttler';
 import type { Request } from 'express';
 import { FeatureKey } from '../app-config/feature-flags/feature-key.enum';
 import { FeatureGuard } from '../app-config/feature-flags/feature.guard';
@@ -34,7 +33,6 @@ export class ExternalServicesController {
   @Get(':appId/:serviceId')
   @UseGuards(FeatureGuard)
   @RequireFeature(FeatureKey.LiveChatInteraction)
-  @Throttle({ default: { limit: 60, ttl: 60000 } })
   @ApiOperation({
     operationId: 'getExternalService',
     summary: 'Get application external-service metadata',
@@ -63,7 +61,6 @@ export class ExternalServicesController {
       'Caller lacks permission, or the liveChatInteraction feature is not enabled',
   })
   @ApiResponse({ status: 404, description: 'External service not found' })
-  @ApiResponse({ status: 429, description: 'Rate limit exceeded' })
   @ApiResponse({
     status: 502,
     description: 'DIAL Core returned an error response',
@@ -84,7 +81,6 @@ export class ExternalServicesController {
   @UseGuards(FeatureGuard)
   @RequireFeature(FeatureKey.LiveChatInteraction)
   @HttpCode(200)
-  @Throttle({ default: { limit: 10, ttl: 60000 } })
   @ApiOperation({
     operationId: 'signInExternalService',
     summary: 'Submit external-service credentials',
@@ -109,7 +105,6 @@ export class ExternalServicesController {
     description:
       'Caller lacks permission, or the liveChatInteraction feature is not enabled',
   })
-  @ApiResponse({ status: 429, description: 'Rate limit exceeded' })
   @ApiResponse({
     status: 502,
     description: 'DIAL Core returned an error response or rejected sign-in',
@@ -133,7 +128,6 @@ export class ExternalServicesController {
   @UseGuards(FeatureGuard)
   @RequireFeature(FeatureKey.LiveChatInteraction)
   @HttpCode(200)
-  @Throttle({ default: { limit: 10, ttl: 60000 } })
   @ApiOperation({
     operationId: 'signOutExternalService',
     summary: 'Revoke external-service credentials',
@@ -158,7 +152,6 @@ export class ExternalServicesController {
     description:
       'Caller lacks permission, or the liveChatInteraction feature is not enabled',
   })
-  @ApiResponse({ status: 429, description: 'Rate limit exceeded' })
   @ApiResponse({
     status: 502,
     description: 'DIAL Core returned an error response',

--- a/apps/chat-api/src/files/files.controller.ts
+++ b/apps/chat-api/src/files/files.controller.ts
@@ -22,7 +22,6 @@ import {
   ApiResponse,
   ApiTags,
 } from '@nestjs/swagger';
-import { Throttle } from '@nestjs/throttler';
 import type { Request, Response } from 'express';
 import type { SessionUser } from '../auth/session/session.types';
 import { ArchiveUploadInterceptor } from './archive-upload.interceptor';
@@ -68,7 +67,6 @@ export class FilesController {
 
   @Post()
   @HttpCode(201)
-  @Throttle({ default: { limit: 100, ttl: 60000 } })
   @UseInterceptors(FileInterceptor('file'))
   @ApiConsumes('multipart/form-data')
   @ApiBody({
@@ -97,7 +95,6 @@ export class FilesController {
     description: 'File already exists (create-only mode)',
   })
   @ApiResponse({ status: 413, description: 'Payload too large' })
-  @ApiResponse({ status: 429, description: 'Rate limit exceeded' })
   @ApiResponse({ status: 502, description: 'DIAL Core returned an error' })
   @ApiResponse({
     status: 503,
@@ -120,7 +117,6 @@ export class FilesController {
 
   @Post('upload-archive')
   @HttpCode(200)
-  @Throttle({ default: { limit: 5, ttl: 60000 } })
   @UseInterceptors(ArchiveUploadInterceptor)
   @ApiConsumes('multipart/form-data')
   @ApiBody({
@@ -153,7 +149,6 @@ export class FilesController {
     description:
       'Archive exceeds ARCHIVE_UPLOAD_MAX_FILES or ARCHIVE_UPLOAD_MAX_UNCOMPRESSED_BYTES',
   })
-  @ApiResponse({ status: 429, description: 'Rate limit exceeded' })
   @ApiResponse({ status: 502, description: 'DIAL Core returned an error' })
   @ApiResponse({
     status: 503,
@@ -178,7 +173,6 @@ export class FilesController {
   }
 
   @Get('list')
-  @Throttle({ default: { limit: 60, ttl: 60000 } })
   @ApiOperation({
     summary: 'List files and folders',
     description:
@@ -199,7 +193,6 @@ export class FilesController {
     description: 'Forbidden — user does not own the bucket',
   })
   @ApiResponse({ status: 404, description: 'Bucket or path not found' })
-  @ApiResponse({ status: 429, description: 'Rate limit exceeded' })
   @ApiResponse({ status: 502, description: 'DIAL Core returned an error' })
   @ApiResponse({
     status: 503,
@@ -224,7 +217,6 @@ export class FilesController {
   }
 
   @Get('public')
-  @Throttle({ default: { limit: 60, ttl: 60000 } })
   @ApiOperation({
     summary: 'List files from the organization (public) bucket',
     description:
@@ -239,7 +231,6 @@ export class FilesController {
   @ApiResponse({ status: 400, description: 'Invalid path or query parameter' })
   @ApiResponse({ status: 401, description: 'Not authenticated' })
   @ApiResponse({ status: 404, description: 'Path not found' })
-  @ApiResponse({ status: 429, description: 'Rate limit exceeded' })
   @ApiResponse({ status: 502, description: 'DIAL Core returned an error' })
   @ApiResponse({
     status: 503,
@@ -262,7 +253,6 @@ export class FilesController {
   }
 
   @Get('shared')
-  @Throttle({ default: { limit: 60, ttl: 60000 } })
   @ApiOperation({
     summary: 'List files shared with the current user',
     description:
@@ -276,7 +266,6 @@ export class FilesController {
   })
   @ApiResponse({ status: 400, description: 'Invalid query parameter' })
   @ApiResponse({ status: 401, description: 'Not authenticated' })
-  @ApiResponse({ status: 429, description: 'Rate limit exceeded' })
   @ApiResponse({ status: 502, description: 'DIAL Core returned an error' })
   @ApiResponse({
     status: 503,
@@ -298,7 +287,6 @@ export class FilesController {
   }
 
   @Get('shared-by-me')
-  @Throttle({ default: { limit: 60, ttl: 60000 } })
   @ApiOperation({
     summary: 'List files and folders shared by the caller with others',
     operationId: 'listSharedByMe',
@@ -306,7 +294,6 @@ export class FilesController {
   @ApiResponse({ status: 200, type: ListFilesResponseDto })
   @ApiResponse({ status: 400, description: 'Invalid query parameters' })
   @ApiResponse({ status: 401, description: 'Not authenticated' })
-  @ApiResponse({ status: 429, description: 'Rate limit exceeded' })
   @ApiResponse({ status: 502, description: 'DIAL Core returned an error' })
   @ApiResponse({
     status: 503,
@@ -321,7 +308,6 @@ export class FilesController {
   }
 
   @Get('metadata')
-  @Throttle({ default: { limit: 60, ttl: 60000 } })
   @ApiOperation({
     summary: 'Get file metadata',
     description:
@@ -339,7 +325,6 @@ export class FilesController {
     description: 'Forbidden — user lacks READ permission on the file',
   })
   @ApiResponse({ status: 404, description: 'File not found' })
-  @ApiResponse({ status: 429, description: 'Rate limit exceeded' })
   @ApiResponse({ status: 502, description: 'DIAL Core returned an error' })
   @ApiResponse({
     status: 503,
@@ -355,7 +340,6 @@ export class FilesController {
 
   @Post('folders')
   @HttpCode(201)
-  @Throttle({ default: { limit: 10, ttl: 60000 } })
   @ApiOperation({ summary: 'Create a folder' })
   @ApiResponse({ status: 201, type: CreateFolderResponseDto })
   @ApiResponse({ status: 400, description: 'Invalid bucket, path, or name' })
@@ -363,7 +347,6 @@ export class FilesController {
   @ApiResponse({ status: 403, description: 'Forbidden' })
   @ApiResponse({ status: 404, description: 'Bucket or parent path not found' })
   @ApiResponse({ status: 409, description: 'Folder already exists' })
-  @ApiResponse({ status: 429, description: 'Rate limit exceeded' })
   @ApiResponse({ status: 502, description: 'DIAL Core returned an error' })
   @ApiResponse({
     status: 503,
@@ -384,7 +367,6 @@ export class FilesController {
 
   @Post('download-archive')
   @HttpCode(200)
-  @Throttle({ default: { limit: 5, ttl: 60000 } })
   @ApiProduces('application/zip')
   @ApiOperation({ summary: 'Download files and folders as a ZIP archive' })
   @ApiResponse({
@@ -400,7 +382,6 @@ export class FilesController {
     status: 413,
     description: 'Too many items or archive too large',
   })
-  @ApiResponse({ status: 429, description: 'Rate limit exceeded' })
   @ApiResponse({ status: 502, description: 'DIAL Core returned an error' })
   @ApiResponse({
     status: 503,
@@ -436,13 +417,11 @@ export class FilesController {
 
   @Post('delete')
   @HttpCode(200)
-  @Throttle({ default: { limit: 10, ttl: 60000 } })
   @ApiOperation({ summary: 'Delete files and folders' })
   @ApiBody({ type: DeleteFilesDto })
   @ApiResponse({ status: 200, type: DeleteFilesResponseDto })
   @ApiResponse({ status: 400, description: 'Invalid request body' })
   @ApiResponse({ status: 401, description: 'Not authenticated' })
-  @ApiResponse({ status: 429, description: 'Rate limit exceeded' })
   @ApiResponse({ status: 502, description: 'DIAL Core returned an error' })
   @ApiResponse({
     status: 503,
@@ -458,13 +437,11 @@ export class FilesController {
 
   @Post('rename')
   @HttpCode(200)
-  @Throttle({ default: { limit: 10, ttl: 60000 } })
   @ApiOperation({ summary: 'Rename files and folders' })
   @ApiBody({ type: RenameFilesDto })
   @ApiResponse({ status: 200, type: RenameFilesResponseDto })
   @ApiResponse({ status: 400, description: 'Invalid request body' })
   @ApiResponse({ status: 401, description: 'Not authenticated' })
-  @ApiResponse({ status: 429, description: 'Rate limit exceeded' })
   @ApiResponse({ status: 502, description: 'DIAL Core returned an error' })
   @ApiResponse({
     status: 503,
@@ -480,13 +457,11 @@ export class FilesController {
 
   @Post('copy')
   @HttpCode(200)
-  @Throttle({ default: { limit: 10, ttl: 60000 } })
   @ApiOperation({ summary: 'Copy files and folders' })
   @ApiBody({ type: CopyFilesDto })
   @ApiResponse({ status: 200, type: CopyFilesResponseDto })
   @ApiResponse({ status: 400, description: 'Invalid request body' })
   @ApiResponse({ status: 401, description: 'Not authenticated' })
-  @ApiResponse({ status: 429, description: 'Rate limit exceeded' })
   @ApiResponse({ status: 502, description: 'DIAL Core returned an error' })
   @ApiResponse({
     status: 503,
@@ -502,13 +477,11 @@ export class FilesController {
 
   @Post('move')
   @HttpCode(200)
-  @Throttle({ default: { limit: 10, ttl: 60000 } })
   @ApiOperation({ summary: 'Move files and folders across folders' })
   @ApiBody({ type: MoveFilesDto })
   @ApiResponse({ status: 200, type: MoveFilesResponseDto })
   @ApiResponse({ status: 400, description: 'Invalid request body' })
   @ApiResponse({ status: 401, description: 'Not authenticated' })
-  @ApiResponse({ status: 429, description: 'Rate limit exceeded' })
   @ApiResponse({ status: 502, description: 'DIAL Core returned an error' })
   @ApiResponse({
     status: 503,
@@ -524,7 +497,6 @@ export class FilesController {
 
   @Post('revoke-access')
   @HttpCode(200)
-  @Throttle({ default: { limit: 10, ttl: 60000 } })
   @ApiOperation({ summary: 'Revoke all shared access to files and folders' })
   @ApiBody({ type: RevokeAccessDto })
   @ApiResponse({ status: 200, type: RevokeAccessResponseDto })
@@ -535,7 +507,6 @@ export class FilesController {
     description: 'Caller does not own one or more resources',
   })
   @ApiResponse({ status: 404, description: 'A resource does not exist' })
-  @ApiResponse({ status: 429, description: 'Rate limit exceeded' })
   @ApiResponse({ status: 502, description: 'DIAL Core returned an error' })
   @ApiResponse({
     status: 503,
@@ -551,7 +522,6 @@ export class FilesController {
 
   @Post('discard-shared')
   @HttpCode(200)
-  @Throttle({ default: { limit: 10, ttl: 60000 } })
   @ApiOperation({ summary: 'Discard resources shared with the caller' })
   @ApiBody({ type: DiscardSharedDto })
   @ApiResponse({ status: 200, type: DiscardSharedResponseDto })
@@ -562,7 +532,6 @@ export class FilesController {
     description: 'Resource is not shared with the caller',
   })
   @ApiResponse({ status: 404, description: 'A resource does not exist' })
-  @ApiResponse({ status: 429, description: 'Rate limit exceeded' })
   @ApiResponse({ status: 502, description: 'DIAL Core returned an error' })
   @ApiResponse({
     status: 503,
@@ -577,7 +546,6 @@ export class FilesController {
   }
 
   @Get('download')
-  @Throttle({ default: { limit: 60, ttl: 60000 } })
   @ApiProduces('application/octet-stream')
   @ApiResponse({
     status: 200,
@@ -588,7 +556,6 @@ export class FilesController {
   @ApiResponse({ status: 401, description: 'Not authenticated' })
   @ApiResponse({ status: 403, description: 'Forbidden' })
   @ApiResponse({ status: 404, description: 'File not found' })
-  @ApiResponse({ status: 429, description: 'Rate limit exceeded' })
   @ApiResponse({ status: 502, description: 'DIAL Core returned an error' })
   @ApiResponse({
     status: 503,

--- a/apps/chat-api/src/models/models.controller.ts
+++ b/apps/chat-api/src/models/models.controller.ts
@@ -1,6 +1,5 @@
 import { Controller, Get, Header, Param, Req } from '@nestjs/common';
 import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
-import { Throttle } from '@nestjs/throttler';
 import type { Request } from 'express';
 import type { SessionUser } from '../auth/session/session.types';
 import {
@@ -16,7 +15,6 @@ export class ModelsController {
   constructor(private readonly modelsService: ModelsService) {}
 
   @Get()
-  @Throttle({ default: { limit: 60, ttl: 60000 } })
   @Header('Cache-Control', 'private, max-age=30')
   @ApiOperation({
     summary: 'List available models',
@@ -38,7 +36,6 @@ export class ModelsController {
     status: 403,
     description: 'Caller lacks permission to list models',
   })
-  @ApiResponse({ status: 429, description: 'Rate limit exceeded' })
   @ApiResponse({ status: 500, description: 'Internal server error' })
   @ApiResponse({
     status: 502,
@@ -54,7 +51,6 @@ export class ModelsController {
   }
 
   @Get(':modelName')
-  @Throttle({ default: { limit: 60, ttl: 60000 } })
   @Header('Cache-Control', 'private, max-age=60')
   @ApiOperation({
     summary: 'Get model by name',
@@ -81,7 +77,6 @@ export class ModelsController {
     description: 'Caller lacks permission to access this model',
   })
   @ApiResponse({ status: 404, description: 'Model not found' })
-  @ApiResponse({ status: 429, description: 'Rate limit exceeded' })
   @ApiResponse({ status: 500, description: 'Internal server error' })
   @ApiResponse({
     status: 502,

--- a/apps/chat-api/src/offline-credentials/offline-credentials.controller.ts
+++ b/apps/chat-api/src/offline-credentials/offline-credentials.controller.ts
@@ -9,7 +9,6 @@ import {
   UseGuards,
 } from '@nestjs/common';
 import { ApiBody, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
-import { Throttle } from '@nestjs/throttler';
 import type { Request } from 'express';
 import { FeatureKey } from '../app-config/feature-flags/feature-key.enum';
 import { FeatureGuard } from '../app-config/feature-flags/feature.guard';
@@ -45,7 +44,6 @@ export class OfflineCredentialsController {
   @Get()
   @UseGuards(FeatureGuard)
   @RequireFeature(FeatureKey.ScheduledTasksEnabled)
-  @Throttle({ default: { limit: 60, ttl: 60000 } })
   @Header('Cache-Control', 'private, no-store')
   @ApiOperation({
     operationId: 'getOfflineCredentials',
@@ -68,7 +66,6 @@ export class OfflineCredentialsController {
     description:
       'Caller lacks permission, or the scheduledTasksEnabled feature is not enabled',
   })
-  @ApiResponse({ status: 429, description: 'Rate limit exceeded' })
   @ApiResponse({
     status: 502,
     description: 'DIAL Core returned an error response',
@@ -85,7 +82,6 @@ export class OfflineCredentialsController {
   @UseGuards(FeatureGuard)
   @RequireFeature(FeatureKey.ScheduledTasksEnabled)
   @HttpCode(200)
-  @Throttle({ default: { limit: 10, ttl: 60000 } })
   @ApiOperation({
     operationId: 'signInOfflineCredentials',
     summary: 'Submit offline-credentials OAuth authorization code',
@@ -114,7 +110,6 @@ export class OfflineCredentialsController {
     description:
       'Caller lacks permission, or the scheduledTasksEnabled feature is not enabled',
   })
-  @ApiResponse({ status: 429, description: 'Rate limit exceeded' })
   @ApiResponse({
     status: 502,
     description: 'DIAL Core returned an error response or rejected sign-in',

--- a/apps/chat-api/src/prompts/prompt.controller.ts
+++ b/apps/chat-api/src/prompts/prompt.controller.ts
@@ -11,7 +11,6 @@ import {
   Req,
 } from '@nestjs/common';
 import { ApiOperation, ApiQuery, ApiResponse, ApiTags } from '@nestjs/swagger';
-import { Throttle } from '@nestjs/throttler';
 import type { Request } from 'express';
 import type { SessionUser } from '../auth/session/session.types';
 import { CreatePromptFolderDto } from './dto/create-prompt-folder.dto';
@@ -94,7 +93,6 @@ export class PromptController {
 
   @Post()
   @HttpCode(201)
-  @Throttle({ default: { limit: 30, ttl: 60000 } })
   @ApiOperation({
     operationId: 'createPrompt',
     summary: 'Create a personal prompt',
@@ -214,7 +212,6 @@ export class PromptController {
 
   @Post('folders')
   @HttpCode(201)
-  @Throttle({ default: { limit: 20, ttl: 60000 } })
   @ApiOperation({
     operationId: 'createPromptFolder',
     summary: 'Create a prompt folder',

--- a/apps/chat-api/src/publish/publish-rules.controller.ts
+++ b/apps/chat-api/src/publish/publish-rules.controller.ts
@@ -1,6 +1,5 @@
 import { Controller, Get, HttpCode, Query, Req } from '@nestjs/common';
 import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
-import { Throttle } from '@nestjs/throttler';
 import type { Request } from 'express';
 import type { SessionUser } from '../auth/session/session.types';
 import { GetPublishRulesQueryDto } from './dto/get-publish-rules-query.dto';
@@ -15,7 +14,6 @@ export class PublishRulesController {
 
   @Get('rules')
   @HttpCode(200)
-  @Throttle({ default: { limit: 60, ttl: 60000 } })
   @ApiOperation({
     operationId: 'getPublishRules',
     summary: "Get a destination folder's already-configured access rules",
@@ -36,7 +34,6 @@ export class PublishRulesController {
     status: 401,
     description: 'Not authenticated — valid session cookie required',
   })
-  @ApiResponse({ status: 429, description: 'Rate limit exceeded' })
   @ApiResponse({
     status: 502,
     description: 'DIAL Core returned an error response',

--- a/apps/chat-api/src/publish/publish.controller.ts
+++ b/apps/chat-api/src/publish/publish.controller.ts
@@ -8,7 +8,6 @@ import {
   Req,
 } from '@nestjs/common';
 import { ApiBody, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
-import { Throttle } from '@nestjs/throttler';
 import type { Request } from 'express';
 import type { SessionUser } from '../auth/session/session.types';
 import { getUserDisplayName } from '../common/utils/user-display-name';
@@ -28,7 +27,6 @@ export class PublishController {
 
   @Post(':entityType/:entityId/publish')
   @HttpCode(201)
-  @Throttle({ default: { limit: 10, ttl: 60000 } })
   @ApiOperation({
     operationId: 'publishCatalogEntity',
     summary: 'Publish a catalog entity to an Organization folder',
@@ -56,7 +54,6 @@ export class PublishController {
     status: 403,
     description: 'Caller lacks write access to the target folder',
   })
-  @ApiResponse({ status: 429, description: 'Rate limit exceeded' })
   @ApiResponse({
     status: 502,
     description: 'DIAL Core returned an error response',
@@ -85,7 +82,6 @@ export class PublishController {
 
   @Post(':entityType/:entityId/unpublish')
   @HttpCode(200)
-  @Throttle({ default: { limit: 10, ttl: 60000 } })
   @ApiOperation({
     operationId: 'unpublishCatalogEntity',
     summary: 'Request removal of a published catalog entity from a folder',
@@ -120,7 +116,6 @@ export class PublishController {
     status: 404,
     description: 'DIAL Core reports the entity or target folder as unknown',
   })
-  @ApiResponse({ status: 429, description: 'Rate limit exceeded' })
   @ApiResponse({
     status: 502,
     description: 'DIAL Core returned an error response',
@@ -148,7 +143,6 @@ export class PublishController {
 
   @Get(':entityType/:entityId/publish-history')
   @HttpCode(200)
-  @Throttle({ default: { limit: 60, ttl: 60000 } })
   @ApiOperation({
     operationId: 'getCatalogPublishHistory',
     summary: 'Get publish history for a catalog entity',
@@ -170,7 +164,6 @@ export class PublishController {
     status: 401,
     description: 'Not authenticated — valid session cookie required',
   })
-  @ApiResponse({ status: 429, description: 'Rate limit exceeded' })
   @ApiResponse({
     status: 502,
     description: 'DIAL Core returned an error response',

--- a/apps/chat-api/src/rate/rate.controller.ts
+++ b/apps/chat-api/src/rate/rate.controller.ts
@@ -1,6 +1,5 @@
 import { Body, Controller, HttpCode, Post, Req } from '@nestjs/common';
 import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
-import { Throttle } from '@nestjs/throttler';
 import type { Request } from 'express';
 import type { SessionUser } from '../auth/session/session.types';
 import { RateMessageDto } from './dto/rate-message.dto';
@@ -13,7 +12,6 @@ export class RateController {
 
   @Post()
   @HttpCode(204)
-  @Throttle({ default: { limit: 30, ttl: 60000 } })
   @ApiOperation({
     summary: 'Rate an assistant message',
     description:
@@ -32,7 +30,6 @@ export class RateController {
     status: 401,
     description: 'Not authenticated — valid session cookie required',
   })
-  @ApiResponse({ status: 429, description: 'Rate limit exceeded' })
   @ApiResponse({
     status: 502,
     description: 'DIAL Core returned an unexpected response',

--- a/apps/chat-api/src/scheduled-tasks/scheduled-tasks.controller.ts
+++ b/apps/chat-api/src/scheduled-tasks/scheduled-tasks.controller.ts
@@ -20,7 +20,6 @@ import {
   ApiResponse,
   ApiTags,
 } from '@nestjs/swagger';
-import { Throttle } from '@nestjs/throttler';
 import type { Request } from 'express';
 import { FeatureKey } from '../app-config/feature-flags/feature-key.enum';
 import { FeatureGuard } from '../app-config/feature-flags/feature.guard';
@@ -50,7 +49,6 @@ export class ScheduledTasksController {
   constructor(private readonly scheduledTasksService: ScheduledTasksService) {}
 
   @Get()
-  @Throttle({ default: { limit: 60, ttl: 60000 } })
   @Header('Cache-Control', 'private, no-store')
   @ApiOperation({
     operationId: 'listScheduledTasks',
@@ -94,7 +92,6 @@ export class ScheduledTasksController {
     description:
       'The scheduledTasksEnabled feature is not enabled for this user',
   })
-  @ApiResponse({ status: 429, description: 'Rate limit exceeded' })
   @ApiResponse({
     status: 502,
     description: 'DIAL Core returned an error response',
@@ -114,7 +111,6 @@ export class ScheduledTasksController {
 
   @Post()
   @HttpCode(201)
-  @Throttle({ default: { limit: 10, ttl: 60000 } })
   @ApiOperation({
     operationId: 'createScheduledTask',
     summary: 'Create a scheduled task',
@@ -139,7 +135,6 @@ export class ScheduledTasksController {
     description:
       'The scheduledTasksEnabled feature is not enabled for this user',
   })
-  @ApiResponse({ status: 429, description: 'Rate limit exceeded' })
   @ApiResponse({
     status: 502,
     description: 'DIAL Core returned an error response',
@@ -158,7 +153,6 @@ export class ScheduledTasksController {
   }
 
   @Get(':scheduleId')
-  @Throttle({ default: { limit: 60, ttl: 60000 } })
   @ApiOperation({
     operationId: 'getScheduledTask',
     summary: 'Get a scheduled task by id',
@@ -179,7 +173,6 @@ export class ScheduledTasksController {
       'The scheduledTasksEnabled feature is not enabled for this user',
   })
   @ApiResponse({ status: 404, description: 'Scheduled task not found' })
-  @ApiResponse({ status: 429, description: 'Rate limit exceeded' })
   @ApiResponse({
     status: 502,
     description: 'DIAL Core returned an error response',
@@ -198,7 +191,6 @@ export class ScheduledTasksController {
   }
 
   @Get(':scheduleId/runs')
-  @Throttle({ default: { limit: 60, ttl: 60000 } })
   @Header('Cache-Control', 'private, no-store')
   @ApiOperation({
     operationId: 'listScheduledTaskRuns',
@@ -236,7 +228,6 @@ export class ScheduledTasksController {
       'The scheduledTasksEnabled feature is not enabled for this user',
   })
   @ApiResponse({ status: 404, description: 'Scheduled task not found' })
-  @ApiResponse({ status: 429, description: 'Rate limit exceeded' })
   @ApiResponse({
     status: 502,
     description: 'DIAL Core returned an error response',
@@ -261,7 +252,6 @@ export class ScheduledTasksController {
 
   @Post(':scheduleId/pause')
   @HttpCode(200)
-  @Throttle({ default: { limit: 10, ttl: 60000 } })
   @ApiOperation({
     operationId: 'pauseScheduledTask',
     summary: 'Pause a scheduled task',
@@ -282,7 +272,6 @@ export class ScheduledTasksController {
       'The scheduledTasksEnabled feature is not enabled for this user',
   })
   @ApiResponse({ status: 404, description: 'Scheduled task not found' })
-  @ApiResponse({ status: 429, description: 'Rate limit exceeded' })
   @ApiResponse({
     status: 502,
     description: 'DIAL Core returned an error response',
@@ -306,7 +295,6 @@ export class ScheduledTasksController {
 
   @Post(':scheduleId/resume')
   @HttpCode(200)
-  @Throttle({ default: { limit: 10, ttl: 60000 } })
   @ApiOperation({
     operationId: 'resumeScheduledTask',
     summary: 'Resume a scheduled task',
@@ -327,7 +315,6 @@ export class ScheduledTasksController {
       'The scheduledTasksEnabled feature is not enabled for this user',
   })
   @ApiResponse({ status: 404, description: 'Scheduled task not found' })
-  @ApiResponse({ status: 429, description: 'Rate limit exceeded' })
   @ApiResponse({
     status: 502,
     description: 'DIAL Core returned an error response',
@@ -351,7 +338,6 @@ export class ScheduledTasksController {
 
   @Put(':scheduleId')
   @HttpCode(200)
-  @Throttle({ default: { limit: 10, ttl: 60000 } })
   @ApiOperation({
     operationId: 'updateScheduledTask',
     summary: 'Update a scheduled task',
@@ -376,7 +362,6 @@ export class ScheduledTasksController {
       'The scheduledTasksEnabled feature is not enabled for this user',
   })
   @ApiResponse({ status: 404, description: 'Scheduled task not found' })
-  @ApiResponse({ status: 429, description: 'Rate limit exceeded' })
   @ApiResponse({
     status: 502,
     description: 'DIAL Core returned an error response',
@@ -402,7 +387,6 @@ export class ScheduledTasksController {
 
   @Delete(':scheduleId')
   @HttpCode(HttpStatus.NO_CONTENT)
-  @Throttle({ default: { limit: 10, ttl: 60000 } })
   @Header('Cache-Control', 'private, no-store')
   @ApiOperation({
     operationId: 'deleteScheduledTask',
@@ -434,7 +418,6 @@ export class ScheduledTasksController {
     status: 409,
     description: 'Scheduled task is already soft-deleted',
   })
-  @ApiResponse({ status: 429, description: 'Rate limit exceeded' })
   @ApiResponse({
     status: 502,
     description:

--- a/apps/chat-api/src/share/share.controller.ts
+++ b/apps/chat-api/src/share/share.controller.ts
@@ -9,7 +9,6 @@ import {
   Req,
 } from '@nestjs/common';
 import { ApiBody, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
-import { Throttle } from '@nestjs/throttler';
 import type { Request } from 'express';
 import type { SessionUser } from '../auth/session/session.types';
 import { AcceptInvitationResponseDto } from './dto/accept-invitation-response.dto';
@@ -38,7 +37,6 @@ export class ShareController {
 
   @Post()
   @HttpCode(201)
-  @Throttle({ default: { limit: 20, ttl: 60000 } })
   @ApiOperation({
     operationId: 'createShareLink',
     summary: 'Create a share link',
@@ -62,7 +60,6 @@ export class ShareController {
     status: 401,
     description: 'Not authenticated — valid session cookie required',
   })
-  @ApiResponse({ status: 429, description: 'Rate limit exceeded' })
   @ApiResponse({
     status: 502,
     description: 'DIAL Core returned an error response',
@@ -81,7 +78,6 @@ export class ShareController {
 
   @Get('invitations/:invitationId')
   @HttpCode(200)
-  @Throttle({ default: { limit: 20, ttl: 60000 } })
   @ApiOperation({
     operationId: 'acceptInvitation',
     summary: 'Accept a share invitation',
@@ -106,7 +102,6 @@ export class ShareController {
     status: 404,
     description: 'Invitation not found, expired, or already revoked',
   })
-  @ApiResponse({ status: 429, description: 'Rate limit exceeded' })
   @ApiResponse({
     status: 502,
     description: 'DIAL Core returned an error response',
@@ -125,7 +120,6 @@ export class ShareController {
 
   @Post('discard')
   @HttpCode(200)
-  @Throttle({ default: { limit: 10, ttl: 60000 } })
   @ApiOperation({
     operationId: 'discardSharedCatalogItem',
     summary: 'Discard a shared catalog resource, conversation, or prompt',
@@ -155,7 +149,6 @@ export class ShareController {
     description: 'Resource is not shared with the caller',
   })
   @ApiResponse({ status: 404, description: 'Resource does not exist' })
-  @ApiResponse({ status: 429, description: 'Rate limit exceeded' })
   @ApiResponse({
     status: 502,
     description: 'DIAL Core returned an error response',
@@ -174,7 +167,6 @@ export class ShareController {
 
   @Get('recipients')
   @HttpCode(200)
-  @Throttle({ default: { limit: 60, ttl: 60000 } })
   @ApiOperation({
     operationId: 'getShareRecipientsCount',
     summary: 'Count current recipients of an owned resource',
@@ -196,7 +188,6 @@ export class ShareController {
     status: 401,
     description: 'Not authenticated — valid session cookie required',
   })
-  @ApiResponse({ status: 429, description: 'Rate limit exceeded' })
   @ApiResponse({
     status: 502,
     description: 'DIAL Core returned an error response',
@@ -215,7 +206,6 @@ export class ShareController {
 
   @Post('revoke')
   @HttpCode(200)
-  @Throttle({ default: { limit: 10, ttl: 60000 } })
   @ApiOperation({
     operationId: 'revokeSharedAccess',
     summary: 'Revoke all shared access to an owned resource',
@@ -243,7 +233,6 @@ export class ShareController {
     description: 'Caller does not own the resource',
   })
   @ApiResponse({ status: 404, description: 'Resource does not exist' })
-  @ApiResponse({ status: 429, description: 'Rate limit exceeded' })
   @ApiResponse({
     status: 502,
     description: 'DIAL Core returned an error response',

--- a/apps/chat-api/src/skills/skills.controller.ts
+++ b/apps/chat-api/src/skills/skills.controller.ts
@@ -27,7 +27,6 @@ import {
   ApiResponse,
   ApiTags,
 } from '@nestjs/swagger';
-import { Throttle } from '@nestjs/throttler';
 import type { Request, Response } from 'express';
 import type { SessionUser } from '../auth/session/session.types';
 import { CreateSkillDto } from './dto/create-skill.dto';
@@ -74,7 +73,6 @@ export class SkillsController {
   constructor(private readonly skillsService: SkillsService) {}
 
   @Get('catalog')
-  @Throttle({ default: { limit: 60, ttl: 60000 } })
   @ApiOperation({
     operationId: 'listCatalogSkills',
     summary: 'List personal, shared, and organisation skills',
@@ -84,7 +82,6 @@ export class SkillsController {
   @ApiResponse({ status: 200, type: SkillCatalogListResponseDto })
   @ApiResponse({ status: 401, description: 'Not authenticated' })
   @ApiResponse({ status: 403, description: 'Forbidden' })
-  @ApiResponse({ status: 429, description: 'Rate limit exceeded' })
   @ApiResponse({ status: 502, description: 'DIAL Core returned an error' })
   @ApiResponse({ status: 503, description: 'DIAL Core is unavailable' })
   listCatalogSkills(@Req() req: Request): Promise<SkillCatalogListResponseDto> {
@@ -93,7 +90,6 @@ export class SkillsController {
   }
 
   @Get()
-  @Throttle({ default: { limit: 60, ttl: 60000 } })
   @ApiOperation({
     operationId: 'listSkills',
     summary: 'List skills and grouping folders',
@@ -108,7 +104,6 @@ export class SkillsController {
   })
   @ApiResponse({ status: 403, description: 'Forbidden' })
   @ApiResponse({ status: 404, description: 'Grouping folder not found' })
-  @ApiResponse({ status: 429, description: 'Rate limit exceeded' })
   @ApiResponse({
     status: 502,
     description: 'DIAL Core returned an error response',
@@ -131,7 +126,6 @@ export class SkillsController {
   }
 
   @Get('files')
-  @Throttle({ default: { limit: 60, ttl: 60000 } })
   @ApiOperation({
     operationId: 'listSkillFiles',
     summary: 'List files inside a skill',
@@ -145,7 +139,6 @@ export class SkillsController {
   })
   @ApiResponse({ status: 403, description: 'Forbidden' })
   @ApiResponse({ status: 404, description: 'Skill not found' })
-  @ApiResponse({ status: 429, description: 'Rate limit exceeded' })
   @ApiResponse({
     status: 502,
     description: 'DIAL Core returned an error response',
@@ -169,7 +162,6 @@ export class SkillsController {
   }
 
   @Get('download')
-  @Throttle({ default: { limit: 30, ttl: 60000 } })
   @ApiProduces('application/zip')
   @ApiOperation({
     operationId: 'downloadSkill',
@@ -194,7 +186,6 @@ export class SkillsController {
   @ApiResponse({ status: 404, description: 'Skill not found' })
   @ApiResponse({ status: 405, description: 'Method not allowed' })
   @ApiResponse({ status: 422, description: 'Unprocessable entity' })
-  @ApiResponse({ status: 429, description: 'Rate limit exceeded' })
   @ApiResponse({
     status: 502,
     description: 'DIAL Core returned an error response',
@@ -246,7 +237,6 @@ export class SkillsController {
   }
 
   @Get('files/download')
-  @Throttle({ default: { limit: 30, ttl: 60000 } })
   @ApiProduces('application/octet-stream')
   @ApiOperation({
     operationId: 'downloadSkillFile',
@@ -265,7 +255,6 @@ export class SkillsController {
   })
   @ApiResponse({ status: 403, description: 'Forbidden' })
   @ApiResponse({ status: 404, description: 'File or skill not found' })
-  @ApiResponse({ status: 429, description: 'Rate limit exceeded' })
   @ApiResponse({
     status: 502,
     description: 'DIAL Core returned an error response',
@@ -322,7 +311,6 @@ export class SkillsController {
 
   @Post()
   @HttpCode(201)
-  @Throttle({ default: { limit: 5, ttl: 60000 } })
   @UseInterceptors(AnyFilesInterceptor())
   @ApiConsumes('multipart/form-data')
   @ApiBody({
@@ -373,7 +361,6 @@ export class SkillsController {
     status: 413,
     description: 'A file or the total content is too large',
   })
-  @ApiResponse({ status: 429, description: 'Rate limit exceeded' })
   @ApiResponse({
     status: 502,
     description: 'DIAL Core returned an error response',
@@ -403,7 +390,6 @@ export class SkillsController {
 
   @Post('import')
   @HttpCode(201)
-  @Throttle({ default: { limit: 5, ttl: 60000 } })
   @UseInterceptors(SkillArchiveUploadInterceptor)
   @ApiConsumes('multipart/form-data')
   @ApiBody({
@@ -447,7 +433,6 @@ export class SkillsController {
     description:
       'Archive is structurally invalid: too many entries, more than one skill, duplicate paths, or an encrypted/symlink/unsupported entry (standalone SKILL.md uploads never produce this status)',
   })
-  @ApiResponse({ status: 429, description: 'Rate limit exceeded' })
   @ApiResponse({
     status: 502,
     description: 'DIAL Core returned an error response',
@@ -477,7 +462,6 @@ export class SkillsController {
 
   @Put()
   @HttpCode(200)
-  @Throttle({ default: { limit: 5, ttl: 60000 } })
   @UseInterceptors(AnyFilesInterceptor())
   @ApiConsumes('multipart/form-data')
   @ApiIfMatchHeader({ required: true })
@@ -534,7 +518,6 @@ export class SkillsController {
     status: 428,
     description: 'If-Match header is required for update',
   })
-  @ApiResponse({ status: 429, description: 'Rate limit exceeded' })
   @ApiResponse({
     status: 502,
     description: 'DIAL Core returned an error response',
@@ -572,7 +555,6 @@ export class SkillsController {
 
   @Put('files')
   @HttpCode(200)
-  @Throttle({ default: { limit: 20, ttl: 60000 } })
   @UseInterceptors(FileInterceptor('file'))
   @ApiConsumes('multipart/form-data')
   @ApiIfMatchHeader()
@@ -608,7 +590,6 @@ export class SkillsController {
   @ApiResponse({ status: 412, description: 'If-Match precondition failed' })
   @ApiResponse({ status: 413, description: 'Upload payload too large' })
   @ApiResponse({ status: 422, description: 'Core resource validation failure' })
-  @ApiResponse({ status: 429, description: 'Rate limit exceeded' })
   @ApiResponse({
     status: 502,
     description: 'DIAL Core returned an error response',
@@ -641,7 +622,6 @@ export class SkillsController {
   }
 
   @Delete()
-  @Throttle({ default: { limit: 10, ttl: 60000 } })
   @ApiIfMatchHeader()
   @ApiOperation({
     operationId: 'deleteSkill',
@@ -657,7 +637,6 @@ export class SkillsController {
   @ApiResponse({ status: 403, description: 'Forbidden' })
   @ApiResponse({ status: 404, description: 'Skill not found' })
   @ApiResponse({ status: 412, description: 'If-Match precondition failed' })
-  @ApiResponse({ status: 429, description: 'Rate limit exceeded' })
   @ApiResponse({
     status: 502,
     description: 'DIAL Core returned an error response',
@@ -681,7 +660,6 @@ export class SkillsController {
   }
 
   @Delete('files')
-  @Throttle({ default: { limit: 10, ttl: 60000 } })
   @ApiIfMatchHeader()
   @ApiOperation({
     operationId: 'deleteSkillFile',
@@ -701,7 +679,6 @@ export class SkillsController {
   @ApiResponse({ status: 403, description: 'Forbidden' })
   @ApiResponse({ status: 404, description: 'File or skill not found' })
   @ApiResponse({ status: 412, description: 'If-Match precondition failed' })
-  @ApiResponse({ status: 429, description: 'Rate limit exceeded' })
   @ApiResponse({
     status: 502,
     description: 'DIAL Core returned an error response',
@@ -727,7 +704,6 @@ export class SkillsController {
 
   @Post('grouping-folders')
   @HttpCode(200)
-  @Throttle({ default: { limit: 10, ttl: 60000 } })
   @ApiOperation({
     operationId: 'createSkillGroupingFolder',
     summary: 'Create a grouping folder',
@@ -746,7 +722,6 @@ export class SkillsController {
   })
   @ApiResponse({ status: 403, description: 'Forbidden' })
   @ApiResponse({ status: 404, description: 'Parent path not found' })
-  @ApiResponse({ status: 429, description: 'Rate limit exceeded' })
   @ApiResponse({
     status: 502,
     description: 'DIAL Core returned an error response',
@@ -768,7 +743,6 @@ export class SkillsController {
   }
 
   @Delete('grouping-folders')
-  @Throttle({ default: { limit: 10, ttl: 60000 } })
   @ApiIfMatchHeader()
   @ApiOperation({
     operationId: 'deleteSkillGroupingFolder',
@@ -785,7 +759,6 @@ export class SkillsController {
   @ApiResponse({ status: 404, description: 'Grouping folder not found' })
   @ApiResponse({ status: 409, description: 'Grouping folder is not empty' })
   @ApiResponse({ status: 412, description: 'If-Match precondition failed' })
-  @ApiResponse({ status: 429, description: 'Rate limit exceeded' })
   @ApiResponse({
     status: 502,
     description: 'DIAL Core returned an error response',

--- a/apps/chat-api/src/themes/theme.controller.ts
+++ b/apps/chat-api/src/themes/theme.controller.ts
@@ -1,6 +1,5 @@
 import { Controller, Get, Header, Query, Res } from '@nestjs/common';
 import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
-import { Throttle } from '@nestjs/throttler';
 import type { Response } from 'express';
 import { lookup } from 'mime-types';
 import { Public } from '../common/decorators/public.decorator';
@@ -29,7 +28,6 @@ export class ThemeController {
    * @throws {ServiceUnavailableException} When the external service is unavailable or times out
    */
   @Get()
-  @Throttle({ default: { limit: 30, ttl: 60000 } }) // 30 requests per minute
   @Header('Cache-Control', 'public, max-age=300') // 5 minutes
   @ApiOperation({
     summary: 'Get themes configuration',
@@ -75,7 +73,6 @@ export class ThemeController {
    * This prevents path traversal attacks.
    */
   @Get('icon')
-  @Throttle({ default: { limit: 50, ttl: 60000 } }) // 50 requests per minute
   @Header('Cache-Control', 'public, max-age=300') // 5 minutes
   @ApiOperation({
     summary: 'Get theme icon',

--- a/apps/chat-api/src/toolsets/mcp-app.controller.ts
+++ b/apps/chat-api/src/toolsets/mcp-app.controller.ts
@@ -9,7 +9,6 @@ import {
   Res,
 } from '@nestjs/common';
 import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
-import { Throttle } from '@nestjs/throttler';
 import type { Request, Response } from 'express';
 import type { SessionUser } from '../auth/session/session.types';
 import { GetToolsetDto } from './dto/get-toolset.dto';
@@ -28,7 +27,6 @@ export class McpAppController {
   constructor(private readonly mcpAppService: McpAppService) {}
 
   @Get(':toolsetName/mcp-app-resource')
-  @Throttle({ default: { limit: 60, ttl: 60000 } })
   @ApiOperation({
     operationId: 'getToolsetMcpAppResource',
     summary: "Fetch a toolset's MCP Apps ui:// resource",
@@ -47,7 +45,6 @@ export class McpAppController {
   })
   @ApiResponse({ status: 403, description: 'Caller lacks permission' })
   @ApiResponse({ status: 404, description: 'Toolset or resource not found' })
-  @ApiResponse({ status: 429, description: 'Rate limit exceeded' })
   @ApiResponse({
     status: 502,
     description: 'DIAL Core returned an error response',
@@ -75,7 +72,6 @@ export class McpAppController {
    * `ToolsetsController`'s own `:toolsetName` route (registered first).
    */
   @Get('mcp-apps/tools')
-  @Throttle({ default: { limit: 60, ttl: 60000 } })
   @ApiOperation({
     operationId: 'listMcpAppTools',
     summary: 'List MCP Apps-capable tools for an MCP-enabled deployment',
@@ -91,7 +87,6 @@ export class McpAppController {
     description: 'Not authenticated — valid session cookie required',
   })
   @ApiResponse({ status: 404, description: 'Deployment not found' })
-  @ApiResponse({ status: 429, description: 'Rate limit exceeded' })
   @ApiResponse({
     status: 502,
     description: "DIAL Core's proxied tools/list failed",
@@ -110,7 +105,6 @@ export class McpAppController {
   }
 
   @Post(':toolsetName/mcp-app-tool-call')
-  @Throttle({ default: { limit: 20, ttl: 60000 } })
   @ApiOperation({
     operationId: 'callToolsetMcpAppTool',
     summary: "Forward an MCP App's self-initiated tool call",
@@ -135,7 +129,6 @@ export class McpAppController {
       'Caller lacks permission, or toolName is not exposed by this toolset',
   })
   @ApiResponse({ status: 404, description: 'Toolset not found' })
-  @ApiResponse({ status: 429, description: 'Rate limit exceeded' })
   @ApiResponse({
     status: 502,
     description: "DIAL Core's proxied tools/call failed",

--- a/apps/chat-api/src/toolsets/toolsets.controller.ts
+++ b/apps/chat-api/src/toolsets/toolsets.controller.ts
@@ -10,7 +10,6 @@ import {
   Req,
 } from '@nestjs/common';
 import { ApiBody, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
-import { Throttle } from '@nestjs/throttler';
 import type { Request } from 'express';
 import type { SessionUser } from '../auth/session/session.types';
 import {
@@ -32,7 +31,6 @@ export class ToolsetsController {
   constructor(private readonly toolsetsService: ToolsetsService) {}
 
   @Get()
-  @Throttle({ default: { limit: 60, ttl: 60000 } })
   @ApiOperation({
     summary: 'List available toolsets',
     description:
@@ -55,7 +53,6 @@ export class ToolsetsController {
     status: 403,
     description: 'Caller lacks permission to list toolsets',
   })
-  @ApiResponse({ status: 429, description: 'Rate limit exceeded' })
   @ApiResponse({ status: 500, description: 'Internal server error' })
   @ApiResponse({
     status: 502,
@@ -71,7 +68,6 @@ export class ToolsetsController {
   }
 
   @Get(':toolsetName')
-  @Throttle({ default: { limit: 60, ttl: 60000 } })
   @ApiOperation({
     summary: 'Get toolset by name',
     description:
@@ -100,7 +96,6 @@ export class ToolsetsController {
     description: 'Caller lacks permission to access this toolset',
   })
   @ApiResponse({ status: 404, description: 'Toolset not found' })
-  @ApiResponse({ status: 429, description: 'Rate limit exceeded' })
   @ApiResponse({ status: 500, description: 'Internal server error' })
   @ApiResponse({
     status: 502,
@@ -116,7 +111,6 @@ export class ToolsetsController {
   }
 
   @Post()
-  @Throttle({ default: { limit: 10, ttl: 60000 } })
   @ApiOperation({
     operationId: 'createToolset',
     summary: 'Create a new toolset',
@@ -140,7 +134,6 @@ export class ToolsetsController {
   })
   @ApiResponse({ status: 403, description: 'Caller lacks permission' })
   @ApiResponse({ status: 409, description: 'Toolset name already taken' })
-  @ApiResponse({ status: 429, description: 'Rate limit exceeded' })
   @ApiResponse({
     status: 502,
     description: 'DIAL Core returned an error response',
@@ -158,7 +151,6 @@ export class ToolsetsController {
   }
 
   @Patch(':toolsetName')
-  @Throttle({ default: { limit: 10, ttl: 60000 } })
   @ApiOperation({
     operationId: 'updateToolset',
     summary: 'Update a toolset',
@@ -182,7 +174,6 @@ export class ToolsetsController {
   })
   @ApiResponse({ status: 403, description: 'Caller lacks permission' })
   @ApiResponse({ status: 404, description: 'Toolset not found' })
-  @ApiResponse({ status: 429, description: 'Rate limit exceeded' })
   @ApiResponse({
     status: 502,
     description: 'DIAL Core returned an error response',
@@ -207,7 +198,6 @@ export class ToolsetsController {
 
   @Delete(':toolsetName')
   @HttpCode(204)
-  @Throttle({ default: { limit: 10, ttl: 60000 } })
   @ApiOperation({
     operationId: 'deleteToolset',
     summary: 'Delete a toolset',
@@ -223,7 +213,6 @@ export class ToolsetsController {
   })
   @ApiResponse({ status: 403, description: 'Caller lacks permission' })
   @ApiResponse({ status: 404, description: 'Toolset not found' })
-  @ApiResponse({ status: 429, description: 'Rate limit exceeded' })
   @ApiResponse({
     status: 502,
     description: 'DIAL Core returned an error response',
@@ -242,7 +231,6 @@ export class ToolsetsController {
 
   @Post(':toolsetName/login')
   @HttpCode(200)
-  @Throttle({ default: { limit: 10, ttl: 60000 } })
   @ApiOperation({
     operationId: 'loginToolset',
     summary: 'Submit toolset credentials',
@@ -262,7 +250,6 @@ export class ToolsetsController {
     description: 'Not authenticated — valid session cookie required',
   })
   @ApiResponse({ status: 403, description: 'Caller lacks permission' })
-  @ApiResponse({ status: 429, description: 'Rate limit exceeded' })
   @ApiResponse({
     status: 502,
     description: 'DIAL Core returned an error response',
@@ -283,7 +270,6 @@ export class ToolsetsController {
 
   @Post(':toolsetName/logout')
   @HttpCode(200)
-  @Throttle({ default: { limit: 10, ttl: 60000 } })
   @ApiOperation({
     operationId: 'logoutToolset',
     summary: 'Revoke toolset credentials',
@@ -309,7 +295,6 @@ export class ToolsetsController {
     description:
       'Toolset not found (only reachable when `authenticationType` is omitted and the lookup fails)',
   })
-  @ApiResponse({ status: 429, description: 'Rate limit exceeded' })
   @ApiResponse({
     status: 502,
     description: 'DIAL Core returned an error response',

--- a/libs/chat-api-client/openapi.json
+++ b/libs/chat-api-client/openapi.json
@@ -202,9 +202,6 @@
           },
           "400": {
             "description": "Missing or invalid appId"
-          },
-          "429": {
-            "description": "Too Many Requests"
           }
         },
         "summary": "Get client-safe application configuration and feature flags",
@@ -232,9 +229,6 @@
           },
           "403": {
             "description": "Caller lacks permission to list application schemas"
-          },
-          "429": {
-            "description": "Rate limit exceeded"
           },
           "502": {
             "description": "DIAL Core returned an error response"
@@ -287,9 +281,6 @@
           "404": {
             "description": "Schema not found"
           },
-          "429": {
-            "description": "Rate limit exceeded"
-          },
           "502": {
             "description": "DIAL Core returned an error response"
           },
@@ -322,9 +313,6 @@
           },
           "403": {
             "description": "Caller lacks permission to list applications"
-          },
-          "429": {
-            "description": "Rate limit exceeded"
           },
           "502": {
             "description": "DIAL Core returned an error response"
@@ -369,9 +357,6 @@
           },
           "409": {
             "description": "Application name already taken"
-          },
-          "429": {
-            "description": "Rate limit exceeded"
           },
           "503": {
             "description": "DIAL Core is unavailable or timed out"
@@ -431,9 +416,6 @@
           "404": {
             "description": "Application not found"
           },
-          "429": {
-            "description": "Rate limit exceeded"
-          },
           "502": {
             "description": "DIAL Core returned an error response"
           },
@@ -475,9 +457,6 @@
           },
           "404": {
             "description": "Application not found"
-          },
-          "429": {
-            "description": "Rate limit exceeded"
           },
           "502": {
             "description": "DIAL Core returned an error response"
@@ -536,9 +515,6 @@
           },
           "403": {
             "description": "Caller lacks permission"
-          },
-          "429": {
-            "description": "Rate limit exceeded"
           },
           "502": {
             "description": "DIAL Core returned an error response"
@@ -639,9 +615,6 @@
           "404": {
             "description": "Deployment limits not found"
           },
-          "429": {
-            "description": "Rate limit exceeded"
-          },
           "500": {
             "description": "Internal server error"
           },
@@ -693,9 +666,6 @@
           "404": {
             "description": "Deployment not found"
           },
-          "429": {
-            "description": "Rate limit exceeded"
-          },
           "502": {
             "description": "DIAL Core returned an error response"
           },
@@ -725,9 +695,6 @@
           },
           "401": {
             "description": "Not authenticated — valid session cookie required"
-          },
-          "429": {
-            "description": "Rate limit exceeded"
           },
           "500": {
             "description": "Internal server error"
@@ -761,9 +728,6 @@
           },
           "401": {
             "description": "Not authenticated — valid session cookie required"
-          },
-          "429": {
-            "description": "Rate limit exceeded"
           },
           "500": {
             "description": "Internal server error"
@@ -995,9 +959,6 @@
           "403": {
             "description": "Caller lacks permission to list models"
           },
-          "429": {
-            "description": "Rate limit exceeded"
-          },
           "500": {
             "description": "Internal server error"
           },
@@ -1051,9 +1012,6 @@
           "404": {
             "description": "Model not found"
           },
-          "429": {
-            "description": "Rate limit exceeded"
-          },
           "500": {
             "description": "Internal server error"
           },
@@ -1089,9 +1047,6 @@
           },
           "403": {
             "description": "Caller lacks permission to list toolsets"
-          },
-          "429": {
-            "description": "Rate limit exceeded"
           },
           "500": {
             "description": "Internal server error"
@@ -1143,9 +1098,6 @@
           "409": {
             "description": "Toolset name already taken"
           },
-          "429": {
-            "description": "Rate limit exceeded"
-          },
           "502": {
             "description": "DIAL Core returned an error response"
           },
@@ -1195,9 +1147,6 @@
           },
           "404": {
             "description": "Toolset not found"
-          },
-          "429": {
-            "description": "Rate limit exceeded"
           },
           "500": {
             "description": "Internal server error"
@@ -1260,9 +1209,6 @@
           "404": {
             "description": "Toolset not found"
           },
-          "429": {
-            "description": "Rate limit exceeded"
-          },
           "502": {
             "description": "DIAL Core returned an error response"
           },
@@ -1303,9 +1249,6 @@
           },
           "404": {
             "description": "Toolset not found"
-          },
-          "429": {
-            "description": "Rate limit exceeded"
           },
           "502": {
             "description": "DIAL Core returned an error response"
@@ -1363,9 +1306,6 @@
           },
           "403": {
             "description": "Caller lacks permission"
-          },
-          "429": {
-            "description": "Rate limit exceeded"
           },
           "502": {
             "description": "DIAL Core returned an error response"
@@ -1427,9 +1367,6 @@
           "404": {
             "description": "Toolset not found (only reachable when `authenticationType` is omitted and the lookup fails)"
           },
-          "429": {
-            "description": "Rate limit exceeded"
-          },
           "502": {
             "description": "DIAL Core returned an error response"
           },
@@ -1481,9 +1418,6 @@
           },
           "404": {
             "description": "Toolset or resource not found"
-          },
-          "429": {
-            "description": "Rate limit exceeded"
           },
           "502": {
             "description": "DIAL Core returned an error response"
@@ -1539,9 +1473,6 @@
           },
           "404": {
             "description": "Deployment not found"
-          },
-          "429": {
-            "description": "Rate limit exceeded"
           },
           "502": {
             "description": "DIAL Core's proxied tools/list failed"
@@ -1599,9 +1530,6 @@
           },
           "404": {
             "description": "Toolset not found"
-          },
-          "429": {
-            "description": "Rate limit exceeded"
           },
           "502": {
             "description": "DIAL Core's proxied tools/call failed"
@@ -1730,9 +1658,6 @@
           "403": {
             "description": "The liveChatInteraction feature is not enabled for this user"
           },
-          "429": {
-            "description": "Rate limit exceeded"
-          },
           "502": {
             "description": "DIAL Core returned an error response"
           }
@@ -1822,9 +1747,6 @@
           "404": {
             "description": "External service not found"
           },
-          "429": {
-            "description": "Rate limit exceeded"
-          },
           "502": {
             "description": "DIAL Core returned an error response"
           }
@@ -1891,9 +1813,6 @@
           "403": {
             "description": "Caller lacks permission, or the liveChatInteraction feature is not enabled"
           },
-          "429": {
-            "description": "Rate limit exceeded"
-          },
           "502": {
             "description": "DIAL Core returned an error response or rejected sign-in"
           }
@@ -1959,9 +1878,6 @@
           },
           "403": {
             "description": "Caller lacks permission, or the liveChatInteraction feature is not enabled"
-          },
-          "429": {
-            "description": "Rate limit exceeded"
           },
           "502": {
             "description": "DIAL Core returned an error response"
@@ -2357,9 +2273,6 @@
           "409": {
             "description": "Another generation is already active for this conversation"
           },
-          "429": {
-            "description": "Rate limit exceeded"
-          },
           "502": {
             "description": "DIAL Core error"
           },
@@ -2472,9 +2385,6 @@
           "404": {
             "description": "Conversation not found"
           },
-          "429": {
-            "description": "Rate limit exceeded"
-          },
           "502": {
             "description": "LLM title generation failed"
           },
@@ -2564,9 +2474,6 @@
           "401": {
             "description": "Not authenticated"
           },
-          "429": {
-            "description": "Rate limit exceeded"
-          },
           "500": {
             "description": "Unexpected internal error"
           }
@@ -2606,9 +2513,6 @@
           },
           "401": {
             "description": "Not authenticated"
-          },
-          "429": {
-            "description": "Rate limit exceeded"
           },
           "500": {
             "description": "Unexpected internal error"
@@ -2707,9 +2611,6 @@
           "404": {
             "description": "Conversation not found"
           },
-          "429": {
-            "description": "Rate limit exceeded"
-          },
           "502": {
             "description": "DIAL Core returned an error response"
           },
@@ -2770,9 +2671,6 @@
           "404": {
             "description": "Conversation not found"
           },
-          "429": {
-            "description": "Rate limit exceeded"
-          },
           "502": {
             "description": "DIAL Core returned an error response"
           },
@@ -2819,9 +2717,6 @@
           },
           "401": {
             "description": "Not authenticated — valid session cookie required"
-          },
-          "429": {
-            "description": "Rate limit exceeded"
           },
           "502": {
             "description": "DIAL Core returned an error response"
@@ -3353,9 +3248,6 @@
           "413": {
             "description": "Payload too large"
           },
-          "429": {
-            "description": "Rate limit exceeded"
-          },
           "502": {
             "description": "DIAL Core returned an error"
           },
@@ -3415,9 +3307,6 @@
           },
           "422": {
             "description": "Archive exceeds ARCHIVE_UPLOAD_MAX_FILES or ARCHIVE_UPLOAD_MAX_UNCOMPRESSED_BYTES"
-          },
-          "429": {
-            "description": "Rate limit exceeded"
           },
           "502": {
             "description": "DIAL Core returned an error"
@@ -3518,9 +3407,6 @@
           "404": {
             "description": "Bucket or path not found"
           },
-          "429": {
-            "description": "Rate limit exceeded"
-          },
           "502": {
             "description": "DIAL Core returned an error"
           },
@@ -3597,9 +3483,6 @@
           "404": {
             "description": "Path not found"
           },
-          "429": {
-            "description": "Rate limit exceeded"
-          },
           "502": {
             "description": "DIAL Core returned an error"
           },
@@ -3663,9 +3546,6 @@
           "401": {
             "description": "Not authenticated"
           },
-          "429": {
-            "description": "Rate limit exceeded"
-          },
           "502": {
             "description": "DIAL Core returned an error"
           },
@@ -3708,9 +3588,6 @@
           },
           "401": {
             "description": "Not authenticated"
-          },
-          "429": {
-            "description": "Rate limit exceeded"
           },
           "502": {
             "description": "DIAL Core returned an error"
@@ -3772,9 +3649,6 @@
           "404": {
             "description": "File not found"
           },
-          "429": {
-            "description": "Rate limit exceeded"
-          },
           "502": {
             "description": "DIAL Core returned an error"
           },
@@ -3825,9 +3699,6 @@
           },
           "409": {
             "description": "Folder already exists"
-          },
-          "429": {
-            "description": "Rate limit exceeded"
           },
           "502": {
             "description": "DIAL Core returned an error"
@@ -3881,9 +3752,6 @@
           "413": {
             "description": "Too many items or archive too large"
           },
-          "429": {
-            "description": "Rate limit exceeded"
-          },
           "502": {
             "description": "DIAL Core returned an error"
           },
@@ -3925,9 +3793,6 @@
           },
           "401": {
             "description": "Not authenticated"
-          },
-          "429": {
-            "description": "Rate limit exceeded"
           },
           "502": {
             "description": "DIAL Core returned an error"
@@ -3971,9 +3836,6 @@
           "401": {
             "description": "Not authenticated"
           },
-          "429": {
-            "description": "Rate limit exceeded"
-          },
           "502": {
             "description": "DIAL Core returned an error"
           },
@@ -4016,9 +3878,6 @@
           "401": {
             "description": "Not authenticated"
           },
-          "429": {
-            "description": "Rate limit exceeded"
-          },
           "502": {
             "description": "DIAL Core returned an error"
           },
@@ -4060,9 +3919,6 @@
           },
           "401": {
             "description": "Not authenticated"
-          },
-          "429": {
-            "description": "Rate limit exceeded"
           },
           "502": {
             "description": "DIAL Core returned an error"
@@ -4112,9 +3968,6 @@
           "404": {
             "description": "A resource does not exist"
           },
-          "429": {
-            "description": "Rate limit exceeded"
-          },
           "502": {
             "description": "DIAL Core returned an error"
           },
@@ -4162,9 +4015,6 @@
           },
           "404": {
             "description": "A resource does not exist"
-          },
-          "429": {
-            "description": "Rate limit exceeded"
           },
           "502": {
             "description": "DIAL Core returned an error"
@@ -4226,9 +4076,6 @@
           "404": {
             "description": "File not found"
           },
-          "429": {
-            "description": "Rate limit exceeded"
-          },
           "502": {
             "description": "DIAL Core returned an error"
           },
@@ -4263,9 +4110,6 @@
           },
           "401": {
             "description": "Not authenticated — valid session cookie required"
-          },
-          "429": {
-            "description": "Rate limit exceeded"
           },
           "502": {
             "description": "DIAL Core returned an unexpected response"
@@ -4444,9 +4288,6 @@
           "401": {
             "description": "Not authenticated — valid session cookie required"
           },
-          "429": {
-            "description": "Rate limit exceeded"
-          },
           "502": {
             "description": "DIAL Core returned an error response"
           },
@@ -4494,9 +4335,6 @@
           },
           "404": {
             "description": "Invitation not found, expired, or already revoked"
-          },
-          "429": {
-            "description": "Rate limit exceeded"
           },
           "502": {
             "description": "DIAL Core returned an error response"
@@ -4547,9 +4385,6 @@
           "404": {
             "description": "Resource does not exist"
           },
-          "429": {
-            "description": "Rate limit exceeded"
-          },
           "502": {
             "description": "DIAL Core returned an error response"
           },
@@ -4593,9 +4428,6 @@
           },
           "401": {
             "description": "Not authenticated — valid session cookie required"
-          },
-          "429": {
-            "description": "Rate limit exceeded"
           },
           "502": {
             "description": "DIAL Core returned an error response"
@@ -4646,9 +4478,6 @@
           "404": {
             "description": "Resource does not exist"
           },
-          "429": {
-            "description": "Rate limit exceeded"
-          },
           "502": {
             "description": "DIAL Core returned an error response"
           },
@@ -4681,9 +4510,6 @@
           },
           "403": {
             "description": "Forbidden"
-          },
-          "429": {
-            "description": "Rate limit exceeded"
           },
           "502": {
             "description": "DIAL Core returned an error"
@@ -4774,9 +4600,6 @@
           "404": {
             "description": "Grouping folder not found"
           },
-          "429": {
-            "description": "Rate limit exceeded"
-          },
           "502": {
             "description": "DIAL Core returned an error response"
           },
@@ -4852,9 +4675,6 @@
           },
           "413": {
             "description": "A file or the total content is too large"
-          },
-          "429": {
-            "description": "Rate limit exceeded"
           },
           "502": {
             "description": "DIAL Core returned an error response"
@@ -4948,9 +4768,6 @@
           "428": {
             "description": "If-Match header is required for update"
           },
-          "429": {
-            "description": "Rate limit exceeded"
-          },
           "502": {
             "description": "DIAL Core returned an error response"
           },
@@ -5020,9 +4837,6 @@
           },
           "412": {
             "description": "If-Match precondition failed"
-          },
-          "429": {
-            "description": "Rate limit exceeded"
           },
           "502": {
             "description": "DIAL Core returned an error response"
@@ -5123,9 +4937,6 @@
           "404": {
             "description": "Skill not found"
           },
-          "429": {
-            "description": "Rate limit exceeded"
-          },
           "502": {
             "description": "DIAL Core returned an error response"
           },
@@ -5211,9 +5022,6 @@
           "422": {
             "description": "Core resource validation failure"
           },
-          "429": {
-            "description": "Rate limit exceeded"
-          },
           "502": {
             "description": "DIAL Core returned an error response"
           },
@@ -5294,9 +5102,6 @@
           "412": {
             "description": "If-Match precondition failed"
           },
-          "429": {
-            "description": "Rate limit exceeded"
-          },
           "502": {
             "description": "DIAL Core returned an error response"
           },
@@ -5363,9 +5168,6 @@
           },
           "422": {
             "description": "Unprocessable entity"
-          },
-          "429": {
-            "description": "Rate limit exceeded"
           },
           "502": {
             "description": "DIAL Core returned an error response"
@@ -5435,9 +5237,6 @@
           "404": {
             "description": "File or skill not found"
           },
-          "429": {
-            "description": "Rate limit exceeded"
-          },
           "502": {
             "description": "DIAL Core returned an error response"
           },
@@ -5500,9 +5299,6 @@
           "422": {
             "description": "Archive is structurally invalid: too many entries, more than one skill, duplicate paths, or an encrypted/symlink/unsupported entry (standalone SKILL.md uploads never produce this status)"
           },
-          "429": {
-            "description": "Rate limit exceeded"
-          },
           "502": {
             "description": "DIAL Core returned an error response"
           },
@@ -5562,9 +5358,6 @@
           },
           "404": {
             "description": "Parent path not found"
-          },
-          "429": {
-            "description": "Rate limit exceeded"
           },
           "502": {
             "description": "DIAL Core returned an error response"
@@ -5639,9 +5432,6 @@
           "412": {
             "description": "If-Match precondition failed"
           },
-          "429": {
-            "description": "Rate limit exceeded"
-          },
           "502": {
             "description": "DIAL Core returned an error response"
           },
@@ -5709,9 +5499,6 @@
           },
           "403": {
             "description": "Caller lacks write access to the target folder"
-          },
-          "429": {
-            "description": "Rate limit exceeded"
           },
           "502": {
             "description": "DIAL Core returned an error response"
@@ -5784,9 +5571,6 @@
           "404": {
             "description": "DIAL Core reports the entity or target folder as unknown"
           },
-          "429": {
-            "description": "Rate limit exceeded"
-          },
           "502": {
             "description": "DIAL Core returned an error response"
           },
@@ -5845,9 +5629,6 @@
           "401": {
             "description": "Not authenticated — valid session cookie required"
           },
-          "429": {
-            "description": "Rate limit exceeded"
-          },
           "502": {
             "description": "DIAL Core returned an error response"
           },
@@ -5891,9 +5672,6 @@
           },
           "401": {
             "description": "Not authenticated — valid session cookie required"
-          },
-          "429": {
-            "description": "Rate limit exceeded"
           },
           "502": {
             "description": "DIAL Core returned an error response"
@@ -5978,9 +5756,6 @@
           "403": {
             "description": "The scheduledTasksEnabled feature is not enabled for this user"
           },
-          "429": {
-            "description": "Rate limit exceeded"
-          },
           "502": {
             "description": "DIAL Core returned an error response"
           },
@@ -6024,9 +5799,6 @@
           },
           "403": {
             "description": "The scheduledTasksEnabled feature is not enabled for this user"
-          },
-          "429": {
-            "description": "Rate limit exceeded"
           },
           "502": {
             "description": "DIAL Core returned an error response"
@@ -6078,9 +5850,6 @@
           },
           "404": {
             "description": "Scheduled task not found"
-          },
-          "429": {
-            "description": "Rate limit exceeded"
           },
           "502": {
             "description": "DIAL Core returned an error response"
@@ -6141,9 +5910,6 @@
           "404": {
             "description": "Scheduled task not found"
           },
-          "429": {
-            "description": "Rate limit exceeded"
-          },
           "502": {
             "description": "DIAL Core returned an error response"
           },
@@ -6188,9 +5954,6 @@
           },
           "409": {
             "description": "Scheduled task is already soft-deleted"
-          },
-          "429": {
-            "description": "Rate limit exceeded"
           },
           "502": {
             "description": "DIAL Scheduler could not unregister the job; no data changed and retrying is safe"
@@ -6268,9 +6031,6 @@
           "404": {
             "description": "Scheduled task not found"
           },
-          "429": {
-            "description": "Rate limit exceeded"
-          },
           "502": {
             "description": "DIAL Core returned an error response"
           },
@@ -6321,9 +6081,6 @@
           },
           "404": {
             "description": "Scheduled task not found"
-          },
-          "429": {
-            "description": "Rate limit exceeded"
           },
           "502": {
             "description": "DIAL Core returned an error response"
@@ -6376,9 +6133,6 @@
           "404": {
             "description": "Scheduled task not found"
           },
-          "429": {
-            "description": "Rate limit exceeded"
-          },
           "502": {
             "description": "DIAL Core returned an error response"
           },
@@ -6411,9 +6165,6 @@
           },
           "403": {
             "description": "Caller lacks permission, or the scheduledTasksEnabled feature is not enabled"
-          },
-          "429": {
-            "description": "Rate limit exceeded"
           },
           "502": {
             "description": "DIAL Core returned an error response"
@@ -6460,9 +6211,6 @@
           },
           "403": {
             "description": "Caller lacks permission, or the scheduledTasksEnabled feature is not enabled"
-          },
-          "429": {
-            "description": "Rate limit exceeded"
           },
           "502": {
             "description": "DIAL Core returned an error response or rejected sign-in"
@@ -8858,6 +8606,10 @@
           "redirectUri": {
             "type": "string",
             "description": "OAuth redirect URI used for the code exchange."
+          },
+          "offlineUsageConsent": {
+            "type": "boolean",
+            "description": "Whether the user consents to an application using this credential while they are offline. Required for on-behalf-of use (e.g. scheduled runs)."
           }
         },
         "required": ["url", "credentialsLevel", "authenticationType"]
@@ -9300,6 +9052,10 @@
           "redirectUri": {
             "type": "string",
             "description": "OAuth redirect URI used for the code exchange."
+          },
+          "offlineUsageConsent": {
+            "type": "boolean",
+            "description": "Whether the user consents to the application using this credential while they are offline. Required for on-behalf-of use (e.g. scheduled runs)."
           }
         },
         "required": ["credentialsLevel", "authenticationType"]

--- a/libs/chat-api-client/src/generated/src/models/index.ts
+++ b/libs/chat-api-client/src/generated/src/models/index.ts
@@ -3567,6 +3567,12 @@ export interface ExternalServiceSigninBodyDto {
    * @memberof ExternalServiceSigninBodyDto
    */
   redirectUri?: string;
+  /**
+   * Whether the user consents to the application using this credential while they are offline. Required for on-behalf-of use (e.g. scheduled runs).
+   * @type {boolean}
+   * @memberof ExternalServiceSigninBodyDto
+   */
+  offlineUsageConsent?: boolean;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Removes `@Throttle` decorators and the global `ThrottlerModule`/`ThrottlerGuard` from `apps/chat-api`, disabling rate limiting on every endpoint (including auth login/callback/logout).
- Root cause of the production 429s: `trust proxy` is not configured in `main.ts`, so `req.ip` resolves to the load balancer's own address for every client — the whole user population shared one throttle bucket per route. This change removes the symptom; the underlying `trust proxy` misconfiguration is not fixed here.
- Regenerated the OpenAPI contract (`libs/chat-api-client`) to drop the now-removed 429 response docs.

## Test plan
- [x] `npm exec nx lint chat-api`
- [x] `npm exec nx build chat-api`
- [x] `npm exec nx test chat-api` (2885 tests passed)
- [x] `npm run openapi` && `npm run openapi:check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)