### PR TITLE
fix(catalog): let the list view's column flex shares apply

### DIFF
--- a/libs/catalog/src/components/ListView/ListView.tsx
+++ b/libs/catalog/src/components/ListView/ListView.tsx
@@ -125,6 +125,14 @@ export const ListView: FC<ListViewProps> = ({
           additionalGridOptions={{
             rowHeight: ROW_HEIGHT,
             defaultColDef: { filter: false, floatingFilter: false },
+            /* The kit's `Grid` hardcodes `autoSizeStrategy: fitGridWidth`, and
+               ag-grid ignores every `colDef.flex` when that strategy is set
+               (warning: "colDef.flex is not supported with
+               gridOptions.autoSizeStrategy"). Clearing it is what lets
+               CATALOG_COLUMNS' 2:1:1 share of the spare width apply at all;
+               `additionalGridOptions` is spread after the default, so
+               `undefined` wins. */
+            autoSizeStrategy: undefined,
             context: {
               searchQuery: query,
               typography,

--- a/libs/catalog/src/components/ListView/tests/ListView.spec.tsx
+++ b/libs/catalog/src/components/ListView/tests/ListView.spec.tsx
@@ -24,6 +24,7 @@ vi.mock('@epam/ai-dial-ui-kit', () => ({
     emptyStateTitle?: string;
     additionalGridOptions?: {
       rowHeight?: number;
+      autoSizeStrategy?: unknown;
       context?: {
         onToggleFavorite?: (id: string, isStarred: boolean) => void;
         selectedItemId?: string;
@@ -41,6 +42,11 @@ vi.mock('@epam/ai-dial-ui-kit', () => ({
       <div
         aria-label={ariaLabel}
         data-row-height={additionalGridOptions?.rowHeight}
+        data-auto-size-strategy={
+          additionalGridOptions && 'autoSizeStrategy' in additionalGridOptions
+            ? 'cleared'
+            : 'kit-default'
+        }
         data-without-header-borders={String(Boolean(withoutHeaderBorders))}
         data-alternate-odd-row-colors={String(Boolean(alternateOddRowColors))}
         data-wrap-custom-cell-renderers={String(
@@ -177,6 +183,20 @@ describe('ListView', () => {
     expect(
       screen.getByLabelText('Catalog').getAttribute('data-row-height'),
     ).toBe('60');
+  });
+
+  it("clears the kit's autoSizeStrategy so the columns' flex shares apply (ag-grid ignores colDef.flex whenever an autoSizeStrategy is set)", () => {
+    render(
+      <ListView
+        type={CatalogEntityType.Model}
+        items={[makeItem({ id: 'x', name: 'x' })]}
+        query=""
+        ariaLabel="Catalog"
+      />,
+    );
+    expect(
+      screen.getByLabelText('Catalog').getAttribute('data-auto-size-strategy'),
+    ).toBe('cleared');
   });
 
   it('hands the grid a window of rows instead of the whole list', () => {


### PR DESCRIPTION
## Problem

The browser console logs this on every catalog list view render:

```
AG Grid: colDef.flex is not supported with gridOptions.autoSizeStrategy
```

`Grid` from `@epam/ai-dial-ui-kit` hardcodes `autoSizeStrategy: { type: 'fitGridWidth' }`, and ag-grid ignores every `colDef.flex` whenever an auto-size strategy is set. So the deliberate 2:1:1 split in `CATALOG_COLUMNS` — Name taking twice the spare width of Folder and Tags — never reached the grid; the columns were sized by `fitGridWidth` instead.

The behaviour the code intended is also what `libs/catalog/README.md` already documents:

> Name, Folder and Tags share the spare width (Name takes twice the share of the other two), so widening the table widens the columns that carry variable-length values rather than only the name.

## Fix

Clear the strategy from `additionalGridOptions`. No ui-kit change is needed: the kit spreads `additionalGridOptions` *after* its own `autoSizeStrategy` default and only destructures `defaultColDef`/`rowSelection` out of them, so `undefined` wins.

Every catalog column carries either a `flex` or an explicit `width`, so nothing depended on the auto-sizing being there.

## Verification

- `nx run-many -t test,lint,typecheck -p @epam/ai-dial-catalog` — 551 tests pass, lint and typecheck clean.
- The new test is a real guard: with the fix reverted it is the one failing test.
- No README/docs change needed — the code now matches what the README already describes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
