### PR TITLE
docs(spec): name the DIAL Core spelling of inputAttachmentTypes where tests read it

### DIFF
--- a/openspec/specs/attachment-unsupported-type-error/spec.md
+++ b/openspec/specs/attachment-unsupported-type-error/spec.md
@@ -12,6 +12,16 @@ Before calling `onUploadAttachment`, the app SHALL validate each attachment's MI
 
 A file is invalid when none of the allowed MIME entries match: exact equality (`application/pdf`) OR wildcard prefix match (`image/*` matches `image/jpeg`). Global wildcards `*` and `*/*` match any MIME type. When `inputAttachmentTypes` is empty or undefined, the attachment button is hidden; however, clipboard paste of images can still add attachments and will reach this validation path. Long pasted plain text is handled separately — see the `isAttachmentsEnabled` requirement in `conversation-input-attachments`.
 
+**Which `inputAttachmentTypes` this is.** The name belongs to the BFF's own API
+(`DeploymentItemDto`, `ModelDetailsDto`, `ApplicationDetailsDto`) and to everything
+downstream of it, which is what this requirement describes. DIAL Core sends the same
+field one layer up as **`input_attachment_types`**, and
+`deployment-mapper.util.ts` renames it on the way through — see the field table in
+`deployments-api`. Read the camelCase name from `/api/v1/deployments`, and the
+snake_case one only from a raw Core payload. Asking Core for the camelCase name
+returns `undefined` for every deployment, which reads as "this model accepts no
+attachments" and is indistinguishable from a model that genuinely accepts none.
+
 Invalid files SHALL be placed immediately into `status: RequestStatus.Error` with `errorReason: AttachmentErrorReason.UnsupportedType` without calling `onUploadAttachment`.
 
 After processing a batch of added files (from file picker, drag-and-drop, or clipboard), if any were invalid the app SHALL show exactly one error notification through the variant-specific `showErrorNotification` helper, with:

--- a/openspec/specs/conversation-input-attachments/spec.md
+++ b/openspec/specs/conversation-input-attachments/spec.md
@@ -291,6 +291,10 @@ The host app is responsible for setting `isAttachmentsEnabled` based on whether 
 - When no deployment is selected, the prop is omitted (undefined → `true`), allowing conversion.
 - When a deployment is selected, the host passes `isAttachmentsEnabled={isAttachmentsAllowed}` where `isAttachmentsAllowed` is derived from `selectedDeployment.inputAttachmentTypes` being non-empty.
 
+`selectedDeployment` here is the BFF's `DeploymentItemDto`, so the field is
+`inputAttachmentTypes`. In a raw DIAL Core payload the same field is
+`input_attachment_types` — see the note in `attachment-unsupported-type-error`.
+
 This prevents the erroneous "Attachments not supported" error banner that appeared when a user pasted a long prompt into the input while a model with no attachment support was selected.
 
 #### Scenario: Long pasted text on a model without attachment support stays inline


### PR DESCRIPTION
Spec-only; no code changes. Closes the gap that sent a UI autotest to the wrong deployment.

## The gap

`inputAttachmentTypes` is the **BFF's** name for the field. DIAL Core sends the same thing one layer up as **`input_attachment_types`**, and [`deployment-mapper.util.ts`](../blob/development/apps/chat-api/src/deployments/utils/deployment-mapper.util.ts) renames it in between:

```ts
inputAttachmentTypes: Array.isArray(raw.input_attachment_types)
  ? raw.input_attachment_types
  : undefined,
```

That rename **is** documented — but only in `deployments-api`, which is not the spec anyone writing an attachment test opens. The two specs they do open, `attachment-unsupported-type-error` and `conversation-input-attachments`, name only the camelCase form and never say which layer it belongs to.

## What it cost

A UI autotest picked its fixture by looking for a deployment with no attachment support, reading `inputAttachmentTypes` from a raw Core payload. The key does not exist there, so **every** deployment answered `undefined` — which is precisely the value that means "this model accepts no attachments". The picker accepted the first model it saw, and the attachment scenarios ran against a deployment that was never the intended one.

The failure is silent by construction: a wrong-layer read and a genuine "no attachments" answer are the same value.

## What changed

Both specs now carry a short cross-reference stating which layer owns which spelling, where the rename happens, and why the wrong-layer read is indistinguishable from a real answer. Nothing behavioural is described differently — camelCase remains correct for the layer these specs cover, and no name is changed anywhere.

## For QA

Read the list from the BFF's `/api/v1/deployments`, where `inputAttachmentTypes` is correct and the shape matches what the UI itself sees; use `input_attachment_types` only against a raw Core payload. Fixture selection for the attachment scenarios is worth re-checking on that basis — TC-ATT-0002, which needs a deployment whose accepted types genuinely exclude `image/png`, is the one most likely to have been running against the wrong model.

## Test plan

`npm run validate:docs` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
