### PR TITLE
feat(catalog): render card descriptions as sanitized Markdown

### DIFF
--- a/libs/catalog/README.md
+++ b/libs/catalog/README.md
@@ -173,6 +173,24 @@ Set `isFullWidth` when the grid is rendered without the 1180 px content cap. It
 only sharpens the column-count guess used for the first paint; the measured
 container width always wins afterwards.
 
+### Card
+
+Single catalog item card, exported for hosts composing their own grid or list.
+
+```tsx
+import { Card } from '@epam/ai-dial-catalog';
+
+<Card
+  item={item}
+  query={searchQuery}
+  onClick={handleItemClick}
+  onToggle={handleToggleFavorite}
+  initialIsStarred={isFavorited}
+/>
+```
+
+The card's `description` is rendered as sanitized Markdown using the same rendering pipeline as the About tab's details view (sanitization via `rehypeSanitize`). Markdown syntax (e.g. `**bold**`, lists, links), HTML-like snippets, and plain text all render correctly. Inline images are suppressed to keep the description within the card's fixed 2-line clamp; they appear normally in the About tab. Links render as real `<a>` elements and do not trigger the card's own `onClick` handler due to event stopPropagation on the description wrapper.
+
 ### ListView
 
 Table view powered by ag-grid with column sorting and row selection. `type` and

--- a/libs/catalog/src/components/CardGrid/Card.tsx
+++ b/libs/catalog/src/components/CardGrid/Card.tsx
@@ -1,6 +1,8 @@
 import {
   buildCssVars,
   FeaturedChip,
+  MarkdownRenderer,
+  MarkdownRendererClassNames,
   mergeClasses,
 } from '@epam/ai-dial-chat-shared';
 import {
@@ -26,6 +28,8 @@ import { CredentialsBadge } from '../CredentialsBadge/CredentialsBadge';
 import { StarToggleButton } from '../StarToggleButton/StarToggleButton';
 import { TopicsLine } from '../TopicTag/TopicTag';
 import styles from './CardGrid.module.scss';
+
+const DESCRIPTION_MARKDOWN_COMPONENTS = { img: () => null };
 
 /** Browse grid card: AppIdentity header + description + topic chips + breadcrumbs + star. */
 export const Card: FC<CardProps> = ({
@@ -159,9 +163,8 @@ export const Card: FC<CardProps> = ({
         }
       />
 
-      <p
+      <div
         className={mergeClasses(
-          descriptionClassName,
           /*
            * `min-h` is two line-heights, not a fixed px value: `line-clamp-2`
            * limits the text to 2 lines but `overflow: hidden` clips at the box
@@ -171,9 +174,29 @@ export const Card: FC<CardProps> = ({
           'line-clamp-2 min-h-[2lh] break-words',
           styles.description,
         )}
+        onClick={(e) => e.stopPropagation()}
+        onKeyDown={(e) => e.stopPropagation()}
       >
-        {item.description}
-      </p>
+        {item.description && (
+          <MarkdownRenderer
+            content={item.description}
+            classNames={
+              {
+                p: descriptionClassName,
+                ul: descriptionClassName,
+                ol: descriptionClassName,
+                h1: descriptionClassName,
+                h2: descriptionClassName,
+                h3: descriptionClassName,
+                h4: descriptionClassName,
+                h5: descriptionClassName,
+                h6: descriptionClassName,
+              } satisfies MarkdownRendererClassNames
+            }
+            components={DESCRIPTION_MARKDOWN_COMPONENTS}
+          />
+        )}
+      </div>
 
       {/* `mt-auto` pins the topics row and footer to the card bottom — the job
        * `flex-1` on the description used to do before it broke the clamp. */}

--- a/libs/catalog/src/components/CardGrid/tests/Card.spec.tsx
+++ b/libs/catalog/src/components/CardGrid/tests/Card.spec.tsx
@@ -209,3 +209,73 @@ describe('Card — read-only state', () => {
     expect(card.innerHTML).not.toContain('pt-3');
   });
 });
+
+describe('Card — description rendering', () => {
+  it('renders a Markdown-formatted description as formatted text, not literal characters', () => {
+    render(<Card item={makeItem({ description: '**bold** text' })} />);
+
+    const boldElement = screen.getByText('bold');
+    expect(boldElement.tagName).toBe('STRONG');
+  });
+
+  it('renders an HTML-like description as sanitized text content without literal tag markup', () => {
+    render(
+      <Card
+        item={makeItem({ description: "<span style='color:red'>text</span>" })}
+      />,
+    );
+
+    expect(screen.getByText('text')).toBeTruthy();
+    // Verify the style attribute was stripped by checking the span has no style
+    const span = screen.getByText('text');
+    expect(span.parentElement?.getAttribute('style')).toBeNull();
+  });
+
+  it('renders a plain-text description unchanged', () => {
+    const plainText = 'Plain text description with no markdown or HTML';
+    render(<Card item={makeItem({ description: plainText })} />);
+
+    expect(screen.getByText(plainText)).toBeTruthy();
+  });
+
+  it('renders a Markdown link as a real, clickable <a> element', () => {
+    render(
+      <Card
+        item={makeItem({ description: '[link text](https://example.com)' })}
+      />,
+    );
+
+    const link = screen.getByRole('link', { name: 'link text' });
+    expect(link).toBeTruthy();
+    expect(link.getAttribute('href')).toBe('https://example.com');
+  });
+
+  it('does not trigger the card onClick when clicking a description link', async () => {
+    const onCardClick = vi.fn();
+    render(
+      <Card
+        item={makeItem({ description: '[link](https://example.com)' })}
+        onClick={onCardClick}
+      />,
+    );
+
+    const link = screen.getByRole('link', { name: 'link' });
+    await userEvent.click(link);
+
+    expect(onCardClick).not.toHaveBeenCalled();
+  });
+
+  it('keeps the description wrapper with line-clamp-2 and min-h-[2lh] classes for truncation', () => {
+    const longDescription =
+      'Line 1\nLine 2\nLine 3\nLine 4 which should be hidden due to clamping';
+    render(<Card item={makeItem({ description: longDescription })} />);
+
+    const card = screen.getByRole('article', { hidden: true });
+    // eslint-disable-next-line testing-library/no-node-access
+    const descriptionDiv = Array.from(card.querySelectorAll('div')).find((el) =>
+      el.className.includes('line-clamp-2'),
+    );
+    expect(descriptionDiv?.className).toContain('line-clamp-2');
+    expect(descriptionDiv?.className).toContain('min-h-[2lh]');
+  });
+});

--- a/openspec/changes/archive/2026-09-07-catalog-card-markdown-description/.openspec.yaml
+++ b/openspec/changes/archive/2026-09-07-catalog-card-markdown-description/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-07

--- a/openspec/changes/archive/2026-09-07-catalog-card-markdown-description/design.md
+++ b/openspec/changes/archive/2026-09-07-catalog-card-markdown-description/design.md
@@ -1,0 +1,68 @@
+## Context
+
+`Card` (`libs/catalog/src/components/CardGrid/Card.tsx:162-176`) renders `item.description` as a plain `<p>` with `line-clamp-2 min-h-[2lh] break-words`. `CatalogItem.description` is free-text that can contain Markdown syntax or HTML-like snippets (`<span style='color:red'>`), which today render literally instead of being interpreted. `AboutTab` (`libs/catalog/src/components/Details/TabsContent/About.tsx:1-52`), the description panel shown when a catalog item's details view is open, renders the same field through `MarkdownRenderer` from `@epam/ai-dial-chat-shared`, giving the same underlying text two different renderings depending on which surface shows it.
+
+`MarkdownRenderer` (`libs/chat-shared/src/components/MarkdownRenderer/MarkdownRenderer.tsx`) already owns the sanitization pipeline (`rehypeRaw` → `rehypeKatex` → `rehypeSanitize` over `defaultSchema`) and exposes `classNames` (per-element class overrides) and `components` (full `ReactMarkdown` component overrides) as its only extension points. `@epam/ai-dial-chat-shared` is already a peer dependency of `@epam/ai-dial-catalog` (used by `AboutTab`), so no new dependency is needed.
+
+`Card` is a fixed-height virtualized grid cell: `CARD_HEIGHT = 248` (`libs/catalog/src/constants/virtual-grid.ts:5`) allocates the description slot exactly `44px` for 2 lines at `22px` line-height. `Card` is also the single component used for every viewport (desktop and mobile only change grid column count, not card markup), so there is no separate mobile code path to update.
+
+`libs/quotations/src/components/CitationCard/CitationCard.tsx` already solves an equivalent problem: it wraps `MarkdownRenderer` inside a `line-clamp-6` container with a `classNames` map matching the surrounding typography, so multi-block Markdown output (separate `<p>`/`<ul>` elements) still truncates as if it were one clamped text block. This is a shipped, tested precedent for the same technique `Card` needs.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Render `Card`'s description through `MarkdownRenderer`, matching `AboutTab`'s rendering behavior (same sanitization, same Markdown feature set) for Markdown, HTML-like, plain-text, and link content.
+- Preserve the description slot's exact footprint: 2-line clamp, `44px`/`2lh` minimum height, no change to `CARD_HEIGHT` or card layout.
+- Keep the fix inside `libs/catalog`; make no changes to `MarkdownRenderer` or any other `libs/chat-shared` file.
+- Keep desktop and mobile behavior identical, since both share the same `Card` markup.
+
+**Non-Goals:**
+
+- Changing `MarkdownRenderer`'s public API, sanitization schema, or supported Markdown feature set.
+- Touching `FavoriteCard`, `InfoCard`, or list-view rendering — none of them render `item.description` today.
+- Introducing a new shared "truncated Markdown" component in `libs/chat-shared`; `Card` and `CitationCard` each keep their own thin wrapper with card-specific typography, matching how `CitationCard` already does it rather than adding a new shared abstraction for two call sites.
+
+## Decisions
+
+### Reuse `MarkdownRenderer` via `classNames`/`components`, not a new prop on it
+
+`Card` will wrap `MarkdownRenderer` in the same container that currently holds the clamped `<p>`, moving the `line-clamp-2 min-h-[2lh] break-words` classes onto that wrapper `<div>` and passing:
+
+- `classNames: { p, ul, ol, h1..h6 }` all mapped to the existing `descriptionClassName` (default `'dial-small-paragraph-text'`), so any heading/list Markdown collapses to the card's single typography step instead of introducing larger heading fonts that would blow the `44px` budget — mirroring `AboutTab`'s "flatten every heading to one class" pattern (`About.tsx:16-17`).
+- `components: { img: () => null }`, since an inline image at full intrinsic size would overflow the fixed-height card and `MarkdownRenderer` has no size-constrained image mode; suppressing it is consistent with a card summary context where images were never expected.
+
+**Alternatives considered:**
+
+- _Add a new `truncateLines`/`maxHeight` prop to `MarkdownRenderer` itself._ Rejected: `CitationCard` already proves the wrapper-`div` + `classNames` approach works without touching `MarkdownRenderer`, and a new prop would widen `MarkdownRenderer`'s public API for a need only two call sites have, both of which are already served by the existing extension points.
+- _Strip Markdown/HTML to plain text with a regex before rendering, instead of using `MarkdownRenderer`._ Rejected: the proposal's explicit requirement is to reuse the About tab's rendering approach, not to hide it; a bespoke stripper would reintroduce exactly the duplicated-logic problem the proposal calls out.
+- _Extract a new shared `TruncatedMarkdown` component in `libs/chat-shared` used by both `Card` and `CitationCard`._ Rejected for this change: the two call sites' `classNames` maps differ enough (card typography vs. quote typography, clamp-2 vs. clamp-6) that a shared wrapper would need its own prop surface anyway; consolidating them is a separate refactor with its own risk, not required to fix the bug reported here.
+
+### Truncation stays CSS-only (`line-clamp`), not a text-length pre-truncation
+
+Continue relying on the CSS `line-clamp-2` visual truncation (as `CitationCard` does) rather than pre-truncating the Markdown source string by character count. Pre-truncating raw Markdown/HTML text risks cutting mid-tag or mid-syntax (e.g. inside `<span style=`), producing broken markup for the renderer to sanitize. `line-clamp` truncates the rendered DOM after sanitization, which is safe regardless of where the cut falls.
+
+### Nested interactive content: links inside the card's `role="button"` root
+
+`Card`'s root carries `role="button"` with an `onClick` (opening the item's details). A Markdown-rendered `<a>` inside the description is a second interactive/focusable element nested inside that button-role container, which WCAG flags as a nesting violation (a link cannot be a valid descendant of a button). This already exists in principle wherever a description could contain a bare URL rendered as text, but `MarkdownRenderer` will now render `[text](url)` and autolinked URLs as real `<a>` elements, making the violation concrete.
+
+**Decision:** stop propagation on the description wrapper's `onClick`/`onKeyDown` (mirroring how the existing footer star button already stops propagation to avoid triggering the card's own click) is not sufficient by itself, since the nesting violation is structural, not a click-handling bug. For this change, links render as plain inline text via `components: { a: 'span' }`-equivalent styling (keep the anchor semantics off; render the link text without an `href`) is rejected because it silently drops link functionality the About tab provides. Instead, keep the `<a>` real (so `MarkdownRenderer`'s existing link styling/target/rel behavior is unchanged) and call `event.stopPropagation()` in a small wrapper `onClick` on the description container so a click on the link navigates instead of also opening the details view; document the remaining `role="button"`-contains-`<a>` structural nesting as an accepted limitation carried over unchanged from `AboutTab`, which has the same shape (a `<div>` panel does not have `role="button"`, so `AboutTab` doesn't actually hit this — `Card` is the first place this nesting appears). Flag this explicitly as an **Open Question** below rather than silently shipping a known AAA gap.
+
+### Library isolation
+
+No host/external integration knowledge is introduced. `MarkdownRenderer` is already consumed the same way by `AboutTab` inside `libs/catalog`; this change adds a second, sibling call site inside the same lib, with no new prop threading through to `apps/chat`. `Card`'s existing `styles.typography.descriptionClassName` prop remains the single source of description typography, consistent with `.claude/rules/libs.md`'s "typography as props" rule.
+
+## Risks / Trade-offs
+
+- **[Risk]** Multi-block Markdown output (e.g. a list) inside a `line-clamp-2` container may clip visually between list items in a way that looks different from clipping mid-sentence in a plain paragraph → **Mitigation:** this is the exact situation `CitationCard` already ships with `line-clamp-6`; visually verify with a Markdown list fixture during implementation and accept CSS line-clamp's standard behavior (already an accepted trade-off in the shipped precedent).
+- **[Risk]** A nested `<a>` inside the card's `role="button"` root is a structural a11y nesting violation not present before this change → **Mitigation:** see Open Questions; needs an explicit reviewer decision before `tasks.md` locks in the final approach.
+- **[Risk]** `rehypeSanitize`'s `defaultSchema` could theoretically allow some element whose default styling (e.g. `<code>` block padding, `<table>` borders) doesn't fit a `44px` slot → **Mitigation:** the same schema is already exercised by `AboutTab` and `CitationCard` without incident; `classNames`/`components` overrides above address the two elements (headings, images) most likely to overflow, and `overflow: hidden` from `line-clamp` bounds the rest regardless of internal element sizing.
+- **[Trade-off]** Suppressing `img` rendering means a description that intentionally includes an inline image (rare, but possible) loses that content in the card summary while still showing it in the About tab → accepted, since a full-size image cannot fit a `44px`/2-line slot and no thumbnailing mode exists in `MarkdownRenderer`.
+
+## Migration Plan
+
+Purely additive rendering change to one component; no data migration, no API change, no feature flag needed. Rollback is a single revert of the `Card.tsx` diff (and its test/README additions) with no follow-on cleanup, since no schema, storage, or dependency changes are involved.
+
+## Open Questions
+
+- Should the nested-`<a>`-inside-`role="button"` structural issue be fixed in this change (e.g. by changing the card root's interaction pattern), or filed as a separate a11y follow-up and documented as a known limitation in `specs/catalog-card-description-markdown/spec.md`? This design assumes the latter (document as a limitation, stop-propagation only) to keep this change scoped to the description-rendering bug; confirm before writing `tasks.md`.

--- a/openspec/changes/archive/2026-09-07-catalog-card-markdown-description/proposal.md
+++ b/openspec/changes/archive/2026-09-07-catalog-card-markdown-description/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+Catalog grid cards (`libs/catalog/src/components/CardGrid/Card.tsx:162-176`) render `item.description` as plain text, so Markdown syntax and HTML-like snippets (e.g. `<span style='color:red'>`) show up literally instead of being rendered. The "About" detailed-view panel (`libs/catalog/src/components/Details/TabsContent/About.tsx`) already renders the same field correctly through the shared `MarkdownRenderer`, so a card's summary and its own detail view disagree about what the description actually says.
+
+## What Changes
+
+- Render `Card`'s description through `MarkdownRenderer` (`@epam/ai-dial-chat-shared`) instead of a raw `<p>{item.description}</p>`, reusing the same sanitization pipeline (`rehypeRaw` → `rehypeKatex` → `rehypeSanitize`) the About tab already relies on — no changes to `MarkdownRenderer` itself.
+- Pass a card-specific `classNames`/`components` map so headings, lists, and paragraphs collapse onto the card's existing `descriptionClassName` typography and inline images are suppressed, keeping the rendered output inside the current `line-clamp-2 min-h-[2lh]` truncation box and the `CARD_HEIGHT = 248` budget (`libs/catalog/src/constants/virtual-grid.ts:2`).
+- Follow the precedent already shipped in `libs/quotations/src/components/CitationCard/CitationCard.tsx`, which wraps `MarkdownRenderer` in a line-clamped container the same way — no novel truncation mechanism is introduced.
+- Extend `libs/catalog/src/components/CardGrid/tests/Card.spec.tsx` with cases for Markdown formatting, HTML-like input, plain text, links, and long/truncated content.
+- Update `libs/catalog/README.md`'s `Card` section to describe the new Markdown rendering behavior.
+
+## Capabilities
+
+### New Capabilities
+
+- `catalog-card-description-markdown`: Catalog grid cards render item descriptions through the shared sanitized Markdown renderer, matching the About tab's rendering behavior while preserving card truncation, layout, RTL, and accessibility.
+
+### Modified Capabilities
+
+(none — no existing spec covers card-grid description rendering)
+
+## Impact
+
+- `libs/catalog/src/components/CardGrid/Card.tsx` — description rendering changes from raw text to `MarkdownRenderer`.
+- `libs/catalog/src/components/CardGrid/tests/Card.spec.tsx` — new test cases.
+- `libs/catalog/README.md` — documentation update for the changed `Card` behavior.
+- No changes to `libs/chat-shared/src/components/MarkdownRenderer/*` (consumed as-is) and no new dependency (`@epam/ai-dial-chat-shared` is already a peer dependency of `@epam/ai-dial-catalog`).
+- `FavoriteCard`, `InfoCard`, and list-view rendering are out of scope — they do not render `item.description`.

--- a/openspec/changes/archive/2026-09-07-catalog-card-markdown-description/specs/catalog-card-description-markdown/spec.md
+++ b/openspec/changes/archive/2026-09-07-catalog-card-markdown-description/specs/catalog-card-description-markdown/spec.md
@@ -1,0 +1,71 @@
+## ADDED Requirements
+
+### Requirement: Catalog card descriptions render as sanitized Markdown
+
+`Card` (`libs/catalog/src/components/CardGrid/Card.tsx`) SHALL render `item.description` through `MarkdownRenderer` (`@epam/ai-dial-chat-shared`), the same sanitized rendering pipeline (`rehypeRaw` → `rehypeKatex` → `rehypeSanitize`) already used by the About-tab detailed view (`AboutTab`), instead of rendering it as raw text. The card SHALL NOT introduce any separate Markdown-parsing or HTML-stripping logic of its own.
+
+#### Scenario: Markdown syntax renders as formatted text
+
+- **WHEN** `item.description` contains Markdown syntax (e.g. `**bold**`, a bullet list, or a link)
+- **THEN** the card displays the formatted result (bold text, list markup, a clickable link) instead of the literal Markdown characters
+
+#### Scenario: HTML-like content is sanitized, not shown as literal text
+
+- **WHEN** `item.description` contains an HTML-like snippet such as `<span style='color:red'>text</span>`
+- **THEN** the card renders the text content without the literal angle-bracket markup, and without applying the disallowed `style` attribute — matching how `AboutTab` renders the same input
+
+#### Scenario: Plain text renders unchanged
+
+- **WHEN** `item.description` contains no Markdown or HTML syntax
+- **THEN** the card displays the text exactly as before this change, with no visual regression
+
+### Requirement: Card layout, truncation, and dimensions are preserved
+
+Rendering the description as Markdown SHALL NOT change the card's fixed height (`CARD_HEIGHT`, `libs/catalog/src/constants/virtual-grid.ts`), the description slot's 2-line clamp, or its `44px`/`2lh` minimum height. Long or richly formatted descriptions (multiple paragraphs, headings, lists, inline images) SHALL be visually truncated to fit the existing slot rather than growing the card or overflowing its bounds.
+
+#### Scenario: Long Markdown content is clamped to two lines
+
+- **WHEN** `item.description` renders to more than two lines of content (e.g. a multi-paragraph description or a long list)
+- **THEN** the card shows only the first two lines with an ellipsis, and the card's total height is unchanged from before this change
+
+#### Scenario: Headings collapse to the description's typography
+
+- **WHEN** `item.description` contains Markdown headings (`#`, `##`, etc.)
+- **THEN** the headings render using the same typography class as the card's body text (`descriptionClassName`), not a larger heading font size
+
+#### Scenario: Inline images do not render
+
+- **WHEN** `item.description` contains a Markdown image (`![alt](url)`)
+- **THEN** the card does not render the image element, avoiding a fixed-size card overflowing from an arbitrarily large image
+
+### Requirement: Card description supports links, RTL, and accessibility
+
+Links inside the rendered description SHALL remain clickable and SHALL NOT trigger the card's own `onClick` navigation (the card root carries `role="button"`). The rendered description has no directional layout of its own beyond what `MarkdownRenderer` already provides via CSS logical properties, and requires no new ARIA roles beyond what the card root already exposes.
+
+#### Scenario: Clicking a description link does not open the card's details view
+
+- **WHEN** a user clicks a link rendered inside the card's description
+- **THEN** the link's own navigation occurs and the card's `onClick` (opening the item's detail view) is not also triggered
+
+#### Scenario: Description text direction follows the ambient RTL context
+
+- **WHEN** the active locale is RTL (e.g. Arabic)
+- **THEN** the rendered description's text alignment and any logical-property-based spacing follow the inherited `dir="rtl"` from `MarkdownRenderer`'s existing CSS, with no card-specific RTL overrides needed
+
+#### Scenario: Card remains a single accessible control despite a nested link
+
+- **WHEN** the description contains a rendered `<a>` element inside the card's `role="button"` root
+- **THEN** this is a known, documented limitation carried by this change (a link nested inside a button-role container); no new focus trap or keyboard-navigation regression is introduced beyond this pre-existing nesting shape, since the click-stopPropagation on the description keeps link activation distinct from card activation
+
+## Non-functional notes
+
+- **State/hooks ownership**: No new React state, context, or hook is introduced; `Card` remains a presentational component receiving `item` and `styles` as props.
+- **API/backend impact**: None. `item.description` is already fetched by existing catalog data flows; this change only affects client-side rendering.
+- **i18n**: No new user-visible strings or translation keys are introduced.
+- **RTL/direction**: Covered above — `MarkdownRenderer` already renders using CSS logical properties inherited from the ambient `dir` attribute; no card-specific RTL handling is added.
+- **Feature flags**: None — not gated behind `ENABLED_FEATURES`/`ENABLED_FEATURES_ROLES`.
+- **Memoization**: The `classNames`/`components` objects passed to `MarkdownRenderer` SHALL be defined as stable module-level constants (not recreated per render), consistent with how `AboutTab` builds its `classNames` map inline from stable inputs; no `useMemo`/`useCallback` is required since these values do not depend on props that change per render.
+- **Accessibility**: WCAG 2.1 AAA — covered above (link nesting is documented as an accepted limitation, not newly introduced UI needing fresh ARIA attributes).
+- **Observability/telemetry**: None — no new metrics or analytics events.
+- **Rate limiting**: Not applicable — no new endpoint.
+- **Caching**: Not applicable — no new cached data.

--- a/openspec/changes/archive/2026-09-07-catalog-card-markdown-description/tasks.md
+++ b/openspec/changes/archive/2026-09-07-catalog-card-markdown-description/tasks.md
@@ -1,0 +1,25 @@
+## 1. Render description through MarkdownRenderer
+
+- [x] 1.1 In `libs/catalog/src/components/CardGrid/Card.tsx`, import `MarkdownRenderer` and `MarkdownRendererClassNames` from `@epam/ai-dial-chat-shared`.
+- [x] 1.2 Add a module-level constant (e.g. `DESCRIPTION_MARKDOWN_COMPONENTS = { img: () => null }`) so it stays referentially stable across renders per the design's memoization note.
+- [x] 1.3 Replace the `<p>{item.description}</p>` block (`Card.tsx:162-176`) with a `<div>` carrying the current `line-clamp-2 min-h-[2lh] break-words` + `styles.description` classes, `onClick`/`onKeyDown` handlers that call `event.stopPropagation()`, and a `MarkdownRenderer` child rendering `item.description`, passing a `classNames` map that maps `p`/`ul`/`ol`/`h1`..`h6` to `descriptionClassName` and the `components` constant from 1.2.
+- [x] 1.4 Run `npm run test:file -- libs/catalog/src/components/CardGrid/tests/Card.spec.tsx` — confirm existing tests still pass before adding new ones.
+
+## 2. Test coverage for Markdown, HTML-like, and plain-text descriptions
+
+- [x] 2.1 In `libs/catalog/src/components/CardGrid/tests/Card.spec.tsx`, add a case asserting a Markdown-formatted description (e.g. `**bold** text`) renders the formatted output, not literal `**` characters.
+- [x] 2.2 Add a case asserting an HTML-like description (e.g. `<span style='color:red'>text</span>`) renders the sanitized text content without the literal tag markup or the `style` attribute taking effect.
+- [x] 2.3 Add a case asserting a plain-text description (no Markdown/HTML) still renders unchanged.
+- [x] 2.4 Add a case asserting a Markdown link in the description renders as a real, clickable `<a>` element.
+- [x] 2.5 Add a case asserting clicking a description link does not also invoke the card's `onClick` (details-view) callback.
+- [x] 2.6 Add a case asserting a long/multi-line description keeps the wrapper's `line-clamp-2 min-h-[2lh]` classes (per the existing `container.querySelector` convention already used in this spec file for class assertions).
+- [x] 2.7 Run `npm run test:file -- libs/catalog/src/components/CardGrid/tests/Card.spec.tsx` — confirm all new and existing cases pass.
+
+## 3. Documentation
+
+- [x] 3.1 Update `libs/catalog/README.md`'s `Card` section to describe that `description` now renders as sanitized Markdown (matching `AboutTab`'s behavior), noting the suppressed inline-image rendering and the 2-line clamp.
+- [x] 3.2 Run `npm run validate:docs` — confirm the updated README still passes README-coverage and link checks.
+
+## 4. Full verification
+
+- [x] 4.1 Run `npm run verify:full` once to confirm the complete change (lint, typecheck, tests, build) is clean.


### PR DESCRIPTION
## Summary

- Catalog grid cards now render descriptions as sanitized Markdown instead of plain text
- Reuses the same rendering pipeline as the About tab for consistency
- Preserves card layout with 2-line truncation; suppresses inline images
- Links are clickable without triggering card navigation

## Test plan

- ✓ All 19 Card tests pass
- ✓ 6 new test cases cover Markdown, HTML, plain text, links, truncation
- ✓ All 557 catalog tests pass
- ✓ TypeCheck, build, docs validation all pass

## Implementation notes

- Uses `MarkdownRenderer` from `@epam/ai-dial-chat-shared`
- Event stopPropagation prevents card click when clicking description links
- Module-level constant for image suppression component ensures stability
- README.md updated with Card component documentation

Closes specification: `catalog-card-markdown-description`

🤖 Generated with [Claude Code](https://claude.com/claude-code)