### PR TITLE
fix(publish): keep a child folder created in a not-yet-listed folder …

### DIFF
--- a/libs/chat-hooks/src/catalog/usePublishFolders/tests/usePublishFolders.spec.ts
+++ b/libs/chat-hooks/src/catalog/usePublishFolders/tests/usePublishFolders.spec.ts
@@ -162,6 +162,47 @@ describe('usePublishFolders', () => {
     expect(vi.mocked(listPublicFiles).mock.calls).toHaveLength(callsBefore);
   });
 
+  /*
+   * Issue #8568: "Add child" on a folder the user had not expanded yet also
+   * expands it, which starts that folder's listing. The created folder used
+   * to live in the same listing cache, so the listing landing afterwards
+   * replaced it and the new folder vanished — while folders higher up in the
+   * hierarchy, already listed during navigation, kept theirs.
+   */
+  it('keeps a folder created under a not-yet-listed folder when that listing lands', async () => {
+    let releaseChildListing: (() => void) | undefined;
+    const { result } = render({
+      listPublicFiles: async ({ path }: { path?: string }) => {
+        if (path == null) return response([makeFolder('Org')]);
+        if (path === 'Org/') {
+          await new Promise<void>((resolve) => {
+            releaseChildListing = resolve;
+          });
+        }
+        return response([]);
+      },
+    });
+    await waitFor(() => expect(result.current.folderItems).toHaveLength(1));
+
+    act(() => {
+      result.current.onExpandedPathsChange(new Set(['Org']));
+    });
+    await act(async () => {
+      await result.current.onCreatePublishFolder(['Org'], 'Drafts');
+    });
+    expect(
+      result.current.folderItems[0].children?.map((child) => child.name),
+    ).toEqual(['Drafts']);
+
+    await act(async () => {
+      releaseChildListing?.();
+    });
+
+    expect(
+      result.current.folderItems[0].children?.map((child) => child.name),
+    ).toEqual(['Drafts']);
+  });
+
   it('denies write access under a restricted folder segment', async () => {
     const { result } = render();
     await waitFor(() => expect(result.current.folderItems).toHaveLength(1));

--- a/libs/chat-hooks/src/catalog/usePublishFolders/usePublishFolders.ts
+++ b/libs/chat-hooks/src/catalog/usePublishFolders/usePublishFolders.ts
@@ -25,9 +25,6 @@ const RESTRICTED_FOLDER_SEGMENT = 'Production';
  */
 const MAX_REMEMBERED_FOLDERS = 50;
 
-const toApiPath = (path: string[]): string | undefined =>
-  path.length ? `${path.join('/')}/` : undefined;
-
 const buildFolderNodes = (
   cache: Map<string, ListFilesItemDto[]>,
   apiPath: string,
@@ -87,7 +84,9 @@ export interface UsePublishFoldersResult {
    * `folderPath`, which DIAL Core storage creates implicitly, the same way
    * writing a file to a new prefix does. This avoids leaving an orphaned
    * empty folder behind when the user picks a new-folder name and then
-   * cancels the publish.
+   * cancels the publish. Because the folder exists only locally, it is kept
+   * apart from the listing cache, so a listing that arrives afterwards
+   * cannot drop it again.
    */
   onCreatePublishFolder: (parentPath: string[], name: string) => Promise<void>;
   /**
@@ -131,6 +130,14 @@ export const usePublishFolders = ({
   const [loadingPaths, setLoadingPaths] = useState<Set<string>>(
     () => new Set(),
   );
+  /*
+   * Folders created during this session, kept as path keys outside `cache`
+   * because they exist only locally (see `onCreatePublishFolder`). Holding
+   * them in the listing cache instead lost them whenever the parent's real
+   * listing landed afterwards — which is exactly what "Add child" on a
+   * not-yet-listed folder triggers, since it expands that folder (#8568).
+   */
+  const [createdFolderKeys, setCreatedFolderKeys] = useState<string[]>([]);
 
   const loadedPaths = useMemo(() => {
     const result = new Set<string>();
@@ -181,32 +188,13 @@ export const usePublishFolders = ({
 
   const onCreatePublishFolder = useCallback(
     (parentPath: string[], name: string): Promise<void> => {
-      const parentApiPath = toApiPath(parentPath) ?? '';
-      const parentItems = cache.get(parentApiPath) ?? [];
-      const parentBucket = parentItems[0]?.bucket ?? cache.get('')?.[0]?.bucket;
-      if (parentBucket == null) {
-        throw new Error('Cannot create folder: parent bucket is unknown');
-      }
-      const folderApiPath = `${parentApiPath}${name}/`;
-      const folderItem: ListFilesItemDto = {
-        name,
-        path: folderApiPath,
-        folderId: `${parentBucket}/${folderApiPath}`,
-        nodeType: ListFilesItemDtoNodeTypeEnum.Folder,
-        bucket: parentBucket,
-        parentPath: parentApiPath || undefined,
-      };
-      setCache((prev) => {
-        const next = new Map(prev);
-        next.set(parentApiPath, [
-          ...(next.get(parentApiPath) ?? []),
-          folderItem,
-        ]);
-        return next;
-      });
+      const folderKey = toFolderPathKey([...parentPath, name]);
+      setCreatedFolderKeys((prev) =>
+        prev.includes(folderKey) ? prev : [...prev, folderKey],
+      );
       return Promise.resolve();
     },
-    [cache],
+    [],
   );
 
   const rememberPublishFolder = useCallback(
@@ -235,11 +223,11 @@ export const usePublishFolders = ({
     const storedKeys = Array.isArray(rememberedFolderKeys)
       ? rememberedFolderKeys.filter((key) => typeof key === 'string')
       : [];
-    return mergeFolderPaths(
-      buildFolderNodes(cache, '', []),
-      storedKeys.map(fromFolderPathKey),
-    );
-  }, [cache, rememberedFolderKeys]);
+    return mergeFolderPaths(buildFolderNodes(cache, '', []), [
+      ...storedKeys.map(fromFolderPathKey),
+      ...createdFolderKeys.map(fromFolderPathKey),
+    ]);
+  }, [cache, rememberedFolderKeys, createdFolderKeys]);
 
   return {
     folderItems,


### PR DESCRIPTION
…(Issue #8568)

`onCreatePublishFolder` stored the locally created folder in the same listing cache `buildFolderNodes` reads, so a listing that resolved after the create replaced the entry and the new folder disappeared. "Add child" on a folder the user has not expanded yet also expands it, which starts exactly that listing — which is why only the deepest folder was affected, while folders higher up (already listed while navigating down) worked.

Created folders now live in their own path-key state and are merged into the tree with `mergeFolderPaths`, the same way remembered destinations already survive listings. The parent-bucket lookup is gone with the cache write, and so is its `Cannot create folder: parent bucket is unknown` throw.

**Description:**

<SHORT_DESCRIPTION>

Issues:

- Issue #<TICKET_ID>

**UI changes**

<Please, provide Screenshots or Figma links>

**Checklist:**

- [ ] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [ ] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
