### PR TITLE
fix(files): hide clientdata folder, recover from emptied-folder 404

### DIFF
--- a/apps/chat-api/src/files/files.constants.ts
+++ b/apps/chat-api/src/files/files.constants.ts
@@ -4,3 +4,9 @@
  */
 export const MARKER_NAME = '.dial_folder';
 export const FOLDER_NODE_TYPE = 'folder';
+
+/**
+ * Root-level folders the BFF itself writes user config/legacy migration data into
+ * (see UserConfigService). They must never be exposed through the files listing API.
+ */
+export const RESERVED_ROOT_FOLDER_NAMES = ['.client_data', 'clientdata'];

--- a/apps/chat-api/src/files/listing/files-listing.service.ts
+++ b/apps/chat-api/src/files/listing/files-listing.service.ts
@@ -10,6 +10,7 @@ import { DialClientService } from '../../dial/dial-client.service';
 import { toRelativePath } from '../dial-resource-path.util';
 import type { FileMetadataResponseDto } from '../dto/file-metadata-response.dto';
 import type { ListFilesResponseDto } from '../dto/list-files.dto';
+import { RESERVED_ROOT_FOLDER_NAMES } from '../files.constants';
 import type { DialFileItem } from '../normalize-file-item';
 import { normalizeFileItem } from '../normalize-file-item';
 import { resolveListingPermissions } from '../resolve-listing-permissions';
@@ -26,6 +27,16 @@ const FULL_FILE_LIST_PAGE_LIMIT = 1000;
 
 const safeDecodePathForCompare = (path: string): string =>
   path.split('/').map(safeDecodeURIComponent).join('/');
+
+const isReservedRootFolder = (item: DialFileItem): boolean => {
+  const nodeType = (item.nodeType ?? '').toLowerCase();
+  if (nodeType !== 'folder') return false;
+
+  const parentPath = (item.parentPath ?? '').replace(/\/+$/, '');
+  if (parentPath !== '') return false;
+
+  return RESERVED_ROOT_FOLDER_NAMES.includes(item.name ?? '');
+};
 
 @Injectable()
 export class FilesListingService {
@@ -147,9 +158,12 @@ export class FilesListingService {
           `listFiles DIAL page: bucket=${bucket}, path=${normalizedPath}, page=${page}, count=${pageData.items.length}, hasNextPage=${nextToken != null}`,
         );
       } while (shouldAggregateAllPages && token != null);
-      const items = rawItems.map((item) => normalizeFileItem(item, bucket));
+      const visibleItems = rawItems.filter(
+        (item) => !isReservedRootFolder(item),
+      );
+      const items = visibleItems.map((item) => normalizeFileItem(item, bucket));
       const resolvedPermissions = resolveListingPermissions(
-        rawItems,
+        visibleItems,
         normalizedPath,
       );
 
