### PR TITLE
fix: huge formula in LaTeX syntax is not shown fully, #Issue 3773

### DIFF
--- a/libs/chat-shared/README.md
+++ b/libs/chat-shared/README.md
@@ -115,12 +115,21 @@ FilterTab.Organization; // 'organization'
 
 ### MarkdownRenderer
 
-Renders markdown content with GFM support (tables, task lists, strikethrough).
+Renders markdown content with GFM support (tables, task lists, strikethrough)
+and LaTeX math through KaTeX. Tables and block formulas each get their own
+horizontal scroll container, so content wider than the column stays reachable
+instead of being clipped; each container becomes a labelled, focusable
+`role="region"` only while it actually overflows. Pass
+`tableScrollRegionAriaLabel` and `mathScrollRegionAriaLabel` to translate those
+labels — they default to `'Scrollable table'` and `'Scrollable formula'`.
 
 ```tsx
 import { MarkdownRenderer } from '@epam/ai-dial-chat-shared';
 
-<MarkdownRenderer content={markdownText} />;
+<MarkdownRenderer
+  content={markdownText}
+  mathScrollRegionAriaLabel={t('Scrollable formula')}
+/>;
 ```
 
 ### MDMessageViewer

--- a/libs/chat-shared/src/components/MarkdownRenderer/MarkdownRenderer.tsx
+++ b/libs/chat-shared/src/components/MarkdownRenderer/MarkdownRenderer.tsx
@@ -14,6 +14,7 @@ import { preprocessLaTeX } from '../../utils/latex';
 import { mergeClasses } from '../../utils/merge-class';
 import { MarkdownCodeBlock } from './CodeBlock/CodeBlock';
 import styles from './MarkdownRenderer.module.scss';
+import { MarkdownMathBlock } from './Math/MarkdownMathBlock';
 import {
   MarkdownTable,
   type MarkdownTableClassNames,
@@ -76,6 +77,8 @@ export interface MarkdownRendererClassNames extends MarkdownTableClassNames {
   tableHeader?: string;
   /** Typography class for `<th>` cells. Defaults to `'dial-tiny-lead-semi-text'`. Text color is set separately via `colors.tableHeaderText`. */
   tableHeaderFont?: string;
+  /** Extra classes on the scrollable wrapper around block (display) LaTeX formulas. */
+  mathBlock?: string;
 }
 
 /** Props for {@link MarkdownRenderer}. */
@@ -110,6 +113,8 @@ export interface MarkdownRendererProps {
   colors?: MarkdownRendererColors;
   /** Accessible label for a table's horizontally scrollable region. Defaults to `'Scrollable table'`. */
   tableScrollRegionAriaLabel?: string;
+  /** Accessible label for a block formula's horizontally scrollable region. Defaults to `'Scrollable formula'`. */
+  mathScrollRegionAriaLabel?: string;
 }
 
 /** CSS custom-property overrides for the `MarkdownRenderer` component. */
@@ -190,6 +195,27 @@ const mathMLTags = [
 ];
 
 /**
+ * Presentation attributes carried by `rehypeKatex`'s MathML output, per tag.
+ * `rehype-sanitize` drops every attribute its schema does not list, and the
+ * default schema knows no MathML: without these, `display="block"` is stripped
+ * from `<math>` and every display formula silently renders as inline math.
+ * All of them are layout-only — nothing here can carry script or a URL.
+ */
+const mathMLAttributes: Record<string, string[]> = {
+  math: ['display', 'xmlns'],
+  annotation: ['encoding'],
+  mfrac: ['linethickness'],
+  mi: ['mathvariant'],
+  mo: ['fence', 'minsize', 'stretchy'],
+  mover: ['accent'],
+  mpadded: ['height', 'lspace', 'width'],
+  mspace: ['width'],
+  mstyle: ['displaystyle', 'mathcolor', 'scriptlevel'],
+  mtable: ['columnalign', 'columnspacing', 'rowspacing', 'width'],
+  mtd: ['width'],
+};
+
+/**
  * KaTeX rehype plugin list, shared across all markdown instances.
  *
  * `rehypeRaw` re-parses raw HTML left as literal text by `remark` (e.g. a
@@ -208,7 +234,14 @@ const baseRehypePlugins: NonNullable<Options['rehypePlugins']> = [
       tagNames: [...(defaultSchema.tagNames ?? []), ...mathMLTags],
       attributes: {
         ...defaultSchema.attributes,
+        ...mathMLAttributes,
         code: [...(defaultSchema.attributes?.code ?? []), ['className']],
+        /* Only KaTeX's own wrapper classes — a class from raw model HTML is
+           still dropped. `katex` is what marks a formula for MarkdownMathBlock. */
+        span: [
+          ...(defaultSchema.attributes?.span ?? []),
+          ['className', 'katex', 'katex-error'],
+        ],
       },
     },
   ],
