### PR TITLE
fix(catalog): open card details from description

### DIFF
--- a/libs/catalog/README.md
+++ b/libs/catalog/README.md
@@ -189,7 +189,7 @@ import { Card } from '@epam/ai-dial-catalog';
 />
 ```
 
-The card's `description` is rendered as sanitized Markdown using the same rendering pipeline as the About tab's details view (sanitization via `rehypeSanitize`). Markdown syntax (e.g. `**bold**`, lists, links), HTML-like snippets, and plain text all render correctly. Inline images are suppressed to keep the description within the card's fixed 2-line clamp; they appear normally in the About tab. Links render as real `<a>` elements and do not trigger the card's own `onClick` handler due to event stopPropagation on the description wrapper.
+The card's `description` is rendered as sanitized Markdown using the same rendering pipeline as the About tab's details view (sanitization via `rehypeSanitize`). Markdown syntax (e.g. `**bold**`, lists, links), HTML-like snippets, and plain text all render correctly. Inline images are suppressed to keep the description within the card's fixed 2-line clamp; they appear normally in the About tab. Links render as real `<a>` elements and activate independently without triggering the card's own `onClick` handler; clicks on other description content still open the card details.
 
 ### ListView
 

--- a/libs/catalog/src/components/CardGrid/Card.tsx
+++ b/libs/catalog/src/components/CardGrid/Card.tsx
@@ -31,6 +31,11 @@ import styles from './CardGrid.module.scss';
 
 const DESCRIPTION_MARKDOWN_COMPONENTS = { img: () => null };
 
+const isLinkEvent = (
+  event: MouseEvent<HTMLElement> | KeyboardEvent<HTMLElement>,
+): boolean =>
+  event.target instanceof Element && event.target.closest('a') !== null;
+
 /** Browse grid card: AppIdentity header + description + topic chips + breadcrumbs + star. */
 export const Card: FC<CardProps> = ({
   item,
@@ -82,11 +87,15 @@ export const Card: FC<CardProps> = ({
    * thing left in it without the star — has nothing to render. */
   const isFooterVisible = !isReadonly || item.folder.length > 0;
 
-  const handleClick = onClick ? () => onClick(item) : undefined;
+  const handleClick = onClick
+    ? (e: MouseEvent<HTMLElement>) => {
+        if (!isLinkEvent(e)) onClick(item);
+      }
+    : undefined;
 
   const handleKeyDown = useCallback(
     (e: KeyboardEvent<HTMLElement>) => {
-      if (!onClick) return;
+      if (!onClick || isLinkEvent(e)) return;
       if (e.key === 'Enter' || e.key === ' ') {
         e.preventDefault();
         onClick(item);
@@ -174,8 +183,6 @@ export const Card: FC<CardProps> = ({
           'line-clamp-2 min-h-[2lh] break-words',
           styles.description,
         )}
-        onClick={(e) => e.stopPropagation()}
-        onKeyDown={(e) => e.stopPropagation()}
       >
         {item.description && (
           <MarkdownRenderer

--- a/libs/catalog/src/components/CardGrid/tests/Card.spec.tsx
+++ b/libs/catalog/src/components/CardGrid/tests/Card.spec.tsx
@@ -238,6 +238,16 @@ describe('Card — description rendering', () => {
     expect(screen.getByText(plainText)).toBeTruthy();
   });
 
+  it('triggers the card onClick when clicking plain description text', async () => {
+    const item = makeItem({ description: 'Open details' });
+    const onCardClick = vi.fn();
+    render(<Card item={item} onClick={onCardClick} />);
+
+    await userEvent.click(screen.getByText('Open details'));
+
+    expect(onCardClick).toHaveBeenCalledWith(item);
+  });
+
   it('renders a Markdown link as a real, clickable <a> element', () => {
     render(
       <Card


### PR DESCRIPTION
**Description:**

Restore opening catalog item details when users click plain Markdown-rendered description content. The previous implementation stopped event propagation for the entire description wrapper, which swallowed normal card clicks. The card now ignores only events originating from links, preserving independent link activation.

**UI changes**

No visual UI changes. This restores the expected card interaction.

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix(catalog):`
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (no issue is associated with this fix)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs