### PR TITLE
fix: Add validation to version field, Issue #8627

### DIFF
--- a/apps/chat/src/constants/translation-keys.ts
+++ b/apps/chat/src/constants/translation-keys.ts
@@ -1052,6 +1052,7 @@ export enum ToolsetEditorI18nKeys {
   NamePlaceholder = 'toolsetEditor.general.namePlaceholder',
   DescriptionPlaceholder = 'toolsetEditor.general.descriptionPlaceholder',
   TopicsPlaceholder = 'toolsetEditor.general.topicsPlaceholder',
+  VersionInvalid = 'toolsetEditor.general.versionInvalid',
   // Settings form
   EndpointCaption = 'toolsetEditor.settings.endpointCaption',
   EndpointRequired = 'toolsetEditor.settings.endpointRequired',

--- a/apps/chat/src/i18n/locales/en.json
+++ b/apps/chat/src/i18n/locales/en.json
@@ -1040,7 +1040,7 @@
       "namePlaceholder": "Enter application name",
       "descriptionPlaceholder": "Describe your application",
       "nameInvalid": "Name may only contain letters, digits, spaces, underscores, dots, and dashes",
-      "versionInvalid": "Version may only contain letters, digits, dots, underscores, and dashes"
+      "versionInvalid": "Version format is invalid (example: 0.0.1)"
     },
     "settingsStep": {
       "loadingLabel": "Loading editor…",
@@ -1063,7 +1063,8 @@
     "general": {
       "namePlaceholder": "Enter name",
       "descriptionPlaceholder": "Describe what this toolset does",
-      "topicsPlaceholder": "Add tags, comma separated"
+      "topicsPlaceholder": "Add tags, comma separated",
+      "versionInvalid": "Version may only contain letters, digits, dots, underscores, and dashes"
     },
     "settings": {
       "endpointCaption": "The HTTPS address where the server accepts MCP requests.",

--- a/apps/chat/src/pages/AppsEditor/GeneralForm.tsx
+++ b/apps/chat/src/pages/AppsEditor/GeneralForm.tsx
@@ -15,6 +15,7 @@ import {
   DeploymentCreationFormFieldErrors,
   DeploymentCreationFormLabels,
   DeploymentCreationFormValues,
+  SEMVER_VERSION_PATTERN,
   validateDeploymentCreationFields,
 } from '@epam/ai-dial-deployment-creation-form';
 import { ErrorMessageNotification } from '@epam/ai-dial-ui-kit';
@@ -215,7 +216,7 @@ const GeneralForm = forwardRef<GeneralFormHandle, Props>(function GeneralForm(
     setErrors({});
     const codes = validateDeploymentCreationFields(values, {
       validateNamePattern: true,
-      validateVersionPattern: true,
+      validateVersionPattern: SEMVER_VERSION_PATTERN,
     });
     if (codes.name || codes.version) {
       let nameError: string | undefined;

--- a/apps/chat/src/pages/ToolsetEditor/CustomAppEditor.tsx
+++ b/apps/chat/src/pages/ToolsetEditor/CustomAppEditor.tsx
@@ -13,6 +13,7 @@ import {
 } from '@epam/ai-dial-chat-hooks';
 import {
   DeploymentCreationFieldErrorCode,
+  SEMVER_VERSION_PATTERN,
   validateDeploymentCreationFields,
 } from '@epam/ai-dial-deployment-creation-form';
 import { ConfirmationPopup, Spinner, StepStatus } from '@epam/ai-dial-ui-kit';
@@ -262,7 +263,7 @@ const CustomAppEditor: FC = () => {
     }
 
     const generalCodes = validateDeploymentCreationFields(generalForm, {
-      validateVersionPattern: true,
+      validateVersionPattern: SEMVER_VERSION_PATTERN,
     });
     if (
       generalCodes.version === DeploymentCreationFieldErrorCode.InvalidFormat

--- a/apps/chat/src/pages/ToolsetEditor/EditorForm/AuthSection.tsx
+++ b/apps/chat/src/pages/ToolsetEditor/EditorForm/AuthSection.tsx
@@ -529,7 +529,7 @@ const AuthSection: FC<Props> = ({
         aria-label={t(ToolsetEditorI18nKeys.AuthSectionTitle)}
         value={auth.authenticationType}
         onChange={(type) => handleSelectType(type as ToolsetAuthTypes)}
-        segmentClassName="px-2 !flex-none !min-w-0"
+        segmentClassName="px-2"
         items={[
           ToolsetAuthTypes.None,
           ToolsetAuthTypes.OAuth,

--- a/apps/chat/src/pages/ToolsetEditor/ToolsetEditor.tsx
+++ b/apps/chat/src/pages/ToolsetEditor/ToolsetEditor.tsx
@@ -271,9 +271,16 @@ const ToolsetEditor: FC = () => {
   const validate = useCallback(
     (data: ToolsetFormData): ToolsetFormErrors => {
       const nextErrors: ToolsetFormErrors = {};
-      const generalCodes = validateDeploymentCreationFields(data);
+      const generalCodes = validateDeploymentCreationFields(data, {
+        validateVersionPattern: true,
+      });
       if (generalCodes.name === DeploymentCreationFieldErrorCode.Required) {
         nextErrors.name = t(EditorI18nKeys.NameRequired);
+      }
+      if (
+        generalCodes.version === DeploymentCreationFieldErrorCode.InvalidFormat
+      ) {
+        nextErrors.version = t(ToolsetEditorI18nKeys.VersionInvalid);
       }
       if (!data.endpoint.trim()) {
         nextErrors.endpoint = t(ToolsetEditorI18nKeys.EndpointRequired);

--- a/apps/chat/src/utils/toolsets.ts
+++ b/apps/chat/src/utils/toolsets.ts
@@ -287,7 +287,9 @@ export const isToolsetFormValid = (
   form: ToolsetFormData,
   isEditMode = false,
 ): boolean =>
-  Object.keys(validateDeploymentCreationFields(form)).length === 0 &&
+  Object.keys(
+    validateDeploymentCreationFields(form, { validateVersionPattern: true }),
+  ).length === 0 &&
   isValidEndpointUrl(form.endpoint) &&
   isToolsetAuthValid(form.auth, isEditMode);
 

--- a/libs/deployment-creation-form/README.md
+++ b/libs/deployment-creation-form/README.md
@@ -151,11 +151,12 @@ import {
   DeploymentCreationFieldErrorCode,
   NAME_PATTERN,
   VERSION_PATTERN,
+  SEMVER_VERSION_PATTERN,
 } from '@epam/ai-dial-deployment-creation-form';
 
 const codes = validateDeploymentCreationFields(values, {
   validateNamePattern: true,
-  validateVersionPattern: true,
+  validateVersionPattern: true, // or: SEMVER_VERSION_PATTERN for a stricter check
 });
 
 const errors = {
@@ -167,8 +168,12 @@ const errors = {
 ```
 
 `NAME_PATTERN` allows letters, digits, spaces, underscores, dots, and dashes;
-`VERSION_PATTERN` allows letters, digits, dots, underscores, and dashes. Both are
-exported so a host can pre-filter input with the same rule the validator applies.
+`VERSION_PATTERN` (the default when `validateVersionPattern: true`) allows
+letters, digits, dots, underscores, and dashes. Pass a `RegExp` instead of
+`true` — e.g. `SEMVER_VERSION_PATTERN`, which requires one or more
+dot-separated numeric segments (`0.0.1`, `2.0`) — for a host that needs a
+stricter version format. All three are exported so a host can pre-filter
+input with the same rule the validator applies.
 
 ## Enums
 

--- a/libs/deployment-creation-form/src/index.ts
+++ b/libs/deployment-creation-form/src/index.ts
@@ -26,6 +26,7 @@ export type {
 export { DeploymentCreationFieldErrorCode } from './models/validation';
 export {
   NAME_PATTERN,
+  SEMVER_VERSION_PATTERN,
   VERSION_PATTERN,
   validateDeploymentCreationFields,
 } from './utils/validate-deployment-creation-fields';

--- a/libs/deployment-creation-form/src/models/validation.ts
+++ b/libs/deployment-creation-form/src/models/validation.ts
@@ -20,6 +20,11 @@ export interface DeploymentCreationFormErrorCodes {
 export interface DeploymentCreationFormValidationOptions {
   /** Whether to reject a name containing characters outside `NAME_PATTERN`. */
   validateNamePattern?: boolean;
-  /** Whether to reject a non-empty version containing characters outside `VERSION_PATTERN`. */
-  validateVersionPattern?: boolean;
+  /**
+   * Whether to reject a non-empty version that doesn't match a pattern.
+   * `true` checks against the default `VERSION_PATTERN`; passing a `RegExp`
+   * checks against that pattern instead (e.g. `SEMVER_VERSION_PATTERN` for a
+   * host that requires a strict dot-separated numeric version).
+   */
+  validateVersionPattern?: boolean | RegExp;
 }

--- a/libs/deployment-creation-form/src/utils/validate-deployment-creation-fields.spec.ts
+++ b/libs/deployment-creation-form/src/utils/validate-deployment-creation-fields.spec.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import type { DeploymentCreationFormValues } from '../models/deployment-creation-form';
 import { DeploymentCreationFieldErrorCode } from '../models/validation';
-import { validateDeploymentCreationFields } from './validate-deployment-creation-fields';
+import {
+  SEMVER_VERSION_PATTERN,
+  validateDeploymentCreationFields,
+} from './validate-deployment-creation-fields';
 
 const baseValues: DeploymentCreationFormValues = {
   name: 'My Entity',
@@ -47,6 +50,30 @@ describe('validateDeploymentCreationFields', () => {
       { validateVersionPattern: true },
     );
     expect(errors.version).toBe(DeploymentCreationFieldErrorCode.InvalidFormat);
+  });
+
+  it('accepts a letters-only version when the default pattern check is enabled', () => {
+    const errors = validateDeploymentCreationFields(
+      { ...baseValues, version: 'abc' },
+      { validateVersionPattern: true },
+    );
+    expect(errors.version).toBeUndefined();
+  });
+
+  it('returns an invalid-format error for a non-numeric version when a stricter pattern is passed', () => {
+    const errors = validateDeploymentCreationFields(
+      { ...baseValues, version: 'abc' },
+      { validateVersionPattern: SEMVER_VERSION_PATTERN },
+    );
+    expect(errors.version).toBe(DeploymentCreationFieldErrorCode.InvalidFormat);
+  });
+
+  it('accepts a dot-separated numeric version when a stricter pattern is passed', () => {
+    const errors = validateDeploymentCreationFields(
+      { ...baseValues, version: '0.0.1' },
+      { validateVersionPattern: SEMVER_VERSION_PATTERN },
+    );
+    expect(errors.version).toBeUndefined();
   });
 
   it('does not flag an empty version even when the pattern check is enabled', () => {

--- a/libs/deployment-creation-form/src/utils/validate-deployment-creation-fields.ts
+++ b/libs/deployment-creation-form/src/utils/validate-deployment-creation-fields.ts
@@ -11,6 +11,9 @@ export const NAME_PATTERN = /^[a-zA-Z0-9 _.-]+$/;
 /** Allowed characters for the version field: letters, digits, dots, underscores, dashes. */
 export const VERSION_PATTERN = /^[a-zA-Z0-9._-]+$/;
 
+/** Stricter version shape: one or more dot-separated numeric segments (e.g. `0.0.1`). */
+export const SEMVER_VERSION_PATTERN = /^\d+(\.\d+)*$/;
+
 /** Validates the General-step fields and returns untranslated error codes; has no side effects. */
 export const validateDeploymentCreationFields = (
   values: DeploymentCreationFormValues,
@@ -26,12 +29,14 @@ export const validateDeploymentCreationFields = (
   }
 
   const trimmedVersion = values.version.trim();
-  if (
-    options.validateVersionPattern &&
-    trimmedVersion &&
-    !VERSION_PATTERN.test(trimmedVersion)
-  ) {
-    errors.version = DeploymentCreationFieldErrorCode.InvalidFormat;
+  if (options.validateVersionPattern && trimmedVersion) {
+    const pattern =
+      options.validateVersionPattern instanceof RegExp
+        ? options.validateVersionPattern
+        : VERSION_PATTERN;
+    if (!pattern.test(trimmedVersion)) {
+      errors.version = DeploymentCreationFieldErrorCode.InvalidFormat;
+    }
   }
 
   return errors;

--- a/openspec/specs/app-editor-flow/spec.md
+++ b/openspec/specs/app-editor-flow/spec.md
@@ -140,7 +140,7 @@ The page header SHALL be the shared `EditorHeader` component (see "Shared editor
 | `appsEditor.generalForm.namePlaceholder` | `Enter application name` |
 | `appsEditor.generalForm.descriptionPlaceholder` | `Describe your application` |
 | `appsEditor.generalForm.nameInvalid` | `Name may only contain letters, digits, spaces, underscores, dots, and dashes` |
-| `appsEditor.generalForm.versionInvalid` | `Version may only contain letters, digits, dots, underscores, and dashes` |
+| `appsEditor.generalForm.versionInvalid` | `Version format is invalid (example: 0.0.1)` |
 | `appsEditor.settingsStep.loadingLabel` | `Loading editor…` |
 | `appsEditor.settingsStep.noEditorPlaceholder` | `Editor not available for this application type yet.` |
 | `appsEditor.error.createFailed` | `Failed to create application. Please try again.` |
@@ -341,7 +341,7 @@ State owned locally via `useState`:
 
 `initialValues`, when supplied, SHALL seed `values` exactly once (guarded by a ref) so later edits are never overwritten by a re-render of the host.
 
-Client-side validation SHALL run through `validateDeploymentCreationFields` with both `validateNamePattern` and `validateVersionPattern` enabled: the Name field is required and must match the allowed-character pattern, and the Version field — when non-empty — must match its own pattern. No URL format validation is performed on the icon URL field; that is enforced server-side only.
+Client-side validation SHALL run through `validateDeploymentCreationFields` with `validateNamePattern` enabled and `validateVersionPattern` set to the library's exported `SEMVER_VERSION_PATTERN`: the Name field is required and must match the allowed-character pattern, and the Version field — when non-empty — must be one or more dot-separated numeric segments (e.g. `0.0.1`, `2.0`), stricter than the shared library's default character-set-only version pattern. No URL format validation is performed on the icon URL field; that is enforced server-side only.
 
 Submitting the form (via the imperative `submit()` handle, or the underlying `<form onSubmit>` if the user presses Enter):
 - Is a no-op while `isSubmitting` is already true.

--- a/openspec/specs/custom-app-editor/spec.md
+++ b/openspec/specs/custom-app-editor/spec.md
@@ -87,15 +87,15 @@ On save in creation mode, `CustomAppEditor` SHALL NOT send `type` in the create 
 - **THEN** the create request body carries no `type` field and no `application_type_schema_id`
 
 ### Requirement: General step validation — name and version
-`CustomAppEditor` SHALL validate the `name` field as required and the `version` field against the shared `DeploymentCreationForm` version pattern (via `validateDeploymentCreationFields` from `@epam/ai-dial-deployment-creation-form`). Each field SHALL be re-validated on blur, independently of the other, so an error shown for one field does not get cleared by fixing the other. The Next button SHALL stay disabled while either field is invalid.
+`CustomAppEditor` SHALL validate the `name` field as required and the `version` field against the shared `DeploymentCreationForm`'s exported `SEMVER_VERSION_PATTERN` (via `validateDeploymentCreationFields` from `@epam/ai-dial-deployment-creation-form`, passing `validateVersionPattern: SEMVER_VERSION_PATTERN`), stricter than that library's default character-set-only version pattern: a non-empty version must be one or more dot-separated numeric segments (e.g. `0.0.1`, `2.0`). Each field SHALL be re-validated on blur, independently of the other, so an error shown for one field does not get cleared by fixing the other. The Next button SHALL stay disabled while either field is invalid. The version-invalid error message SHALL be `"Version format is invalid (example: 0.0.1)"` (`appsEditor.generalForm.versionInvalid`).
 
 #### Scenario: Name required error on blur
 - **WHEN** the Name field is blank and loses focus
 - **THEN** a name-required error is shown under the Name field
 
 #### Scenario: Version format error on blur
-- **WHEN** the Version field contains a value that does not match the allowed version pattern and loses focus
-- **THEN** a version-invalid error is shown under the Version field
+- **WHEN** the Version field contains a value that is not entirely dot-separated numeric segments (e.g. contains letters) and loses focus
+- **THEN** a version-invalid error ("Version format is invalid (example: 0.0.1)") is shown under the Version field
 
 #### Scenario: Next disabled while General step invalid
 - **WHEN** the Name or Version field currently holds an invalid value

--- a/openspec/specs/deployment-creation-form/spec.md
+++ b/openspec/specs/deployment-creation-form/spec.md
@@ -46,10 +46,20 @@ identifiers.
 
 ### Requirement: Shared field validation function
 `libs/deployment-creation-form` SHALL export a pure `validateDeploymentCreationFields` function that
-takes the shared field values and returns field-level errors: a required-name error when name
-is empty, and a name-format error when name contains characters outside letters, digits, spaces,
-underscores, dots, and dashes. The function SHALL NOT validate an `intro` field. The
-function SHALL have no side effects and SHALL NOT depend on i18n, routing, or network state.
+takes the shared field values and an options object, and returns field-level errors: a
+required-name error when name is empty, a name-format error (opt-in via `validateNamePattern`)
+when name contains characters outside letters, digits, spaces, underscores, dots, and dashes
+(`NAME_PATTERN`), and a version-format error (opt-in via `validateVersionPattern`) for a
+non-empty version that fails the applicable version pattern. A non-empty version never produces
+a required error. The function SHALL NOT validate an `intro` field. The function SHALL have no
+side effects and SHALL NOT depend on i18n, routing, or network state.
+
+`validateVersionPattern` SHALL accept either `true` — checking the non-empty version against the
+exported default `VERSION_PATTERN` (letters, digits, dots, underscores, dashes) — or a `RegExp`,
+checked instead of the default. The library SHALL also export `SEMVER_VERSION_PATTERN` (one or
+more dot-separated numeric segments, e.g. `0.0.1`, `2.0`) as a stricter alternative a host can
+pass when it requires a dot-separated numeric version rather than the default permissive
+character-set check.
 
 #### Scenario: Valid values produce no errors
 - **WHEN** the function is called with a non-empty, correctly formatted name
@@ -58,6 +68,22 @@ function SHALL have no side effects and SHALL NOT depend on i18n, routing, or ne
 #### Scenario: Name is required
 - **WHEN** the function is called with an empty name
 - **THEN** it returns a required-field error for name
+
+#### Scenario: Default version pattern check
+- **WHEN** the function is called with `validateVersionPattern: true` and a non-empty version
+  containing a character outside `VERSION_PATTERN`
+- **THEN** it returns a version-format error; a version made only of letters, digits, dots,
+  underscores, and dashes (e.g. `abc`) produces no error
+
+#### Scenario: Stricter version pattern override
+- **WHEN** the function is called with `validateVersionPattern: SEMVER_VERSION_PATTERN` and a
+  non-empty version that is not entirely dot-separated numeric segments (e.g. `abc`)
+- **THEN** it returns a version-format error; a version such as `0.0.1` or `2.0` produces no error
+
+#### Scenario: Empty version is never flagged
+- **WHEN** the function is called with `validateVersionPattern` set (either `true` or a `RegExp`)
+  and an empty version
+- **THEN** it returns no error for version
 
 ### Requirement: Library isolation boundary
 `libs/deployment-creation-form` SHALL NOT import `react-i18next`, `@epam/chat-api-client`,

--- a/openspec/specs/toolset-authoring/spec.md
+++ b/openspec/specs/toolset-authoring/spec.md
@@ -21,6 +21,16 @@ The system SHALL provide a `/toolset-editor` route that opens the toolset editor
 ### Requirement: Metadata section fields
 The Metadata section SHALL allow editing the toolset avatar, name, version, description, and topics. The avatar SHALL be picked via the shared `AddAvatar` control (preview box plus "Add avatar" button), which opens the `AvatarPickerModal` file manager restricted to a single image up to a host-configured size, rather than a plain URL text field. The name and description fields SHALL also allow editing translations for additional locales through the shared `DeploymentLocalesField` popup. These fields SHALL be rendered and validated through the shared `deployment-creation-form` library component. The Metadata section SHALL NOT contain any connection or authentication fields.
 
+The Version field SHALL be validated against the shared `deployment-creation-form` library's default `VERSION_PATTERN` (via `validateDeploymentCreationFields` with `validateVersionPattern: true`) — letters, digits, dots, underscores, and dashes are all allowed, unlike the stricter dot-separated-numeric-only pattern the Quick App and Custom App editors use. A non-empty version that contains any other character SHALL surface a version-invalid error (`toolsetEditor.general.versionInvalid`, "Version may only contain letters, digits, dots, underscores, and dashes") under the Version field and SHALL keep the Save button disabled.
+
+#### Scenario: Version format error
+- **WHEN** a user types a version containing a character outside letters, digits, dots, underscores, and dashes (e.g. a space or `/`)
+- **THEN** a version-invalid error is shown under the Version field and the Save button stays disabled
+
+#### Scenario: Letters-only version is accepted
+- **WHEN** a user types a version made only of letters, digits, dots, underscores, and dashes (e.g. `abc` or `1.0-beta`)
+- **THEN** no version error is shown
+
 #### Scenario: Edit metadata fields
 - **WHEN** a user picks an avatar image and types a name, version, description, and adds topic tags
 - **THEN** those values are held in component state without saving

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@epam/ai-dial-react-file-manager": "0.2.0-dev.11",
         "@epam/ai-dial-react-pdf-highlighter": "0.2.0-dev.28",
         "@epam/ai-dial-shared": "0.48.0",
-        "@epam/ai-dial-ui-kit": "^0.14.0-dev.28",
+        "@epam/ai-dial-ui-kit": "^0.14.0-dev.34",
         "@epam/ai-dial-visualizer-connector": "0.48.0",
         "@epam/pdf-highlighter-kit": "^0.0.18",
         "@mcp-ui/client": "^7.1.1",
@@ -2765,9 +2765,9 @@
       }
     },
     "node_modules/@epam/ai-dial-ui-kit": {
-      "version": "0.14.0-dev.28",
-      "resolved": "https://registry.npmjs.org/@epam/ai-dial-ui-kit/-/ai-dial-ui-kit-0.14.0-dev.28.tgz",
-      "integrity": "sha512-OhOCcl9vEgdS3fRNpYD8gInbegv5zySV55Y3tMn3N82cEbTPAbrUOGHxQySltiS7WL7VPQS8X/EvuYXd+h8viw==",
+      "version": "0.14.0-dev.34",
+      "resolved": "https://registry.npmjs.org/@epam/ai-dial-ui-kit/-/ai-dial-ui-kit-0.14.0-dev.34.tgz",
+      "integrity": "sha512-n7pk7qlXVaeXlTcd+RknW+L9lA2Ij74KgvyCOSsgCcs8Xy98VmaDqCqLm+yJ21f2FBvxAAT04Wwn9IM9000CRA==",
       "license": "Apache-2.0",
       "dependencies": {
         "ag-grid-community": "^35.2.1",

--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "@epam/ai-dial-react-file-manager": "0.2.0-dev.11",
     "@epam/ai-dial-react-pdf-highlighter": "0.2.0-dev.28",
     "@epam/ai-dial-shared": "0.48.0",
-    "@epam/ai-dial-ui-kit": "^0.14.0-dev.28",
+    "@epam/ai-dial-ui-kit": "^0.14.0-dev.34",
     "@epam/ai-dial-visualizer-connector": "0.48.0",
     "@epam/pdf-highlighter-kit": "^0.0.18",
     "@mcp-ui/client": "^7.1.1",


### PR DESCRIPTION
**Description:**

Added validation for version field in editors

Issues:

- Issue #8627

**UI changes**

<Please, provide Screenshots or Figma links>

**Checklist:**

- [X] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [X]  the pull request name starts with `fix(<scope>):`, `feat(<scope>):`, `feature(<scope>):`, `chore(<scope>):`, `hotfix(<scope>):` or `e2e(<scope>):`. If contains breaking changes then the pull request name must start with `fix(<scope>)!:`, `feat(<scope>)!:`, `feature(<scope>)!:`, `chore(<scope>)!:`, `hotfix(<scope>)!:` or `e2e(<scope>)!:` where `<scope>` is name of affected project: `chat`, `chat-e2e`, `overlay`, `shared`, `sandbox-overlay`, etc.
- [X] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [X] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
