### PR TITLE
fix: remove duplicate useGridEditingScroll export in chat-hooks

### DIFF
--- a/libs/chat-hooks/src/entry-points/file-manager.ts
+++ b/libs/chat-hooks/src/entry-points/file-manager.ts
@@ -28,4 +28,8 @@ export * from '../files/useDialFileMetadata/useDialFileMetadata';
 export * from '../files/useDialFileMutations/useDialFileMutations';
 export * from '../files/useDialFileSharing/useDialFileSharing';
 export * from '../files/useDialFileUploadBatch/useDialFileUploadBatch';
+export type {
+  UseGridEditingScrollOptions,
+  UseGridEditingScrollResult,
+} from '@epam/ai-dial-chat-shared';
 export { useGridEditingScroll } from '@epam/ai-dial-chat-shared';

--- a/libs/chat-hooks/src/index.ts
+++ b/libs/chat-hooks/src/index.ts
@@ -123,7 +123,6 @@ export * from './files/useDialFileMetadata/useDialFileMetadata';
 export * from './files/useDialFileMutations/useDialFileMutations';
 export * from './files/useDialFileSharing/useDialFileSharing';
 export * from './files/useDialFileUploadBatch/useDialFileUploadBatch';
-export { useGridEditingScroll } from '@epam/ai-dial-chat-shared';
 export * from './shared/application-schema';
 export * from './shared/browser-timezone';
 export * from './shared/cron-weekday';


### PR DESCRIPTION
## Summary
- `libs/chat-hooks/src/index.ts` exported `useGridEditingScroll` twice (once alone, once alongside its types), causing a `TS2300: Duplicate identifier` error
- This broke `typecheck`/`lint` for `@epam/ai-dial-chat-hooks`, failing the `release / test / style_checks` CI job on `development` (run [33902126437](https://github.com/epam/ai-dial-chat/actions/runs/33902126437/job/101118483892))

## Test plan
- [x] `npm exec nx run @epam/ai-dial-chat-hooks:typecheck` no longer reports `TS2300`/duplicate identifier