@@ -232,6 +265,32 @@ interface HastTextLike {
   children?: HastTextLike[];
 }
 
+/** Shape of a hast element node, enough to recognise KaTeX's display-math output. */
+interface HastElementLike extends HastTextLike {
+  tagName?: string;
+  properties?: Record<string, unknown>;
+}
+
+/**
+ * Recognises the markup `rehype-katex` emits for block math. With MathML output
+ * KaTeX wraps both inline and display formulas in `<span class="katex">`; only
+ * the `display="block"` attribute on the inner `<math>` tells them apart.
+ */
+const isDisplayMathElement = (node: HastElementLike | undefined): boolean => {
+  const className = node?.properties?.className;
+
+  if (!Array.isArray(className) || !className.includes('katex')) return false;
+
+  const children = (node?.children ?? []) as HastElementLike[];
+
+  return children.some(
+    (child) =>
+      child.type === 'element' &&
+      child.tagName === 'math' &&
+      child.properties?.display === 'block',
+  );
+};
+
 /** Recursively concatenates the text content of a hast node. */
 const getNodeText = (node: HastTextLike | undefined): string => {
   if (!node) return '';
@@ -239,13 +298,26 @@ const getNodeText = (node: HastTextLike | undefined): string => {
   return (node.children ?? []).map(getNodeText).join('');
 };
 
+/** Everything `buildMarkdownComponents` needs beyond the className overrides. */
+interface MarkdownComponentOptions {
+  isStreaming?: boolean;
+  codeBlockCopyLabel?: string;
+  codeBlockCopiedLabel?: string;
+  codeBlockTheme?: CodeBlockTheme;
+  tableScrollRegionAriaLabel?: string;
+  mathScrollRegionAriaLabel?: string;
+}
+
 const buildMarkdownComponents = (
   cn: MarkdownRendererClassNames,
-  isStreaming?: boolean,
-  codeBlockCopyLabel?: string,
-  codeBlockCopiedLabel?: string,
-  codeBlockTheme?: CodeBlockTheme,
-  tableScrollRegionAriaLabel?: string,
+  {
+    isStreaming,
+    codeBlockCopyLabel,
+    codeBlockCopiedLabel,
+    codeBlockTheme,
+    tableScrollRegionAriaLabel,
+    mathScrollRegionAriaLabel,
+  }: MarkdownComponentOptions,
 ): Components => ({
   h1: ({ children }) => <h1 className={cn.h1}>{children}</h1>,
   h2: ({ children }) => <h2 className={cn.h2}>{children}</h2>,
@@ -345,6 +417,17 @@ const buildMarkdownComponents = (
     type === 'checkbox' ? (
       <MarkdownTaskCheckbox checked={checked ?? false} />
     ) : null,
+  span: ({ children, node, ...props }) =>
+    isDisplayMathElement(node) ? (
+      <MarkdownMathBlock
+        className={cn.mathBlock}
+        scrollRegionAriaLabel={mathScrollRegionAriaLabel}
+      >
+        {children}
+      </MarkdownMathBlock>
+    ) : (
+      <span {...props}>{children}</span>
+    ),
   table: ({ children }) => (
     <MarkdownTable
       classNames={cn}
@@ -418,6 +501,7 @@ export const MarkdownRenderer: FC<MarkdownRendererProps> = memo(
     codeBlockTheme,
     colors,
     tableScrollRegionAriaLabel,
+    mathScrollRegionAriaLabel,
   }) => {
     const displayedContent = useStreamedMarkdownContent(
       content,
@@ -445,14 +529,14 @@ export const MarkdownRenderer: FC<MarkdownRendererProps> = memo(
 
     const mergedComponents = useMemo(
       () => ({
-        ...buildMarkdownComponents(
-          classNames,
+        ...buildMarkdownComponents(classNames, {
           isStreaming,
           codeBlockCopyLabel,
           codeBlockCopiedLabel,
           codeBlockTheme,
           tableScrollRegionAriaLabel,
-        ),
+          mathScrollRegionAriaLabel,
+        }),
         ...defaultMarkdownComponents,
         ...components,
       }),
@@ -463,6 +547,7 @@ export const MarkdownRenderer: FC<MarkdownRendererProps> = memo(
         codeBlockCopiedLabel,
         codeBlockTheme,
         tableScrollRegionAriaLabel,
+        mathScrollRegionAriaLabel,
         components,
       ],
     );

--- a/libs/chat-shared/src/components/MarkdownRenderer/Math/MarkdownMathBlock.module.scss
+++ b/libs/chat-shared/src/components/MarkdownRenderer/Math/MarkdownMathBlock.module.scss
@@ -1,0 +1,33 @@
+.scrollContainer {
+  scrollbar-width: thin;
+  scrollbar-color: var(--cm-math-scrollbar, var(--stroke-primary, #57647a))
+    transparent;
+
+  &::-webkit-scrollbar {
+    height: 4px;
+  }
+
+  &::-webkit-scrollbar-track {
+    background-color: transparent;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background-color: var(--cm-math-scrollbar, var(--stroke-primary, #57647a));
+    border-radius: 4px;
+  }
+
+  &:focus-visible {
+    outline: 1px solid var(--cm-math-focus, var(--stroke-focus-black, #161b2d));
+    outline-offset: 2px;
+  }
+}
+
+/* KaTeX emits display math as an inline `span.katex` wrapping a block-level
+   `<math display="block">`. Sizing that span to `max-content` gives the scroll
+   container a real overflow width to scroll through, while `min-width: 100%`
+   keeps a short formula filling the row. */
+.mathContent {
+  display: block;
+  width: max-content;
+  min-width: 100%;
+}

--- a/libs/chat-shared/src/components/MarkdownRenderer/Math/MarkdownMathBlock.tsx
+++ b/libs/chat-shared/src/components/MarkdownRenderer/Math/MarkdownMathBlock.tsx
@@ -1,0 +1,58 @@
+import { type FC, type ReactNode, memo } from 'react';
+import { useHorizontalOverflow } from '../../../hooks/useHorizontalOverflow';
+import { mergeClasses } from '../../../utils/merge-class';
+import styles from './MarkdownMathBlock.module.scss';
+
+/** Props for {@link MarkdownMathBlock}. */
+export interface MarkdownMathBlockProps {
+  /** Rendered KaTeX output — the `<math display="block">` element and its subtree. */
+  children: ReactNode;
+  /** Extra classes on the scroll container. */
+  className?: string;
+  /** Accessible label for the horizontally scrollable region. Defaults to `'Scrollable formula'`. */
+  scrollRegionAriaLabel?: string;
+}
+
+/**
+ * Wraps KaTeX display math in a horizontally scrollable region so a formula
+ * wider than the message column stays reachable instead of being clipped.
+ * The region only becomes a labelled, keyboard-focusable landmark while it
+ * actually overflows, so ordinary formulas add no tab stop or noise.
+ */
+export const MarkdownMathBlock: FC<MarkdownMathBlockProps> = memo(
+  ({ children, className, scrollRegionAriaLabel = 'Scrollable formula' }) => {
+    const {
+      scrollContainerRef,
+      contentRef,
+      hasContentBeyondStart,
+      hasContentBeyondEnd,
+      handleScroll,
+    } = useHorizontalOverflow<HTMLSpanElement>();
+    const isScrollable = hasContentBeyondStart || hasContentBeyondEnd;
+
+    return (
+      <div
+        ref={scrollContainerRef}
+        /* `overflow-x-auto` alone computes `overflow-y` to `auto` too, which adds a
+           spurious vertical scrollbar once the horizontal one claims height; tall
+           formulas grow the container instead, so pinning it clips nothing. */
+        className={mergeClasses(
+          'w-full min-w-0 max-w-full overflow-x-auto overflow-y-hidden',
+          styles.scrollContainer,
+          className,
+        )}
+        onScroll={handleScroll}
+        role={isScrollable ? 'region' : undefined}
+        aria-label={isScrollable ? scrollRegionAriaLabel : undefined}
+        tabIndex={isScrollable ? 0 : undefined}
+      >
+        <span
+          ref={contentRef}
+          className={mergeClasses('katex', styles.mathContent)}
+        >
+          {children}
+        </span>
+      </div>
+    );
+  },
+);

--- a/libs/chat-shared/src/components/MarkdownRenderer/Math/tests/MarkdownMathBlock.spec.tsx
+++ b/libs/chat-shared/src/components/MarkdownRenderer/Math/tests/MarkdownMathBlock.spec.tsx
@@ -1,0 +1,94 @@
+import { act, render } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { MarkdownMathBlock } from '../MarkdownMathBlock';
+
+let resizeObserverCallback: ResizeObserverCallback;
+
+class ResizeObserverMock {
+  constructor(callback: ResizeObserverCallback) {
+    resizeObserverCallback = callback;
+  }
+
+  observe() {
+    // No-op in JSDOM.
+  }
+  unobserve() {
+    // No-op in JSDOM.
+  }
+  disconnect() {
+    // No-op in JSDOM.
+  }
+}
+
+/*
+ * The scroll container and the KaTeX span are presentational wrappers with no
+ * accessible role until the formula overflows, so the rendered tree is walked
+ * directly rather than queried semantically.
+ */
+const renderMathBlock = () => {
+  const { container } = render(
+    <MarkdownMathBlock scrollRegionAriaLabel="Scrollable formula">
+      <span>formula</span>
+    </MarkdownMathBlock>,
+  );
+  // eslint-disable-next-line testing-library/no-node-access
+  const scrollContainer = container.firstElementChild as HTMLElement;
+  // eslint-disable-next-line testing-library/no-node-access
+  const content = scrollContainer.firstElementChild as HTMLElement;
+
+  return { scrollContainer, content };
+};
+
+/** Makes the content 400px wide inside a 200px container, scrolled to the start. */
+const simulateOverflow = (
+  scrollContainer: HTMLElement,
+  content: HTMLElement,
+) => {
+  Object.defineProperties(scrollContainer, {
+    clientWidth: { configurable: true, value: 200 },
+    scrollWidth: { configurable: true, value: 400 },
+  });
+  vi.spyOn(scrollContainer, 'getBoundingClientRect').mockReturnValue({
+    left: 0,
+    right: 200,
+  } as DOMRect);
+  vi.spyOn(content, 'getBoundingClientRect').mockReturnValue({
+    left: 0,
+    right: 400,
+  } as DOMRect);
+};
+
+beforeEach(() => {
+  vi.stubGlobal('ResizeObserver', ResizeObserverMock);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe('MarkdownMathBlock', () => {
+  it('renders the formula in a scrollable container without adding a tab stop when it fits', () => {
+    const { scrollContainer } = renderMathBlock();
+
+    act(() => resizeObserverCallback([], {} as ResizeObserver));
+
+    expect(scrollContainer.className).toContain('overflow-x-auto');
+    expect(scrollContainer.getAttribute('role')).toBeNull();
+    expect(scrollContainer.getAttribute('aria-label')).toBeNull();
+    expect(scrollContainer.getAttribute('tabindex')).toBeNull();
+  });
+
+  it('exposes an overflowing formula as a labelled, keyboard-reachable region', () => {
+    const { scrollContainer, content } = renderMathBlock();
+    simulateOverflow(scrollContainer, content);
+
+    act(() => resizeObserverCallback([], {} as ResizeObserver));
+
+    expect(scrollContainer.getAttribute('role')).toBe('region');
+    expect(scrollContainer.getAttribute('aria-label')).toBe(
+      'Scrollable formula',
+    );
+    expect(scrollContainer.getAttribute('tabindex')).toBe('0');
+  });
+});

--- a/libs/chat-shared/src/components/MarkdownRenderer/Table/MarkdownTable.tsx
+++ b/libs/chat-shared/src/components/MarkdownRenderer/Table/MarkdownTable.tsx
@@ -1,5 +1,5 @@
 import { type FC, type ReactNode, memo } from 'react';
-import { useTableScroll } from '../../../hooks/useTableScroll';
+import { useHorizontalOverflow } from '../../../hooks/useHorizontalOverflow';
 import { buildCssVars } from '../../../utils/build-css-vars';
 import { mergeClasses } from '../../../utils/merge-class';
 import styles from './MarkdownTable.module.scss';
@@ -50,11 +50,11 @@ export const MarkdownTable: FC<MarkdownTableProps> = memo(
   }) => {
     const {
       scrollContainerRef,
-      tableRef,
+      contentRef,
       hasContentBeyondStart,
       hasContentBeyondEnd,
       handleScroll,
-    } = useTableScroll();
+    } = useHorizontalOverflow<HTMLTableElement>();
     const cssVars = buildCssVars({
       '--cm-markdown-border': colors?.border,
       '--cm-table-scrollbar': colors?.scrollbar,
@@ -95,7 +95,7 @@ export const MarkdownTable: FC<MarkdownTableProps> = memo(
           tabIndex={isScrollable ? 0 : undefined}
         >
           <table
-            ref={tableRef}
+            ref={contentRef}
             className={mergeClasses(
               'w-max min-w-full border-collapse',
               classNames.tableFont ?? 'dial-small-text',

--- a/libs/chat-shared/src/components/MarkdownRenderer/markdown-class-names.ts
+++ b/libs/chat-shared/src/components/MarkdownRenderer/markdown-class-names.ts
@@ -15,6 +15,7 @@ export const DEFAULT_MARKDOWN_CLASS_NAMES: MarkdownRendererClassNames = {
   blockquote: 'my-4',
   link: 'break-words [overflow-wrap:anywhere]',
   tableWrapper: 'my-4',
+  mathBlock: 'my-4',
 };
 
 /**

--- a/libs/chat-shared/src/components/MarkdownRenderer/tests/MarkdownRenderer.spec.tsx
+++ b/libs/chat-shared/src/components/MarkdownRenderer/tests/MarkdownRenderer.spec.tsx
@@ -45,6 +45,12 @@ const TWO_PARAGRAPHS_MARKDOWN = 'Paragraph one.\n\nParagraph two.';
 
 const LIST_MARKDOWN = '- Item one\n- Item two\n- Item three';
 
+const DISPLAY_MATH_MARKDOWN = `Einstein's field equations:
+
+$$
+R_{\\mu\\nu} - \\frac{1}{2}g_{\\mu\\nu}R + \\Lambda g_{\\mu\\nu} = \\frac{8\\pi G}{c^4}T_{\\mu\\nu}
+$$`;
+
 describe('MarkdownRenderer', () => {
   it('renders GFM tables in a horizontally scrollable container', () => {
     render(<MarkdownRenderer content={TABLE_MARKDOWN} />);
@@ -320,6 +326,54 @@ describe('MarkdownRenderer', () => {
      */
     // eslint-disable-next-line testing-library/no-node-access
     expect(document.querySelector('math')).toBeTruthy();
+  });
+
+  it('wraps block LaTeX in a horizontally scrollable container so a wide formula stays reachable', () => {
+    render(<MarkdownRenderer content={DISPLAY_MATH_MARKDOWN} />);
+
+    /*
+     * MathML elements have no accessible role under jsdom, so the scroll
+     * container is reached by walking up from the <math> element itself.
+     */
+    // eslint-disable-next-line testing-library/no-node-access
+    const math = document.querySelector('math[display="block"]');
+    // eslint-disable-next-line testing-library/no-node-access
+    const katexSpan = math?.parentElement;
+    // eslint-disable-next-line testing-library/no-node-access
+    const scrollContainer = katexSpan?.parentElement;
+
+    expect(math).toBeTruthy();
+    expect(katexSpan?.className).toContain('katex');
+    expect(scrollContainer?.className).toContain('overflow-x-auto');
+    expect(scrollContainer?.className).toContain('max-w-full');
+    expect(scrollContainer?.className).toContain('min-w-0');
+  });
+
+  it('keeps KaTeX wrapper classes through sanitization but drops classes from raw HTML', () => {
+    render(
+      <MarkdownRenderer
+        content={`${DISPLAY_MATH_MARKDOWN}\n\n<span class="injected">text</span><script>alert(1)</script>`}
+      />,
+    );
+
+    // eslint-disable-next-line testing-library/no-node-access -- class-level assertions have no semantic query
+    expect(document.querySelector('span.katex')).toBeTruthy();
+    // eslint-disable-next-line testing-library/no-node-access
+    expect(document.querySelector('span.injected')).toBeNull();
+    // eslint-disable-next-line testing-library/no-node-access
+    expect(document.querySelector('script')).toBeNull();
+  });
+
+  it('leaves inline LaTeX inside its paragraph rather than in a scroll container', () => {
+    render(<MarkdownRenderer content="Cost: $x + y$ per unit" />);
+
+    // eslint-disable-next-line testing-library/no-node-access -- see note above: MathML has no role under jsdom
+    const math = document.querySelector('math');
+    // eslint-disable-next-line testing-library/no-node-access
+    const katexSpan = math?.parentElement;
+
+    expect(math?.getAttribute('display')).toBeNull();
+    expect(katexSpan?.parentElement?.tagName).toBe('P');
   });
 
   it('renders single-dollar inline LaTeX as a KaTeX math element', () => {

--- a/libs/chat-shared/src/hooks/tests/useHorizontalOverflow.spec.tsx
+++ b/libs/chat-shared/src/hooks/tests/useHorizontalOverflow.spec.tsx
@@ -1,7 +1,7 @@
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import { type FC } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { useTableScroll } from '../../../../chat-shared/src/hooks/useTableScroll';
+import { useHorizontalOverflow } from '../useHorizontalOverflow';
 
 let resizeObserverCallback: ResizeObserverCallback;
 
@@ -21,16 +21,16 @@ class ResizeObserverMock {
   }
 }
 
-const TestTableScroll: FC<{ direction?: 'ltr' | 'rtl' }> = ({
+const TestHorizontalOverflow: FC<{ direction?: 'ltr' | 'rtl' }> = ({
   direction = 'ltr',
 }) => {
   const {
     scrollContainerRef,
-    tableRef,
+    contentRef,
     hasContentBeyondStart,
     hasContentBeyondEnd,
     handleScroll,
-  } = useTableScroll();
+  } = useHorizontalOverflow<HTMLTableElement>();
 
   return (
     <div
@@ -42,7 +42,7 @@ const TestTableScroll: FC<{ direction?: 'ltr' | 'rtl' }> = ({
       style={{ direction }}
       onScroll={handleScroll}
     >
-      <table ref={tableRef}>
+      <table ref={contentRef}>
         <tbody>
           <tr>
             <td>Value</td>
@@ -97,11 +97,11 @@ afterEach(() => {
   vi.unstubAllGlobals();
 });
 
-describe('useTableScroll', () => {
+describe('useHorizontalOverflow', () => {
   it.each(['ltr', 'rtl'] as const)(
     'tracks content beyond both logical edges in %s',
     (direction) => {
-      render(<TestTableScroll direction={direction} />);
+      render(<TestHorizontalOverflow direction={direction} />);
       const scrollContainer = setHorizontalMeasurements({
         direction,
         position: 'start',

--- a/libs/chat-shared/src/hooks/useHorizontalOverflow.ts
+++ b/libs/chat-shared/src/hooks/useHorizontalOverflow.ts
@@ -3,45 +3,51 @@ import { useCallback, useLayoutEffect, useRef, useState } from 'react';
 
 const OVERFLOW_TOLERANCE = 1;
 
-/** Return value of `useTableScroll`. */
-export interface UseTableScrollResult {
-  /** Ref attached to the horizontally scrollable table container. */
+/** Return value of `useHorizontalOverflow`. */
+export interface UseHorizontalOverflowResult<TContent extends HTMLElement> {
+  /** Ref attached to the horizontally scrollable container. */
   scrollContainerRef: RefObject<HTMLDivElement | null>;
-  /** Ref attached to the table whose visible bounds are measured. */
-  tableRef: RefObject<HTMLTableElement | null>;
-  /** Whether table content remains beyond the logical start of the viewport. */
+  /** Ref attached to the content element whose visible bounds are measured. */
+  contentRef: RefObject<TContent | null>;
+  /** Whether content remains beyond the logical start of the viewport. */
   hasContentBeyondStart: boolean;
-  /** Whether table content remains beyond the logical end of the viewport. */
+  /** Whether content remains beyond the logical end of the viewport. */
   hasContentBeyondEnd: boolean;
-  /** Re-measures the visible table bounds after horizontal scrolling. */
+  /** Re-measures the visible content bounds after horizontal scrolling. */
   handleScroll: UIEventHandler<HTMLDivElement>;
 }
 
-/** Tracks whether a horizontally scrollable table has content beyond its logical end. */
-export const useTableScroll = (): UseTableScrollResult => {
+/**
+ * Tracks whether horizontally scrollable content extends past either logical
+ * edge of its container, so a caller can render direction-aware affordances
+ * (edge fades, a focusable scroll region) only while scrolling is possible.
+ */
+export const useHorizontalOverflow = <
+  TContent extends HTMLElement,
+>(): UseHorizontalOverflowResult<TContent> => {
   const scrollContainerRef = useRef<HTMLDivElement>(null);
-  const tableRef = useRef<HTMLTableElement>(null);
+  const contentRef = useRef<TContent>(null);
   const [hasContentBeyondStart, setHasContentBeyondStart] = useState(false);
   const [hasContentBeyondEnd, setHasContentBeyondEnd] = useState(false);
 
   const measureContentBounds = useCallback(() => {
     const scrollContainer = scrollContainerRef.current;
-    const table = tableRef.current;
+    const content = contentRef.current;
 
-    if (!scrollContainer || !table) return;
+    if (!scrollContainer || !content) return;
 
     const hasOverflow =
       scrollContainer.scrollWidth - scrollContainer.clientWidth >
       OVERFLOW_TOLERANCE;
     const scrollContainerRect = scrollContainer.getBoundingClientRect();
-    const tableRect = table.getBoundingClientRect();
+    const contentRect = content.getBoundingClientRect();
     const isRtl = getComputedStyle(scrollContainer).direction === 'rtl';
     const contentExtendsBeyondStart = isRtl
-      ? tableRect.right > scrollContainerRect.right + OVERFLOW_TOLERANCE
-      : tableRect.left < scrollContainerRect.left - OVERFLOW_TOLERANCE;
+      ? contentRect.right > scrollContainerRect.right + OVERFLOW_TOLERANCE
+      : contentRect.left < scrollContainerRect.left - OVERFLOW_TOLERANCE;
     const contentExtendsBeyondEnd = isRtl
-      ? tableRect.left < scrollContainerRect.left - OVERFLOW_TOLERANCE
-      : tableRect.right > scrollContainerRect.right + OVERFLOW_TOLERANCE;
+      ? contentRect.left < scrollContainerRect.left - OVERFLOW_TOLERANCE
+      : contentRect.right > scrollContainerRect.right + OVERFLOW_TOLERANCE;
 
     setHasContentBeyondStart(hasOverflow && contentExtendsBeyondStart);
     setHasContentBeyondEnd(hasOverflow && contentExtendsBeyondEnd);
@@ -51,22 +57,22 @@ export const useTableScroll = (): UseTableScrollResult => {
     measureContentBounds();
 
     const scrollContainer = scrollContainerRef.current;
-    const table = tableRef.current;
+    const content = contentRef.current;
 
-    if (!scrollContainer || !table || typeof ResizeObserver === 'undefined') {
+    if (!scrollContainer || !content || typeof ResizeObserver === 'undefined') {
       return;
     }
 
     const resizeObserver = new ResizeObserver(measureContentBounds);
     resizeObserver.observe(scrollContainer);
-    resizeObserver.observe(table);
+    resizeObserver.observe(content);
 
     return () => resizeObserver.disconnect();
   }, [measureContentBounds]);
 
   return {
     scrollContainerRef,
-    tableRef,
+    contentRef,
     hasContentBeyondStart,
     hasContentBeyondEnd,
     handleScroll: measureContentBounds,


### PR DESCRIPTION
Issue #3773

## Problem

A display formula wider than the message column was clipped, with no way to reach the rest of it. QA re-confirmed it still reproduced on 2026-09-03.

With `output: 'mathml'`, KaTeX emits **no** `.katex-display` wrapper — inline and display math both come out as `<span class="katex">`, differing only by `display="block"` on the inner `<math>`. That span is inline, has no scroll container, and MathML never wraps, so the overflow was cut off by the first ancestor hiding overflow.

While fixing this I found a second, pre-existing defect on `development`: `rehype-sanitize` (added recently) whitelists the MathML **tag** names but none of their attributes, and the default schema knows no MathML. It was therefore stripping `display="block"` from every `<math>` and `class="katex"` from every wrapper span — so display math was already rendering as inline math, and block formulas could not be identified at all. The scroll fix cannot work without this, so both are addressed here.

## Changes

- **New `MarkdownMathBlock`** wraps display math in an `overflow-x-auto` container with a thin scrollbar. The inner `span.katex` becomes `display: block; width: max-content; min-width: 100%`, giving the container the formula's real width to scroll through while a short formula still fills the row.
- **`span` component override** routes only `span.katex` containing `<math display="block">` into that wrapper. Inline math and `katex-error` spans pass through untouched.
- **Sanitize schema** now allows KaTeX's MathML presentation attributes (`display`, `xmlns`, `encoding`, `linethickness`, `mathvariant`, `stretchy`, `columnalign`, …) — enumerated from KaTeX's actual output, all layout-only, none able to carry script or a URL. `className` on `<span>` is allowed **only** for the values `katex` / `katex-error`, so a class from raw model HTML is still dropped.
- **Accessibility**: the scroll container becomes a labelled `role="region"` with `tabIndex={0}` *only while it actually overflows*, so ordinary formulas add no tab stop or landmark noise. `mathScrollRegionAriaLabel` is exposed with an English default for the host to translate, mirroring the existing table prop.
- **Reuse**: the table's overflow-measuring hook is generalised as `useHorizontalOverflow` (was `useTableScroll`, `tableRef` → `contentRef`) and shared with the math block rather than duplicated. It was internal — never exported from `index.ts` — so the rename has no public impact.
- `MarkdownRenderer`'s private `buildMarkdownComponents` now takes an options object; a seventh adjacent `string | undefined` positional argument was a live footgun.

## Verification

- `lint`, `typecheck`, `test` (329 tests) and `build` green for `chat-shared`; `validate:docs` passes.
- New tests: block LaTeX lands in the scroll container; inline LaTeX stays in its `<p>`; the region/tab-stop appears only under simulated overflow; KaTeX classes survive sanitization while a raw `<span class="injected">` and a `<script>` do not.
- **Browser check** (jsdom cannot lay out MathML) — drove the issue's own quartic formula through the real plugin chain, sanitize included, in Chromium:
  - `display="block"` and `class="katex"` survive; `<math>` computes to `display: block math`.
  - Wide formula: `scrollWidth` 1274 vs `clientWidth` 606 → scrollbar present, scrolling reveals the previously hidden tail including the closing paren.
  - Short formula (`5 - 4 = 1`): 606 = 606 → not scrollable, no tab stop.
  - RTL keeps the same scroll range.

## Note

`mathScrollRegionAriaLabel` is not yet plumbed from the app through `MDMessageViewer`. The existing `tableScrollRegionAriaLabel` isn't either — no consumer passes it — so both currently fall back to their English defaults. Worth a separate pass if we want them translated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
