### PR TITLE
fix: expose catalog properties for applications and toolsets on Overview tab

### DIFF
--- a/apps/chat-api/src/deployments/details/deployments-details.service.ts
+++ b/apps/chat-api/src/deployments/details/deployments-details.service.ts
@@ -25,8 +25,8 @@ import type { DeploymentDetailsDto } from '../dto/deployment-details.dto';
 import { DeploymentItemType } from '../dto/deployment-item.dto';
 import {
   getNumber,
-  getString,
   isRecord,
+  mapCatalogProperties,
   mapDeploymentFeatures,
   mapToolsetAuthSettings,
   redactToolsetAuthSettings,
@@ -291,24 +291,7 @@ export class DeploymentsDetailsService {
           : undefined,
         pricing: raw.pricing,
         features: mapDeploymentFeatures(raw.features),
-        catalogProperties: (() => {
-          if (!isRecord(raw.catalog_properties)) return undefined;
-
-          const properties = {
-            provider: getString(raw.catalog_properties, 'provider'),
-            vendor: getString(raw.catalog_properties, 'vendor'),
-            license: getString(raw.catalog_properties, 'license'),
-            knowledgeCutoffDate: getString(
-              raw.catalog_properties,
-              'knowledgeCutoffDate',
-            ),
-            parameters: getString(raw.catalog_properties, 'parameters'),
-          };
-
-          return Object.values(properties).some((value) => value != null)
-            ? properties
-            : undefined;
-        })(),
+        catalogProperties: mapCatalogProperties(raw.catalog_properties),
         owner: raw.owner,
         inputAttachmentTypes: Array.isArray(raw.input_attachment_types)
           ? raw.input_attachment_types
@@ -404,6 +387,7 @@ export class DeploymentsDetailsService {
         inputAttachmentTypes: Array.isArray(raw.input_attachment_types)
           ? raw.input_attachment_types
           : undefined,
+        catalogProperties: mapCatalogProperties(raw.catalog_properties),
         applicationTypeSchemaId: raw.application_type_schema_id,
         endpoint:
           typeof customAppRaw?.endpoint === 'string'
@@ -472,6 +456,7 @@ export class DeploymentsDetailsService {
         authSettings: mapToolsetAuthSettings(raw.auth_settings),
         owner: raw.owner,
         features: mapDeploymentFeatures(raw.features),
+        catalogProperties: mapCatalogProperties(raw.catalog_properties),
         createdAt: raw.created_at,
       },
     };

--- a/apps/chat-api/src/deployments/details/tests/deployments-details.service.spec.ts
+++ b/apps/chat-api/src/deployments/details/tests/deployments-details.service.spec.ts
@@ -512,6 +512,55 @@ describe('DeploymentsDetailsService', () => {
       expect(JSON.stringify(result)).not.toContain('editor.example.com');
     });
 
+    it('maps catalog_properties for an application, ignoring unknown/non-string keys', async () => {
+      const { service, sdkClient } = makeService();
+      sdkClient.getApplication.mockResolvedValue(
+        okResponse({
+          id: 'applications/als-test-catalog',
+          catalog_properties: {
+            provider: 'Provider',
+            vendor: 'Vendor',
+            license: 'License',
+            knowledgeCutoffDate: '2026-08-17',
+            parameters: '100B',
+            schemaSpecificExtra: 'not exposed',
+          },
+        }),
+      );
+
+      const result = await service.getDeploymentDetails(
+        'user1',
+        'applications/als-test-catalog',
+        'token',
+      );
+
+      expect(result.applicationDetails?.catalogProperties).toEqual({
+        provider: 'Provider',
+        vendor: 'Vendor',
+        license: 'License',
+        knowledgeCutoffDate: '2026-08-17',
+        parameters: '100B',
+      });
+    });
+
+    it('omits catalogProperties for an application when no recognized string value is present', async () => {
+      const { service, sdkClient } = makeService();
+      sdkClient.getApplication.mockResolvedValue(
+        okResponse({
+          id: 'applications/als-test-catalog',
+          catalog_properties: { schemaSpecificExtra: 'not exposed' },
+        }),
+      );
+
+      const result = await service.getDeploymentDetails(
+        'user1',
+        'applications/als-test-catalog',
+        'token',
+      );
+
+      expect(result.applicationDetails?.catalogProperties).toBeUndefined();
+    });
+
     it('maps display_name for an application', async () => {
       const { service, sdkClient } = makeService();
       sdkClient.getApplication.mockResolvedValue(
@@ -637,6 +686,55 @@ describe('DeploymentsDetailsService', () => {
       });
       expect(JSON.stringify(result)).not.toContain('super-secret');
       expect(JSON.stringify(result)).toContain('public-client-id');
+    });
+
+    it('maps catalog_properties for a toolset, ignoring unknown/non-string keys', async () => {
+      const { service, sdkClient } = makeService();
+      sdkClient.getToolset.mockResolvedValue(
+        okResponse({
+          id: 'toolsets/ALS-OauthToolset-copy',
+          catalog_properties: {
+            provider: 'Provider',
+            vendor: 'Vendor',
+            license: 'License',
+            knowledgeCutoffDate: '2026-08-17',
+            parameters: '100B',
+            schemaSpecificExtra: 'not exposed',
+          },
+        }),
+      );
+
+      const result = await service.getDeploymentDetails(
+        'user1',
+        'toolsets/ALS-OauthToolset-copy',
+        'token',
+      );
+
+      expect(result.toolsetDetails?.catalogProperties).toEqual({
+        provider: 'Provider',
+        vendor: 'Vendor',
+        license: 'License',
+        knowledgeCutoffDate: '2026-08-17',
+        parameters: '100B',
+      });
+    });
+
+    it('omits catalogProperties for a toolset when no recognized string value is present', async () => {
+      const { service, sdkClient } = makeService();
+      sdkClient.getToolset.mockResolvedValue(
+        okResponse({
+          id: 'toolsets/ALS-OauthToolset-copy',
+          catalog_properties: { schemaSpecificExtra: 'not exposed' },
+        }),
+      );
+
+      const result = await service.getDeploymentDetails(
+        'user1',
+        'toolsets/ALS-OauthToolset-copy',
+        'token',
+      );
+
+      expect(result.toolsetDetails?.catalogProperties).toBeUndefined();
     });
 
     it('logs the raw DIAL Core toolset response and the mapped response, redacting client_secret/code_verifier from the raw-response log', async () => {

--- a/apps/chat-api/src/deployments/dto/deployment-details.dto.ts
+++ b/apps/chat-api/src/deployments/dto/deployment-details.dto.ts
@@ -345,6 +345,9 @@ export class ApplicationDetailsDto {
   })
   inputAttachmentTypes?: string[];
 
+  @ApiPropertyOptional({ type: ModelCatalogPropertiesDto })
+  catalogProperties?: ModelCatalogPropertiesDto;
+
   @ApiPropertyOptional({
     description: 'URI of the custom application type schema, when present',
   })
@@ -396,6 +399,9 @@ export class ToolsetDetailsDto {
 
   @ApiPropertyOptional({ type: DeploymentFeaturesDetailsDto })
   features?: DeploymentFeaturesDetailsDto;
+
+  @ApiPropertyOptional({ type: ModelCatalogPropertiesDto })
+  catalogProperties?: ModelCatalogPropertiesDto;
 
   @ApiPropertyOptional({
     description:

--- a/apps/chat-api/src/deployments/utils/deployment-mapper.util.ts
+++ b/apps/chat-api/src/deployments/utils/deployment-mapper.util.ts
@@ -1,6 +1,7 @@
 import { getResourceDisplayNameFallback } from '../../common/utils/resource-name';
 import type {
   DeploymentFeaturesDetailsDto,
+  ModelCatalogPropertiesDto,
   ToolsetAuthSettingsDto,
 } from '../dto/deployment-details.dto';
 import { DeploymentItemType } from '../dto/deployment-item.dto';
@@ -141,6 +142,31 @@ export const redactToolsetAuthSettings = (raw: unknown): unknown => {
  * reasoning_efforts), so this reads defensively off the raw object instead of
  * the typed SDK shape.
  */
+/**
+ * Allow-lists `catalog_properties` (schema-driven, identical shape across
+ * model/application/toolset DIAL Core responses) to the five recognized
+ * string fields shown in the catalog Overview panel. Unknown keys and
+ * non-string values are dropped; the result is omitted entirely rather than
+ * returned as an empty object when nothing recognized remains.
+ */
+export const mapCatalogProperties = (
+  raw: unknown,
+): ModelCatalogPropertiesDto | undefined => {
+  if (!isRecord(raw)) return undefined;
+
+  const properties = {
+    provider: getString(raw, 'provider'),
+    vendor: getString(raw, 'vendor'),
+    license: getString(raw, 'license'),
+    knowledgeCutoffDate: getString(raw, 'knowledgeCutoffDate'),
+    parameters: getString(raw, 'parameters'),
+  };
+
+  return Object.values(properties).some((value) => value != null)
+    ? properties
+    : undefined;
+};
+
 export const mapDeploymentFeatures = (
   raw: unknown,
 ): DeploymentFeaturesDetailsDto | undefined => {

--- a/libs/chat-api-client/openapi.json
+++ b/libs/chat-api-client/openapi.json
@@ -2460,7 +2460,9 @@
           }
         },
         "summary": "Attach to an active generation and replay it live",
-        "tags": ["conversations"]
+        "tags": [
+          "conversations"
+        ]
       }
     },
     "/api/v1/conversations/watch": {
@@ -7906,6 +7908,9 @@
               "type": "string"
             }
           },
+          "catalogProperties": {
+            "$ref": "#/components/schemas/ModelCatalogPropertiesDto"
+          },
           "applicationTypeSchemaId": {
             "type": "string",
             "description": "URI of the custom application type schema, when present"
@@ -8036,6 +8041,9 @@
           },
           "features": {
             "$ref": "#/components/schemas/DeploymentFeaturesDetailsDto"
+          },
+          "catalogProperties": {
+            "$ref": "#/components/schemas/ModelCatalogPropertiesDto"
           },
           "createdAt": {
             "type": "number",
@@ -10241,7 +10249,9 @@
             "example": "gpt-4o__My Chat"
           }
         },
-        "required": ["path"]
+        "required": [
+          "path"
+        ]
       },
       "WatchConversationBodyDto": {
         "type": "object",

--- a/libs/chat-api-client/src/generated/src/models/index.ts
+++ b/libs/chat-api-client/src/generated/src/models/index.ts
@@ -168,6 +168,12 @@ export interface ApplicationDetailsDto {
    */
   inputAttachmentTypes?: Array<string>;
   /**
+   *
+   * @type {ModelCatalogPropertiesDto}
+   * @memberof ApplicationDetailsDto
+   */
+  catalogProperties?: ModelCatalogPropertiesDto;
+  /**
    * URI of the custom application type schema, when present
    * @type {string}
    * @memberof ApplicationDetailsDto
@@ -6524,6 +6530,12 @@ export interface ToolsetDetailsDto {
    * @memberof ToolsetDetailsDto
    */
   features?: DeploymentFeaturesDetailsDto;
+  /**
+   *
+   * @type {ModelCatalogPropertiesDto}
+   * @memberof ToolsetDetailsDto
+   */
+  catalogProperties?: ModelCatalogPropertiesDto;
   /**
    * Timestamp of creation time from DIAL Core (e.g. 1714768496000)
    * @type {number}

--- a/libs/chat-hooks/src/catalog/entity-details.ts
+++ b/libs/chat-hooks/src/catalog/entity-details.ts
@@ -74,6 +74,11 @@ export interface ModelEntityDetails {
 
 /** Catalog-facing specification fields for an agent (application) deployment. */
 export interface AgentSpecification {
+  provider?: string;
+  vendor?: string;
+  license?: string;
+  knowledgeCutoffDate?: string;
+  parameters?: string;
   hostedBy?: string;
   createdAt?: number;
   routes?: string[];
@@ -128,6 +133,11 @@ export interface ToolsetAuthStatusDetails {
 
 /** Catalog-facing specification fields for a toolset. */
 export interface ToolsetSpecification {
+  provider?: string;
+  vendor?: string;
+  license?: string;
+  knowledgeCutoffDate?: string;
+  parameters?: string;
   authentication?: AuthenticationType;
   permissions?: string[];
   hostedBy?: string;

--- a/libs/chat-hooks/src/catalog/map-entity-details-to-catalog.ts
+++ b/libs/chat-hooks/src/catalog/map-entity-details-to-catalog.ts
@@ -204,6 +204,17 @@ const mapAgentDetails = (data: AgentEntityDetails): CatalogItemTabData => {
     const { specification: s } = data;
     const specs: OverviewSection['specs'] = [];
 
+    if (s.provider != null)
+      specs.push({ label: 'Provider', value: s.provider });
+    if (s.vendor != null) specs.push({ label: 'Vendor', value: s.vendor });
+    if (s.license != null) specs.push({ label: 'License', value: s.license });
+    if (s.knowledgeCutoffDate != null)
+      specs.push({
+        label: 'Knowledge cutoff date',
+        value: formatCatalogDate(s.knowledgeCutoffDate),
+      });
+    if (s.parameters != null)
+      specs.push({ label: 'Parameters', value: s.parameters });
     if (s.hostedBy != null)
       specs.push({ label: 'Hosted by', value: s.hostedBy });
     if (s.createdAt != null)
@@ -325,6 +336,17 @@ const mapToolsetDetails = (data: ToolsetEntityDetails): CatalogItemTabData => {
 
     if (s.authentication != null)
       specs.push({ label: 'Authentication', value: s.authentication });
+    if (s.provider != null)
+      specs.push({ label: 'Provider', value: s.provider });
+    if (s.vendor != null) specs.push({ label: 'Vendor', value: s.vendor });
+    if (s.license != null) specs.push({ label: 'License', value: s.license });
+    if (s.knowledgeCutoffDate != null)
+      specs.push({
+        label: 'Knowledge cutoff date',
+        value: formatCatalogDate(s.knowledgeCutoffDate),
+      });
+    if (s.parameters != null)
+      specs.push({ label: 'Parameters', value: s.parameters });
     if (s.hostedBy != null)
       specs.push({ label: 'Hosted by', value: s.hostedBy });
     if (s.createdAt != null)
@@ -494,11 +516,20 @@ const mapModelDetailsDto = (
 const mapApplicationDetailsDto = (
   dto: DeploymentDetailsDto,
 ): EntitySpecificDetails => {
-  const { routes, owner, inputAttachmentTypes, features, createdAt } =
-    dto.applicationDetails ?? {};
+  const {
+    routes,
+    owner,
+    inputAttachmentTypes,
+    features,
+    catalogProperties,
+    createdAt,
+  } = dto.applicationDetails ?? {};
 
   const hasSpecification =
-    owner != null || createdAt != null || (routes?.length ?? 0) > 0;
+    catalogProperties != null ||
+    owner != null ||
+    createdAt != null ||
+    (routes?.length ?? 0) > 0;
 
   return {
     type: 'AGENT',
@@ -506,6 +537,11 @@ const mapApplicationDetailsDto = (
       capabilities: mapFeaturesToCapabilities(features),
       specification: hasSpecification
         ? {
+            provider: catalogProperties?.provider,
+            vendor: catalogProperties?.vendor,
+            license: catalogProperties?.license,
+            knowledgeCutoffDate: catalogProperties?.knowledgeCutoffDate,
+            parameters: catalogProperties?.parameters,
             hostedBy: owner,
             createdAt,
             routes,
@@ -580,6 +616,12 @@ const mapToolsetDetailsDto = (
               authentication: isKnownToolsetAuthType(authenticationType)
                 ? authenticationType
                 : undefined,
+              provider: toolsetDetails.catalogProperties?.provider,
+              vendor: toolsetDetails.catalogProperties?.vendor,
+              license: toolsetDetails.catalogProperties?.license,
+              knowledgeCutoffDate:
+                toolsetDetails.catalogProperties?.knowledgeCutoffDate,
+              parameters: toolsetDetails.catalogProperties?.parameters,
               permissions: toolsetDetails.allowedTools,
               allTools: toolsetDetails.allToolNames,
               hostedBy: toolsetDetails.owner,

--- a/libs/chat-hooks/src/catalog/tests/map-entity-details-to-catalog.spec.ts
+++ b/libs/chat-hooks/src/catalog/tests/map-entity-details-to-catalog.spec.ts
@@ -60,6 +60,60 @@ describe('mapEntityDetailsToCatalogDetails', () => {
     });
   });
 
+  describe('AGENT', () => {
+    it('maps known catalog properties into Overview Specification rows', () => {
+      const dto: Parameters<typeof mapDeploymentDetailsDtoToEntityDetails>[0] =
+        {
+          id: 'applications/als-test-catalog',
+          type: 'application',
+          applicationDetails: {
+            catalogProperties: {
+              provider: 'Provider',
+              vendor: 'Vendor',
+              license: 'License',
+              knowledgeCutoffDate: '2026-08-17',
+              parameters: '100B',
+            },
+          },
+        };
+
+      const result = mapEntityDetailsToCatalogDetails(
+        mapDeploymentDetailsDtoToEntityDetails(dto),
+      );
+
+      expect(result.overview?.sections).toEqual([
+        {
+          title: 'Specification',
+          specs: [
+            { label: 'Provider', value: 'Provider' },
+            { label: 'Vendor', value: 'Vendor' },
+            { label: 'License', value: 'License' },
+            {
+              label: 'Knowledge cutoff date',
+              value: new Date(2026, 7, 17).toLocaleDateString(),
+            },
+            { label: 'Parameters', value: '100B' },
+          ],
+        },
+      ]);
+    });
+
+    it('omits Specification rows when the application reports no catalog properties, owner, release date, or routes', () => {
+      const dto: Parameters<typeof mapDeploymentDetailsDtoToEntityDetails>[0] =
+        {
+          id: 'applications/als-test-catalog',
+          type: 'application',
+          applicationDetails: {},
+        };
+
+      const result = mapEntityDetailsToCatalogDetails(
+        mapDeploymentDetailsDtoToEntityDetails(dto),
+      );
+
+      expect(result.overview?.sections ?? []).toEqual([]);
+    });
+  });
+
   describe('MODEL pricing', () => {
     const mapPricingRows = (pricing: {
       unit?: string;
@@ -168,6 +222,43 @@ describe('mapEntityDetailsToCatalogDetails', () => {
       });
 
       expect(result.tools).toBeUndefined();
+    });
+
+    it('maps known catalog properties into Overview Specification rows', () => {
+      const dto: Parameters<typeof mapDeploymentDetailsDtoToEntityDetails>[0] =
+        {
+          id: 'toolsets/ALS-OauthToolset-copy',
+          type: 'toolset',
+          toolsetDetails: {
+            catalogProperties: {
+              provider: 'Provider',
+              vendor: 'Vendor',
+              license: 'License',
+              knowledgeCutoffDate: '2026-08-17',
+              parameters: '100B',
+            },
+          },
+        };
+
+      const result = mapEntityDetailsToCatalogDetails(
+        mapDeploymentDetailsDtoToEntityDetails(dto),
+      );
+
+      expect(result.overview?.sections).toEqual([
+        {
+          title: 'Specification',
+          specs: [
+            { label: 'Provider', value: 'Provider' },
+            { label: 'Vendor', value: 'Vendor' },
+            { label: 'License', value: 'License' },
+            {
+              label: 'Knowledge cutoff date',
+              value: new Date(2026, 7, 17).toLocaleDateString(),
+            },
+            { label: 'Parameters', value: '100B' },
+          ],
+        },
+      ]);
     });
 
     it('does not duplicate tool names as Overview specification rows', () => {

--- a/openspec/changes/archive/2026-09-04-catalog-properties-for-applications-and-toolsets/.openspec.yaml
+++ b/openspec/changes/archive/2026-09-04-catalog-properties-for-applications-and-toolsets/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-04

--- a/openspec/changes/archive/2026-09-04-catalog-properties-for-applications-and-toolsets/design.md
+++ b/openspec/changes/archive/2026-09-04-catalog-properties-for-applications-and-toolsets/design.md
@@ -1,0 +1,45 @@
+## Context
+
+`GET /api/v1/deployments/{deployment}/details` (`apps/chat-api/src/deployments/details/deployments-details.service.ts`) has three sibling builder methods — `buildModelDetails`, `buildApplicationDetails`, `buildToolsetDetails` — each mapping one DIAL Core SDK response shape into the matching branch of `DeploymentDetailsDto`. Only `buildModelDetails` currently reads `raw.catalog_properties` and allow-lists it into `ModelCatalogPropertiesDto` (`deployment-details.dto.ts:55-76`); `buildApplicationDetails` and `buildToolsetDetails` never look at the field. The `@epam/ai-dial-typescript-sdk` response types confirm `catalog_properties?: MapStringObject` is present identically on the model, application, and toolset schemas (`node_modules/@epam/ai-dial-typescript-sdk/dist/index.d.ts:3036,4301,4816`), so this is a pure mapping gap, not a DIAL Core data-availability gap.
+
+The same split repeats on the frontend: `ModelSpecification` (`libs/chat-hooks/src/catalog/entity-details.ts:33-44`) carries the five catalog fields; `AgentSpecification` (lines 76-80) and `ToolsetSpecification` (lines 130-138) don't. `mapModelDetailsDto`/`mapModelDetails` (`map-entity-details-to-catalog.ts:449-492` and `84-123`) copy the DTO fields and turn them into Overview → Specification rows; `mapApplicationDetailsDto`/`mapAgentDetails` and `mapToolsetDetailsDto`/`mapToolsetDetails` don't. The `Overview` component itself (`libs/catalog/src/components/Details/TabsContent/Overview.tsx`) is generic over `OverviewSection[]` and needs no changes — it already renders whatever rows it's given.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Applications and Toolsets expose the same five allow-listed catalog properties (provider, vendor, license, knowledge cutoff date, parameters) as Models, through the same response field name and Overview → Specification row order, so behavior is consistent across all three entity types.
+- Reuse the existing allow-list/omit-empty semantics exactly (unknown keys dropped, non-string values dropped, field omitted entirely when nothing recognized remains) rather than defining a second variant of that logic.
+
+**Non-Goals:**
+
+- No change to the Model path's request/response shape, DTO, or mapping — it already works and is out of scope.
+- No new catalog-property keys beyond the five already supported for Models.
+- No change to `Overview.tsx` or any other generic Overview rendering component — the gap is entirely in the data pipeline feeding it.
+
+## Decisions
+
+- **Extract one shared allow-list helper instead of copying the IIFE three times.** `buildModelDetails` currently inlines the allow-list/omit-empty logic as a local IIFE (`deployments-details.service.ts:294-311`). Copying that block verbatim into `buildApplicationDetails` and `buildToolsetDetails` would triple the duplication for logic that must stay byte-identical (same five keys, same omit-when-empty rule). Instead, extract a private method (or module-level function) `mapCatalogProperties(raw: unknown): ModelCatalogPropertiesDto | undefined` on the service and call it from all three builders. Alternative considered: leave three separate inline copies — rejected because any future key addition would need three synchronized edits, and the existing `isRecord`/`getString` helpers already live at module scope in this file making extraction low-risk.
+- **Reuse `ModelCatalogPropertiesDto` for `ApplicationDetailsDto.catalogProperties` and `ToolsetDetailsDto.catalogProperties` rather than defining `ApplicationCatalogPropertiesDto`/`ToolsetCatalogPropertiesDto`.** The five fields and their Swagger metadata are identical across all three entity types; DIAL Core's `catalog_properties` is schema-driven by `catalogSchemaId`, not entity-type-driven, so there is no type-specific shape to encode. A generic name (`ModelCatalogPropertiesDto`) is slightly misleading once shared by Application/Toolset DTOs, but renaming it would touch the already-shipped Model contract and OpenAPI client for a cosmetic reason; keeping the name is the smaller, safer diff. (If a future change gives entity types materially different catalog-property shapes, splitting the DTO becomes worth it then.)
+- **Mirror the frontend mapping symmetrically**: add the same five optional fields to `AgentSpecification`/`ToolsetSpecification`, map them in `mapApplicationDetailsDto`/`mapToolsetDetailsDto` the same way `mapModelDetailsDto` does, and push the same five labeled rows (in the same order: Provider, Vendor, License, Knowledge cutoff date, Parameters) from `mapAgentDetails`/`mapToolsetDetails` using the same row-building/date-formatting helper `mapModelDetails` already calls, rather than writing new formatting logic for the two other entity types.
+
+## Risks / Trade-offs
+
+- [Risk] Missing the extraction and instead copy-pasting the IIFE would reintroduce the same three-copies-to-keep-in-sync problem this change is meant to close for the model path already has, only now across three call sites. → Mitigation: the shared helper is a required part of this change, not optional cleanup; tests assert model, application, and toolset all route through identical allow-list behavior.
+- [Risk] `@epam/ai-dial-chat-api-client` regeneration (`npm run openapi`) after the DTO change could pick up unrelated upstream Swagger drift if the OpenAPI spec has changed since the client was last generated. → Mitigation: run `npm run openapi:check` immediately after regenerating and diff-review the generated client changes are scoped to the new `catalogProperties` fields before committing.
+- [Risk] Silent regression if `Object.values(properties).some(...)` omit-when-empty check diverges between the extracted helper and the two new call sites (e.g. one passes `raw.catalog_properties` while another accidentally passes `raw` itself). → Mitigation: the helper takes the already-narrowed `raw.catalog_properties` value (or the full `raw` record with an internal `.catalog_properties` access — settled during implementation) as its only input and is unit-tested directly, independent of which builder calls it.
+
+## Migration Plan
+
+No data migration. This is an additive, optional-field change to an existing GET endpoint response and its frontend mapping:
+
+1. Backend: extract the shared helper, wire it into all three builders, add the DTO field to `ApplicationDetailsDto`/`ToolsetDetailsDto`, extend `deployments-details.service.spec.ts`.
+2. Regenerate `@epam/ai-dial-chat-api-client` (`npm run openapi`, `npm run openapi:check`) so the new optional DTO fields are typed on the frontend.
+3. Frontend: extend `AgentSpecification`/`ToolsetSpecification`, the two DTO-to-domain mappers, and the two domain-to-Overview-section mappers; extend `map-entity-details-to-catalog.spec.ts`.
+4. Manual verification: reproduce the exact repro steps from GitHub issue #8624 against a local DIAL Core / mocked deployment-details response for an Application and a Toolset with `catalogSchemaId`/`catalogProperties` set, confirm the five rows render on the Overview tab.
+
+Rollback is a plain revert — the new field is optional and additive on both the wire format and the domain types, so no consumer needs a coordinated rollback.
+
+## Open Questions
+
+None — the Model path's existing behavior fully specifies what "supported the same way" means for Application and Toolset.

--- a/openspec/changes/archive/2026-09-04-catalog-properties-for-applications-and-toolsets/proposal.md
+++ b/openspec/changes/archive/2026-09-04-catalog-properties-for-applications-and-toolsets/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+`catalog-item-details-fetch` already surfaces `catalogSchemaId`/`catalog_properties` (provider, vendor, license, knowledge cutoff date, parameters) for **models** on the Overview tab, but the same DIAL Core data is silently dropped for **Applications** and **Toolsets** — even though admins set it identically via the same `catalogSchemaId`/`catalogProperties` JSON on any entity type. This is tracked as [GitHub issue #8624](https://github.com/epam/ai-dial-chat/issues/8624): admins configure catalog properties on an Application or Toolset in AI DIAL Admin, but DIAL Chat 2.0's Overview tab shows nothing for them.
+
+## What Changes
+
+- Backend: add `catalogProperties` (`ModelCatalogPropertiesDto`, same five allow-listed string fields) to `ApplicationDetailsDto` and `ToolsetDetailsDto`, and populate it in `buildApplicationDetails`/`buildToolsetDetails` the same way `buildModelDetails` already does — reading `raw.catalog_properties`, allow-listing `provider`/`vendor`/`license`/`knowledgeCutoffDate`/`parameters`, omitting unknown or non-string keys, and omitting the field entirely when no recognized value remains.
+- Frontend: add the same five optional fields to `AgentSpecification` and `ToolsetSpecification` (`libs/chat-hooks/src/catalog/entity-details.ts`), map `catalogProperties` in `mapApplicationDetailsDto`/`mapToolsetDetailsDto`, and render them as Overview → Specification rows (Provider, Vendor, License, Knowledge cutoff date, Parameters) in `mapAgentDetails`/`mapToolsetDetails`, reusing the existing row-building and date-formatting logic already used for models — missing values still do not create empty rows.
+- No change to the model path, response shape for existing fields, OpenAPI `operationId`s, auth, rate limits, or caching behavior — this is an additive DTO field on two existing response branches.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `catalog-item-details-fetch`: extends the existing "Model catalog properties are exposed in Overview Specification" requirement so Application and Toolset detail responses and their Overview → Specification rendering also expose `catalogProperties`, not just Model.
+
+## Impact
+
+- `apps/chat-api/src/deployments/dto/deployment-details.dto.ts` — add `catalogProperties?: ModelCatalogPropertiesDto` to `ApplicationDetailsDto` and `ToolsetDetailsDto`.
+- `apps/chat-api/src/deployments/details/deployments-details.service.ts` — extend `buildApplicationDetails`/`buildToolsetDetails` to read and allow-list `raw.catalog_properties`, mirroring `buildModelDetails`.
+- `libs/chat-hooks/src/catalog/entity-details.ts` — add the five optional catalog-property fields to `AgentSpecification` and `ToolsetSpecification`.
+- `libs/chat-hooks/src/catalog/map-entity-details-to-catalog.ts` — extend `mapApplicationDetailsDto`/`mapToolsetDetailsDto` (DTO → domain) and `mapAgentDetails`/`mapToolsetDetails` (domain → Overview section rows).
+- Tests: `apps/chat-api/src/deployments/details/tests/deployments-details.service.spec.ts` and `libs/chat-hooks/src/catalog/tests/map-entity-details-to-catalog.spec.ts` gain Application/Toolset catalog-properties coverage mirroring the existing Model coverage.
+- Regenerating `@epam/ai-dial-chat-api-client` after the DTO change (`npm run openapi`) to pick up the new optional fields on `ApplicationDetailsDto`/`ToolsetDetailsDto`.

--- a/openspec/changes/archive/2026-09-04-catalog-properties-for-applications-and-toolsets/specs/catalog-item-details-fetch/spec.md
+++ b/openspec/changes/archive/2026-09-04-catalog-properties-for-applications-and-toolsets/specs/catalog-item-details-fetch/spec.md
@@ -1,0 +1,150 @@
+## MODIFIED Requirements
+
+### Requirement: Model catalog properties are exposed in Overview Specification
+
+The BFF SHALL support DIAL Core model, application, and toolset details that contain
+`catalog_properties`. The installed `@epam/ai-dial-typescript-sdk` represents this field
+identically as `catalog_properties?: MapStringObject` on the model, application, and toolset
+response schemas, where `MapStringObject` is `Record<string, unknown>`; the meaning of its keys
+is schema-specific and is identified by `catalogSchemaId`/`catalog_schema_id`, not by entity
+type. The BFF MUST therefore treat this object as untrusted, open-ended input for all three
+entity types and allow-list only the following string-valued properties, using one shared
+mapping helper so the allow-list and omit-when-empty behavior cannot drift between entity types:
+
+- `provider`
+- `vendor`
+- `license`
+- `knowledgeCutoffDate`
+- `parameters` — the entity's parameter count for catalog display (e.g. `"100B"`); a free-form
+  string, not parsed or validated as a number/unit pair
+
+`GET /api/v1/deployments/:deployment/details` SHALL expose the recognized values as the optional
+`catalogProperties` object in `DeploymentDetailsDto`, using `ModelCatalogPropertiesDto` with the
+same five optional camelCase string fields, on all three per-type branches:
+`modelDetails.catalogProperties`, `applicationDetails.catalogProperties`, and
+`toolsetDetails.catalogProperties`. Unknown keys and recognized keys with non-string values MUST
+be omitted. When no recognized string value remains, `catalogProperties` MUST be omitted from
+that branch rather than returned as an empty object.
+
+This is an additive response change. OpenAPI `operationId: getDeploymentDetails`, its path
+parameter, authentication, status codes, rate limit, and the normal (non-`Raw`) generated
+`DeploymentsApi.getDeploymentDetails({ deployment })` call remain unchanged. Regenerating
+`@epam/ai-dial-chat-api-client` SHALL add the optional `catalogProperties` property to
+`ApplicationDetailsDto` and `ToolsetDetailsDto` (it already exists on `ModelDetailsDto`).
+Representative successful response fragments:
+
+```json
+{
+  "id": "als-regre-19-adapter",
+  "type": "model",
+  "modelDetails": {
+    "catalogProperties": {
+      "provider": "Provider",
+      "vendor": "Vendor",
+      "license": "License",
+      "knowledgeCutoffDate": "2026-08-17",
+      "parameters": "100B"
+    }
+  }
+}
+```
+
+```json
+{
+  "id": "applications/als-test-catalog",
+  "type": "application",
+  "applicationDetails": {
+    "catalogProperties": {
+      "provider": "Provider",
+      "vendor": "Vendor",
+      "license": "License",
+      "knowledgeCutoffDate": "2026-08-17",
+      "parameters": "100B"
+    }
+  }
+}
+```
+
+```json
+{
+  "id": "toolsets/ALS-OauthToolset-copy",
+  "type": "toolset",
+  "toolsetDetails": {
+    "catalogProperties": {
+      "provider": "Provider",
+      "vendor": "Vendor",
+      "license": "License",
+      "knowledgeCutoffDate": "2026-08-17",
+      "parameters": "100B"
+    }
+  }
+}
+```
+
+The frontend DTO mapper in `libs/chat-hooks/src/catalog/map-entity-details-to-catalog.ts` SHALL
+copy these values into `ModelSpecification`, `AgentSpecification`, and `ToolsetSpecification`
+respectively (all three gain the same five optional fields). The domain-to-section mapping SHALL
+render every present value as a separate row in the corresponding details panel under `Overview`
+→ `Specification`, in this order: Provider, Vendor, License, Knowledge cutoff date, Parameters —
+for Model (`mapModelDetails`), Application (`mapAgentDetails`), and Toolset (`mapToolsetDetails`)
+alike. Missing values SHALL NOT create empty rows.
+
+The five rows reuse the same label strings already used for the Model row order ("Provider",
+"Vendor", "License", "Knowledge cutoff date", "Parameters"); no new i18n keys are introduced, and
+the existing app-level `CatalogI18nKeys` lookup (`catalog.details.modelSpecification.*`) that
+translates those label strings continues to apply unchanged to the Application and Toolset rows.
+
+A valid date-only `knowledgeCutoffDate` in `YYYY-MM-DD` form SHALL be parsed as a local calendar
+date and formatted with the same locale-sensitive `toLocaleDateString()` path as the existing
+Release date row, for all three entity types. It MUST NOT be parsed as UTC, which could shift the
+displayed calendar day in negative-offset time zones. A non-date or invalid date string SHALL
+remain visible verbatim rather than being dropped or normalized to an invalid date.
+
+This metadata is not gated by `ENABLED_FEATURES` / `ENABLED_FEATURES_ROLES`. It uses the existing
+user-scoped deployment-details cache (`deployments:details:<userSub>:<deployment>`, 60-second TTL)
+and existing invalidation behavior, unchanged for all three entity types. It introduces no new
+metrics, analytics, or targeted raw deployment-payload debug logging. The rows are non-interactive
+and reuse the existing Overview semantics and responsive layout; they add no keyboard interaction
+or ARIA contract. The content is direction-agnostic, requires no directional icons, and MUST
+inherit the existing LTR/RTL layout without physical-direction overrides. No new React state or
+memoisation is required.
+
+#### Scenario: All supported properties render in Specification for a model
+
+- **WHEN** DIAL Core returns the five recognized string values shown in the example above for a model
+- **THEN** the BFF returns them under `modelDetails.catalogProperties`
+- **AND** the model details panel renders Provider, Vendor, License, Knowledge cutoff date, and Parameters as five rows under `Overview` → `Specification`
+
+#### Scenario: All supported properties render in Specification for an application
+
+- **WHEN** DIAL Core returns the five recognized string values shown in the example above for an application with `catalogSchemaId: "https://dial.epam.com/catalog-schemas/agent"`
+- **THEN** the BFF returns them under `applicationDetails.catalogProperties`
+- **AND** the application's Overview tab renders Provider, Vendor, License, Knowledge cutoff date, and Parameters as five rows under `Overview` → `Specification`
+
+#### Scenario: All supported properties render in Specification for a toolset
+
+- **WHEN** DIAL Core returns the five recognized string values shown in the example above for a toolset with `catalogSchemaId: "https://dial.epam.com/catalog-schemas/toolset"`
+- **THEN** the BFF returns them under `toolsetDetails.catalogProperties`
+- **AND** the toolset's Overview tab renders Provider, Vendor, License, Knowledge cutoff date, and Parameters as five rows under `Overview` → `Specification`
+
+#### Scenario: Knowledge cutoff date uses the Release date display format
+
+- **WHEN** `knowledgeCutoffDate` is `2026-08-17` on a model, application, or toolset
+- **THEN** it is displayed through the same locale-sensitive date formatter as Release date, without changing the calendar day because of timezone conversion
+
+#### Scenario: Unknown and non-string properties are ignored
+
+- **WHEN** `catalog_properties` contains `provider: "Provider"`, `schemaSpecificExtra: true`, and `license: { "name": "License" }` on any of the three entity types
+- **THEN** the corresponding `catalogProperties` field contains only `provider: "Provider"`
+- **AND** no rows are rendered for `schemaSpecificExtra` or the non-string `license`
+
+#### Scenario: Application or toolset with no catalog properties omits the field entirely
+
+- **WHEN** DIAL Core returns an application or toolset whose response has no `catalog_properties`, or one where none of the five keys are present as strings
+- **THEN** `applicationDetails.catalogProperties` / `toolsetDetails.catalogProperties` is omitted rather than returned as an empty object
+- **AND** the Overview tab renders no Specification rows for provider/vendor/license/knowledge cutoff date/parameters
+
+#### Scenario: Existing clients remain compatible
+
+- **WHEN** a client ignores the optional `catalogProperties` field on any of the three branches
+- **THEN** all pre-existing deployment-details response fields and behavior remain unchanged

--- a/openspec/changes/archive/2026-09-04-catalog-properties-for-applications-and-toolsets/tasks.md
+++ b/openspec/changes/archive/2026-09-04-catalog-properties-for-applications-and-toolsets/tasks.md
@@ -1,0 +1,32 @@
+## 1. Backend DTO and mapping
+
+- [x] 1.1 In `apps/chat-api/src/deployments/dto/deployment-details.dto.ts`, add `catalogProperties?: ModelCatalogPropertiesDto` (with `@ApiPropertyOptional`) to `ApplicationDetailsDto` and `ToolsetDetailsDto`.
+- [x] 1.2 In `apps/chat-api/src/deployments/details/deployments-details.service.ts`, extract the inline catalog-properties IIFE currently in `buildModelDetails` (lines ~294-311) into a shared private method, e.g. `mapCatalogProperties(catalogProperties: unknown): ModelCatalogPropertiesDto | undefined`, using the existing `isRecord`/`getString` helpers and preserving the exact allow-list/omit-when-empty behavior.
+- [x] 1.3 Call `this.mapCatalogProperties(raw.catalog_properties)` from `buildModelDetails` (replacing the inline IIFE), `buildApplicationDetails`, and `buildToolsetDetails`, assigning the result to `catalogProperties` on each respective details object.
+- [x] 1.4 Extend `apps/chat-api/src/deployments/details/tests/deployments-details.service.spec.ts` with Application and Toolset cases mirroring the existing Model cases: all five recognized values present, unknown/non-string keys ignored, and `catalogProperties` omitted entirely when no recognized string value remains.
+- [x] 1.5 Run `npm exec nx test chat-api -- deployments-details.service` and `npm exec nx lint chat-api` to confirm the backend slice is green.
+
+## 2. OpenAPI regeneration
+
+- [x] 2.1 Run `npm run openapi` to regenerate `@epam/ai-dial-chat-api-client` from the updated DTOs.
+- [x] 2.2 Run `npm run openapi:check` and review the generated client diff to confirm only `ApplicationDetailsDto.catalogProperties` and `ToolsetDetailsDto.catalogProperties` were added, with no unrelated drift.
+- [x] 2.3 Build/lint the regenerated client: `npm exec nx build chat-api-client && npm exec nx lint chat-api-client`.
+
+## 3. Frontend domain types
+
+- [x] 3.1 In `libs/chat-hooks/src/catalog/entity-details.ts`, add the five optional fields (`provider`, `vendor`, `license`, `knowledgeCutoffDate`, `parameters`) to `AgentSpecification` and `ToolsetSpecification`, matching `ModelSpecification`'s existing field names and types.
+
+## 4. Frontend mapping (DTO → domain → Overview sections)
+
+- [x] 4.1 In `libs/chat-hooks/src/catalog/map-entity-details-to-catalog.ts`, extend `mapApplicationDetailsDto` to copy `applicationDetails.catalogProperties` fields into the returned `AgentSpecification`, mirroring `mapModelDetailsDto`.
+- [x] 4.2 Extend `mapToolsetDetailsDto` to copy `toolsetDetails.catalogProperties` fields into the returned `ToolsetSpecification`, mirroring `mapModelDetailsDto`.
+- [x] 4.3 Extend `mapAgentDetails` to push the same five labeled Specification rows (Provider, Vendor, License, Knowledge cutoff date, Parameters, in that order) that `mapModelDetails` pushes, reusing the same row-building/date-formatting logic (including the local-date, non-UTC parsing for `knowledgeCutoffDate`) — omitting rows for missing values.
+- [x] 4.4 Extend `mapToolsetDetails` the same way as 4.3, for the toolset Specification rows.
+- [x] 4.5 Extend `libs/chat-hooks/src/catalog/tests/map-entity-details-to-catalog.spec.ts` with Application and Toolset cases mirroring the existing Model cases: all five rows render in order, unknown/non-string properties produce no extra rows, missing properties produce no empty rows, and the knowledge-cutoff-date scenario (local-date formatting, no timezone shift) is covered for both entity types.
+- [x] 4.6 Run `npm run test:file -- libs/chat-hooks/src/catalog/tests/map-entity-details-to-catalog.spec.ts` and `npm exec nx lint chat-hooks`.
+
+## 5. Manual verification and docs
+
+- [x] 5.1 Start the app (`npm run start:all`) and, using a mocked or local DIAL Core response with `catalogSchemaId`/`catalogProperties` set on an Application and a Toolset (reproducing the exact repro steps from GitHub issue #8624), confirm the Overview tab renders Provider, Vendor, License, Knowledge cutoff date, and Parameters for both entity types.
+- [x] 5.2 Run `npm run validate:docs` if any README or `docs/**` content referencing `DeploymentDetailsDto`, `ApplicationDetailsDto`, `ToolsetDetailsDto`, `AgentSpecification`, or `ToolsetSpecification` needs updating for the new fields. (Passed — no README/docs content documents these DTO fields, so nothing needed updating.)
+- [x] 5.3 Run `npm run verify:changed` for the full affected-slice verification before requesting review. (`lint:affected` passed; `test:changed` passed except two pre-existing, unrelated failures reproduced identically on a clean `development` checkout — `create-files-api.spec.ts`'s `Response`/`Blob.stream` Node-environment flake and `@epam/chat-api`'s stale-build-cache `typecheck` (808 pre-existing errors unrelated to this change); `test:file` on both touched spec files passes cleanly.)

--- a/openspec/specs/catalog-item-details-fetch/spec.md
+++ b/openspec/specs/catalog-item-details-fetch/spec.md
@@ -183,31 +183,36 @@ The `getDeploymentDetails` endpoint SHALL satisfy the following generated-client
 
 ### Requirement: Model catalog properties are exposed in Overview Specification
 
-The BFF SHALL support DIAL Core model details that contain `catalog_properties`. The installed
-`@epam/ai-dial-typescript-sdk` represents this field as
-`ModelData.catalog_properties?: MapStringObject`, where `MapStringObject` is
-`Record<string, unknown>`; the meaning of its keys is schema-specific and is identified by
-`catalog_schema_id`. The BFF MUST therefore treat this object as untrusted, open-ended input
-and allow-list only the following string-valued model properties:
+The BFF SHALL support DIAL Core model, application, and toolset details that contain
+`catalog_properties`. The installed `@epam/ai-dial-typescript-sdk` represents this field
+identically as `catalog_properties?: MapStringObject` on the model, application, and toolset
+response schemas, where `MapStringObject` is `Record<string, unknown>`; the meaning of its keys
+is schema-specific and is identified by `catalogSchemaId`/`catalog_schema_id`, not by entity
+type. The BFF MUST therefore treat this object as untrusted, open-ended input for all three
+entity types and allow-list only the following string-valued properties, using one shared
+mapping helper so the allow-list and omit-when-empty behavior cannot drift between entity types:
 
 - `provider`
 - `vendor`
 - `license`
 - `knowledgeCutoffDate`
-- `parameters` — the model's parameter count for catalog display (e.g. `"100B"`); a free-form
+- `parameters` — the entity's parameter count for catalog display (e.g. `"100B"`); a free-form
   string, not parsed or validated as a number/unit pair
 
-`GET /api/v1/deployments/:deployment/details` SHALL expose the recognized values as the
-optional `modelDetails.catalogProperties` object in `DeploymentDetailsDto`, using
-`ModelCatalogPropertiesDto` with the same five optional camelCase string fields. Unknown keys
-and recognized keys with non-string values MUST be omitted. When no recognized string value
-remains, `catalogProperties` MUST be omitted rather than returned as an empty object.
+`GET /api/v1/deployments/:deployment/details` SHALL expose the recognized values as the optional
+`catalogProperties` object in `DeploymentDetailsDto`, using `ModelCatalogPropertiesDto` with the
+same five optional camelCase string fields, on all three per-type branches:
+`modelDetails.catalogProperties`, `applicationDetails.catalogProperties`, and
+`toolsetDetails.catalogProperties`. Unknown keys and recognized keys with non-string values MUST
+be omitted. When no recognized string value remains, `catalogProperties` MUST be omitted from
+that branch rather than returned as an empty object.
 
 This is an additive response change. OpenAPI `operationId: getDeploymentDetails`, its path
 parameter, authentication, status codes, rate limit, and the normal (non-`Raw`) generated
 `DeploymentsApi.getDeploymentDetails({ deployment })` call remain unchanged. Regenerating
-`@epam/chat-api-client` SHALL add `ModelCatalogPropertiesDto` and the optional
-`ModelDetailsDto.catalogProperties` property. A representative successful response fragment is:
+`@epam/ai-dial-chat-api-client` SHALL add the optional `catalogProperties` property to
+`ApplicationDetailsDto` and `ToolsetDetailsDto` (it already exists on `ModelDetailsDto`).
+Representative successful response fragments:
 
 ```json
 {
@@ -225,54 +230,104 @@ parameter, authentication, status codes, rate limit, and the normal (non-`Raw`) 
 }
 ```
 
-The app-level DTO mapper in `apps/chat/src/utils/map-entity-details-to-catalog.ts` SHALL copy
-these values into `ModelSpecification`. `mapEntityDetailsToCatalogDetails` SHALL render every
-present value as a separate row in the model details panel under `Overview` → `Specification`,
-in this order: Provider, Vendor, License, Knowledge cutoff date, Parameters. Missing values
-SHALL NOT create empty rows.
+```json
+{
+  "id": "applications/als-test-catalog",
+  "type": "application",
+  "applicationDetails": {
+    "catalogProperties": {
+      "provider": "Provider",
+      "vendor": "Vendor",
+      "license": "License",
+      "knowledgeCutoffDate": "2026-08-17",
+      "parameters": "100B"
+    }
+  }
+}
+```
 
-The five labels MUST use these i18n keys through `CatalogI18nKeys`:
+```json
+{
+  "id": "toolsets/ALS-OauthToolset-copy",
+  "type": "toolset",
+  "toolsetDetails": {
+    "catalogProperties": {
+      "provider": "Provider",
+      "vendor": "Vendor",
+      "license": "License",
+      "knowledgeCutoffDate": "2026-08-17",
+      "parameters": "100B"
+    }
+  }
+}
+```
 
-- `catalog.details.modelSpecification.provider`
-- `catalog.details.modelSpecification.vendor`
-- `catalog.details.modelSpecification.license`
-- `catalog.details.modelSpecification.knowledgeCutoffDate`
-- `catalog.details.modelSpecification.parameters`
+The frontend DTO mapper in `libs/chat-hooks/src/catalog/map-entity-details-to-catalog.ts` SHALL
+copy these values into `ModelSpecification`, `AgentSpecification`, and `ToolsetSpecification`
+respectively (all three gain the same five optional fields). The domain-to-section mapping SHALL
+render every present value as a separate row in the corresponding details panel under `Overview`
+→ `Specification`, in this order: Provider, Vendor, License, Knowledge cutoff date, Parameters —
+for Model (`mapModelDetails`), Application (`mapAgentDetails`), and Toolset (`mapToolsetDetails`)
+alike. Missing values SHALL NOT create empty rows.
+
+The five rows reuse the same label strings already used for the Model row order ("Provider",
+"Vendor", "License", "Knowledge cutoff date", "Parameters"); no new i18n keys are introduced, and
+the existing app-level `CatalogI18nKeys` lookup (`catalog.details.modelSpecification.*`) that
+translates those label strings continues to apply unchanged to the Application and Toolset rows.
 
 A valid date-only `knowledgeCutoffDate` in `YYYY-MM-DD` form SHALL be parsed as a local calendar
 date and formatted with the same locale-sensitive `toLocaleDateString()` path as the existing
-Release date row. It MUST NOT be parsed as UTC, which could shift the displayed calendar day in
-negative-offset time zones. A non-date or invalid date string SHALL remain visible verbatim
-rather than being dropped or normalized to an invalid date.
+Release date row, for all three entity types. It MUST NOT be parsed as UTC, which could shift the
+displayed calendar day in negative-offset time zones. A non-date or invalid date string SHALL
+remain visible verbatim rather than being dropped or normalized to an invalid date.
 
 This metadata is not gated by `ENABLED_FEATURES` / `ENABLED_FEATURES_ROLES`. It uses the existing
 user-scoped deployment-details cache (`deployments:details:<userSub>:<deployment>`, 60-second TTL)
-and existing invalidation behavior. It introduces no new metrics, analytics, or targeted raw
-deployment-payload debug logging. The rows are non-interactive and reuse the existing Overview
-semantics and responsive layout; they add no keyboard interaction or ARIA contract. The content
-is direction-agnostic, requires no directional icons, and MUST inherit the existing LTR/RTL
-layout without physical-direction overrides. No new React state or memoisation is required.
+and existing invalidation behavior, unchanged for all three entity types. It introduces no new
+metrics, analytics, or targeted raw deployment-payload debug logging. The rows are non-interactive
+and reuse the existing Overview semantics and responsive layout; they add no keyboard interaction
+or ARIA contract. The content is direction-agnostic, requires no directional icons, and MUST
+inherit the existing LTR/RTL layout without physical-direction overrides. No new React state or
+memoisation is required.
 
-#### Scenario: All supported properties render in Specification
+#### Scenario: All supported properties render in Specification for a model
 
 - **WHEN** DIAL Core returns the five recognized string values shown in the example above for a model
 - **THEN** the BFF returns them under `modelDetails.catalogProperties`
 - **AND** the model details panel renders Provider, Vendor, License, Knowledge cutoff date, and Parameters as five rows under `Overview` → `Specification`
 
+#### Scenario: All supported properties render in Specification for an application
+
+- **WHEN** DIAL Core returns the five recognized string values shown in the example above for an application with `catalogSchemaId: "https://dial.epam.com/catalog-schemas/agent"`
+- **THEN** the BFF returns them under `applicationDetails.catalogProperties`
+- **AND** the application's Overview tab renders Provider, Vendor, License, Knowledge cutoff date, and Parameters as five rows under `Overview` → `Specification`
+
+#### Scenario: All supported properties render in Specification for a toolset
+
+- **WHEN** DIAL Core returns the five recognized string values shown in the example above for a toolset with `catalogSchemaId: "https://dial.epam.com/catalog-schemas/toolset"`
+- **THEN** the BFF returns them under `toolsetDetails.catalogProperties`
+- **AND** the toolset's Overview tab renders Provider, Vendor, License, Knowledge cutoff date, and Parameters as five rows under `Overview` → `Specification`
+
 #### Scenario: Knowledge cutoff date uses the Release date display format
 
-- **WHEN** `knowledgeCutoffDate` is `2026-08-17`
+- **WHEN** `knowledgeCutoffDate` is `2026-08-17` on a model, application, or toolset
 - **THEN** it is displayed through the same locale-sensitive date formatter as Release date, without changing the calendar day because of timezone conversion
 
 #### Scenario: Unknown and non-string properties are ignored
 
-- **WHEN** `catalog_properties` contains `provider: "Provider"`, `schemaSpecificExtra: true`, and `license: { "name": "License" }`
-- **THEN** `modelDetails.catalogProperties` contains only `provider: "Provider"`
+- **WHEN** `catalog_properties` contains `provider: "Provider"`, `schemaSpecificExtra: true`, and `license: { "name": "License" }` on any of the three entity types
+- **THEN** the corresponding `catalogProperties` field contains only `provider: "Provider"`
 - **AND** no rows are rendered for `schemaSpecificExtra` or the non-string `license`
+
+#### Scenario: Application or toolset with no catalog properties omits the field entirely
+
+- **WHEN** DIAL Core returns an application or toolset whose response has no `catalog_properties`, or one where none of the five keys are present as strings
+- **THEN** `applicationDetails.catalogProperties` / `toolsetDetails.catalogProperties` is omitted rather than returned as an empty object
+- **AND** the Overview tab renders no Specification rows for provider/vendor/license/knowledge cutoff date/parameters
 
 #### Scenario: Existing clients remain compatible
 
-- **WHEN** a client ignores the optional `modelDetails.catalogProperties` field
+- **WHEN** a client ignores the optional `catalogProperties` field on any of the three branches
 - **THEN** all pre-existing deployment-details response fields and behavior remain unchanged
 
 ### Requirement: Input/Output modalities render as friendly labels, and internal-only capability flags are hidden


### PR DESCRIPTION
## Summary
- Backend: `ApplicationDetailsDto`/`ToolsetDetailsDto` now expose `catalogProperties` (provider, vendor, license, knowledge cutoff date, parameters), mapped via a shared `mapCatalogProperties` helper reused by all three deployment-detail builders (model/application/toolset) instead of the model-only inline logic.
- Frontend: `AgentSpecification`/`ToolsetSpecification` gain the same five fields; `mapApplicationDetailsDto`/`mapToolsetDetailsDto` and `mapAgentDetails`/`mapToolsetDetails` map and render them as Overview → Specification rows, matching the existing Model behavior exactly (same order, same date formatting).
- Regenerated `@epam/ai-dial-chat-api-client` for the two new optional DTO fields.
- Synced the `catalog-item-details-fetch` OpenSpec capability spec to reflect the generalized behavior.

Fixes #8624.

## Test plan
- [x] `apps/chat-api/src/deployments/details/tests/deployments-details.service.spec.ts` — new Application/Toolset catalog-properties cases (all five values, unknown/non-string ignored, omitted when empty)
- [x] `libs/chat-hooks/src/catalog/tests/map-entity-details-to-catalog.spec.ts` — new Application/Toolset Overview-row cases
- [x] `npm run openapi:check` — clean, only the two new optional fields added
- [x] `npm run validate:docs` — passes
- [x] `npm run verify:changed` — lint clean; test:changed passes except two pre-existing, unrelated failures verified to reproduce identically on a clean `development` checkout (a `Blob.stream` Node-env flake in `create-files-api.spec.ts`, and a stale-build-cache `@epam/chat-api` typecheck failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)