### PR TITLE
feat(conversation-panel): theme the panel's corner radii with custom properties

### DIFF
--- a/libs/conversation-panel/README.md
+++ b/libs/conversation-panel/README.md
@@ -74,13 +74,32 @@ the group and defaults to `"Filter chats"`;
 `styles.typography.tabClassName` sets the label typography and defaults to
 `'dial-tiny-semi-text'`.
 
-The search field is a ui-kit `Search` inside a `role="search"` landmark.
-`styles.searchWrapperClassName` is the class applied to its wrapper and defaults
-to `'rounded-full'`. A value **replaces** that default rather than merging with
-it, so pass the full class you want — `'rounded-xl'` for a 12px radius, for
-example. Two competing `rounded-*` utilities on one element would resolve by
-stylesheet order rather than by the order they appear in the class attribute,
-which is why the slot overwrites instead of appending.
+### Corner radii
+
+The panel's controls take their corner radius from CSS custom properties, so a
+host sets them once instead of passing a class per control. Each falls back to
+the value the panel has always rendered:
+
+| Property             | Applies to                     | Default   |
+| -------------------- | ------------------------------ | --------- |
+| `--cp-row-radius`    | Each conversation row's button | `0.75rem` |
+| `--cp-search-radius` | The search field               | `9999px`  |
+
+```css
+/* a host that wants 8px rows under a 12px search field */
+:root {
+  --cp-row-radius: 8px;
+  --cp-search-radius: 12px;
+}
+```
+
+The New chat button is not on this list on purpose: it is a labelled button, so
+it reads the ui-kit's own `--radius-control` and stays in step with every other
+button in the host app.
+
+`styles.searchWrapperClassName` remains for anything else the search wrapper
+needs; a `rounded-*` utility passed there still wins over `--cp-search-radius`,
+since a host's utilities are emitted after this package's stylesheet.
 
 ## Enums
 

