### PR TITLE
fix: Fix how file is downloaded when no extension and . in the name, Issue #8492

### DIFF
--- a/libs/attachment-canvas/src/hooks/useOpenAttachmentCanvas/useOpenAttachmentCanvas.ts
+++ b/libs/attachment-canvas/src/hooks/useOpenAttachmentCanvas/useOpenAttachmentCanvas.ts
@@ -6,6 +6,7 @@ import {
   AttachmentType,
   FileExtension,
   MIMEType,
+  stripUrlQueryAndFragment,
 } from '@epam/ai-dial-chat-shared';
 import { useCallback } from 'react';
 import { useAttachmentCanvas } from '../../context/AttachmentCanvasContext';
@@ -131,7 +132,7 @@ const getUrlFileName = (url: string): string => {
   } catch {
     /* A relative DIAL resource path has no base to resolve against, so the
      * query and hash are stripped by hand instead. */
-    path = url.split(/[?#]/)[0];
+    path = stripUrlQueryAndFragment(url);
   }
   const segment = path.split('/').filter(Boolean).pop() ?? '';
   try {

--- a/libs/chat-hooks/src/files/attachment-canvas.ts
+++ b/libs/chat-hooks/src/files/attachment-canvas.ts
@@ -30,6 +30,7 @@ import {
   base64ToBlob,
   FileExtension,
   MIMEType,
+  stripUrlQueryAndFragment,
   tryBase64ToBytes,
 } from '@epam/ai-dial-chat-shared';
 import {
@@ -119,7 +120,7 @@ export const getUrlFileName = (url: string): string => {
   } catch {
     /* A relative DIAL resource path has no base to resolve against, so the
      * query and hash are stripped by hand instead. */
-    path = url.split(/[?#]/)[0];
+    path = stripUrlQueryAndFragment(url);
   }
   const segment = path.split('/').filter(Boolean).pop() ?? '';
   try {

--- a/libs/chat-shared/src/utils/file-download.ts
+++ b/libs/chat-shared/src/utils/file-download.ts
@@ -1,27 +1,43 @@
 import { MIME_TYPE_EXT_MAP } from '../constants/mime-types';
+import { stripUrlQueryAndFragment } from './mime-type';
+
+/**
+ * Matches a plausible file extension: letters/digits only, no spaces or
+ * punctuation. Guards against a title's incidental `.` (e.g. `"vs. KKR"` or
+ * `"(Word Document)"`) being mistaken for a real extension.
+ */
+const PLAUSIBLE_EXTENSION_REGEXP = /^[a-zA-Z0-9]{1,10}$/;
+
+/** Returns the trailing extension of `value` (without the dot) when it looks like a real file extension. */
+const extractPlausibleExtension = (value: string): string | undefined => {
+  const dot = value.lastIndexOf('.');
+  if (dot <= 0 || dot >= value.length - 1) return undefined;
+  const ext = value.slice(dot + 1);
+  return PLAUSIBLE_EXTENSION_REGEXP.test(ext) ? ext : undefined;
+};
 
 /**
  * Returns `name` with a file extension appended when it lacks one.
- * Priority: extension already present → extension from the last segment of `url` → extension from `contentType` via `MIME_TYPE_EXT_MAP`.
+ * Priority: extension already present on `name` → extension from `contentType` via `MIME_TYPE_EXT_MAP` → extension from the last segment of `url`.
+ * A trailing `.` in `name` or the `url` segment is only trusted when it looks
+ * like a real extension (letters/digits only) — otherwise it is treated as
+ * ordinary punctuation (e.g. a title such as `"Report vs. Summary"`).
  */
 export const ensureDownloadFilename = (
   name: string,
   url: string | undefined,
   contentType: string | undefined,
 ): string => {
-  const dot = name.lastIndexOf('.');
-  if (dot > 0 && dot < name.length - 1) return name;
-
-  if (url != null) {
-    const segment = url.split(/[?#]/)[0].split('/').pop() ?? '';
-    const segDot = segment.lastIndexOf('.');
-    if (segDot > 0 && segDot < segment.length - 1) {
-      return `${name}.${segment.slice(segDot + 1)}`;
-    }
-  }
+  if (extractPlausibleExtension(name) != null) return name;
 
   if (contentType != null) {
     const ext = MIME_TYPE_EXT_MAP[contentType];
+    if (ext != null) return `${name}.${ext}`;
+  }
+
+  if (url != null) {
+    const segment = stripUrlQueryAndFragment(url).split('/').pop() ?? '';
+    const ext = extractPlausibleExtension(segment);
     if (ext != null) return `${name}.${ext}`;
   }
 

--- a/libs/chat-shared/src/utils/mime-type.ts
+++ b/libs/chat-shared/src/utils/mime-type.ts
@@ -83,13 +83,17 @@ const EXTENSION_TO_MIME_TYPE: Record<string, MIMEType> = {
   ogg: MIMEType.OGG,
 };
 
+/** Strips a trailing `?query` string and/or `#fragment` from a URL or path. */
+export const stripUrlQueryAndFragment = (url: string): string =>
+  url.split(/[?#]/)[0];
+
 /**
  * Infers a `MIMEType` from a file path's extension, ignoring any query string
  * or `#` fragment. Returns `undefined` when the path has no extension or the
  * extension is not recognized.
  */
 export const inferMimeTypeFromPath = (path: string): MIMEType | undefined => {
-  const clean = path.split(/[?#]/)[0];
+  const clean = stripUrlQueryAndFragment(path);
   const dotIdx = clean.lastIndexOf('.');
   if (dotIdx === -1) return undefined;
   const ext = clean.slice(dotIdx + 1).toLowerCase();

--- a/libs/chat-shared/src/utils/tests/file-download.spec.ts
+++ b/libs/chat-shared/src/utils/tests/file-download.spec.ts
@@ -50,6 +50,34 @@ describe('ensureDownloadFilename', () => {
       ),
     ).toBe('Report.pdf');
   });
+
+  it('appends the MIME-type extension when the title contains a dot that is not a real extension', () => {
+    expect(
+      ensureDownloadFilename(
+        'Blackstone vs. KKR Comparative Intelligence Briefing (Word Document)',
+        'files/bucket/appdata/applications/public/pg/pg-agent__1.0.0/Blackstone_KKR_Detailed_Report.docx',
+        'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+      ),
+    ).toBe(
+      'Blackstone vs. KKR Comparative Intelligence Briefing (Word Document).docx',
+    );
+  });
+
+  it('falls back to the url extension when the title has no real extension and no contentType is given', () => {
+    expect(
+      ensureDownloadFilename(
+        'Report v2. Final (draft)',
+        'files/bucket/report.pdf',
+        undefined,
+      ),
+    ).toBe('Report v2. Final (draft).pdf');
+  });
+
+  it('does not mistake a name ending in "vs." followed by more text for an extension', () => {
+    expect(
+      ensureDownloadFilename('Blackstone vs. KKR Report', undefined, undefined),
+    ).toBe('Blackstone vs. KKR Report');
+  });
 });
 
 describe('getFileExtensionForLanguage', () => {


### PR DESCRIPTION
**Description:**

Fix for situation when file is like this (no extension in title, but there is a dot)
{
    "index": 1,
    "type": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
    "title": "Blackstone vs. KKR Comparative Intelligence Briefing (Word Document)",
    "url": "files/2V56nym3wV/appdata/applications/public/pg/pg-agent__1.0.0/Blackstone_KKR_Detailed_Report.docx"
}

Issues:

- Issue #8492

**UI changes**

<Please, provide Screenshots or Figma links>

**Checklist:**

- [X] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [X] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [X] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
