### PR TITLE
fix(chat): fix documents canvas opening from sources and derive prompt folderId from resource path (Issue #8551)

### DIFF
--- a/apps/chat-api/src/prompts/utils/prompt-mapper.util.ts
+++ b/apps/chat-api/src/prompts/utils/prompt-mapper.util.ts
@@ -144,7 +144,7 @@ export const mapPromptToResponse = (
   name: prompt.name ?? nameFromId(path),
   description: prompt.description,
   content: prompt.content ?? '',
-  folderId: prompt.folderId ?? folderIdFromId(path),
+  folderId: folderIdFromId(path),
   author: metadata.author,
   createdAt: metadata.createdAt ?? 0,
   updatedAt: metadata.updatedAt ?? 0,

--- a/libs/attachment-canvas/README.md
+++ b/libs/attachment-canvas/README.md
@@ -229,6 +229,7 @@ import {
   isHtmlPreviewable,
   isOoxmlPreviewable,
   getOoxmlFileType,
+  getOoxmlMimeType,
   extensionToLanguage,
   createUnsupportedCanvasContent,
   createLoadErrorCanvasContent,
@@ -242,6 +243,9 @@ if (isOoxmlPreviewable(fileName, mimeType)) { ... }
 
 // Resolve the format needed by OoxmlCanvasContent
 const format = getOoxmlFileType(fileName, mimeType);
+
+// Resolve the canonical MIME type for a recognized OOXML format
+const canonicalMimeType = getOoxmlMimeType(fileName, mimeType);
 
 // Resolve a syntax-highlighting language from a file extension
 const language = extensionToLanguage('ts');

--- a/libs/attachment-canvas/src/index.ts
+++ b/libs/attachment-canvas/src/index.ts
@@ -15,6 +15,7 @@ export {
   isHtmlPreviewable,
   isOoxmlPreviewable,
   getOoxmlFileType,
+  getOoxmlMimeType,
   extensionToLanguage,
   createUnsupportedCanvasContent,
   createLoadErrorCanvasContent,

--- a/libs/attachment-canvas/src/utils/content.ts
+++ b/libs/attachment-canvas/src/utils/content.ts
@@ -25,6 +25,12 @@ const OOXML_MIME_TO_FILE_TYPE: Record<string, OoxmlFileType> = {
   [OOXML_MIME_TYPES.pptx]: OoxmlFileType.Pptx,
 };
 
+const OOXML_FILE_TYPE_TO_MIME: Record<OoxmlFileType, string> = {
+  [OoxmlFileType.Docx]: OOXML_MIME_TYPES.docx,
+  [OoxmlFileType.Xlsx]: OOXML_MIME_TYPES.xlsx,
+  [OoxmlFileType.Pptx]: OOXML_MIME_TYPES.pptx,
+};
+
 /** Resolves a supported OOXML format from a MIME type or file extension. */
 export const getOoxmlFileType = (
   name: string,
@@ -44,6 +50,15 @@ export const getOoxmlFileType = (
 /** Returns true when a file can be rendered by the built-in OOXML viewer. */
 export const isOoxmlPreviewable = (name: string, mimeType?: string): boolean =>
   getOoxmlFileType(name, mimeType) != null;
+
+/** Returns the canonical OOXML MIME type recognized from `name`'s extension or `mimeType`, or `undefined` if neither matches a supported format. */
+export const getOoxmlMimeType = (
+  name: string,
+  mimeType?: string,
+): string | undefined => {
+  const fileType = getOoxmlFileType(name, mimeType);
+  return fileType != null ? OOXML_FILE_TYPE_TO_MIME[fileType] : undefined;
+};
 
 /** Returns true if the file name has an extension known to be text-previewable. */
 export const isTextPreviewable = (name: string): boolean => {

--- a/libs/attachment-canvas/src/utils/tests/content.spec.ts
+++ b/libs/attachment-canvas/src/utils/tests/content.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { OoxmlFileType } from '../../types/attachment-canvas';
 import {
   getOoxmlFileType,
+  getOoxmlMimeType,
   isOoxmlPreviewable,
   isTextPreviewable,
 } from '../content';
@@ -82,5 +83,35 @@ describe('OOXML content detection', () => {
     expect(isTextPreviewable('report.docx')).toBe(false);
     expect(isTextPreviewable('budget.xlsx')).toBe(false);
     expect(isTextPreviewable('slides.pptx')).toBe(false);
+  });
+
+  it.each([
+    [
+      'report.docx',
+      'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+    ],
+    [
+      'budget.xlsx',
+      'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    ],
+    [
+      'slides.pptx',
+      'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+    ],
+  ])('resolves the canonical MIME type for %s by extension', (name, mime) => {
+    expect(getOoxmlMimeType(name)).toBe(mime);
+  });
+
+  it('resolves the canonical MIME type from a recognized but non-canonical MIME string', () => {
+    expect(
+      getOoxmlMimeType(
+        'attachment',
+        'APPLICATION/VND.OPENXMLFORMATS-OFFICEDOCUMENT.SPREADSHEETML.SHEET; charset=binary',
+      ),
+    ).toBe('application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
+  });
+
+  it('returns undefined without an extension or a matching MIME type', () => {
+    expect(getOoxmlMimeType('Quarterly Report')).toBeUndefined();
   });
 });

--- a/libs/chat-hooks/README.md
+++ b/libs/chat-hooks/README.md
@@ -2548,7 +2548,7 @@ const content = await resolveMarkdownCanvasContent(attachment, resolvers);
 clearAttachmentCache();
 ```
 
-Also exports `resolveImageCanvasContent`, `resolveTextCanvasContent`, `resolveCodeCanvasContent`, `resolveHtmlCanvasContent`, `resolveOoxmlCanvasContent`, `resolveJsonCanvasContent`, `resolveVisualizerCanvasContent`, `annotationToPdfCanvasContent`, `referenceAttachmentToPdfCanvasContent`, `hasAttachmentTextSource`, `getUrlFileName`, `isExternalSourcePreviewable`, and `resolveExternalSourceContentType` (corrects a content type that mislabels an external citation — e.g. a web-search grounding API reporting `text/markdown` for every reference — against a `.pdf` URL extension).
+Also exports `resolveImageCanvasContent`, `resolveTextCanvasContent`, `resolveCodeCanvasContent`, `resolveHtmlCanvasContent`, `resolveOoxmlCanvasContent`, `resolveJsonCanvasContent`, `resolveVisualizerCanvasContent`, `annotationToPdfCanvasContent`, `referenceAttachmentToPdfCanvasContent`, `hasAttachmentTextSource`, `getUrlFileName`, `isExternalSourcePreviewable`, and `resolveExternalSourceContentType` (corrects a content type that mislabels an external citation — e.g. a web-search grounding API reporting `text/markdown` for every reference — against a `.pdf`/`.docx`/`.xlsx`/`.pptx` URL extension).
 
 ### attachmentDtoToDisplayAttachment / attachmentDtosToDisplayAttachments / annotationToDisplayAttachment
 

--- a/libs/chat-hooks/src/files/attachment-canvas.ts
+++ b/libs/chat-hooks/src/files/attachment-canvas.ts
@@ -14,7 +14,9 @@ import type {
 import {
   AttachmentContentType,
   AttachmentErrorType,
+  getOoxmlMimeType,
   isHtmlPreviewable,
+  isOoxmlPreviewable,
   isTextPreviewable,
 } from '@epam/ai-dial-attachment-canvas';
 import type {
@@ -93,14 +95,15 @@ const networkFailureContent = (url: string): ErrorCanvasContent => ({
 /* Returns true when an external source URL should be opened in the canvas
  * rather than a new browser tab.
  *
- * Image, audio, and PDF content types are trusted directly: web-search
- * grounding APIs do not mislabel images/audio, and a citation annotation's
- * `attachment.type` is the same authoritative PDF marker the quotation
- * canvas path (`annotationToPdfCanvasContent`) trusts — the PDF's own URL
- * commonly carries no `.pdf` extension (a citation/reference id, not a file
- * name). For other document types we rely on the URL path extension —
- * Google's grounding API labels every web reference (YouTube, Forbes, etc.)
- * as 'text/markdown', so content-type alone is unreliable there. */
+ * Image, audio, PDF, and OOXML (docx/xlsx/pptx) content types are trusted
+ * directly: web-search grounding APIs do not mislabel images/audio, and a
+ * citation annotation's `attachment.type` is the same authoritative PDF/OOXML
+ * marker the quotation canvas path (`annotationToPdfCanvasContent`) trusts —
+ * such a URL commonly carries no matching extension (a citation/reference id,
+ * not a file name). For other document types we rely on the URL path
+ * extension — Google's grounding API labels every web reference (YouTube,
+ * Forbes, etc.) as 'text/markdown', so content-type alone is unreliable
+ * there. */
 /**
  * Returns the last path segment of `url` — its file name — for both absolute
  * URLs and DIAL-relative resource paths such as
@@ -128,32 +131,38 @@ export const getUrlFileName = (url: string): string => {
   }
 };
 
+/** Returns true when `contentType` alone already trustworthily identifies an image, audio, PDF, or OOXML (docx/xlsx/pptx) source. */
+const isTrustedSourceContentType = (contentType: string): boolean =>
+  contentType.startsWith('image/') ||
+  contentType.startsWith('audio/') ||
+  contentType === MIMEType.PDF ||
+  isOoxmlPreviewable('', contentType);
+
 /**
  * Returns the content type to trust for an external citation source: `contentType`
- * unchanged when it is already an image/audio/PDF marker, otherwise `MIMEType.PDF`
- * when `url`'s path extension is `.pdf`, otherwise `contentType` unchanged.
+ * unchanged when it is already an image/audio/PDF/OOXML marker, otherwise the
+ * type implied by `url`'s path extension (`MIMEType.PDF` for `.pdf`, the
+ * canonical OOXML MIME for `.docx`/`.xlsx`/`.pptx`) when that extension is
+ * recognized, otherwise `contentType` unchanged.
  *
- * Web-search grounding APIs label every reference — PDFs included — as
- * `text/markdown`, so a mislabeled `contentType` must not win over a `.pdf`
- * URL extension: doing so previously sent PDF bytes into the markdown/text
- * canvas viewer, which rendered them as raw garbled text instead of opening
- * the PDF viewer.
+ * Web-search grounding APIs label every reference — PDFs and Office documents
+ * included — as `text/markdown`, so a mislabeled `contentType` must not win
+ * over a recognized URL extension: doing so previously sent a PDF's raw bytes
+ * into the markdown/text canvas viewer, rendering garbled text instead of
+ * opening the PDF/OOXML viewer.
  */
 export const resolveExternalSourceContentType = (
   contentType: string,
   url: string,
 ): string => {
-  if (
-    contentType.startsWith('image/') ||
-    contentType.startsWith('audio/') ||
-    contentType === MIMEType.PDF
-  ) {
+  if (isTrustedSourceContentType(contentType)) {
     return contentType;
   }
   const fileName = getUrlFileName(url);
   const dot = fileName.lastIndexOf('.');
   const ext = dot === -1 ? '' : fileName.slice(dot + 1).toLowerCase();
-  return ext === FileExtension.PDF ? MIMEType.PDF : contentType;
+  if (ext === FileExtension.PDF) return MIMEType.PDF;
+  return getOoxmlMimeType(fileName) ?? contentType;
 };
 
 /** Returns true when an external (non-DIAL) source URL should be opened in the canvas rather than a new browser tab. */
@@ -162,11 +171,7 @@ export const isExternalSourcePreviewable = (
   url: string,
 ): boolean => {
   const resolvedType = resolveExternalSourceContentType(contentType, url);
-  if (
-    resolvedType.startsWith('image/') ||
-    resolvedType.startsWith('audio/') ||
-    resolvedType === MIMEType.PDF
-  ) {
+  if (isTrustedSourceContentType(resolvedType)) {
     return true;
   }
   const fileName = getUrlFileName(url);
@@ -486,6 +491,26 @@ const isFetchableExternalUrl = (url: string): boolean => {
   }
 };
 
+/**
+ * Returns `attachment.url` when it is a fetchable external (non-DIAL) URL the
+ * canvas viewer can load directly, or `undefined` otherwise. Shared by
+ * `resolvePdfCanvasContent`/`resolveOoxmlCanvasContent` as the fallback used
+ * when `resolveAttachmentBlobUrl` has no DIAL-hosted download URL, preview
+ * URL, or inline data to offer — the same approach
+ * `annotationToPdfCanvasContent`/`referenceAttachmentToPdfCanvasContent` use
+ * for a citation whose source is an external PDF: hand the URL to the canvas
+ * viewer directly rather than failing, since it fetches and renders the URL
+ * itself.
+ */
+const resolveExternalAttachmentUrl = (
+  attachment: DisplayAttachment,
+): string | undefined =>
+  attachment.url != null &&
+  !isDialFileId(attachment.url) &&
+  isFetchableExternalUrl(attachment.url)
+    ? attachment.url
+    : undefined;
+
 /** Resolves a PDF canvas content payload from a DisplayAttachment, or `null` if unavailable. */
 export const resolvePdfCanvasContent = async (
   attachment: DisplayAttachment,
@@ -496,19 +521,10 @@ export const resolvePdfCanvasContent = async (
     if (typeof result !== 'string') return result;
     return { type: AttachmentContentType.Pdf, url: result };
   }
-  /* No DIAL-hosted download URL, preview URL, or inline data — the same
-   * fallback `annotationToPdfCanvasContent`/`referenceAttachmentToPdfCanvasContent`
-   * use for a citation whose source is an external (non-`files/`) PDF URL:
-   * hand it to the PDF canvas viewer directly rather than failing, since it
-   * fetches and renders the URL itself. */
-  if (
-    attachment.url != null &&
-    !isDialFileId(attachment.url) &&
-    isFetchableExternalUrl(attachment.url)
-  ) {
-    return { type: AttachmentContentType.Pdf, url: attachment.url };
-  }
-  return null;
+  const externalUrl = resolveExternalAttachmentUrl(attachment);
+  return externalUrl != null
+    ? { type: AttachmentContentType.Pdf, url: externalUrl }
+    : null;
 };
 
 /** Resolves an OOXML canvas content payload from a DisplayAttachment, or `null` if unavailable. */
@@ -518,9 +534,14 @@ export const resolveOoxmlCanvasContent = async (
   format: OoxmlFileType,
 ): Promise<OoxmlCanvasContent | ErrorCanvasContent | null> => {
   const result = await resolveAttachmentBlobUrl(attachment, resolvers);
-  if (result == null) return null;
-  if (typeof result !== 'string') return result;
-  return { type: AttachmentContentType.Ooxml, url: result, format };
+  if (result != null) {
+    if (typeof result !== 'string') return result;
+    return { type: AttachmentContentType.Ooxml, url: result, format };
+  }
+  const externalUrl = resolveExternalAttachmentUrl(attachment);
+  return externalUrl != null
+    ? { type: AttachmentContentType.Ooxml, url: externalUrl, format }
+    : null;
 };
 
 /**

--- a/libs/chat-hooks/src/files/tests/attachment-canvas.spec.ts
+++ b/libs/chat-hooks/src/files/tests/attachment-canvas.spec.ts
@@ -2,6 +2,8 @@ import {
   AttachmentContentType,
   AttachmentErrorType,
   OoxmlFileType,
+  getOoxmlMimeType,
+  isOoxmlPreviewable,
   isTextPreviewable,
 } from '@epam/ai-dial-attachment-canvas';
 import {
@@ -60,44 +62,16 @@ vi.mock('@epam/ai-dial-attachment-canvas', () => ({
   },
   isHtmlPreviewable: vi.fn().mockReturnValue(false),
   isTextPreviewable: vi.fn(),
-  /* Real (not stubbed) behavior, mirroring the actual OOXML_MIME_TYPES map in
-   * `@epam/ai-dial-attachment-canvas`, since resolveExternalSourceContentType/
-   * isExternalSourcePreviewable tests assert genuine extension/MIME detection. */
-  getOoxmlMimeType: (name: string, mimeType?: string) => {
-    const mimeToType: Record<string, string> = {
-      'application/vnd.openxmlformats-officedocument.wordprocessingml.document':
-        'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-      'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet':
-        'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-      'application/vnd.openxmlformats-officedocument.presentationml.presentation':
-        'application/vnd.openxmlformats-officedocument.presentationml.presentation',
-    };
-    const normalizedMime = mimeType?.split(';', 1)[0].trim().toLowerCase();
-    if (normalizedMime != null && mimeToType[normalizedMime] != null) {
-      return mimeToType[normalizedMime];
-    }
-    const dot = name.lastIndexOf('.');
-    if (dot === -1) return undefined;
-    const extToMime: Record<string, string> = {
-      docx: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-      xlsx: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-      pptx: 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
-    };
-    return extToMime[name.slice(dot + 1).toLowerCase()];
-  },
-  isOoxmlPreviewable: (name: string, mimeType?: string) => {
-    const validMimes = new Set([
-      'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-      'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-      'application/vnd.openxmlformats-officedocument.presentationml.presentation',
-    ]);
-    if (mimeType != null && validMimes.has(mimeType.split(';', 1)[0].trim())) {
-      return true;
-    }
-    const dot = name.lastIndexOf('.');
-    if (dot === -1) return false;
-    return ['docx', 'xlsx', 'pptx'].includes(name.slice(dot + 1).toLowerCase());
-  },
+  /* Plain stubs, not a reimplementation of the real OOXML_MIME_TYPES map —
+   * the map's own correctness is covered by
+   * `libs/attachment-canvas/src/utils/tests/content.spec.ts`, which imports
+   * `getOoxmlMimeType`/`isOoxmlPreviewable` directly from `../content` and so
+   * doesn't hit the `@epam/pdf-highlighter-kit` resolution problem above.
+   * Tests here only need to verify that `resolveExternalSourceContentType`/
+   * `isExternalSourcePreviewable` correctly use whatever these return —
+   * each test configures the exact return value it needs. */
+  getOoxmlMimeType: vi.fn(),
+  isOoxmlPreviewable: vi.fn(),
 }));
 
 /* Stand-in for the host's DIAL-URL resolvers, mirroring the app's real
@@ -1035,6 +1009,11 @@ describe('getUrlFileName', () => {
 });
 
 describe('resolveExternalSourceContentType', () => {
+  beforeEach(() => {
+    vi.mocked(isOoxmlPreviewable).mockReset();
+    vi.mocked(getOoxmlMimeType).mockReset();
+  });
+
   it('returns an image/* content type unchanged regardless of url', () => {
     expect(
       resolveExternalSourceContentType(
@@ -1087,30 +1066,37 @@ describe('resolveExternalSourceContentType', () => {
   ])(
     'overrides a mislabeled content type when the url ends with .%s',
     (ext, canonicalMime) => {
+      vi.mocked(isOoxmlPreviewable).mockReturnValue(false);
+      vi.mocked(getOoxmlMimeType).mockReturnValue(canonicalMime);
       expect(
         resolveExternalSourceContentType(
           'text/markdown',
           `https://example.com/citation/report.${ext}`,
         ),
       ).toBe(canonicalMime);
+      expect(getOoxmlMimeType).toHaveBeenCalledWith(`report.${ext}`);
     },
   );
 
   it('returns a canonical OOXML content type unchanged when already reported', () => {
     const pptxMime =
       'application/vnd.openxmlformats-officedocument.presentationml.presentation';
+    vi.mocked(isOoxmlPreviewable).mockReturnValue(true);
     expect(
       resolveExternalSourceContentType(
         pptxMime,
         'https://example.com/citation/doc-id-123',
       ),
     ).toBe(pptxMime);
+    expect(isOoxmlPreviewable).toHaveBeenCalledWith('', pptxMime);
   });
 });
 
 describe('isExternalSourcePreviewable', () => {
   beforeEach(() => {
     vi.mocked(isTextPreviewable).mockReturnValue(false);
+    vi.mocked(isOoxmlPreviewable).mockReset();
+    vi.mocked(getOoxmlMimeType).mockReset();
   });
 
   it('returns true for an image/* content type regardless of url', () => {
@@ -1147,6 +1133,17 @@ describe('isExternalSourcePreviewable', () => {
   });
 
   it('returns true for a url whose path ends with .pptx even with a mislabeled content type', () => {
+    const pptxMime =
+      'application/vnd.openxmlformats-officedocument.presentationml.presentation';
+    /* First call (inside resolveExternalSourceContentType) checks the raw
+     * 'text/markdown' content type and must report it as untrusted so the
+     * extension override runs; the second call (isExternalSourcePreviewable's
+     * own check) queries the *resolved* pptx MIME type and must report it as
+     * trusted. */
+    vi.mocked(isOoxmlPreviewable).mockImplementation(
+      (_, mimeType) => mimeType === pptxMime,
+    );
+    vi.mocked(getOoxmlMimeType).mockReturnValue(pptxMime);
     expect(
       isExternalSourcePreviewable(
         'text/markdown',
@@ -1156,12 +1153,16 @@ describe('isExternalSourcePreviewable', () => {
   });
 
   it('returns true for a canonical pptx content type even when the url has no matching extension', () => {
+    const pptxMime =
+      'application/vnd.openxmlformats-officedocument.presentationml.presentation';
+    vi.mocked(isOoxmlPreviewable).mockReturnValue(true);
     expect(
       isExternalSourcePreviewable(
-        'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+        pptxMime,
         'https://example.com/citation/doc-id-123',
       ),
     ).toBe(true);
+    expect(isOoxmlPreviewable).toHaveBeenCalledWith('', pptxMime);
   });
 
   it('returns true when isTextPreviewable reports the filename is previewable', () => {

--- a/libs/chat-hooks/src/files/tests/attachment-canvas.spec.ts
+++ b/libs/chat-hooks/src/files/tests/attachment-canvas.spec.ts
@@ -60,6 +60,44 @@ vi.mock('@epam/ai-dial-attachment-canvas', () => ({
   },
   isHtmlPreviewable: vi.fn().mockReturnValue(false),
   isTextPreviewable: vi.fn(),
+  /* Real (not stubbed) behavior, mirroring the actual OOXML_MIME_TYPES map in
+   * `@epam/ai-dial-attachment-canvas`, since resolveExternalSourceContentType/
+   * isExternalSourcePreviewable tests assert genuine extension/MIME detection. */
+  getOoxmlMimeType: (name: string, mimeType?: string) => {
+    const mimeToType: Record<string, string> = {
+      'application/vnd.openxmlformats-officedocument.wordprocessingml.document':
+        'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+      'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet':
+        'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+      'application/vnd.openxmlformats-officedocument.presentationml.presentation':
+        'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+    };
+    const normalizedMime = mimeType?.split(';', 1)[0].trim().toLowerCase();
+    if (normalizedMime != null && mimeToType[normalizedMime] != null) {
+      return mimeToType[normalizedMime];
+    }
+    const dot = name.lastIndexOf('.');
+    if (dot === -1) return undefined;
+    const extToMime: Record<string, string> = {
+      docx: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+      xlsx: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+      pptx: 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+    };
+    return extToMime[name.slice(dot + 1).toLowerCase()];
+  },
+  isOoxmlPreviewable: (name: string, mimeType?: string) => {
+    const validMimes = new Set([
+      'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+      'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+      'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+    ]);
+    if (mimeType != null && validMimes.has(mimeType.split(';', 1)[0].trim())) {
+      return true;
+    }
+    const dot = name.lastIndexOf('.');
+    if (dot === -1) return false;
+    return ['docx', 'xlsx', 'pptx'].includes(name.slice(dot + 1).toLowerCase());
+  },
 }));
 
 /* Stand-in for the host's DIAL-URL resolvers, mirroring the app's real
@@ -859,6 +897,47 @@ describe('resolveOoxmlCanvasContent', () => {
 
     expect(result).toBeNull();
   });
+
+  it('returns OOXML content with the raw url for a non-DIAL external xlsx source', async () => {
+    const result = await resolveOoxmlCanvasContent(
+      makeRemoteAttachment(
+        'budget.xlsx',
+        'https://example.com/citation/budget-report',
+      ),
+      resolvers,
+      OoxmlFileType.Xlsx,
+    );
+    expect(result).toEqual({
+      type: AttachmentContentType.Ooxml,
+      url: 'https://example.com/citation/budget-report',
+      format: OoxmlFileType.Xlsx,
+    });
+  });
+
+  it('returns OOXML content with the raw url for a non-DIAL external pptx source', async () => {
+    const result = await resolveOoxmlCanvasContent(
+      makeRemoteAttachment(
+        'slides.pptx',
+        'https://example.com/citation/slides-deck',
+      ),
+      resolvers,
+      OoxmlFileType.Pptx,
+    );
+    expect(result).toEqual({
+      type: AttachmentContentType.Ooxml,
+      url: 'https://example.com/citation/slides-deck',
+      format: OoxmlFileType.Pptx,
+    });
+  });
+
+  it('returns null for a non-DIAL Office source url with no fetchable scheme', async () => {
+    const result = await resolveOoxmlCanvasContent(
+      makeRemoteAttachment('report.docx', 'citation-reference-id-456'),
+      resolvers,
+      OoxmlFileType.Docx,
+    );
+    expect(result).toBeNull();
+  });
 });
 
 describe('resolveVisualizerCanvasContent', () => {
@@ -991,6 +1070,42 @@ describe('resolveExternalSourceContentType', () => {
       ),
     ).toBe('text/markdown');
   });
+
+  it.each([
+    [
+      'docx',
+      'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+    ],
+    [
+      'xlsx',
+      'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    ],
+    [
+      'pptx',
+      'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+    ],
+  ])(
+    'overrides a mislabeled content type when the url ends with .%s',
+    (ext, canonicalMime) => {
+      expect(
+        resolveExternalSourceContentType(
+          'text/markdown',
+          `https://example.com/citation/report.${ext}`,
+        ),
+      ).toBe(canonicalMime);
+    },
+  );
+
+  it('returns a canonical OOXML content type unchanged when already reported', () => {
+    const pptxMime =
+      'application/vnd.openxmlformats-officedocument.presentationml.presentation';
+    expect(
+      resolveExternalSourceContentType(
+        pptxMime,
+        'https://example.com/citation/doc-id-123',
+      ),
+    ).toBe(pptxMime);
+  });
 });
 
 describe('isExternalSourcePreviewable', () => {
@@ -1027,6 +1142,24 @@ describe('isExternalSourcePreviewable', () => {
       isExternalSourcePreviewable(
         'application/octet-stream',
         'https://example.com/files/report.pdf',
+      ),
+    ).toBe(true);
+  });
+
+  it('returns true for a url whose path ends with .pptx even with a mislabeled content type', () => {
+    expect(
+      isExternalSourcePreviewable(
+        'text/markdown',
+        'https://example.com/citation/slides.pptx',
+      ),
+    ).toBe(true);
+  });
+
+  it('returns true for a canonical pptx content type even when the url has no matching extension', () => {
+    expect(
+      isExternalSourcePreviewable(
+        'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+        'https://example.com/citation/doc-id-123',
       ),
     ).toBe(true);
   });

--- a/openspec/specs/attachment-canvas-ooxml-viewer/spec.md
+++ b/openspec/specs/attachment-canvas-ooxml-viewer/spec.md
@@ -125,7 +125,18 @@ Resolution order SHALL be **MIME type first, then file extension**:
 
 `isOoxmlPreviewable(name, mimeType)` SHALL return `getOoxmlFileType(name, mimeType) != null`.
 
-Both SHALL be exported from the library's public entry point.
+`libs/attachment-canvas/src/utils/content.ts` SHALL additionally export:
+
+```ts
+export const getOoxmlMimeType = (
+  name: string,
+  mimeType?: string,
+) => string | undefined
+```
+
+`getOoxmlMimeType` SHALL resolve a format the same way `getOoxmlFileType` does (same MIME-then-extension order) and return that format's canonical MIME type string (`OOXML_MIME_TYPES.docx`/`.xlsx`/`.pptx`), or `undefined` when neither signal matches. It exists because a caller correcting a mislabeled `contentType` (see `resolveExternalSourceContentType` in `libs/chat-hooks/src/files/attachment-canvas.ts`) needs the canonical MIME string itself, not just the `OoxmlFileType` enum member — the corrected `contentType` is what `useOpenAttachmentCanvas`'s `getOoxmlFileType('', contentType)` MIME branch checks downstream.
+
+All three SHALL be exported from the library's public entry point.
 
 **Rationale:** neither signal is reliable alone. DIAL attachments can carry a generic `application/octet-stream` for a correctly-named `report.docx`, and a correct `contentType` can arrive with a `name` that is a citation title with no extension. MIME is checked first because when present and canonical it is the stronger signal; extension is the fallback that covers a mislabeled `contentType`.
 
@@ -186,6 +197,21 @@ MIME parameters must be stripped because upstream `contentType` values are not c
 - **WHEN** `isOoxmlPreviewable('deck.pptx')` is called
 - **THEN** it returns `true`
 - **AND** `isOoxmlPreviewable('notes.txt')` returns `false`
+
+#### Scenario: getOoxmlMimeType resolves the canonical MIME type by extension
+
+- **WHEN** `getOoxmlMimeType('budget.xlsx')` is called
+- **THEN** it returns `OOXML_MIME_TYPES.xlsx`
+
+#### Scenario: getOoxmlMimeType resolves the canonical MIME type from a non-canonical MIME string
+
+- **WHEN** `getOoxmlMimeType('attachment', 'APPLICATION/VND.OPENXMLFORMATS-OFFICEDOCUMENT.SPREADSHEETML.SHEET; charset=binary')` is called
+- **THEN** it returns `OOXML_MIME_TYPES.xlsx`
+
+#### Scenario: getOoxmlMimeType returns undefined when unmatched
+
+- **WHEN** `getOoxmlMimeType('Quarterly Report')` is called
+- **THEN** it returns `undefined`
 
 ---
 
@@ -475,9 +501,10 @@ The function SHALL delegate to the existing `resolveAttachmentBlobUrl` helper an
 
 - return `{ type: AttachmentContentType.Ooxml, url: result, format }` when the helper yields a URL string;
 - return the helper's `ErrorCanvasContent` unchanged when it yields one;
-- return `null` when the helper yields `undefined` (no source available).
+- otherwise (the helper yields `undefined` — no local file, DIAL URL, preview URL, or inline data), return `{ type: AttachmentContentType.Ooxml, url: attachment.url, format }` when `attachment.url` is set, is not a DIAL `files/` id, and is a fetchable absolute URL (`http:`, `https:`, or `blob:` scheme, via the shared `resolveExternalAttachmentUrl` helper — a relative or opaque string, e.g. a bare citation/reference id, fails this check);
+- return `null` when none of the above yields a URL.
 
-This is the same three-way shape as `resolvePdfCanvasContent`, and reusing `resolveAttachmentBlobUrl` is deliberate: Office files inherit the blob LRU cache, the `403 → Forbidden` / other-failure → `LoadFailed` classification, and support for locally-picked `File`s, DIAL download URLs, `previewUrl`, and inline base64 — identically to PDFs, with no duplicated fetch logic.
+This is the same shape as `resolvePdfCanvasContent`, and reusing `resolveAttachmentBlobUrl` and `resolveExternalAttachmentUrl` is deliberate: Office files inherit the blob LRU cache, the `403 → Forbidden` / other-failure → `LoadFailed` classification, support for locally-picked `File`s, DIAL download URLs, `previewUrl`, and inline base64, and the external-URL fallback — identically to PDFs, with no duplicated fetch or URL-validation logic.
 
 **Adapter contract (library isolation).** This function keeps host knowledge out of `libs/attachment-canvas`. The fetch, the blob cache, and the HTTP status classification live in `libs/chat-hooks`, which is host-agnostic; the genuinely app-specific part — DIAL URL construction, CSRF/auth — is injected as the `resolvers` argument by `apps/chat/src/hooks/attachment/useAttachmentCanvasResolvers.ts`, which binds this function and exposes it to the canvas hook as `resolveOoxmlContent(attachment, format)`. What crosses into `libs/attachment-canvas` is a resolved `url` string and an `OoxmlFileType` — nothing more. No new backend endpoint is introduced; Office bytes are served by the existing DIAL file download route.
 
@@ -498,8 +525,18 @@ This is the same three-way shape as `resolvePdfCanvasContent`, and reusing `reso
 
 #### Scenario: no source available returns null
 
-- **WHEN** the attachment has no file, no DIAL URL, no `previewUrl`, and no inline data
+- **WHEN** the attachment has no file, no DIAL URL, no `previewUrl`, no inline data, and no `url`
 - **THEN** it returns `null`
+
+#### Scenario: external non-DIAL Office source resolves to its raw url
+
+- **WHEN** `resolveOoxmlCanvasContent` is called with an attachment whose `url` is an external `https://` `.xlsx` link (no DIAL download URL, `previewUrl`, or inline data)
+- **THEN** it returns `{ type: Ooxml, url: <the external url>, format }`
+
+#### Scenario: non-fetchable url is rejected rather than handed to the viewer
+
+- **WHEN** the attachment's `url` is a bare opaque string with no `http:`/`https:`/`blob:` scheme (e.g. a citation/reference id) and no other source is available
+- **THEN** it returns `null`, not a payload whose viewer would receive an unfetchable `url`
 
 #### Scenario: the format argument is passed through unchanged
 

--- a/openspec/specs/conversation-sources-sidebar/spec.md
+++ b/openspec/specs/conversation-sources-sidebar/spec.md
@@ -267,19 +267,19 @@ For both states:
 
 **Content type resolution** — `resolveExternalSourceContentType(contentType, url)` exported from `libs/chat-hooks/src/files/attachment-canvas.ts`:
 
-- Returns `contentType` unchanged if it starts with `'image/'`, starts with `'audio/'`, or already equals `MIMEType.PDF` (`'application/pdf'`).
-- Otherwise, extracts the last path segment of `url` (ignoring query string and fragment); if its extension after the last `.` is `'pdf'` (`FileExtension.PDF`), returns `MIMEType.PDF` — **overriding** the reported `contentType`.
+- Returns `contentType` unchanged if it already trustworthily identifies the source: it starts with `'image/'`, starts with `'audio/'`, equals `MIMEType.PDF` (`'application/pdf'`), or `isOoxmlPreviewable('', contentType)` (from `@epam/ai-dial-attachment-canvas`) recognizes it as a canonical DOCX/XLSX/PPTX MIME type.
+- Otherwise, extracts the last path segment of `url` (ignoring query string and fragment): if its extension after the last `.` is `'pdf'` (`FileExtension.PDF`), returns `MIMEType.PDF`; otherwise, if `getOoxmlMimeType(fileName)` (from `@epam/ai-dial-attachment-canvas`) recognizes a `.docx`/`.xlsx`/`.pptx` extension, returns that format's canonical OOXML MIME type. Either case **overrides** the reported `contentType`.
 - Otherwise returns `contentType` unchanged.
 
-This override exists because some web-search grounding APIs (e.g. Google Vertex AI) label every web reference — YouTube, news articles, blog posts, and PDFs alike — with `content-type: text/markdown` regardless of actual content. Without it, a mislabelled PDF's `contentType` would win over its `.pdf` URL extension when building the `DisplayAttachment`, routing the canvas into the markdown/text viewer, which renders the PDF's raw bytes as garbled text instead of opening the PDF viewer. The `DisplayAttachment` built in step 2 above uses this resolved content type (not the raw `QuotationSource.contentType`) for both its `contentType` and `type` (`AttachmentType.Image` vs `AttachmentType.File`) fields.
+This override exists because some web-search grounding APIs (e.g. Google Vertex AI) label every web reference — YouTube, news articles, blog posts, PDFs, and Office documents alike — with `content-type: text/markdown` regardless of actual content. Without it, a mislabelled PDF's or Office document's `contentType` would win over its `.pdf`/`.docx`/`.xlsx`/`.pptx` URL extension when building the `DisplayAttachment`, routing the canvas into the markdown/text viewer, which renders the file's raw bytes as garbled text instead of opening the PDF/OOXML viewer. The `DisplayAttachment` built in step 2 above uses this resolved content type (not the raw `QuotationSource.contentType`) for both its `contentType` and `type` (`AttachmentType.Image` vs `AttachmentType.File`) fields.
 
 **Previewability test** — `isExternalSourcePreviewable(contentType, url)` exported from `libs/chat-hooks/src/files/attachment-canvas.ts`, built on `resolveExternalSourceContentType`:
 
-- Resolves the effective content type via `resolveExternalSourceContentType(contentType, url)`. Returns `true` if the resolved type starts with `'image/'`, starts with `'audio/'`, or equals `MIMEType.PDF`.
+- Resolves the effective content type via `resolveExternalSourceContentType(contentType, url)`. Returns `true` if the resolved type starts with `'image/'`, starts with `'audio/'`, equals `MIMEType.PDF`, or `isOoxmlPreviewable('', resolvedType)` recognizes it as a canonical OOXML MIME type.
 - Otherwise, extracts the last path segment of `url` and returns `true` when `isTextPreviewable(fileName)` or `isHtmlPreviewable(fileName)` from `@epam/ai-dial-attachment-canvas` returns `true` — covers `.md`, `.markdown`, `.json`, `.txt`, `.xml`, `.csv`, `.html`/`.htm`, and all other plain-text formats the canvas text renderer supports.
 - Returns `false` on invalid URLs or a last path segment with no file extension.
 
-Image and audio content types, and an already-correct `application/pdf` content type, are trusted directly because web-search grounding APIs do not mislabel them (or, for PDF, because a citation annotation's own `attachment.type` field — the same authoritative marker `annotationToPdfCanvasContent` trusts — is reliable even when the PDF's URL carries no `.pdf` extension, e.g. an opaque citation/reference id rather than a file name).
+Image and audio content types, and an already-correct PDF or OOXML content type, are trusted directly because web-search grounding APIs do not mislabel images/audio (or, for PDF/OOXML, because a citation annotation's own `attachment.type` field — the same authoritative marker `annotationToPdfCanvasContent` trusts — is reliable even when the source's URL carries no matching extension, e.g. an opaque citation/reference id rather than a file name).
 
 #### Scenario: Web-search reference URL without a file extension opens in a new tab
 


### PR DESCRIPTION
**Description:**

fix documents canvas opening from sources and derive prompt folderId from resource path

Issues:

- Issue #8551

**UI changes**

<Please, provide Screenshots or Figma links>

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
