### PR TITLE
fix: make attachment canvas package verification CI-safe

### DIFF
--- a/tools/attachment-canvas-consumer-fixture/README.md
+++ b/tools/attachment-canvas-consumer-fixture/README.md
@@ -23,7 +23,7 @@ and then builds against it.
    shape `tools/publish-lib.mjs` produces for a real `npm publish` (strips
    `"./dist/"` export prefixes, drops the `"@epam/source"` condition,
    `"private"`, and `"nx"`), runs `npm pack` from inside `dist/`, and installs
-   the resulting tarball with a real offline `npm install` into this project's own
+   the resulting tarball with a real cache-first `npm install` into this project's own
    `node_modules/@epam/ai-dial-attachment-canvas` — never the workspace
    root's, which npm workspaces symlinks straight to `libs/attachment-canvas`
    source.

--- a/tools/attachment-canvas-consumer-fixture/scripts/pack-and-install.mjs
+++ b/tools/attachment-canvas-consumer-fixture/scripts/pack-and-install.mjs
@@ -109,7 +109,7 @@ try {
       '--ignore-scripts',
       '--legacy-peer-deps',
       '--package-lock=false',
-      '--offline',
+      '--prefer-offline',
       tarballPath,
     ],
     {

--- a/tools/attachment-canvas-consumer-fixture/scripts/verify-build-output.mjs
+++ b/tools/attachment-canvas-consumer-fixture/scripts/verify-build-output.mjs
@@ -6,7 +6,7 @@
  * plain `node_modules`, never the workspace's `@epam/source` alias) and
  * bundled into an ordinary app, the PDF engine (`pdfjs-dist`, via
  * `@epam/ai-dial-react-pdf-highlighter`) and the syntax-highlighter engine
- * (`react-syntax-highlighter`'s `refractor` grammar library) load only
+ * (`react-syntax-highlighter`'s package-specific line-number class) load only
  * on demand — never as part of this app's eager entry graph.
  *
  * Usage: node scripts/verify-build-output.mjs
@@ -49,7 +49,8 @@ const onDemandRefs = allAssetFiles.filter((file) => !eagerRefs.includes(file));
 const readAsset = (ref) => readFileSync(resolve(distDir, ref), 'utf-8');
 
 const PDF_ENGINE_TELLTALE = 'GlobalWorkerOptions'; // pdfjs-dist's own API surface
-const SYNTAX_HIGHLIGHTER_ENGINE_TELLTALE = 'refractor'; // react-syntax-highlighter's grammar engine
+const SYNTAX_HIGHLIGHTER_ENGINE_TELLTALE =
+  'react-syntax-highlighter-line-number'; // package-specific rendered class
 
 const eagerJsRefs = eagerRefs.filter((ref) => ref.endsWith('.js'));
 const eagerCssRefs = eagerRefs.filter((ref) => ref.endsWith('.css'));


### PR DESCRIPTION
**Description:**

Replaces the fixture’s strict offline install with a cache-first install that can fetch missing npm metadata on clean CI runners. Also updates the lazy syntax-highlighter check to use a stable package-specific signature.
Validated the full consumer fixture against an empty npm cache, along with lint, docs, and formatting checks.
**Checklist:**

- [ ] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [X] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
