### PR TITLE
feat(chat-api): add attached dial prompt skill to be shared with the quick app (#8529)

### DIFF
--- a/apps/chat-api/src/share/share.service.ts
+++ b/apps/chat-api/src/share/share.service.ts
@@ -13,6 +13,10 @@ import {
   mapDialHttpStatus,
 } from '../common/dial/dial-error.mapper';
 import { getBearerAuthHeaders } from '../common/utils/auth-header';
+import {
+  APPLICATION_RESOURCE_PREFIX,
+  parseDialApplicationResource,
+} from '../common/utils/dial-application-resource';
 import { encodeDialResourcePath } from '../common/utils/encode-dial-path';
 import {
   countRecipientsByUrl,
@@ -120,6 +124,23 @@ const CONVERSATION_SHARE_INVITATION_ROUTE_PATH = '/conversations/shared';
 const CONVERSATION_RESOURCE_PREFIX = 'conversations/';
 const FILE_RESOURCE_PREFIX = 'files/';
 
+/*
+ * The only `application_properties.skills[]` entry shape that references a
+ * separate DIAL resource this repo must grant access to. A quick app's
+ * `application_properties` is authored by the embedded Quick Apps editor and
+ * treated as opaque here — so this is a defensive literal match against
+ * `type === 'dial-prompt'`, not an import of the editor's `QuickApp2Config`
+ * type (which lives in the editor package, not this repo). Every other skill
+ * entry shape (`type: 'custom'`, future kinds) carries inline content or no
+ * resource url and is left alone.
+ */
+const DIAL_PROMPT_SKILL_TYPE = 'dial-prompt';
+
+interface DialPromptSkillEntry {
+  type?: unknown;
+  url?: unknown;
+}
+
 interface AnnotationWithAttachment {
   body?: {
     source?: {
@@ -188,6 +209,54 @@ const collectConversationResourceUrls = (conversation: unknown): string[] => {
   return [...resourceUrls];
 };
 
+/*
+ * Collects unique prompt resource urls referenced by a quick app's
+ * `application_properties.skills[]`. Only `type: 'dial-prompt'` entries carry
+ * a separate DIAL prompt resource (`prompts/{bucket}/...`) that must be
+ * granted alongside the app; other skill kinds and the `custom` system prompt
+ * hold content inline and share nothing. `application_properties` is opaque
+ * (authored by the embedded Quick Apps editor), so the walk is defensive — a
+ * missing/malformed `skills` array yields no urls rather than throwing. Each
+ * url is stripped of `#`-fragments, rejected if it contains a `..` traversal
+ * segment, and normalized through `toShareResourceUrl` before deduping so
+ * encoded/decoded variants of the same prompt collapse to one entry.
+ */
+export const collectApplicationPromptResourceUrls = (
+  application: unknown,
+): string[] => {
+  if (!isRecord(application)) return [];
+  const properties = application.application_properties;
+  if (!isRecord(properties)) return [];
+
+  const skills = properties.skills;
+  if (!Array.isArray(skills)) return [];
+
+  const resourceUrls = new Set<string>();
+  for (const entry of skills as DialPromptSkillEntry[]) {
+    if (!isRecord(entry)) continue;
+    if (entry.type !== DIAL_PROMPT_SKILL_TYPE) continue;
+    if (typeof entry.url !== 'string') continue;
+
+    // Strip `#`-fragments — a fragment identifies a view, not a distinct resource.
+    const resourceUrl = entry.url.split('#', 1)[0];
+    if (!isPromptResourceUrl(resourceUrl)) continue;
+
+    // Normalize before dedup so encoded/decoded variants collapse to one entry.
+    const normalizedUrl = toShareResourceUrl(resourceUrl);
+
+    // Drop `..` traversal segments. Decode the full url before splitting so a
+    // `%2F`-encoded slash (e.g. `..%2F..%2Fother`) can't hide a `..` segment
+    // from the check — `encodeDialResourcePath` decodes each segment but splits
+    // on `/` first, so `%2F` inside a segment survives as a literal.
+    if (safeDecodeURIComponent(normalizedUrl).split('/').includes('..'))
+      continue;
+
+    resourceUrls.add(normalizedUrl);
+  }
+
+  return [...resourceUrls];
+};
+
 const getInvitationRoutePath = (itemId: string): string =>
   itemId.startsWith(CONVERSATION_RESOURCE_PREFIX)
     ? CONVERSATION_SHARE_INVITATION_ROUTE_PATH
@@ -249,8 +318,26 @@ export class ShareService {
     sessionBucket: string,
     resourceUrl: string,
   ): Promise<string[]> {
-    if (!resourceUrl.startsWith(CONVERSATION_RESOURCE_PREFIX)) return [];
+    if (resourceUrl.startsWith(CONVERSATION_RESOURCE_PREFIX)) {
+      return this.getConversationRelatedResourceUrls(
+        accessToken,
+        sessionBucket,
+        resourceUrl,
+      );
+    }
 
+    if (resourceUrl.startsWith(APPLICATION_RESOURCE_PREFIX)) {
+      return this.getApplicationRelatedResourceUrls(accessToken, resourceUrl);
+    }
+
+    return [];
+  }
+
+  private async getConversationRelatedResourceUrls(
+    accessToken: string,
+    sessionBucket: string,
+    resourceUrl: string,
+  ): Promise<string[]> {
     const conversationPath = resourceUrl.slice(
       CONVERSATION_RESOURCE_PREFIX.length,
     );
@@ -296,6 +383,79 @@ export class ShareService {
     });
   }
 
+  /*
+   * Loads a quick app's `application_properties` and returns the prompt
+   * resource urls it references via `skills[]` (`type: 'dial-prompt'`), so the
+   * attached prompts are granted alongside the app itself — otherwise the
+   * recipient hits "Access denied to the prompt" when they open the shared
+   * app (issue #8529). Reuses the same `applications/{bucket}/{path}` →
+   * `getCustomApplication` resolution `buildApplicationDetails` uses.
+   *
+   * Best-effort: the pre-read MUST NOT block sharing the application itself.
+   * Before this related-resource lookup existed, an `applications/...` itemId
+   * could be shared as long as `shareResource` succeeded — the app itself was
+   * never gated on a prior read. Any failure here (network error, upstream
+   * error, empty body, malformed `application_properties`) is logged as a
+   * warning and degrades to sharing the application alone, so a transient
+   * DIAL Core hiccup or token issue on the pre-read never regresses the
+   * baseline "share the app" path. The attached prompts are an enhancement
+   * on top of that baseline, not a precondition for it.
+   *
+   * Same cross-bucket rule as conversations: DIAL Core rejects a single share
+   * request mixing more than one owning bucket, and the caller cannot grant
+   * access to a prompt in another user's private bucket, so a referenced
+   * prompt whose bucket is neither the app's own nor the public/organization
+   * bucket is silently dropped rather than failing the whole share.
+   */
+  private async getApplicationRelatedResourceUrls(
+    accessToken: string,
+    resourceUrl: string,
+  ): Promise<string[]> {
+    const resource = parseDialApplicationResource(resourceUrl);
+    if (resource == null) return [];
+
+    let result;
+    try {
+      result = await this.dialClient.client.getCustomApplication(
+        resource.bucket,
+        resource.path,
+        { headers: getBearerAuthHeaders(accessToken) },
+      );
+    } catch (err) {
+      this.logger.warn(
+        `Failed to load application resources before sharing resourceUrl=${resourceUrl}; sharing without related prompts`,
+        err instanceof Error ? err.stack : undefined,
+      );
+      return [];
+    }
+
+    if (result.error != null || result.data == null) {
+      this.logger.warn(
+        `DIAL Core returned ${
+          result.error != null
+            ? `an error (status ${result.response?.status})`
+            : 'an empty body'
+        } for resourceUrl=${resourceUrl}; sharing without related prompts`,
+      );
+      return [];
+    }
+
+    return collectApplicationPromptResourceUrls(result.data).filter((url) => {
+      /*
+       * `collectApplicationPromptResourceUrls` normalizes each url through
+       * `toShareResourceUrl`, so the bucket segment read here is the encoded
+       * form (e.g. `My%20Bucket`). `resource.bucket` is the raw bucket
+       * segment from the application's itemId, which may itself be encoded or
+       * unencoded depending on the caller. Decode both before comparing so a
+       * percent-encoded bucket name (S3-style) matches regardless of which
+       * side carries the encoding.
+       */
+      const promptBucket = safeDecodeURIComponent(getResourceBucket(url));
+      const appBucket = safeDecodeURIComponent(resource.bucket);
+      return promptBucket === appBucket || promptBucket === PUBLIC_BUCKET;
+    });
+  }
+
   /**
    * Creates a share link for a DIAL Core resource (catalog entity, prompt, or conversation).
    *
@@ -316,9 +476,21 @@ export class ShareService {
       bucket,
       resourceUrl,
     );
+    /*
+     * Each related url is normalized through `toShareResourceUrl` for the same
+     * reason the primary `itemId` is: a prompt resource url may be stored in
+     * `application_properties.skills[].url` in the raw, human-readable form
+     * (e.g. `prompts/owner-bucket/My prompt`) that DIAL Core rejects with 400
+     * when sent unencoded. `toShareResourceUrl` encodes prompt urls and passes
+     * every other kind through unchanged; `encodeDialResourcePath` is
+     * idempotent, so already-encoded urls are not double-encoded.
+     */
     const requestBody = {
       invitationType: 'LINK' as const,
-      resources: [resourceUrl, ...relatedResourceUrls].map((url) => ({
+      resources: [
+        resourceUrl,
+        ...relatedResourceUrls.map(toShareResourceUrl),
+      ].map((url) => ({
         url,
         permissions,
       })),

--- a/apps/chat-api/src/share/tests/share.service.spec.ts
+++ b/apps/chat-api/src/share/tests/share.service.spec.ts
@@ -15,7 +15,7 @@ import type { DialClientService } from '../../dial/dial-client.service';
 import type { SkillsLookupService } from '../../skills/lookup/skills-lookup.service';
 import type { ToolsetsService } from '../../toolsets/toolsets.service';
 import { ShareAccess } from '../dto/create-share-link.dto';
-import { ShareService } from '../share.service';
+import { collectApplicationPromptResourceUrls, ShareService } from '../share.service';
 
 const okResponse = (data: unknown) =>
   ({ data, response: {} as Response }) as never;
@@ -28,6 +28,9 @@ function makeService(callbackBaseUrl = 'https://example.com/callback') {
     client: {
       shareResource: vi.fn(),
       getConversation: vi.fn().mockResolvedValue(okResponse({ messages: [] })),
+      getCustomApplication: vi
+        .fn()
+        .mockResolvedValue(okResponse({ application_properties: {} })),
       getInvitation: vi.fn(),
       discardSharedResources: vi.fn(),
       revokeSharedResources: vi.fn(),
@@ -408,18 +411,19 @@ describe('ShareService', () => {
       expect(shareSpy).not.toHaveBeenCalled();
     });
 
-    it('does not load related resources for a non-conversation item', async () => {
+    it('does not load related resources for a non-conversation, non-application item', async () => {
       const { service, dialClient } = makeService();
       vi.spyOn(dialClient.client, 'shareResource').mockResolvedValue(
-        okResponse({ invitationLink: '/invite/app' }),
+        okResponse({ invitationLink: '/invite/skill' }),
       );
 
       await service.createShareLink('token-abc', 'my-bucket', {
-        itemId: 'applications/my-bucket/my-app',
+        itemId: 'skills/my-bucket/my-skill',
         access: [ShareAccess.View],
       });
 
       expect(dialClient.client.getConversation).not.toHaveBeenCalled();
+      expect(dialClient.client.getCustomApplication).not.toHaveBeenCalled();
     });
 
     it('creates a share link for a skills/{bucket}/{path} itemId', async () => {
@@ -478,8 +482,11 @@ describe('ShareService', () => {
       expect(dialClient.client.getConversation).not.toHaveBeenCalled();
     });
 
-    it('leaves any itemId untouched, with no per-kind qualification', async () => {
-      const { service } = makeService();
+    it('shares only the application when it has no dial-prompt skills to attach', async () => {
+      const { service, dialClient } = makeService();
+      vi.spyOn(dialClient.client, 'getCustomApplication').mockResolvedValue(
+        okResponse({}),
+      );
       const spy = vi
         .spyOn(service['dialClient'].client, 'shareResource')
         .mockResolvedValue(okResponse({ invitationLink: '/invite/abc' }));
@@ -543,6 +550,575 @@ describe('ShareService', () => {
           access: [ShareAccess.View],
         }),
       ).rejects.toThrow(ServiceUnavailableException);
+    });
+  });
+
+  describe('createShareLink — application attached prompts', () => {
+    it('shares a dial-prompt skill referenced by a quick app alongside the app', async () => {
+      const { service, dialClient } = makeService();
+      vi.spyOn(dialClient.client, 'getCustomApplication').mockResolvedValue(
+        okResponse({
+          application_properties: {
+            skills: [
+              { type: 'dial-prompt', url: 'prompts/owner-bucket/My prompt' },
+            ],
+          },
+        }),
+      );
+      const shareSpy = vi
+        .spyOn(dialClient.client, 'shareResource')
+        .mockResolvedValue(okResponse({ invitationLink: '/invite/app' }));
+
+      await service.createShareLink('token-abc', 'session-bucket', {
+        itemId: 'applications/owner-bucket/My%20App__1.0',
+        access: [ShareAccess.View],
+      });
+
+      expect(dialClient.client.getCustomApplication).toHaveBeenCalledWith(
+        'owner-bucket',
+        'My%20App__1.0',
+        { headers: { Authorization: 'Bearer token-abc' } },
+      );
+      expect(shareSpy).toHaveBeenCalledWith({
+        headers: { Authorization: 'Bearer token-abc' },
+        body: {
+          invitationType: 'LINK',
+          resources: [
+            {
+              url: 'applications/owner-bucket/My%20App__1.0',
+              permissions: ['READ'],
+            },
+            {
+              url: 'prompts/owner-bucket/My%20prompt',
+              permissions: ['READ'],
+            },
+          ],
+        },
+      });
+    });
+
+    it('shares each unique dial-prompt skill once, ignoring non-prompt skills', async () => {
+      const { service, dialClient } = makeService();
+      vi.spyOn(dialClient.client, 'getCustomApplication').mockResolvedValue(
+        okResponse({
+          application_properties: {
+            skills: [
+              { type: 'dial-prompt', url: 'prompts/owner-bucket/first' },
+              { type: 'dial-prompt', url: 'prompts/owner-bucket/first' },
+              { type: 'dial-prompt', url: 'prompts/owner-bucket/second' },
+              { type: 'custom', content: 'inline system prompt' },
+            ],
+          },
+        }),
+      );
+      const shareSpy = vi
+        .spyOn(dialClient.client, 'shareResource')
+        .mockResolvedValue(okResponse({ invitationLink: '/invite/app' }));
+
+      await service.createShareLink('token-abc', 'session-bucket', {
+        itemId: 'applications/owner-bucket/my-app__1.0',
+        access: [ShareAccess.View, ShareAccess.Edit],
+      });
+
+      expect(shareSpy).toHaveBeenCalledWith({
+        headers: { Authorization: 'Bearer token-abc' },
+        body: {
+          invitationType: 'LINK',
+          resources: [
+            {
+              url: 'applications/owner-bucket/my-app__1.0',
+              permissions: ['READ', 'WRITE'],
+            },
+            {
+              url: 'prompts/owner-bucket/first',
+              permissions: ['READ', 'WRITE'],
+            },
+            {
+              url: 'prompts/owner-bucket/second',
+              permissions: ['READ', 'WRITE'],
+            },
+          ],
+        },
+      });
+    });
+
+    it('drops a referenced prompt left in a different private bucket than the app', async () => {
+      const { service, dialClient } = makeService();
+      vi.spyOn(dialClient.client, 'getCustomApplication').mockResolvedValue(
+        okResponse({
+          application_properties: {
+            skills: [
+              { type: 'dial-prompt', url: 'prompts/owner-bucket/mine' },
+              {
+                type: 'dial-prompt',
+                url: 'prompts/other-user-bucket/theirs',
+              },
+            ],
+          },
+        }),
+      );
+      const shareSpy = vi
+        .spyOn(dialClient.client, 'shareResource')
+        .mockResolvedValue(okResponse({ invitationLink: '/invite/app' }));
+
+      await service.createShareLink('token-abc', 'session-bucket', {
+        itemId: 'applications/owner-bucket/my-app__1.0',
+        access: [ShareAccess.View],
+      });
+
+      expect(shareSpy).toHaveBeenCalledWith({
+        headers: { Authorization: 'Bearer token-abc' },
+        body: {
+          invitationType: 'LINK',
+          resources: [
+            {
+              url: 'applications/owner-bucket/my-app__1.0',
+              permissions: ['READ'],
+            },
+            {
+              url: 'prompts/owner-bucket/mine',
+              permissions: ['READ'],
+            },
+          ],
+        },
+      });
+    });
+
+    it('keeps a referenced prompt in the public/organization bucket', async () => {
+      const { service, dialClient } = makeService();
+      vi.spyOn(dialClient.client, 'getCustomApplication').mockResolvedValue(
+        okResponse({
+          application_properties: {
+            skills: [
+              { type: 'dial-prompt', url: 'prompts/owner-bucket/mine' },
+              { type: 'dial-prompt', url: 'prompts/public/shared' },
+            ],
+          },
+        }),
+      );
+      const shareSpy = vi
+        .spyOn(dialClient.client, 'shareResource')
+        .mockResolvedValue(okResponse({ invitationLink: '/invite/app' }));
+
+      await service.createShareLink('token-abc', 'session-bucket', {
+        itemId: 'applications/owner-bucket/my-app__1.0',
+        access: [ShareAccess.View],
+      });
+
+      expect(shareSpy).toHaveBeenCalledWith({
+        headers: { Authorization: 'Bearer token-abc' },
+        body: {
+          invitationType: 'LINK',
+          resources: [
+            {
+              url: 'applications/owner-bucket/my-app__1.0',
+              permissions: ['READ'],
+            },
+            {
+              url: 'prompts/owner-bucket/mine',
+              permissions: ['READ'],
+            },
+            {
+              url: 'prompts/public/shared',
+              permissions: ['READ'],
+            },
+          ],
+        },
+      });
+    });
+
+    it('keeps a referenced prompt whose bucket segment is percent-encoded', async () => {
+      const { service, dialClient } = makeService();
+      vi.spyOn(dialClient.client, 'getCustomApplication').mockResolvedValue(
+        okResponse({
+          application_properties: {
+            skills: [
+              {
+                type: 'dial-prompt',
+                url: 'prompts/my%20bucket/my-prompt',
+              },
+            ],
+          },
+        }),
+      );
+      const shareSpy = vi
+        .spyOn(dialClient.client, 'shareResource')
+        .mockResolvedValue(okResponse({ invitationLink: '/invite/app' }));
+
+      await service.createShareLink('token-abc', 'session-bucket', {
+        itemId: 'applications/my%20bucket/my-app__1.0',
+        access: [ShareAccess.View],
+      });
+
+      expect(shareSpy).toHaveBeenCalledWith({
+        headers: { Authorization: 'Bearer token-abc' },
+        body: {
+          invitationType: 'LINK',
+          resources: [
+            {
+              url: 'applications/my%20bucket/my-app__1.0',
+              permissions: ['READ'],
+            },
+            {
+              url: 'prompts/my%20bucket/my-prompt',
+              permissions: ['READ'],
+            },
+          ],
+        },
+      });
+    });
+
+    it('shares no related resources when the app has no dial-prompt skills', async () => {
+      const { service, dialClient } = makeService();
+      vi.spyOn(dialClient.client, 'getCustomApplication').mockResolvedValue(
+        okResponse({
+          application_properties: {
+            orchestrator: {
+              system_prompt: { type: 'custom', variables: {}, content: '' },
+            },
+            skills: [],
+            contexts: [],
+            tool_sets: [],
+          },
+        }),
+      );
+      const shareSpy = vi
+        .spyOn(dialClient.client, 'shareResource')
+        .mockResolvedValue(okResponse({ invitationLink: '/invite/app' }));
+
+      await service.createShareLink('token-abc', 'session-bucket', {
+        itemId: 'applications/owner-bucket/my-app__1.0',
+        access: [ShareAccess.View],
+      });
+
+      expect(shareSpy).toHaveBeenCalledWith({
+        headers: { Authorization: 'Bearer token-abc' },
+        body: {
+          invitationType: 'LINK',
+          resources: [
+            {
+              url: 'applications/owner-bucket/my-app__1.0',
+              permissions: ['READ'],
+            },
+          ],
+        },
+      });
+    });
+
+    it('shares no related resources when the app has no application_properties', async () => {
+      const { service, dialClient } = makeService();
+      vi.spyOn(dialClient.client, 'getCustomApplication').mockResolvedValue(
+        okResponse({}),
+      );
+      const shareSpy = vi
+        .spyOn(dialClient.client, 'shareResource')
+        .mockResolvedValue(okResponse({ invitationLink: '/invite/app' }));
+
+      await service.createShareLink('token-abc', 'session-bucket', {
+        itemId: 'applications/owner-bucket/my-app__1.0',
+        access: [ShareAccess.View],
+      });
+
+      expect(dialClient.client.getCustomApplication).toHaveBeenCalledOnce();
+      expect(shareSpy).toHaveBeenCalledWith({
+        headers: { Authorization: 'Bearer token-abc' },
+        body: {
+          invitationType: 'LINK',
+          resources: [
+            {
+              url: 'applications/owner-bucket/my-app__1.0',
+              permissions: ['READ'],
+            },
+          ],
+        },
+      });
+    });
+
+    it('shares the app alone when the application pre-read rejects, without blocking the share', async () => {
+      const { service, dialClient } = makeService();
+      vi.spyOn(dialClient.client, 'getCustomApplication').mockRejectedValue(
+        new TypeError('network error'),
+      );
+      const shareSpy = vi
+        .spyOn(dialClient.client, 'shareResource')
+        .mockResolvedValue(okResponse({ invitationLink: '/invite/app' }));
+
+      const result = await service.createShareLink(
+        'token-abc',
+        'session-bucket',
+        {
+          itemId: 'applications/owner-bucket/my-app__1.0',
+          access: [ShareAccess.View],
+        },
+      );
+
+      expect(shareSpy).toHaveBeenCalledOnce();
+      expect(shareSpy).toHaveBeenCalledWith({
+        headers: { Authorization: 'Bearer token-abc' },
+        body: {
+          invitationType: 'LINK',
+          resources: [
+            {
+              url: 'applications/owner-bucket/my-app__1.0',
+              permissions: ['READ'],
+            },
+          ],
+        },
+      });
+      expect(result.url).toBe('https://example.com/catalog/shared/app');
+    });
+
+    it('shares the app alone when the application pre-read returns an upstream error, without blocking the share', async () => {
+      const { service, dialClient } = makeService();
+      vi.spyOn(dialClient.client, 'getCustomApplication').mockResolvedValue(
+        errResponse(HttpStatus.NOT_FOUND),
+      );
+      const shareSpy = vi
+        .spyOn(dialClient.client, 'shareResource')
+        .mockResolvedValue(okResponse({ invitationLink: '/invite/app' }));
+
+      const result = await service.createShareLink(
+        'token-abc',
+        'session-bucket',
+        {
+          itemId: 'applications/owner-bucket/my-app__1.0',
+          access: [ShareAccess.View],
+        },
+      );
+
+      expect(shareSpy).toHaveBeenCalledOnce();
+      expect(shareSpy).toHaveBeenCalledWith({
+        headers: { Authorization: 'Bearer token-abc' },
+        body: {
+          invitationType: 'LINK',
+          resources: [
+            {
+              url: 'applications/owner-bucket/my-app__1.0',
+              permissions: ['READ'],
+            },
+          ],
+        },
+      });
+      expect(result.url).toBe('https://example.com/catalog/shared/app');
+    });
+
+    it('shares no related resources when the application lookup returns no data', async () => {
+      const { service, dialClient } = makeService();
+      vi.spyOn(dialClient.client, 'getCustomApplication').mockResolvedValue(
+        okResponse(null),
+      );
+      const shareSpy = vi
+        .spyOn(dialClient.client, 'shareResource')
+        .mockResolvedValue(okResponse({ invitationLink: '/invite/app' }));
+
+      await service.createShareLink('token-abc', 'session-bucket', {
+        itemId: 'applications/owner-bucket/my-app__1.0',
+        access: [ShareAccess.View],
+      });
+
+      expect(shareSpy).toHaveBeenCalledOnce();
+      expect(shareSpy).toHaveBeenCalledWith({
+        headers: { Authorization: 'Bearer token-abc' },
+        body: {
+          invitationType: 'LINK',
+          resources: [
+            {
+              url: 'applications/owner-bucket/my-app__1.0',
+              permissions: ['READ'],
+            },
+          ],
+        },
+      });
+    });
+  });
+
+  describe('collectApplicationPromptResourceUrls', () => {
+    it('returns the prompt url for a single dial-prompt skill', () => {
+      expect(
+        collectApplicationPromptResourceUrls({
+          application_properties: {
+            skills: [
+              { type: 'dial-prompt', url: 'prompts/owner-bucket/my-prompt' },
+            ],
+          },
+        }),
+      ).toEqual(['prompts/owner-bucket/my-prompt']);
+    });
+
+    it('deduplicates repeated prompt urls in first-seen order', () => {
+      expect(
+        collectApplicationPromptResourceUrls({
+          application_properties: {
+            skills: [
+              { type: 'dial-prompt', url: 'prompts/owner-bucket/first' },
+              { type: 'dial-prompt', url: 'prompts/owner-bucket/second' },
+              { type: 'dial-prompt', url: 'prompts/owner-bucket/first' },
+            ],
+          },
+        }),
+      ).toEqual(['prompts/owner-bucket/first', 'prompts/owner-bucket/second']);
+    });
+
+    it('deduplicates encoded and unencoded forms of the same prompt url', () => {
+      expect(
+        collectApplicationPromptResourceUrls({
+          application_properties: {
+            skills: [
+              { type: 'dial-prompt', url: 'prompts/owner-bucket/My prompt' },
+              { type: 'dial-prompt', url: 'prompts/owner-bucket/My%20prompt' },
+            ],
+          },
+        }),
+      ).toEqual(['prompts/owner-bucket/My%20prompt']);
+    });
+
+    it('ignores non-dial-prompt skill entries', () => {
+      expect(
+        collectApplicationPromptResourceUrls({
+          application_properties: {
+            skills: [
+              { type: 'custom', content: 'inline' },
+              { type: 'dial-prompt', url: 'prompts/owner-bucket/kept' },
+              { type: 'unknown-kind', url: 'prompts/owner-bucket/dropped' },
+            ],
+          },
+        }),
+      ).toEqual(['prompts/owner-bucket/kept']);
+    });
+
+    it('drops urls that are not DIAL prompt resource urls', () => {
+      expect(
+        collectApplicationPromptResourceUrls({
+          application_properties: {
+            skills: [
+              { type: 'dial-prompt', url: 'files/owner-bucket/report.pdf' },
+              { type: 'dial-prompt', url: 'https://example.com/prompt' },
+              { type: 'dial-prompt', url: 'prompts/owner-bucket/kept' },
+            ],
+          },
+        }),
+      ).toEqual(['prompts/owner-bucket/kept']);
+    });
+
+    it('strips a #-fragment suffix from a skill url', () => {
+      expect(
+        collectApplicationPromptResourceUrls({
+          application_properties: {
+            skills: [
+              {
+                type: 'dial-prompt',
+                url: 'prompts/owner-bucket/my-prompt#variables',
+              },
+              { type: 'dial-prompt', url: 'prompts/owner-bucket/other' },
+            ],
+          },
+        }),
+      ).toEqual([
+        'prompts/owner-bucket/my-prompt',
+        'prompts/owner-bucket/other',
+      ]);
+    });
+
+    it('drops a skill url containing a `..` path-traversal segment', () => {
+      expect(
+        collectApplicationPromptResourceUrls({
+          application_properties: {
+            skills: [
+              {
+                type: 'dial-prompt',
+                url: 'prompts/owner-bucket/../../other-bucket/target',
+              },
+              { type: 'dial-prompt', url: 'prompts/owner-bucket/kept' },
+            ],
+          },
+        }),
+      ).toEqual(['prompts/owner-bucket/kept']);
+    });
+
+    it('drops a percent-encoded `..` traversal segment that decodes after normalization', () => {
+      expect(
+        collectApplicationPromptResourceUrls({
+          application_properties: {
+            skills: [
+              {
+                type: 'dial-prompt',
+                url: 'prompts/owner-bucket/%2E%2E/other-bucket/target',
+              },
+              { type: 'dial-prompt', url: 'prompts/owner-bucket/kept' },
+            ],
+          },
+        }),
+      ).toEqual(['prompts/owner-bucket/kept']);
+    });
+
+    it('drops a `..` traversal hidden behind a percent-encoded slash (`%2F`)', () => {
+      expect(
+        collectApplicationPromptResourceUrls({
+          application_properties: {
+            skills: [
+              {
+                type: 'dial-prompt',
+                url: 'prompts/owner-bucket/..%2F..%2Fother-bucket/target',
+              },
+              { type: 'dial-prompt', url: 'prompts/owner-bucket/kept' },
+            ],
+          },
+        }),
+      ).toEqual(['prompts/owner-bucket/kept']);
+    });
+
+    it('skips entries whose url is not a string', () => {
+      expect(
+        collectApplicationPromptResourceUrls({
+          application_properties: {
+            skills: [
+              { type: 'dial-prompt', url: 42 },
+              { type: 'dial-prompt', url: { path: 'prompts/x/y' } },
+              { type: 'dial-prompt', url: 'prompts/owner-bucket/kept' },
+            ],
+          },
+        }),
+      ).toEqual(['prompts/owner-bucket/kept']);
+    });
+
+    it('skips entries that are not objects', () => {
+      expect(
+        collectApplicationPromptResourceUrls({
+          application_properties: {
+            skills: [
+              null,
+              'prompts/owner-bucket/stray',
+              { type: 'dial-prompt', url: 'prompts/owner-bucket/kept' },
+            ],
+          },
+        }),
+      ).toEqual(['prompts/owner-bucket/kept']);
+    });
+
+    it('returns [] when skills is not an array', () => {
+      expect(
+        collectApplicationPromptResourceUrls({
+          application_properties: { skills: 'not-an-array' },
+        }),
+      ).toEqual([]);
+    });
+
+    it('returns [] when application_properties is not an object', () => {
+      expect(
+        collectApplicationPromptResourceUrls({
+          application_properties: 'not-an-object',
+        }),
+      ).toEqual([]);
+    });
+
+    it('returns [] when application_properties is absent', () => {
+      expect(collectApplicationPromptResourceUrls({})).toEqual([]);
+    });
+
+    it('returns [] when the application itself is not an object', () => {
+      expect(collectApplicationPromptResourceUrls(null)).toEqual([]);
+      expect(collectApplicationPromptResourceUrls(undefined)).toEqual([]);
+      expect(collectApplicationPromptResourceUrls('string')).toEqual([]);
     });
   });
 

--- a/openspec/changes/archive/2026-09-07-share-attached-quick-app-prompt/.openspec.yaml
+++ b/openspec/changes/archive/2026-09-07-share-attached-quick-app-prompt/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-07

--- a/openspec/changes/archive/2026-09-07-share-attached-quick-app-prompt/design.md
+++ b/openspec/changes/archive/2026-09-07-share-attached-quick-app-prompt/design.md
@@ -1,0 +1,120 @@
+## Context
+
+`ShareService.createShareLink` (`apps/chat-api/src/share/share.service.ts`) builds a
+DIAL Core `shareResource` request from a single `itemId`. Before this change it
+resolved related resources only for conversations:
+
+```
+createShareLink(itemId, access)
+  ├── resourceUrl = toShareResourceUrl(itemId)
+  ├── getRelatedResourceUrls(accessToken, bucket, resourceUrl)
+  │     └── if NOT conversations/  → return []        ← applications got nothing
+  └── shareResource({ resources: [resourceUrl, ...related] })
+```
+
+For an application, `getRelatedResourceUrls` returned `[]`, so DIAL Core was asked
+to share only the application. The prompt a quick app references as a
+`dial-prompt` skill (`application_properties.skills[].url`, a `prompts/{bucket}/...`
+resource) got no grant — the recipient hit "Access denied to the prompt."
+
+## Approach
+
+Generalize `getRelatedResourceUrls` to dispatch by resource kind, mirroring the
+existing conversation pattern for applications:
+
+```
+getRelatedResourceUrls(accessToken, sessionBucket, resourceUrl)
+  ├── conversations/ → getConversationRelatedResourceUrls (existing logic, extracted)
+  ├── applications/  → getApplicationRelatedResourceUrls (new)
+  └── else            → return []
+```
+
+`getApplicationRelatedResourceUrls` reuses the `applications/{bucket}/{path}` →
+`getCustomApplication` resolution that
+`DeploymentsDetailsService.buildApplicationDetails`
+(`apps/chat-api/src/deployments/details/deployments-details.service.ts`) already
+uses — `parseDialApplicationResource` (`apps/chat-api/src/common/utils/dial-application-resource.ts`)
+splits the resource id, then the SDK's `getCustomApplication(bucket, path)` loads
+the full application body, forwarding the caller's bearer token.
+
+The new `collectApplicationPromptResourceUrls` helper walks
+`application_properties.skills[]` and keeps the `url` of every entry whose `type`
+is exactly `'dial-prompt'` and whose `url` is a DIAL prompt resource url
+(`isPromptResourceUrl` from `apps/chat-api/src/prompts/utils/prompt-mapper.util.ts`).
+The `orchestrator.system_prompt` (`type: 'custom'`, inline content), `contexts[]`
+(file resources), `tool_sets[]`, and every other skill kind carry no separate DIAL
+resource and are left alone. Dedup is by exact url string, first-seen order.
+
+Collected prompt urls are appended after the application in
+`shareResource.resources` with the same resolved permissions
+(`READ` for view, `READ`+`WRITE` for edit) — identical to how conversation file
+attachments are handled today.
+
+## Cross-bucket rule
+
+DIAL Core rejects a single `shareResource` request mixing more than one owning
+bucket (`"You're not allowed to share resources of different owners in a single
+request"`). The caller also cannot grant access to a resource in another user's
+private bucket. So a referenced prompt whose bucket (`getResourceBucket`, segment
+`[1]` of a `prompts/{bucket}/...` url) is neither the application's own bucket nor
+the public/organization bucket (`PUBLIC_BUCKET`,
+`apps/chat-api/src/conversations/constants/conversation.constants.ts`) is silently
+dropped — same rule the conversation path already applies to `files/...`
+attachments. A prompt in the `public` bucket has no exclusive owner and is kept.
+
+## Opaque application_properties
+
+`application_properties` is authored by the embedded Quick Apps editor iframe and
+treated as opaque everywhere in this repo (persisted/read as
+`Record<string, unknown>`). The helper does not import the editor's
+`QuickApp2Config` / `DialPromptSkill` types (they live in the editor package, not
+this repo). The walk is defensive: `isRecord` + `Array.isArray` + `typeof === 'string'`
+guards mean a missing or malformed `skills` array yields no urls rather than
+throwing. This matches the defensive style of `collectConversationResourceUrls`.
+
+## Error handling
+
+The application pre-read is **best-effort**: it must never block sharing the
+application itself. Before this related-resource lookup existed, an
+`applications/...` itemId could be shared as long as `shareResource` succeeded —
+the app itself was never gated on a prior read. Any failure here degrades to
+app-only sharing rather than failing the share:
+
+- Application read throws (network/timeout) → logged as a warning, returns `[]`.
+- Application read returns an upstream error (e.g. 404) → logged as a warning
+  (including the upstream status), returns `[]`.
+- Application read returns no data (an empty body, or a plain custom app with no
+  `application_properties`) → logged as a warning, returns `[]`.
+
+In every failure case the share proceeds with the application resource alone —
+`shareResource` is still called, just with no related prompt urls appended. The
+attached prompts are an enhancement on top of the baseline "share the app" path,
+not a precondition for it. This deliberately diverges from the conversation path
+(which fails the share on a read error): a conversation with no data is a DIAL
+Core malfunction, whereas a plain custom application legitimately has no
+`application_properties`, and a transient pre-read error must not regress the
+baseline ability to share the app.
+
+## Alternatives considered
+
+- **Share prompts client-side, from the frontend.** Rejected: the frontend does
+  not reliably know which prompts a quick app references (that state lives in the
+  embedded editor's data model), and the existing share endpoint is a single
+  server-side call. Resolving related resources server-side, as conversations
+  already do, is the consistent pattern.
+- **Share every referenced resource (prompts + toolsets + files in `contexts[]`).**
+  Rejected for scope: #8529 is specifically the attached prompt. Toolsets have
+  more varied reference shapes and are a separate follow-up. `contexts[]` are
+  file resources already covered when the recipient opens the app (and sharing
+  them per-app would duplicate the conversation-file logic for a resource kind
+  not in the issue).
+- **Fail the whole share when a cross-bucket prompt is found.** Rejected: it
+  would block sharing any quick app that references someone else's prompt, a
+  likely regressive break. Dropping silently matches the conversation path's
+  established behavior.
+
+## No new endpoint, DTO, or frontend change
+
+`POST /api/v1/share` request and response shapes are unchanged. The server only
+resolves more related resources before proxying to DIAL Core. No generated-client
+impact, no OpenAPI regeneration needed, no i18n, no RTL, no feature flag.

--- a/openspec/changes/archive/2026-09-07-share-attached-quick-app-prompt/proposal.md
+++ b/openspec/changes/archive/2026-09-07-share-attached-quick-app-prompt/proposal.md
@@ -1,0 +1,72 @@
+## Why
+
+Sharing a quick app (an application built on a quick-app schema) shares only the
+application resource itself — the prompt attached to it as a `dial-prompt` skill
+(`application_properties.skills[]`) is a separate DIAL Core prompt resource that never
+receives a share grant. The recipient of the share link opens the app and hits
+"Access denied to the prompt" every time (issue #8529).
+
+`ShareService.createShareLink` already resolves related resources for conversations
+(it walks a conversation's `custom_content` for `files/...` attachment urls and shares
+them alongside the conversation). It does no such lookup for applications — the
+`conversation-share` spec explicitly mandated "no related-resource lookup" for every
+non-conversation kind. That left quick apps' attached prompts unshared.
+
+## What Changes
+
+- `ShareService.getRelatedResourceUrls` now dispatches by resource kind:
+  - `conversations/` → existing file-attachment walk (extracted unchanged into
+    `getConversationRelatedResourceUrls`).
+  - `applications/` → new `getApplicationRelatedResourceUrls`: parses
+    `applications/{bucket}/{path}` via `parseDialApplicationResource`, calls
+    `getCustomApplication`, and collects the `url` of every
+    `application_properties.skills[]` entry whose `type` is exactly `'dial-prompt'`.
+  - everything else (toolsets, skills, models, prompts) → `[]`, proxied directly.
+- Collected prompt urls are appended after the application in
+  `shareResource.resources` with the same permissions as the app, so the recipient
+  is granted access to both.
+- Same cross-bucket rule as conversations: a referenced prompt whose bucket is
+  neither the app's own nor the public/organization bucket is silently dropped
+  (DIAL Core rejects mixed-owner share requests, and the caller cannot grant
+  access to a prompt in another user's private bucket).
+- `collectApplicationPromptResourceUrls` is a defensive pure helper that walks
+  `application_properties` as an opaque `Record<string, unknown>` — it does not
+  import the Quick Apps editor's `QuickApp2Config` type (which lives in the editor
+  package, not this repo). A missing/malformed `skills` array yields no urls rather
+  than throwing; an application read that returns no data degrades to app-only
+  sharing rather than failing.
+
+## Non-goals
+
+- Sharing toolsets referenced by a quick app (`application_properties.tool_sets[]`).
+  Same class of bug, but broader and more varied reference shapes; explicitly out
+  of scope for #8529 and left for a follow-up.
+- Any frontend change. The `POST /api/v1/share` request/response contract is
+  unchanged; the server just resolves more related resources before proxying to
+  DIAL Core.
+- Any new endpoint or DTO.
+
+## Acceptance criteria
+
+- Sharing a quick app with one `dial-prompt` skill shares the app and the prompt
+  with the same permissions.
+- Multiple `dial-prompt` skills are shared once each (deduped, first-seen order);
+  `type: 'custom'` and other skill kinds contribute nothing.
+- A referenced prompt in another user's private bucket is omitted; the share
+  still succeeds. A prompt in the `public` bucket is kept.
+- The application pre-read is best-effort: if it rejects, returns an upstream
+  error, or returns no data, the failure is logged as a warning and the app is
+  shared alone (no related prompts, no failure). The pre-read never blocks
+  sharing the app itself — before this lookup existed, an `applications/...`
+  itemId could be shared as long as `shareResource` succeeded, and that baseline
+  path stays intact.
+- `collectApplicationPromptResourceUrls` is covered by direct unit tests pinning
+  its defensive edge cases (non-array `skills`, non-object entries, non-string
+  urls, non-prompt urls, absent `application_properties`, non-object application).
+
+## Rollback / backward-compat
+
+Non-breaking. The change only adds related resources to the share request DIAL Core
+already accepts; it never removes or rewrites the application resource itself.
+Reverting the single `getRelatedResourceUrls` dispatch restores the prior behavior
+(applications shared alone).

--- a/openspec/changes/archive/2026-09-07-share-attached-quick-app-prompt/specs/conversation-share/spec.md
+++ b/openspec/changes/archive/2026-09-07-share-attached-quick-app-prompt/specs/conversation-share/spec.md
@@ -1,0 +1,65 @@
+## MODIFIED Requirements
+
+### Requirement: Conversation share reuses the existing generic share-link endpoint
+
+No new backend endpoint is introduced. `ShareConversationPopoverContainer` SHALL call the existing `getShareLink(itemId, access)` utility (`apps/chat/src/utils/share-link.ts`), which POSTs to `POST /api/v1/share` via `createShareLink` (`apps/chat/src/server-api/share.api.ts`), passing the conversation's DIAL Core resource path as `itemId` and `access: [ShareLinkAccess.View]`.
+
+The backend `POST /api/v1/share` (`apps/chat-api/src/share/share.controller.ts`) `@ApiOperation.description` SHALL be updated to state it creates a share link "for a DIAL Core resource (catalog entity or conversation)", replacing the catalog-only wording. `CreateShareLinkDto`, response DTOs, and the `@Throttle({ limit: 20, ttl: 60000 })` rate limit are unchanged. Conversation-specific related-resource resolution is defined below; non-conversation resources continue to be proxied directly without an additional lookup.
+
+#### Scenario: Conversation itemId is accepted by the existing endpoint
+
+- **WHEN** `POST /api/v1/share` is called with `{ itemId: '<owned-conversation-path>', access: ['view'] }`
+- **THEN** the request is validated, the conversation and its related DIAL file resources are resolved server-side, and all resolved resources are included in the request proxied to DIAL Core
+
+#### Scenario: Non-conversation, non-application itemId requires no related-resource lookup
+
+- **WHEN** `POST /api/v1/share` is called with a toolset, skill, model, or prompt `itemId`
+- **THEN** the backend does not call DIAL Core's conversation-read or application-read API and proxies the resolved `itemId` directly to the sharing API
+
+#### Scenario: Swagger description reflects conversation support
+
+- **WHEN** the OpenAPI spec is generated (`npm run openapi`)
+- **THEN** the `createShareLink` operation description mentions conversations as a valid shareable resource
+
+## ADDED Requirements
+
+### Requirement: Sharing an application includes its attached prompt resources
+
+Before calling DIAL Core's `shareResource`, `ShareService.createShareLink` SHALL load a quick app whose resolved resource URL starts with `applications/`. The read SHALL parse `applications/{bucket}/{path}` via `parseDialApplicationResource` (`apps/chat-api/src/common/utils/dial-application-resource.ts`) into the `bucket`/`path` pair, call `getCustomApplication(bucket, path)`, and forward the caller's bearer token — the same resolution `buildApplicationDetails` already uses.
+
+The service SHALL collect unique DIAL prompt resource URLs from `application_properties.skills[]` entries whose `type` is exactly `'dial-prompt'`. Only entries whose `url` is a DIAL Core prompt resource url (`prompts/{bucket}/{path}`, per `isPromptResourceUrl`) are shareable. The `orchestrator.system_prompt` (`type: 'custom'`, inline content), `contexts[]` (file resources), `tool_sets[]`, and every other skill kind carry no separate DIAL resource and SHALL NOT be added to the sharing request. Deduplication is by exact url string, in first-seen order.
+
+The application resource SHALL remain the first item in `shareResource.resources`, followed by each unique related prompt resource. Every related prompt SHALL receive the same resolved permissions as the application (`READ` for view access, `READ` and `WRITE` for edit access).
+
+A referenced prompt whose bucket (`getResourceBucket`, segment `[1]` of a `prompts/{bucket}/...` url) is neither the application's own bucket nor the public/organization bucket (`PUBLIC_BUCKET`, `apps/chat-api/src/conversations/constants/conversation.constants.ts`) SHALL be silently omitted rather than failing the share — DIAL Core rejects a single share request mixing more than one owning bucket, and the caller cannot grant access to a prompt in another user's private bucket.
+
+The application pre-read is best-effort: it MUST NOT block sharing the application itself. If the read throws, returns an upstream error, or returns no data (an empty body, or a plain custom application with no `application_properties`), the failure SHALL be logged as a warning and the share SHALL proceed with the application resource alone — no related prompts, no failure. Before this related-resource lookup existed, an `applications/...` itemId could be shared as long as `shareResource` succeeded; the pre-read never gates that baseline path. The attached prompts are an enhancement on top of it, not a precondition.
+
+#### Scenario: Attached dial-prompt is shared alongside the application
+
+- **GIVEN** an owned quick app references `prompts/owner-bucket/My prompt` via a `dial-prompt` skill
+- **WHEN** a view share link is created for `applications/owner-bucket/My%20App__1.0`
+- **THEN** `shareResource.resources` contains the application first and `prompts/owner-bucket/My prompt` second, both with `permissions: ['READ']`
+
+#### Scenario: Duplicate prompt references are shared once
+
+- **GIVEN** the same prompt url appears in multiple `dial-prompt` skill entries alongside a `type: 'custom'` skill
+- **WHEN** a share link is created
+- **THEN** the prompt url appears exactly once in `shareResource.resources` and the custom skill contributes nothing
+
+#### Scenario: Cross-bucket private prompt is dropped
+
+- **GIVEN** a quick app references `prompts/other-user-bucket/theirs` via a `dial-prompt` skill
+- **WHEN** a share link is created for `applications/owner-bucket/my-app__1.0`
+- **THEN** `prompts/other-user-bucket/theirs` is omitted from `shareResource.resources` and the share still succeeds
+
+#### Scenario: Public-bucket prompt is kept
+
+- **GIVEN** a quick app references `prompts/public/shared` via a `dial-prompt` skill
+- **WHEN** a share link is created for `applications/owner-bucket/my-app__1.0`
+- **THEN** `prompts/public/shared` is included in `shareResource.resources`
+
+#### Scenario: Application pre-read failure degrades to app-only sharing without blocking
+
+- **WHEN** DIAL Core rejects or fails the application read performed before sharing
+- **THEN** the failure is logged as a warning and the share proceeds with the application resource alone (no related prompts), and `shareResource` is still called

--- a/openspec/changes/archive/2026-09-07-share-attached-quick-app-prompt/tasks.md
+++ b/openspec/changes/archive/2026-09-07-share-attached-quick-app-prompt/tasks.md
@@ -1,0 +1,13 @@
+## Tasks
+
+- [x] Generalize `ShareService.getRelatedResourceUrls` to dispatch by resource kind (conversations / applications / else).
+- [x] Extract the existing conversation walk into `getConversationRelatedResourceUrls` (behavior unchanged).
+- [x] Add `getApplicationRelatedResourceUrls`: parse `applications/{bucket}/{path}`, call `getCustomApplication`, collect `dial-prompt` skill urls, filter cross-bucket.
+- [x] Add `collectApplicationPromptResourceUrls` defensive pure helper (opaque `application_properties`, `isPromptResourceUrl` filter, dedup).
+- [x] Export `collectApplicationPromptResourceUrls` for direct unit testing.
+- [x] Update `share.service.spec.ts`: mock `getCustomApplication`; add integration tests for app prompt sharing (single, dedup, cross-bucket drop, public-bucket keep, no skills, no application_properties, lookup reject / upstream error / no data).
+- [x] Update the existing "non-conversation item" test to a skill itemId asserting neither `getConversation` nor `getCustomApplication` is called.
+- [x] Add direct unit tests for `collectApplicationPromptResourceUrls` edge cases.
+- [x] Update `openspec/specs/conversation-share/spec.md`: carve out the application exception and add the "Sharing an application includes its attached prompt resources" requirement with scenarios.
+- [x] Run `npm run test:file -- apps/chat-api/src/share/tests/share.service.spec.ts` (pass).
+- [x] Run `nx lint chat-api` (clean) and `nx build chat-api` (clean).

--- a/openspec/specs/conversation-share/spec.md
+++ b/openspec/specs/conversation-share/spec.md
@@ -57,15 +57,56 @@ The backend `POST /api/v1/share` (`apps/chat-api/src/share/share.controller.ts`)
 - **WHEN** `POST /api/v1/share` is called with `{ itemId: '<owned-conversation-path>', access: ['view'] }`
 - **THEN** the request is validated, the conversation and its related DIAL file resources are resolved server-side, and all resolved resources are included in the request proxied to DIAL Core
 
-#### Scenario: Non-conversation itemId requires no related-resource lookup
+#### Scenario: Non-conversation, non-application itemId requires no related-resource lookup
 
-- **WHEN** `POST /api/v1/share` is called with an application, toolset, skill, model, or prompt `itemId`
-- **THEN** the backend does not call DIAL Core's conversation-read API and proxies the resolved `itemId` directly to the sharing API
+- **WHEN** `POST /api/v1/share` is called with a toolset, skill, model, or prompt `itemId`
+- **THEN** the backend does not call DIAL Core's conversation-read or application-read API and proxies the resolved `itemId` directly to the sharing API
 
 #### Scenario: Swagger description reflects conversation support
 
 - **WHEN** the OpenAPI spec is generated (`npm run openapi`)
 - **THEN** the `createShareLink` operation description mentions conversations as a valid shareable resource
+
+### Requirement: Sharing an application includes its attached prompt resources
+
+Before calling DIAL Core's `shareResource`, `ShareService.createShareLink` SHALL load a quick app whose resolved resource URL starts with `applications/`. The read SHALL parse `applications/{bucket}/{path}` via `parseDialApplicationResource` (`apps/chat-api/src/common/utils/dial-application-resource.ts`) into the `bucket`/`path` pair, call `getCustomApplication(bucket, path)`, and forward the caller's bearer token — the same resolution `buildApplicationDetails` already uses.
+
+The service SHALL collect unique DIAL prompt resource URLs from `application_properties.skills[]` entries whose `type` is exactly `'dial-prompt'`. Only entries whose `url` is a DIAL Core prompt resource url (`prompts/{bucket}/{path}`, per `isPromptResourceUrl`) are shareable. The `orchestrator.system_prompt` (`type: 'custom'`, inline content), `contexts[]` (file resources), `tool_sets[]`, and every other skill kind carry no separate DIAL resource and SHALL NOT be added to the sharing request. Deduplication is by exact url string, in first-seen order.
+
+The application resource SHALL remain the first item in `shareResource.resources`, followed by each unique related prompt resource. Every related prompt SHALL receive the same resolved permissions as the application (`READ` for view access, `READ` and `WRITE` for edit access).
+
+A referenced prompt whose bucket (`getResourceBucket`, segment `[1]` of a `prompts/{bucket}/...` url) is neither the application's own bucket nor the public/organization bucket (`PUBLIC_BUCKET`, `apps/chat-api/src/conversations/constants/conversation.constants.ts`) SHALL be silently omitted rather than failing the share — DIAL Core rejects a single share request mixing more than one owning bucket, and the caller cannot grant access to a prompt in another user's private bucket.
+
+The application pre-read is best-effort: it MUST NOT block sharing the application itself. If the read throws, returns an upstream error, or returns no data (an empty body, or a plain custom application with no `application_properties`), the failure SHALL be logged as a warning and the share SHALL proceed with the application resource alone — no related prompts, no failure. Before this related-resource lookup existed, an `applications/...` itemId could be shared as long as `shareResource` succeeded; the pre-read never gates that baseline path. The attached prompts are an enhancement on top of it, not a precondition.
+
+#### Scenario: Attached dial-prompt is shared alongside the application
+
+- **GIVEN** an owned quick app references `prompts/owner-bucket/My prompt` via a `dial-prompt` skill
+- **WHEN** a view share link is created for `applications/owner-bucket/My%20App__1.0`
+- **THEN** `shareResource.resources` contains the application first and `prompts/owner-bucket/My prompt` second, both with `permissions: ['READ']`
+
+#### Scenario: Duplicate prompt references are shared once
+
+- **GIVEN** the same prompt url appears in multiple `dial-prompt` skill entries alongside a `type: 'custom'` skill
+- **WHEN** a share link is created
+- **THEN** the prompt url appears exactly once in `shareResource.resources` and the custom skill contributes nothing
+
+#### Scenario: Cross-bucket private prompt is dropped
+
+- **GIVEN** a quick app references `prompts/other-user-bucket/theirs` via a `dial-prompt` skill
+- **WHEN** a share link is created for `applications/owner-bucket/my-app__1.0`
+- **THEN** `prompts/other-user-bucket/theirs` is omitted from `shareResource.resources` and the share still succeeds
+
+#### Scenario: Public-bucket prompt is kept
+
+- **GIVEN** a quick app references `prompts/public/shared` via a `dial-prompt` skill
+- **WHEN** a share link is created for `applications/owner-bucket/my-app__1.0`
+- **THEN** `prompts/public/shared` is included in `shareResource.resources`
+
+#### Scenario: Application pre-read failure degrades to app-only sharing without blocking
+
+- **WHEN** DIAL Core rejects or fails the application read performed before sharing
+- **THEN** the failure is logged as a warning and the share proceeds with the application resource alone (no related prompts), and `shareResource` is still called
 
 ### Requirement: Sharing a conversation includes its related DIAL file resources
 


### PR DESCRIPTION
## Summary

Fixes #8529 — sharing a quick app (an application built on a quick-app schema) shared only the application resource itself. The prompt attached to it as a `dial-prompt` skill (`application_properties.skills[]`) is a separate DIAL Core prompt resource that received no share grant, so the recipient hit "Access denied to the prompt."

`ShareService.createShareLink` already resolved related resources for conversations (file attachments) but did no lookup for applications. The `conversation-share` spec explicitly mandated "no related-resource lookup" for every non-conversation kind, which left quick apps' attached prompts unshared.

## Changes

**`apps/chat-api/src/share/chat-api` only — no frontend change, no new endpoint, no DTO change.**

- `ShareService.getRelatedResourceUrls` now dispatches by resource kind:
  - `conversations/` → existing file-attachment walk (extracted unchanged into `getConversationRelatedResourceUrls`)
  - `applications/` → new `getApplicationRelatedResourceUrls`: parses `applications/{bucket}/{path}`, calls `getCustomApplication`, collects `application_properties.skills[]` entries where `type === 'dial-prompt'`, and appends their `url` to the share request with the same permissions as the app.
  - everything else → `[]`, proxied directly (unchanged).
- Same cross-bucket rule as conversations: a referenced prompt in another user's private bucket is silently dropped (DIAL Core rejects mixed-owner share requests); a `public`-bucket prompt is kept.
- Related prompt urls pass through `toShareResourceUrl` (encoding) — a prompt stored raw in `skills[].url` (e.g. with a space) is encoded before hitting DIAL Core, which rejects unencoded paths with 400.
- `#`-fragment suffixes stripped from skill urls, matching the conversation attachment collector.
- `collectApplicationPromptResourceUrls` is a defensive pure helper (opaque `application_properties`, no import of the editor's `QuickApp2Config` type); covered by direct unit tests for its edge cases.

## Test plan

- [x] `share.service.spec.ts` — integration tests (single prompt shared, dedup, cross-bucket drop, public-bucket keep, no skills, no application_properties, lookup reject/error/no-data) + direct unit tests for `collectApplicationPromptResourceUrls`.
- [x] `nx lint chat-api` clean.
- [x] `nx build chat-api` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)