### PR TITLE
fix(catalog): show tooltip for truncated app names

### DIFF
--- a/libs/catalog/src/components/AppIdentity/AppIdentity.tsx
+++ b/libs/catalog/src/components/AppIdentity/AppIdentity.tsx
@@ -103,15 +103,14 @@ export const AppIdentity: FC<AppIdentityProps> = ({
 
         <div className="flex min-w-0 flex-col">
           <div className="flex min-w-0 items-start gap-1 overflow-hidden">
-            <span
+            <EllipsisTooltip
+              text={query ? <Highlight text={name} query={query} /> : name}
               className={mergeClasses(
-                'min-w-0 flex-1 truncate',
+                'min-w-0 flex-1',
                 typography?.nameClassName ?? 'dial-body-semi-text',
                 styles.name,
               )}
-            >
-              {query ? <Highlight text={name} query={query} /> : name}
-            </span>
+            />
             {version && (
               /* Capped at 30% of the row so a long version truncates instead of
                  squeezing the name out of the card. */


### PR DESCRIPTION
## Summary
- Model/app name in Catalog and Your Favorites cards was truncated with CSS ellipsis only, with no way to see the full name on hover (unlike the version text right next to it, which already used `EllipsisTooltip`).
- Switched the name rendering in `AppIdentity` from a plain `<span className="truncate">` to `EllipsisTooltip`, matching the existing version tooltip behavior. Search highlighting via `Highlight` is preserved inside the tooltip's `text`.

## Test plan
- [x] `nx lint ai-dial-catalog` — passes (pre-existing warnings only)
- [x] `nx typecheck ai-dial-catalog` — passes
- [ ] Manually verify hover tooltip shows full name on truncated Catalog/Favorites cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)