### PR TITLE
fix(chat): prevent conversation panel flicker (#8639)

### DIFF
--- a/apps/chat/src/context/ConversationsContext.tsx
+++ b/apps/chat/src/context/ConversationsContext.tsx
@@ -64,7 +64,10 @@ interface ConversationsContextType {
   generateConversationTitle: (id: string) => Promise<string>;
   /** Duplicate a conversation into the user's own bucket; returns the new conversation id. */
   duplicateConversation: (id: string) => Promise<string>;
-  /** Re-fetch the full conversation list from the server. */
+  /**
+   * Re-fetch the full conversation list in the background without hiding
+   * loaded items.
+   */
   refreshConversations: () => Promise<void>;
   /** Updates the sidebar title for a conversation without changing its id. */
   updateConversationTitle: (id: string, title: string) => void;
@@ -117,15 +120,12 @@ export const ConversationsProvider = ({
   }, [conversations]);
 
   const refreshConversations = useCallback(async () => {
-    setIsLoading(true);
     setError(null);
     try {
       const response = await listConversations();
       setConversations(response.items);
     } catch (err) {
       setError(err instanceof Error ? err : new Error(String(err)));
-    } finally {
-      setIsLoading(false);
     }
   }, []);
 

--- a/apps/chat/src/context/tests/ConversationsContext.spec.tsx
+++ b/apps/chat/src/context/tests/ConversationsContext.spec.tsx
@@ -154,6 +154,72 @@ describe('ConversationsContext — identity-keyed refetch', () => {
   });
 });
 