@@ -213,6 +227,7 @@ export class FilesListingService {
       const rawItems = sharedData.resources ?? [];
 
       const allItems = rawItems
+        .filter((item) => !isReservedRootFolder(item))
         .map((item) => normalizeFileItem(item, item.bucket ?? ''))
         .filter((item) => {
           if (!query.path) return true;
@@ -266,6 +281,7 @@ export class FilesListingService {
 
       const items = rawItems
         .filter((item) => (item.bucket ?? '') === bucket)
+        .filter((item) => !isReservedRootFolder(item))
         .map((item) => normalizeFileItem(item, bucket));
 
       this.logger.debug(

--- a/apps/chat-api/src/files/tests/listing/files-listing.service.spec.ts
+++ b/apps/chat-api/src/files/tests/listing/files-listing.service.spec.ts
@@ -470,6 +470,64 @@ describe('FilesListingService', () => {
         'report.pdf',
       ]);
     });
+
+    it('filters out reserved root-level config folders (.client_data, clientdata)', async () => {
+      const { service, sdkClient } = makeService();
+      sdkClient.getFileMetadata.mockResolvedValue(
+        okList([
+          {
+            nodeType: 'FOLDER',
+            url: '.client_data/',
+            name: '.client_data',
+            parentPath: '',
+          },
+          {
+            nodeType: 'FOLDER',
+            url: 'clientdata/',
+            name: 'clientdata',
+            parentPath: '',
+          },
+          {
+            nodeType: 'ITEM',
+            url: 'report.pdf',
+            name: 'report.pdf',
+            parentPath: '',
+          },
+        ]),
+      );
+
+      const result = await service.listFiles(
+        'my-bucket',
+        undefined,
+        {},
+        'token',
+      );
+
+      expect(result.items.map((item) => item.name)).toEqual(['report.pdf']);
+    });
+
+    it('keeps a non-root folder literally named clientdata', async () => {
+      const { service, sdkClient } = makeService();
+      sdkClient.getFileMetadata.mockResolvedValue(
+        okList([
+          {
+            nodeType: 'FOLDER',
+            url: 'nested/clientdata/',
+            name: 'clientdata',
+            parentPath: 'nested/',
+          },
+        ]),
+      );
+
+      const result = await service.listFiles(
+        'my-bucket',
+        'nested/',
+        {},
+        'token',
+      );
+
+      expect(result.items.map((item) => item.name)).toEqual(['clientdata']);
+    });
   });
 
   describe('listPublicFiles', () => {

--- a/libs/chat-hooks/src/files/useDialFileListing/tests/useDialFileListing.spec.tsx
+++ b/libs/chat-hooks/src/files/useDialFileListing/tests/useDialFileListing.spec.tsx
@@ -98,6 +98,33 @@ describe('useDialFileListing', () => {
     expect(filesApi.listPublicFiles).toHaveBeenCalled();
   });
 
+  it('falls back to the parent folder when the current folder 404s (e.g. emptied and removed)', async () => {
+    vi.mocked(filesApi.listFiles).mockImplementation((query) => {
+      if (query.path === 'reports/') {
+        return Promise.reject(
+          Object.assign(new Error('Not Found'), {
+            response: { status: 404, json: () => Promise.resolve({}) },
+          }),
+        );
+      }
+      return Promise.resolve({
+        bucket: BUCKET,
+        path: '',
+        items: [],
+        nextToken: undefined,
+      });
+    });
+
+    const { result } = renderListing();
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    act(() => result.current.onPathChange('/My files/reports/'));
+
+    await waitFor(() => expect(result.current.folderPath).toBe(''));
+    expect(result.current.error).toBeNull();
+    expect(result.current.path).toBe('/My files');
+  });
+
   describe('onSearchFiles', () => {
     it('debounces search and calls listFiles only once after 300ms', async () => {
       vi.mocked(filesApi.listFiles).mockResolvedValue({

--- a/libs/chat-hooks/src/files/useDialFileListing/useDialFileListing.ts
+++ b/libs/chat-hooks/src/files/useDialFileListing/useDialFileListing.ts
@@ -10,6 +10,7 @@ import {
 } from '@epam/ai-dial-react-file-manager';
 import { NotificationVariant } from '@epam/ai-dial-ui-kit';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { getApiErrorStatus } from '../../api-error/api-error';
 import { safeDecodeURI } from '../../shared/string-utils';
 import {
   buildFromCache,
@@ -31,7 +32,10 @@ import {
   type FileManagerNotification,
 } from '../dial-file-manager.types';
 import type { DialFilesApi } from '../dial-files-api';
-import { virtualPathToApiPath } from '../resolve-dial-file-api-path';
+import {
+  getParentFolderPath,
+  virtualPathToApiPath,
+} from '../resolve-dial-file-api-path';
 
 /** Options accepted by `useDialFileListing`. */
 export interface UseDialFileListingOptions {
@@ -240,8 +244,16 @@ export const useDialFileListing = ({
           );
         }
       })
-      .catch(() => {
+      .catch((err: unknown) => {
         if (cancelled) return;
+        /* The folder just browsed into can vanish (e.g. its last file was
+         * deleted, dropping the now-empty folder from DIAL Core) — DIAL Core
+         * then 404s the listing. Fall back to the parent folder instead of
+         * surfacing a dead-end error. */
+        if (folderPath !== '' && getApiErrorStatus(err) === 404) {
+          setFolderPath(getParentFolderPath(folderPath));
+          return;
+        }
         setError('dialFileManager.error');
       })
       .finally(() => {

--- a/openspec/specs/chat-hooks-file-manager-listing/spec.md
+++ b/openspec/specs/chat-hooks-file-manager-listing/spec.md
@@ -42,6 +42,32 @@ SHALL accept an injected `DialFilesApi` instance and SHALL NOT import
 - **THEN** the cache entry for that path is deleted immediately without a
   refetch
 
+### Requirement: A 404 on the browsed folder falls back to its parent instead of erroring
+
+The main folder-listing effect SHALL distinguish a `404` response for a
+non-root `folderPath` from every other failure. On `404`, the hook SHALL set
+`folderPath` to the parent of the failed path (via `getParentFolderPath`)
+instead of setting `error`, so a folder that disappeared between navigation
+and fetch (for example, its last remaining file was just deleted) resolves to
+its parent folder's listing rather than a dead-end error screen. Every other
+failure, and any `404` while `folderPath` is already root (`""`), SHALL still
+set `error` as before.
+
+#### Scenario: The current folder 404s after its last file is deleted
+
+- **GIVEN** the user is browsing `folderPath = "reports/"`
+- **WHEN** the last file in `reports/` is deleted and the resulting refetch of
+  `reports/` returns `404`
+- **THEN** the hook sets `folderPath` to its parent (`""`) and does not set
+  `error`
+
+#### Scenario: A 404 at the root folder still surfaces as an error
+
+- **GIVEN** `folderPath` is `""` (root)
+- **WHEN** the listing fetch returns `404`
+- **THEN** the hook sets `error` as it does for any other failure, since there
+  is no parent to fall back to
+
 ### Requirement: Search always searches from the current folder and cancels stale requests
 
 `onSearchFiles` SHALL ignore its `folder` parameter and always search from

--- a/openspec/specs/file-list/spec.md
+++ b/openspec/specs/file-list/spec.md
@@ -116,6 +116,20 @@ The `GET /api/v1/files/list` endpoint scope is limited to the user's own bucket 
 
 ---
 
+#### Scenario: Reserved root-level config folders are excluded from listing
+
+- **GIVEN** DIAL Core's response for a bucket root includes folder items
+  named `.client_data` or `clientdata` (the folders `UserConfigService`
+  itself writes user config and legacy migration data into) with an empty
+  `parentPath`
+- **WHEN** the service normalizes `items`
+- **THEN** those root-level folder items are excluded from the returned
+  `items`, for every caller of `listFiles` (`GET /api/v1/files/list`,
+  `GET /api/v1/files/public`) as well as `listSharedFiles` and
+  `listSharedByMe`
+- **AND** a folder with the same name nested below the root (non-empty
+  `parentPath`) is NOT excluded
+
 #### Scenario: Bucket without physical folder objects (virtual folders)
 
 - **GIVEN** a bucket whose storage has only object keys such as `reports/q1.pdf` and `reports/q2.pdf` but no physical object at `reports/`


### PR DESCRIPTION
## Summary
- Filter the BFF's own reserved root-level config folders (`.client_data`, legacy `clientdata`) out of `GET /api/v1/files/list`, `GET /api/v1/files/public`, and the shared-listing endpoints, so they're never returned to the client — a nested folder with the same name is left alone.
- Fix a dead-end: deleting the last file in a folder makes that (virtual) folder disappear from DIAL Core, so the next file-manager listing refetch for that path 404s. `useDialFileListing` now falls back to the parent folder on a non-root 404 instead of showing a stuck error.
- Updated `openspec/specs/file-list` and `openspec/specs/chat-hooks-file-manager-listing` to document both behaviors.

## Test plan
- [x] `nx test @epam/chat-api` — files-listing suite (45 tests) passes, including new reserved-folder tests
- [x] `nx test @epam/ai-dial-chat-hooks` — useDialFileListing suite (12 tests) passes, including new 404-fallback test
- [x] `nx lint @epam/chat-api` / `nx lint @epam/ai-dial-chat-hooks` clean
- [x] `openspec validate file-list chat-hooks-file-manager-listing --type spec --strict` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)