### PR TITLE
chore: sync package-lock.json with peer dependency changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -253,7 +253,6 @@
         "@mcp-ui/client": "^7.1.1",
         "@modelcontextprotocol/sdk": "^1.27.1",
         "@tabler/icons-react": "^3.44.0",
-        "pdfjs-dist": ">=4.0.0",
         "react": "^19.0.0",
         "react-json-view-lite": "^2.5.0",
         "react-syntax-highlighter": "^16.1.1"
@@ -511,6 +510,8 @@
         "@epam/ai-dial-editor-builder": "*",
         "@epam/ai-dial-ui-kit": "*",
         "@tabler/icons-react": "^3.0.0",
+        "@uiw/react-markdown-preview": "*",
+        "@uiw/react-md-editor": "*",
         "react": "^19.0.0"
       }
     },
@@ -560,6 +561,8 @@
         "@epam/ai-dial-chat-shared": "*",
         "@epam/ai-dial-ui-kit": "*",
         "@tabler/icons-react": "^3.44.0",
+        "@uiw/react-markdown-preview": "*",
+        "@uiw/react-md-editor": "*",
         "react": "^19.0.0"
       }
     },
@@ -607,6 +610,8 @@
         "@epam/ai-dial-react-file-manager": "^0.2.0-dev.10",
         "@epam/ai-dial-ui-kit": "*",
         "@tabler/icons-react": "^3.0.0",
+        "@uiw/react-markdown-preview": "*",
+        "@uiw/react-md-editor": "*",
         "react": "^19.0.0"
       }
     },


### PR DESCRIPTION
## Summary
- `package-lock.json` had drifted from `package.json`: `scheduled-tasks`, `skill-editor`, and `prompt-editor` already declare `@uiw/react-md-editor` / `@uiw/react-markdown-preview` as peer deps, and `@mcp-ui/client` no longer needs `pdfjs-dist`
- Regenerated the lockfile to match the committed `package.json` files

## Test plan
- [x] `npm install` produces no further lockfile diff