--- a/libs/conversation-panel/src/components/ConversationPanel/ConversationPanel.module.scss
+++ b/libs/conversation-panel/src/components/ConversationPanel/ConversationPanel.module.scss
@@ -1,5 +1,12 @@
 .item {
   color: var(--cp-text, var(--text-primary, #161b2d));
+  /*
+   * The row is a ui-kit `Button`, which ships its own radius from
+   * `.dial-kit-base-button`. This rule sits on top of the kit's, which holds
+   * because a host imports this package's stylesheet after the kit's. The
+   * fallback is the 12px the row has always rendered.
+   */
+  border-radius: var(--cp-row-radius, 0.75rem);
 
   &:hover {
     background: var(--cp-item-hover, var(--bg-control-accent-alpha, #2764d90f));
@@ -45,6 +52,17 @@
 
 .unreadDot {
   background: var(--cp-unread-dot, var(--text-accent, #1d4ed8));
+}
+
+/*
+ * The search field is a ui-kit `Search`, which ships its own radius from
+ * `.dial-input`. Same layering as `.item` above; the fallback is the fully
+ * rounded field the panel has always rendered. A caller that still passes
+ * `styles.searchWrapperClassName` overrides this the way it always did — with
+ * a Tailwind utility from the host's own stylesheet.
+ */
+.search {
+  border-radius: var(--cp-search-radius, 9999px);
 }
 
 :export {

--- a/libs/conversation-panel/src/components/ConversationPanel/ConversationPanel.tsx
+++ b/libs/conversation-panel/src/components/ConversationPanel/ConversationPanel.tsx
@@ -72,7 +72,7 @@ export const ConversationPanel: FC<ConversationPanelProps> = memo(
       colors,
       typography,
       newChatButton: newChatButtonColors,
-      searchWrapperClassName = 'rounded-full',
+      searchWrapperClassName,
     } = panelStyles ?? {};
 
     const {
@@ -406,7 +406,10 @@ export const ConversationPanel: FC<ConversationPanelProps> = memo(
 
         <div role="search" className="px-3 py-2">
           <Search
-            wrapperClassName={searchWrapperClassName}
+            wrapperClassName={mergeClasses(
+              styles.search,
+              searchWrapperClassName,
+            )}
             value={searchQuery}
             onChange={handleSearchChange}
             placeholder={searchPlaceholder}

--- a/libs/conversation-panel/src/components/ConversationPanel/tests/ConversationPanel.spec.tsx
+++ b/libs/conversation-panel/src/components/ConversationPanel/tests/ConversationPanel.spec.tsx
@@ -384,12 +384,20 @@ describe('ConversationPanel', () => {
     ).toBeNull();
   });
 
-  it('gives the search field fully rounded corners by default', () => {
+  /*
+   * The corner radius itself is a CSS custom property read by the stylesheet
+   * (--cp-search-radius), so what a DOM test can pin is that the panel no
+   * longer hardcodes a radius utility on the wrapper.
+   */
+  it('sets no radius utility on the search field by default', () => {
     render(<ConversationPanel {...BASE_PROPS} conversations={[]} />);
-    expect(screen.getByTestId('search-wrapper').className).toBe('rounded-full');
+
+    expect(screen.getByTestId('search-wrapper').className).not.toMatch(
+      /rounded-/,
+    );
   });
 
-  it('replaces the search field corner radius with styles.searchWrapperClassName', () => {
+  it('still forwards styles.searchWrapperClassName to the search field', () => {
     render(
       <ConversationPanel
         {...BASE_PROPS}
@@ -397,11 +405,9 @@ describe('ConversationPanel', () => {
         styles={{ searchWrapperClassName: 'rounded-xl' }}
       />,
     );
-    /*
-     * The default has to be gone, not merely overridden: two competing
-     * `rounded-*` utilities would resolve by stylesheet order, not by the order
-     * they appear in the class attribute.
-     */
-    expect(screen.getByTestId('search-wrapper').className).toBe('rounded-xl');
+
+    expect(
+      screen.getByTestId('search-wrapper').classList.contains('rounded-xl'),
+    ).toBe(true);
   });
 });

--- a/libs/conversation-panel/src/components/ConversationRow/ConversationRow.tsx
+++ b/libs/conversation-panel/src/components/ConversationRow/ConversationRow.tsx
@@ -251,7 +251,8 @@ export const ConversationRow: FC<ConversationRowProps> = ({
           onClick={item.href ? undefined : () => onSelectConversation(item.id)}
           tabIndex={item.href ? -1 : undefined}
           className={mergeClasses(
-            'h-8 w-full justify-start gap-2 rounded-xl py-2 ps-0 after:pointer-events-none',
+            /* The row's corner radius comes from `styles.item` (--cp-row-radius). */
+            'h-8 w-full justify-start gap-2 py-2 ps-0 after:pointer-events-none',
             buttonPaddingEnd,
             styles.item,
             isActive && styles.itemActive,

--- a/libs/conversation-panel/src/components/ConversationRow/tests/ConversationRow.spec.tsx
+++ b/libs/conversation-panel/src/components/ConversationRow/tests/ConversationRow.spec.tsx
@@ -35,15 +35,17 @@ vi.mock('@epam/ai-dial-ui-kit', () => ({
     iconAfter,
     'aria-current': ariaCurrent,
     onClick,
+    className,
   }: {
     iconBefore?: React.ReactNode;
     label?: React.ReactNode;
     iconAfter?: React.ReactNode;
     'aria-current'?: React.AriaAttributes['aria-current'];
     onClick?: () => void;
+    className?: string;
     [key: string]: unknown;
   }) => (
-    <button aria-current={ariaCurrent} onClick={onClick}>
+    <button aria-current={ariaCurrent} onClick={onClick} className={className}>
       {iconBefore}
       {label}
       {iconAfter}
@@ -330,5 +332,25 @@ describe('ConversationRow', () => {
 
       expect(onSelectConversation).toHaveBeenCalledWith(baseItem.id);
     });
+  });
+
+  /*
+   * The row's corner radius is a CSS custom property read by the stylesheet
+   * (--cp-row-radius), so what a DOM test can pin is that the row no longer
+   * hardcodes a radius utility while keeping its layout utilities.
+   */
+  it('sets no radius utility on the row button', () => {
+    render(
+      <ConversationRow
+        item={baseItem}
+        isActive={false}
+        onSelectConversation={vi.fn()}
+      />,
+    );
+
+    const button = screen.getByRole('button');
+    expect(button.className).not.toMatch(/rounded-/);
+    expect(button.classList.contains('h-8')).toBe(true);
+    expect(button.classList.contains('w-full')).toBe(true);
   });
 });

--- a/libs/conversation-panel/src/components/NewChatButton/NewChatButton.module.scss
+++ b/libs/conversation-panel/src/components/NewChatButton/NewChatButton.module.scss
@@ -1,6 +1,13 @@
 .button {
   background: var(--cp-new-chat-bg, var(--bg-control-neutral, #fcfcfc));
   color: var(--cp-new-chat-text, var(--text-accent, #1d4ed8));
+  /*
+   * This is a hand-rolled button rather than the ui-kit `Button`, so it does
+   * not inherit the kit's control radius on its own. Reading the same token
+   * keeps it in step with every other labelled button in a host app; the
+   * fallback is the fully rounded pill it has always been.
+   */
+  border-radius: var(--radius-control, 9999px);
 
   &:focus-visible {
     outline: 1px solid

--- a/libs/conversation-panel/src/components/NewChatButton/NewChatButton.tsx
+++ b/libs/conversation-panel/src/components/NewChatButton/NewChatButton.tsx
@@ -32,7 +32,7 @@ export const NewChatButton: FC<NewChatButtonProps> = memo(
           onClick={onClick}
           type="button"
           className={mergeClasses(
-            'flex h-[36px] w-full cursor-pointer items-center justify-center gap-2 rounded-full px-3 py-1 shadow-chat-button hover:shadow-xs focus-visible:shadow-xs active:shadow-xs',
+            'flex h-[36px] w-full cursor-pointer items-center justify-center gap-2 px-3 py-1 shadow-chat-button hover:shadow-xs focus-visible:shadow-xs active:shadow-xs',
             styles.button,
           )}
         >

--- a/libs/conversation-panel/src/models/panel-props.ts
+++ b/libs/conversation-panel/src/models/panel-props.ts
@@ -113,10 +113,10 @@ export interface ConversationPanelStyles {
   /** Typography class applied to the task pill badge in each conversation row. Defaults to `'dial-caption-lead-semi-text'`. Colors come from the module stylesheet. */
   taskBadgeClassName?: string;
   /**
-   * CSS class applied to the search field's wrapper. Defaults to
-   * `'rounded-full'`; a value here replaces that default instead of merging with
-   * it, so a caller can set a different corner radius without two competing
-   * `rounded-*` utilities on the same element.
+   * Extra CSS class merged onto the search field's wrapper. The wrapper's
+   * corner radius is themed with the `--cp-search-radius` custom property, so
+   * this is only needed for anything the panel's own stylesheet does not
+   * cover; a `rounded-*` utility passed here still wins over that property.
    */
   searchWrapperClassName?: string;
 }


### PR DESCRIPTION
## What

Moves the panel's three hardcoded corner radii onto CSS custom properties, alongside the `--cp-*` colors it already themes this way.

| Property | Applies to | Fallback |
| --- | --- | --- |
| `--cp-row-radius` | Each conversation row's button | `0.75rem` |
| `--cp-search-radius` | The search field wrapper | `9999px` |
| `--radius-control` (ui-kit's own) | The New chat button | `9999px` |

Every fallback is the value the panel rendered before, so a host that sets nothing is unchanged.

## Why

The radii lived in Tailwind utilities inside the JSX (`rounded-xl` on the row, `rounded-full` on the search wrapper and the New chat button), so a host whose design differs had to reach into the rendered DOM from its own stylesheet:

```scss
/* what a consumer had to write */
li[class*='group/conversation'] > a > button {
  border-radius: 8px;
}
```

That selector encodes this package's internal element structure and its `group/conversation` marker class — it breaks the moment either changes.

A class slot per control was the obvious alternative, and this replaces one: `styles.searchWrapperClassName` was added a few releases ago for exactly the search field. Properties turned out to fit better here:

- These controls are also rendered deep inside other libraries' screens, where no call site is available to pass a class to.
- The panel already themes its colors through `--cp-*` properties read by its module stylesheet, so radii join an existing mechanism rather than adding a second one.
- One host-side block sets everything, with no risk of a class slot and a property drifting apart.

The New chat button is deliberately **not** on the `--cp-*` list. It is a hand-rolled `<button>` standing in for a ui-kit `Button`, so it reads the kit's own `--radius-control` and stays in step with every other labelled button in a host app — a host that squares its buttons should not have to remember this one separately.

## How

- `ConversationPanel.module.scss` — `.item` gains `border-radius: var(--cp-row-radius, 0.75rem)`; a new `.search` rule carries `var(--cp-search-radius, 9999px)`.
- `ConversationRow.tsx` — `rounded-xl` dropped from the row button's class list.
- `ConversationPanel.tsx` — the search wrapper gets `styles.search` merged with the caller's `searchWrapperClassName`, whose `'rounded-full'` default is gone (the property now carries it).
- `NewChatButton` — `rounded-full` dropped from the class list; `.button` in its module reads `--radius-control`.

Both module rules sit on top of the kit's own radius (`.dial-kit-base-button`, `.dial-input`), which holds because a host imports this package's stylesheet after the kit's — the same layering the panel's colors already rely on. Noted in the stylesheet next to each rule.

`styles.searchWrapperClassName` is kept and re-documented rather than removed: it is published API, and a `rounded-*` utility passed there still wins over the property, since a host's utilities are emitted after this package's stylesheet.

## Testing

- `vitest run --root libs/conversation-panel` — 136 tests / 8 files pass.
- The two DOM tests that pinned the old hardcoded utilities now assert the opposite — no `rounded-*` on the row button or the search wrapper — while checking the row keeps its layout utilities (`h-8`, `w-full`) and that `searchWrapperClassName` is still forwarded. The radius itself is a custom property, so jsdom cannot assert the computed value; the built stylesheet was checked by hand instead:
  - `_item_…{color:…;border-radius:var(--cp-row-radius,.75rem)}`
  - `_search_…{border-radius:var(--cp-search-radius,9999px)}`
  - `_button_…{…;border-radius:var(--radius-control,9999px)}`
- `eslint`, `prettier --check`, and `tsc -b` on the lib and spec projects are clean. `npm run validate:docs` reports only the pre-existing `libs/chat-hooks/README.md` / `useGridEditingScroll` failure already present on `development`.
- README gained a "Corner radii" section with the table above.

Supersedes #8592, which added a class slot for the row instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
