### PR TITLE
feat(chat): show model name and version in composer selector

### DIFF
--- a/apps/chat/src/components/ConversationView/ConversationView.tsx
+++ b/apps/chat/src/components/ConversationView/ConversationView.tsx
@@ -336,6 +336,7 @@ const ConversationView: FC<Props> = ({
         ({
           id,
           displayName,
+          displayVersion,
           iconUrl,
           type,
           inputAttachmentTypes,
@@ -343,6 +344,7 @@ const ConversationView: FC<Props> = ({
         }) => ({
           id,
           displayName: resolveLocalizedText(displayName, language),
+          displayVersion,
           iconUrl: iconUrl ? resolveCatalogIconUrl(iconUrl) : undefined,
           type,
           inputAttachmentTypes,

--- a/apps/chat/src/pages/ConversationRoute/ConversationRoute.tsx
+++ b/apps/chat/src/pages/ConversationRoute/ConversationRoute.tsx
@@ -230,13 +230,23 @@ const ConversationRoute: FC = () => {
 
   const deploymentItems: DeploymentItem[] = useMemo(
     () =>
-      items.map(({ id, displayName, iconUrl, type, inputAttachmentTypes }) => ({
-        id,
-        displayName: resolveLocalizedText(displayName, language),
-        iconUrl: iconUrl ? resolveCatalogIconUrl(iconUrl) : undefined,
-        type,
-        inputAttachmentTypes,
-      })),
+      items.map(
+        ({
+          id,
+          displayName,
+          displayVersion,
+          iconUrl,
+          type,
+          inputAttachmentTypes,
+        }) => ({
+          id,
+          displayName: resolveLocalizedText(displayName, language),
+          displayVersion,
+          iconUrl: iconUrl ? resolveCatalogIconUrl(iconUrl) : undefined,
+          type,
+          inputAttachmentTypes,
+        }),
+      ),
     [items, language],
   );
 

--- a/libs/conversation-input/src/components/Input/Input.module.scss
+++ b/libs/conversation-input/src/components/Input/Input.module.scss
@@ -37,6 +37,17 @@
     color: var(--ci-model-selector-caret-color, var(--text-primary, #161b2d));
   }
 
+  .modelSelectorName {
+    color: var(--ci-model-selector-name-color, var(--text-primary, #161b2d));
+  }
+
+  .modelSelectorVersion {
+    color: var(
+      --ci-model-selector-version-color,
+      var(--text-secondary, #57647a)
+    );
+  }
+
   &:hover {
     background: var(
       --ci-model-selector-hover-bg,

--- a/libs/conversation-input/src/components/Input/Input.tsx
+++ b/libs/conversation-input/src/components/Input/Input.tsx
@@ -130,6 +130,8 @@ export const Input: FC<InputProps> = ({
         '--ci-model-selector-caret-color': colors?.modelSelectorCaret,
         '--ci-model-selector-hover-bg': colors?.modelSelectorHoverBg,
         '--ci-model-selector-disabled-color': colors?.modelSelectorDisabled,
+        '--ci-model-selector-name-color': colors?.modelSelectorName,
+        '--ci-model-selector-version-color': colors?.modelSelectorVersion,
         '--ci-voice-error': colors?.voiceError,
         '--ci-voice-waveform': colors?.voiceWaveform,
         '--ci-voice-accent': colors?.voiceAccent,

--- a/libs/conversation-input/src/components/Input/ModelSelectorControl.tsx
+++ b/libs/conversation-input/src/components/Input/ModelSelectorControl.tsx
@@ -61,6 +61,7 @@ export const ModelSelectorControl: FC<Props> = ({
     selectorIcon,
     selectorAriaLabel,
     selectedLabel,
+    selectedVersion,
     menuItems,
     menuHeader,
     onOpenChange: handleModelSelectorOpenChange,
@@ -144,6 +145,10 @@ export const ModelSelectorControl: FC<Props> = ({
   }
 
   if (modelPickerOverlay) {
+    const chipTooltip = selectedVersion
+      ? `${selectedLabel} · ${selectedVersion}`
+      : selectedLabel;
+
     return (
       <Dropdown
         placement="top-end"
@@ -157,13 +162,13 @@ export const ModelSelectorControl: FC<Props> = ({
         }
         listClassName="!w-[368px] !bg-layer-raised"
       >
-        <Tooltip tooltip={selectedLabel}>
+        <Tooltip tooltip={chipTooltip}>
           <button
             type="button"
             aria-label={selectorAriaLabel}
             aria-disabled={isDisabled || undefined}
             className={mergeClasses(
-              'flex items-center justify-center gap-1 rounded-full p-2',
+              'flex min-w-0 items-center gap-1.5 rounded-full py-1.5 pe-2 ps-1.5',
               styles.modelSelectorButton,
               disabledIconClassName,
               isDisabled && styles.modelSelectorButtonDisabled,
@@ -175,6 +180,26 @@ export const ModelSelectorControl: FC<Props> = ({
             }}
           >
             {selectorIcon}
+            <span className="flex min-w-0 max-w-[180px] items-baseline gap-1">
+              <span
+                className={mergeClasses(
+                  'dial-small-text max-w-[180px] shrink-0 truncate',
+                  styles.modelSelectorName,
+                )}
+              >
+                {selectedLabel}
+              </span>
+              {selectedVersion && (
+                <span
+                  className={mergeClasses(
+                    'dial-tiny-text min-w-0 truncate',
+                    styles.modelSelectorVersion,
+                  )}
+                >
+                  {selectedVersion}
+                </span>
+              )}
+            </span>
             {caretIcon}
           </button>
         </Tooltip>

--- a/libs/conversation-input/src/hooks/useModelSelector.tsx
+++ b/libs/conversation-input/src/hooks/useModelSelector.tsx
@@ -68,6 +68,8 @@ export interface UseModelSelectorResult {
   selectorAriaLabel: string;
   /** Display name of the currently selected deployment, or `undefined` when none is selected or loading. */
   selectedLabel: string | undefined;
+  /** Display version of the currently selected deployment, or `undefined` when none is selected, loading, or the deployment has no version. */
+  selectedVersion: string | undefined;
   /** Menu items for the deployment dropdown. */
   menuItems: DropdownItem[];
   /** Sticky search header rendered above the menu items. */
@@ -123,6 +125,7 @@ export const useModelSelector = ({
   );
 
   const selectedLabel = selectedItem?.displayName ?? selectedItem?.id;
+  const selectedVersion = selectedItem?.displayVersion;
   const selectorAriaLabel = selectedLabel
     ? `${modelSelectorLabels?.ariaLabel ?? 'Select model'}: ${selectedLabel}`
     : (modelSelectorLabels?.ariaLabel ?? 'Select model');
@@ -240,6 +243,7 @@ export const useModelSelector = ({
     selectorIcon,
     selectorAriaLabel,
     selectedLabel,
+    selectedVersion,
     menuItems,
     menuHeader,
     onOpenChange: handleOpenChange,

--- a/libs/conversation-input/src/models/Input.ts
+++ b/libs/conversation-input/src/models/Input.ts
@@ -37,6 +37,10 @@ export interface InputColors {
   modelSelectorHoverBg?: string;
   /** Model-selector chip caret color when disabled. Defaults to `--text-control-disable-primary`. */
   modelSelectorDisabled?: string;
+  /** Model-selector chip name text color (desktop only). Defaults to `--text-primary`. */
+  modelSelectorName?: string;
+  /** Model-selector chip version text color (desktop only). Defaults to `--text-secondary`. */
+  modelSelectorVersion?: string;
   /** Voice bar error border/icon color. Defaults to `--stroke-error`/`--text-error`. */
   voiceError?: string;
   /** Voice bar waveform and timer text color. Defaults to `--text-primary`. */


### PR DESCRIPTION
**Description:**

Adds the model's display version alongside its name in the conversation composer's model-selector chip. `DeploymentItem.displayVersion` is threaded from the catalog mapping (`ConversationView`, `ConversationRoute`) through `conversation-input`'s `useModelSelector` hook into `ModelSelectorControl`, with new theming hooks (`modelSelectorName`, `modelSelectorVersion` colors) in `Input.ts`/`Input.module.scss`.

The chip's name+version text is bounded to a max width and truncates gracefully — version yields first, name only truncates on its own if no version is present — with the full "Name · Version" text restored as a tooltip. Mobile continues to render icon + caret only.

Issues:

- No issue tracked for this change (explicitly skipped per request).

**UI changes**

The model-selector chip in the chat composer now shows the model name and version text next to the icon, instead of icon + caret only, with a hover tooltip showing the full name/version. No screenshots captured for this PR.

**Checklist:**

- [x] the pull request name complies with Conventional Commits
- [x] the pull request name starts with `feat(chat):`
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` — skipped, no issue ID provided
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)