+describe('ConversationsContext — background refresh', () => {
+  it('keeps the loaded list visible while conversations are refreshed', async () => {
+    const { result } = renderHook(() => useConversations(), {
+      wrapper: ConversationsProvider,
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    let resolveRefresh!: (value: { items: typeof seedConversations }) => void;
+    const refreshResponse = new Promise<{ items: typeof seedConversations }>(
+      (resolve) => {
+        resolveRefresh = resolve;
+      },
+    );
+    mockListConversations.mockReturnValueOnce(refreshResponse);
+
+    let refreshPromise!: Promise<void>;
+    act(() => {
+      refreshPromise = result.current.refreshConversations();
+    });
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.conversations).toEqual(seedConversations);
+
+    await act(async () => {
+      resolveRefresh({ items: [seedConversations[0]] });
+      await refreshPromise;
+    });
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.conversations).toEqual([seedConversations[0]]);
+  });
+
+  it('keeps the loaded list visible when a background refresh fails', async () => {
+    const { result } = renderHook(() => useConversations(), {
+      wrapper: ConversationsProvider,
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    let rejectRefresh!: (reason: Error) => void;
+    const refreshResponse = new Promise<never>((_resolve, reject) => {
+      rejectRefresh = reject;
+    });
+    mockListConversations.mockReturnValueOnce(refreshResponse);
+
+    let refreshPromise!: Promise<void>;
+    act(() => {
+      refreshPromise = result.current.refreshConversations();
+    });
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.conversations).toEqual(seedConversations);
+
+    const refreshError = new Error('Refresh failed');
+    await act(async () => {
+      rejectRefresh(refreshError);
+      await refreshPromise;
+    });
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.conversations).toEqual(seedConversations);
+    expect(result.current.error).toBe(refreshError);
+  });
+});
+
 describe('ConversationsContext — deleteAllConversations', () => {
   it('refreshes list on complete success (preserves shared/public)', async () => {
     const { result } = renderHook(() => useConversations(), {

--- a/openspec/changes/archive/2026-09-07-avoid-conversation-panel-refresh-flicker/.openspec.yaml
+++ b/openspec/changes/archive/2026-09-07-avoid-conversation-panel-refresh-flicker/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-07

--- a/openspec/changes/archive/2026-09-07-avoid-conversation-panel-refresh-flicker/design.md
+++ b/openspec/changes/archive/2026-09-07-avoid-conversation-panel-refresh-flicker/design.md
@@ -1,0 +1,84 @@
+## Context
+
+`ConversationsProvider` owns both the cached conversation list and an
+`isLoading` flag. The identity-keyed load effect uses that flag correctly for
+the initial request and for a user change: it clears the old list and blocks the
+panel until the new identity's data arrives.
+
+The same flag is also toggled by `refreshConversations()`. When navigation makes
+a newly created conversation active, `useActiveConversationSync` cannot find it
+in the previous list and calls that refresh. `ConversationPanelView` forwards
+the flag to `ConversationPanel`, which replaces its complete body with skeleton
+rows. This makes a normal background synchronization look like a fresh page
+load.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Keep already loaded conversation rows visible while an explicit list refresh
+  is pending.
+- Preserve blocking loading behavior for initial load and authenticated-identity
+  changes.
+- Continue replacing the list with the server response and reporting refresh
+  errors through the existing context state.
+
+**Non-Goals:**
+
+- Change when `useActiveConversationSync` requests a refresh.
+- Add an optimistic row for a newly created conversation.
+- Change `ConversationPanel`'s generic `isLoading` rendering contract.
+- Change routing, backend endpoints, generated clients, or any `libs/*` code.
+
+## Decisions
+
+### Keep loading semantics in `ConversationsContext`
+
+`refreshConversations()` SHALL stop setting `isLoading` before and after its
+request. It will keep clearing `error`, replace `conversations` on success, and
+store an `Error` on failure. The identity-keyed load effect remains the sole
+owner of blocking conversation-list loading.
+
+This follows the context's existing public description of `isLoading` as the
+initial-fetch state and fixes every background-refresh caller consistently. It
+also keeps the app-level ownership of server-backed state in
+`apps/chat/src/context/ConversationsContext.tsx`.
+
+Masking the flag only in `ConversationPanelView` was rejected because other
+consumers would still observe a background refresh as a full load. Changing the
+presentational `ConversationPanel` was rejected because it correctly renders
+the state supplied by its host and should not infer whether a request is
+initial or background work.
+
+### Preserve stale rows until replacement data arrives
+
+The existing array stays rendered during the request and is atomically replaced
+by `response.items` on success. No list merge or optimistic insertion is added.
+This keeps server ordering and metadata authoritative while removing the visual
+reset.
+
+An additional background-loading flag was considered and rejected because no
+current UI consumes refresh progress. Adding state without a consumer would
+increase the context surface without changing observable behavior.
+
+## Risks / Trade-offs
+
+- [Risk] Rows can be briefly stale while a refresh is pending. → This is the
+  intended stale-while-refresh behavior; the response still replaces the full
+  list when it arrives.
+- [Risk] A failed refresh leaves the old rows visible. → Preserve the existing
+  error assignment so current error handling can observe the failure without
+  discarding usable data.
+- [Risk] Future code may assume `isLoading` covers every list request. → Document
+  the background-refresh contract on `refreshConversations()` and cover it with
+  a deferred-response context test.
+
+## Migration Plan
+
+No data, API, dependency, feature-flag, or rollout migration is required. Deploy
+the frontend change normally. Roll back by restoring the `isLoading` toggles in
+`refreshConversations()`.
+
+## Open Questions
+
+None.

--- a/openspec/changes/archive/2026-09-07-avoid-conversation-panel-refresh-flicker/proposal.md
+++ b/openspec/changes/archive/2026-09-07-avoid-conversation-panel-refresh-flicker/proposal.md
@@ -1,0 +1,72 @@
+## Why
+
+After the first message creates a conversation and navigation moves from `/` to
+`/conversations/<id>`, `useActiveConversationSync` does not find the new id in
+the previously loaded list and requests a refresh. `ConversationsContext`
+currently marks that refresh as a full loading state, so the conversation panel
+temporarily replaces its existing rows with skeletons and visibly flickers.
+
+## What Changes
+
+### Solution
+
+- Reserve `ConversationsContext.isLoading` for the initial load and an
+  authenticated-identity change, where no prior user's list may remain visible.
+- Make `refreshConversations()` update the conversation list in the background,
+  preserving the currently loaded rows until the request settles.
+- Add regression coverage proving that a background refresh leaves
+  `isLoading=false` and keeps existing conversations visible until fresh data
+  arrives.
+
+The closest existing behavior is the missing-active-conversation refresh in
+`libs/chat-hooks/src/conversation/useActiveConversationSync/useActiveConversationSync.ts:42`
+and the initial/identity load in
+`apps/chat/src/context/ConversationsContext.tsx:229`.
+
+### Non-goals
+
+- Changing the `/conversations/<id>` route or conversation creation API.
+- Changing the generic `ConversationPanel` contract: it still renders skeleton
+  rows whenever its host passes `isLoading=true`.
+- Adding optimistic conversation-list entries or changing list ordering.
+- Changing any library under `libs/*`.
+
+### Acceptance criteria
+
+- Navigating to a newly created conversation may refresh the list, but the
+  already loaded panel rows remain rendered while that request is pending.
+- The refreshed response still replaces the list when it resolves, and refresh
+  failures continue to populate the context error state.
+- Initial provider loading and an authenticated-identity change still clear the
+  list and expose `isLoading=true` until their request settles.
+- No new user-visible strings, RTL behavior, accessibility semantics, feature
+  flags, telemetry, or backend/API changes are introduced.
+
+The conservative alternative was to mask `isLoading` in
+`ConversationPanelView`; it was rejected because the context already documents
+the flag as initial-fetch state, and other refresh consumers would retain the
+same stale full-loading behavior. Changing `libs/conversation-panel` was also
+rejected because its prop contract is correct and host-agnostic.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `conversations-context`: define background-refresh behavior separately from
+  initial and authenticated-identity loading.
+
+## Impact
+
+- Affected code:
+  `apps/chat/src/context/ConversationsContext.tsx` and its colocated context
+  tests.
+- APIs and dependencies: no changes.
+- Library isolation: no `libs/*` code changes and no host or external-system
+  knowledge crosses into a library.
+- Compatibility and rollback: non-breaking internal state-semantics change;
+  rollback consists of restoring the loading-state toggle inside
+  `refreshConversations()`.

--- a/openspec/changes/archive/2026-09-07-avoid-conversation-panel-refresh-flicker/specs/conversations-context/spec.md
+++ b/openspec/changes/archive/2026-09-07-avoid-conversation-panel-refresh-flicker/specs/conversations-context/spec.md
@@ -1,0 +1,39 @@
+## ADDED Requirements
+
+### Requirement: Explicit conversation-list refresh preserves loaded content
+
+`ConversationsContext` SHALL own the distinction between blocking list loads
+and background refreshes. When `refreshConversations()` is called after the
+provider has loaded, it SHALL request the full conversation list without
+clearing `conversations` and without changing `isLoading` to `true`. On success,
+it SHALL replace `conversations` with the returned `items`. On failure, it SHALL
+preserve the loaded list and populate the existing `error` state.
+
+This background behavior SHALL NOT change the initial or authenticated-identity
+load defined by the existing identity-keyed requirement: those loads continue
+to clear the list and expose `isLoading=true`. No backend endpoint, generated
+client, cache, feature flag, user-visible string, RTL behavior, accessibility
+semantic, memoisation contract, rate limit, or telemetry event is added.
+
+#### Scenario: Loaded rows remain available during background refresh
+
+- **GIVEN** `ConversationsProvider` has completed its initial load with one or
+  more conversations and `isLoading` is `false`
+- **WHEN** `refreshConversations()` is called and its list request is pending
+- **THEN** `isLoading` remains `false` and `conversations` retains the previously
+  loaded items
+
+#### Scenario: Successful background refresh replaces the list
+
+- **GIVEN** a background `refreshConversations()` request is pending while the
+  previous conversation list remains available
+- **WHEN** the request resolves with a new `items` array
+- **THEN** `conversations` is replaced by that array and `isLoading` remains
+  `false`
+
+#### Scenario: Failed background refresh preserves usable data
+
+- **GIVEN** `ConversationsProvider` already contains a loaded conversation list
+- **WHEN** `refreshConversations()` fails
+- **THEN** the loaded list remains unchanged, `error` contains the failure, and
+  `isLoading` remains `false`

--- a/openspec/changes/archive/2026-09-07-avoid-conversation-panel-refresh-flicker/tasks.md
+++ b/openspec/changes/archive/2026-09-07-avoid-conversation-panel-refresh-flicker/tasks.md
@@ -1,0 +1,29 @@
+## 1. Preserve the conversation panel during refresh
+
+Slicing strategy: one vertical frontend-state slice covering the context
+contract, observable panel behavior, and regression test.
+
+- [x] 1.1 Add deferred-request cases to
+  `apps/chat/src/context/tests/ConversationsContext.spec.tsx` proving that an
+  explicit refresh preserves loaded conversations and `isLoading=false` while
+  pending, replaces the list on success, and preserves the list while setting
+  `error` on failure. Verification: run
+  `npm run test:file -- apps/chat/src/context/tests/ConversationsContext.spec.tsx`.
+- [x] 1.2 Update `refreshConversations()` and its public JSDoc in
+  `apps/chat/src/context/ConversationsContext.tsx` so explicit refreshes update
+  in the background, while the existing initial/identity effect remains the
+  only path that clears the list and toggles blocking loading. Verification:
+  run
+  `npm run test:file -- apps/chat/src/context/tests/ConversationsContext.spec.tsx`.
+
+## 2. Verify the completed slice
+
+- [x] 2.1 Run `npm run verify:changed` once after the context implementation and
+  regression coverage are complete.
+- [x] 2.2 Run exactly one final non-mutating `npm run verify:full` and record any
+  unrelated pre-existing warnings separately from change failures.
+
+  Result: the command stopped in the repository-wide typecheck on unrelated
+  `apps/chat-api` and `mcp-app-sandbox` errors (`TS6305` missing declaration
+  outputs plus existing telemetry/skills/toolsets test typing errors). The
+  change-specific test and `verify:changed` passed.

--- a/openspec/specs/conversations-context/spec.md
+++ b/openspec/specs/conversations-context/spec.md
@@ -26,3 +26,41 @@ Reset and refetch semantics of `ConversationsContext` when the authenticated ide
 
 - **WHEN** the user logs out (`status` transitions away from `Authenticated`) and a new identity subsequently authenticates, remounting `ConversationsProvider`
 - **THEN** the freshly-mounted provider starts with `conversations: []` and issues exactly one `listConversations()` call for the new identity, independent of the identity-keyed effect
+
+### Requirement: Explicit conversation-list refresh preserves loaded content
+
+`ConversationsContext` SHALL own the distinction between blocking list loads
+and background refreshes. When `refreshConversations()` is called after the
+provider has loaded, it SHALL request the full conversation list without
+clearing `conversations` and without changing `isLoading` to `true`. On success,
+it SHALL replace `conversations` with the returned `items`. On failure, it SHALL
+preserve the loaded list and populate the existing `error` state.
+
+This background behavior SHALL NOT change the initial or authenticated-identity
+load defined by the existing identity-keyed requirement: those loads continue
+to clear the list and expose `isLoading=true`. No backend endpoint, generated
+client, cache, feature flag, user-visible string, RTL behavior, accessibility
+semantic, memoisation contract, rate limit, or telemetry event is added.
+
+#### Scenario: Loaded rows remain available during background refresh
+
+- **GIVEN** `ConversationsProvider` has completed its initial load with one or
+  more conversations and `isLoading` is `false`
+- **WHEN** `refreshConversations()` is called and its list request is pending
+- **THEN** `isLoading` remains `false` and `conversations` retains the previously
+  loaded items
+
+#### Scenario: Successful background refresh replaces the list
+
+- **GIVEN** a background `refreshConversations()` request is pending while the
+  previous conversation list remains available
+- **WHEN** the request resolves with a new `items` array
+- **THEN** `conversations` is replaced by that array and `isLoading` remains
+  `false`
+
+#### Scenario: Failed background refresh preserves usable data
+
+- **GIVEN** `ConversationsProvider` already contains a loaded conversation list
+- **WHEN** `refreshConversations()` fails
+- **THEN** the loaded list remains unchanged, `error` contains the failure, and
+  `isLoading` remains `false`


### PR DESCRIPTION
**Description:**

When a newly created conversation becomes active, the conversation list is refreshed because the new ID is not yet present locally. This refresh previously enabled the initial loading state, replacing existing sidebar rows with skeletons and causing visible flickering.
This change keeps the existing conversation list visible during background refreshes. The loading skeleton remains reserved for initial loading and authenticated user changes. Regression tests cover pending, successful, and failed refreshes.
Issues:

- https://github.com/epam/ai-dial-chat/issues/8639

**Checklist:**

- [X] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [X] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [X] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
