### PR TITLE
chore(deps): bump ui-kit to 0.14.0-dev.28 and file-manager to 0.2.0-dev.11

### DIFF
--- a/libs/prompt-editor/src/components/PromptEditor/PromptEditor.tsx
+++ b/libs/prompt-editor/src/components/PromptEditor/PromptEditor.tsx
@@ -79,6 +79,7 @@ export const PromptEditor: FC<PromptEditorProps> = ({
     ...initialValues,
   });
   const contentLabelId = useId();
+  const contentEditorId = useId();
 
   /* Hosts that load asynchronously re-seed the form through `initialValues`. */
   useEffect(() => {
@@ -209,8 +210,13 @@ export const PromptEditor: FC<PromptEditorProps> = ({
           aria-labelledby={contentLabelId}
           className="flex flex-1 flex-col gap-2"
         >
+          {/*
+           * htmlFor is what names the editor's textarea; without it the label
+           * is only visible text sitting above an unnamed control.
+           */}
           <Label
             id={contentLabelId}
+            htmlFor={contentEditorId}
             label={labels?.contentLabel ?? 'Instructions'}
             required
             className={contentLabelClassName}
@@ -225,6 +231,7 @@ export const PromptEditor: FC<PromptEditorProps> = ({
             }
           >
             <MarkdownEditor
+              id={contentEditorId}
               value={values.content}
               onChange={(value) => setField('content', value)}
               height={480}

--- a/libs/prompt-editor/src/components/PromptEditor/tests/PromptEditor.spec.tsx
+++ b/libs/prompt-editor/src/components/PromptEditor/tests/PromptEditor.spec.tsx
@@ -17,12 +17,15 @@ vi.mock('@epam/ai-dial-ui-kit', async () => {
           value,
           onChange,
           placeholder,
+          id,
         }: {
           value?: string;
           onChange?: (value: string) => void;
           placeholder?: string;
+          id?: string;
         }) => (
           <textarea
+            id={id}
             value={value}
             placeholder={placeholder}
             onChange={(event) => onChange?.(event.target.value)}
@@ -206,5 +209,10 @@ describe('PromptEditor', () => {
 
     expect(screen.getByRole('heading', { name: 'Neuer Prompt' })).toBeTruthy();
     expect(screen.getByRole('button', { name: 'OK' })).toBeTruthy();
+  });
+  it('names the Instructions editor through its label', () => {
+    renderEditor();
+
+    expect(screen.getByRole('textbox', { name: /Instructions/ })).toBeTruthy();
   });
 });

--- a/libs/scheduled-tasks/src/components/ScheduledTaskCreateForm/ScheduledTaskCreateForm.tsx
+++ b/libs/scheduled-tasks/src/components/ScheduledTaskCreateForm/ScheduledTaskCreateForm.tsx
@@ -11,7 +11,7 @@ import {
   LazyMarkdownEditor,
   Select,
 } from '@epam/ai-dial-ui-kit';
-import { lazy, Suspense, type FC } from 'react';
+import { lazy, Suspense, useId, type FC } from 'react';
 import { DESCRIPTION_MAX_LENGTH } from '../../constants/scheduled-task-create-form';
 import { ScheduledTaskCreateFormProps } from '../../models/scheduled-task-create-form-props';
 import { ScheduledTaskRepeat } from '../../types/scheduled-task-schedule';
@@ -54,6 +54,7 @@ export const ScheduledTaskCreateForm: FC<ScheduledTaskCreateFormProps> = ({
   markdownEditorTheme,
   styles: formStyles,
 }) => {
+  const instructionsEditorId = useId();
   const { colors, typography } = formStyles ?? {};
   const titleClassName = typography?.titleClassName ?? 'dial-h1-text';
   const sectionTitleClassName =
@@ -382,16 +383,21 @@ export const ScheduledTaskCreateForm: FC<ScheduledTaskCreateFormProps> = ({
           </p>
         </div>
 
-        <div
-          role="group"
-          aria-label={labels.instructionsLabel}
-          className="flex flex-1 flex-col gap-1"
-        >
-          <span className={instructionsLabelClassName}>
+        <div className="flex flex-1 flex-col gap-1">
+          {/*
+           * A real <label for>, not a span: the markdown editor renders a plain
+           * textarea, and text sitting next to it names nothing the browser
+           * associates with the control.
+           */}
+          <label
+            htmlFor={instructionsEditorId}
+            className={instructionsLabelClassName}
+          >
             {labels.instructionsLabel}
-          </span>
+          </label>
           <Suspense fallback={<Spinner />}>
             <MarkdownEditor
+              id={instructionsEditorId}
               value={values.prompt}
               onChange={(value) => onFieldChange('prompt', value)}
               height={480}

--- a/libs/scheduled-tasks/src/components/ScheduledTaskCreateForm/tests/ScheduledTaskCreateForm.spec.tsx
+++ b/libs/scheduled-tasks/src/components/ScheduledTaskCreateForm/tests/ScheduledTaskCreateForm.spec.tsx
@@ -198,11 +198,17 @@ vi.mock('@epam/ai-dial-ui-kit', () => ({
       MarkdownEditor: ({
         value,
         onChange,
+        id,
       }: {
         value: string;
         onChange: (value: string) => void;
+        id?: string;
       }) => (
-        <textarea value={value} onChange={(e) => onChange(e.target.value)} />
+        <textarea
+          id={id}
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+        />
       ),
     }),
 }));
@@ -420,6 +426,12 @@ describe('ScheduledTaskCreateForm', () => {
     expect(save.disabled).toBe(true);
     expect(save.getAttribute('aria-busy')).toBe('false');
     expect(screen.getByRole('status').textContent).toBe('');
+  });
+
+  it('names the Instructions editor through a real label association', async () => {
+    await renderForm();
+
+    expect(screen.getByRole('textbox', { name: 'Instructions' })).toBeTruthy();
   });
 
   it('renders Details and Configuration as two distinct regions', async () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,11 +14,11 @@
         "libs/*"
       ],
       "dependencies": {
-        "@epam/ai-dial-react-file-manager": "0.2.0-dev.10",
+        "@epam/ai-dial-react-file-manager": "0.2.0-dev.11",
         "@epam/ai-dial-react-pdf-highlighter": "0.2.0-dev.28",
         "@epam/ai-dial-shared": "0.48.0",
         "@epam/ai-dial-typescript-sdk": "0.1.0-dev.39",
-        "@epam/ai-dial-ui-kit": "^0.14.0-dev.15",
+        "@epam/ai-dial-ui-kit": "^0.14.0-dev.28",
         "@epam/ai-dial-visualizer-connector": "0.48.0",
         "@epam/pdf-highlighter-kit": "^0.0.18",
         "@mcp-ui/client": "^7.1.1",
@@ -2609,9 +2609,9 @@
       "link": true
     },
     "node_modules/@epam/ai-dial-react-file-manager": {
-      "version": "0.2.0-dev.10",
-      "resolved": "https://registry.npmjs.org/@epam/ai-dial-react-file-manager/-/ai-dial-react-file-manager-0.2.0-dev.10.tgz",
-      "integrity": "sha512-FztNM1pzn8boAAIfCM997UA2iVAyXck7Uo6OrmfjCLAC+iCbdXtNC42k1Rb2hOVpRd1WwsEs0AfFCrfnpTZ/QQ==",
+      "version": "0.2.0-dev.11",
+      "resolved": "https://registry.npmjs.org/@epam/ai-dial-react-file-manager/-/ai-dial-react-file-manager-0.2.0-dev.11.tgz",
+      "integrity": "sha512-eEla63qmnm+MEnWAljjLzFgrSjW1HQH1E39Bese5yQjsJmRTsopvMBphBGOronX4zQTdr47prmWBrbDaPhc+MQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "classnames": "^2.5.1",
@@ -2697,9 +2697,9 @@
       }
     },
     "node_modules/@epam/ai-dial-ui-kit": {
-      "version": "0.14.0-dev.15",
-      "resolved": "https://registry.npmjs.org/@epam/ai-dial-ui-kit/-/ai-dial-ui-kit-0.14.0-dev.15.tgz",
-      "integrity": "sha512-UAf6C7UIDHC0QQ3AxKjoctluBxEHOZkfn7B6Tp80bRRcdhV4IPfoXoKbpcbpb+7ha9JML8F1Ahhr9dNqHoFdjA==",
+      "version": "0.14.0-dev.28",
+      "resolved": "https://registry.npmjs.org/@epam/ai-dial-ui-kit/-/ai-dial-ui-kit-0.14.0-dev.28.tgz",
+      "integrity": "sha512-OhOCcl9vEgdS3fRNpYD8gInbegv5zySV55Y3tMn3N82cEbTPAbrUOGHxQySltiS7WL7VPQS8X/EvuYXd+h8viw==",
       "license": "Apache-2.0",
       "dependencies": {
         "ag-grid-community": "^35.2.1",

--- a/package.json
+++ b/package.json
@@ -118,11 +118,11 @@
     "webpack-node-externals": "^3.0.0"
   },
   "dependencies": {
-    "@epam/ai-dial-react-file-manager": "0.2.0-dev.10",
+    "@epam/ai-dial-react-file-manager": "0.2.0-dev.11",
     "@epam/ai-dial-react-pdf-highlighter": "0.2.0-dev.28",
     "@epam/ai-dial-shared": "0.48.0",
     "@epam/ai-dial-typescript-sdk": "0.1.0-dev.39",
-    "@epam/ai-dial-ui-kit": "^0.14.0-dev.15",
+    "@epam/ai-dial-ui-kit": "^0.14.0-dev.28",
     "@epam/ai-dial-visualizer-connector": "0.48.0",
     "@epam/pdf-highlighter-kit": "^0.0.18",
     "@mcp-ui/client": "^7.1.1",


### PR DESCRIPTION
Picks up two upstream fixes and wires the one that needs a call-site change. Together these close the last two open findings from the QA divergence triage in #8604.

| Package | From | To | Brings |
| --- | --- | --- | --- |
| `@epam/ai-dial-react-file-manager` | 0.2.0-dev.10 | 0.2.0-dev.11 | epam/ai-dial-react-file-manager#29 — batch-upload partition |
| `@epam/ai-dial-ui-kit` | 0.14.0-dev.15 | 0.14.0-dev.28 | epam/ai-dial-ui-kit#851 — `MarkdownEditor` accessible name |

## TC-FILE-0125 — no call-site change needed

A batch mixing colliding and free file names no longer waits as a whole on the conflict popup: the free names upload immediately, only the colliding ones hold. `useDialFileUploadBatch` already derived an upload mode per file and uploaded straight away — it was simply never invoked until the popup was resolved, so the bump is the whole fix on our side.

## TC-TASK-0045 — wired here

The kit's `MarkdownEditor` now accepts `id` and `ariaLabel`, which is what lets its underlying textarea be named at all. Both Instructions editors are updated:

- **`ScheduledTaskCreateForm`** rendered its label as a `<span>` beside the editor. A span names nothing the browser associates with a control, so the textarea was announced as unlabelled even though the form looked labelled. It is now a real `<label htmlFor>` pointing at the editor's `id`. The `role="group" aria-label` wrapper around that single field goes with it — it existed to give the region a name that the control itself now carries, and leaving it would announce "Instructions" twice.
- **`PromptEditor`** already used the kit's `Label`, whose own docs call for `htmlFor` in exactly this case, but was not passing it. It now does. This surface was not in the QA report and had the same defect.

## Test plan

- A test in each form asserts `getByRole('textbox', { name: 'Instructions' })` — the association, not the visible text. Both editor mocks now forward `id`, without which the assertion would pass vacuously.
- `lint`, `typecheck` and `test` green for `@epam/chat` and the nine libs depending on either package.
- `nx build @epam/chat` and `npm run validate:docs` pass.

Two pre-existing `typecheck` failures are unaffected and unrelated — `@epam/chat-api` (801 implicit-any errors in specs) and `mcp-app-sandbox` (`main.ts:28`, `number | undefined` port). Neither project depends on either bumped package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
