### PR TITLE
fix(chat): stop double-decoding DIAL Core file names in file manager

### DIFF
--- a/apps/chat-api/src/files/archive/files-archive-download.service.ts
+++ b/apps/chat-api/src/files/archive/files-archive-download.service.ts
@@ -8,10 +8,9 @@ import { Injectable, Logger, PayloadTooLargeException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import archiver from 'archiver';
 import { getBearerAuthHeaders } from '../../common/utils/auth-header';
-import { encodeDialResourcePath } from '../../common/utils/encode-dial-path';
 import type { EnvironmentVariables } from '../../config/environment.config';
 import { DialClientService } from '../../dial/dial-client.service';
-import { toRelativePath } from '../dial-resource-path.util';
+import { encodeDialFilePath, toRelativePath } from '../dial-resource-path.util';
 import type { ArchiveItemDto } from '../dto/download-archive.dto';
 import { ArchiveItemNodeType } from '../dto/download-archive.dto';
 import type { ExpandedFile } from '../listing/files-listing.service';
@@ -421,7 +420,7 @@ export class FilesArchiveDownloadService {
         response,
       } = (await this.dialClient.client.downloadFile(
         file.bucket,
-        encodeDialResourcePath(file.path),
+        encodeDialFilePath(file.path),
         {
           headers: getBearerAuthHeaders(at),
           parseAs: 'stream',

--- a/apps/chat-api/src/files/batch/files-batch-operations.service.ts
+++ b/apps/chat-api/src/files/batch/files-batch-operations.service.ts
@@ -2,10 +2,12 @@ import { HttpException, HttpStatus, Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { handleDialSdkError } from '../../common/dial/dial-error.mapper';
 import { getBearerAuthHeaders } from '../../common/utils/auth-header';
-import { encodeDialResourcePath } from '../../common/utils/encode-dial-path';
 import type { EnvironmentVariables } from '../../config/environment.config';
 import { DialClientService } from '../../dial/dial-client.service';
-import { buildDialFileResourceUrl } from '../dial-resource-path.util';
+import {
+  buildDialFileResourceUrl,
+  encodeDialFilePath,
+} from '../dial-resource-path.util';
 import type { CopyItemDto } from '../dto/copy-files.dto';
 import { CopyFilesResponseDto, CopyItemResultDto } from '../dto/copy-files.dto';
 import type { DeleteItemDto } from '../dto/delete-files.dto';
@@ -196,7 +198,7 @@ export class FilesBatchOperationsService {
       const { data, error, response } =
         await this.dialClient.client.getFileMetadata(
           bucket,
-          encodeDialResourcePath(path),
+          encodeDialFilePath(path),
           {
             headers: getBearerAuthHeaders(at),
             signal: AbortSignal.timeout(this.getTimeoutMs()),
@@ -257,7 +259,7 @@ export class FilesBatchOperationsService {
     try {
       const { error, response } = (await this.dialClient.client.deleteFile(
         bucket,
-        encodeDialResourcePath(relPath),
+        encodeDialFilePath(relPath),
         {
           headers: getBearerAuthHeaders(at),
           signal: AbortSignal.timeout(this.getTimeoutMs()),

--- a/apps/chat-api/src/files/dial-resource-path.util.ts
+++ b/apps/chat-api/src/files/dial-resource-path.util.ts
@@ -1,14 +1,27 @@
-import { encodeDialResourcePath } from '../common/utils/encode-dial-path';
-
 /** Builds the `files/{bucket}/{path}` DIAL resource URL from a relative path. */
 export const buildDialFileUrl = (bucket: string, path: string): string =>
   `files/${bucket}/${path}`;
+
+/**
+ * Percent-encodes a bucket-relative files path, segment by segment.
+ *
+ * Unlike the shared `encodeDialResourcePath`, it does not decode first. Paths
+ * in the files domain are already plain — DIAL Core returns `name`/`parentPath`
+ * decoded and only `url` percent-encoded — so a pre-decode would silently
+ * rewrite a name that legitimately contains a percent escape (`a%20b.pdf`
+ * would reach DIAL Core as `a b.pdf`, a resource that does not exist).
+ */
+export const encodeDialFilePath = (path: string): string =>
+  path
+    .split('/')
+    .map((segment) => encodeURIComponent(segment))
+    .join('/');
 
 /** Same as {@link buildDialFileUrl}, but percent-encodes the path first. */
 export const buildDialFileResourceUrl = (
   bucket: string,
   path: string,
-): string => buildDialFileUrl(bucket, encodeDialResourcePath(path));
+): string => buildDialFileUrl(bucket, encodeDialFilePath(path));
 
 /** Strips the `files/{bucket}/` prefix from a full DIAL resource path, if present. */
 export const toRelativePath = (path: string, bucket: string): string => {

--- a/apps/chat-api/src/files/download/files-download.service.ts
+++ b/apps/chat-api/src/files/download/files-download.service.ts
@@ -2,10 +2,9 @@ import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { handleDialSdkError } from '../../common/dial/dial-error.mapper';
 import { getBearerAuthHeaders } from '../../common/utils/auth-header';
-import { encodeDialResourcePath } from '../../common/utils/encode-dial-path';
 import type { EnvironmentVariables } from '../../config/environment.config';
 import { DialClientService } from '../../dial/dial-client.service';
-import { toRelativePath } from '../dial-resource-path.util';
+import { encodeDialFilePath, toRelativePath } from '../dial-resource-path.util';
 
 export const SAFE_DOWNLOAD_HEADERS = [
   'content-type',
@@ -36,7 +35,7 @@ export class FilesDownloadService {
     try {
       const { error, response } = (await this.dialClient.client.downloadFile(
         bucket,
-        encodeDialResourcePath(relativePath),
+        encodeDialFilePath(relativePath),
         {
           headers: getBearerAuthHeaders(token),
           parseAs: 'stream',

--- a/apps/chat-api/src/files/file-metadata-match.ts
+++ b/apps/chat-api/src/files/file-metadata-match.ts
@@ -5,11 +5,12 @@ const stripTrailingSlash = (path: string): string =>
 
 /*
  * DIAL Core echoes `url` percent-encoded (`New%20folder/a.pdf`) while the paths
- * this app carries around are plain, so both sides are decoded before being
- * compared. A url that is not valid percent-encoding is compared raw rather
- * than throwing.
+ * this app carries around are plain, so only the url side is decoded before
+ * being compared. Decoding the plain side too would make a resource named
+ * `a%20b.pdf` match one named `a b.pdf`. A url that is not valid
+ * percent-encoding is compared raw rather than throwing.
  */
-const normalizeResourcePath = (value: string): string => {
+const decodeResourceUrl = (value: string): string => {
   try {
     return stripTrailingSlash(decodeURIComponent(value));
   } catch {
@@ -34,7 +35,6 @@ export const fileMetadataMatchesPath = (
   if (url == null) return false;
 
   return (
-    normalizeResourcePath(toRelativePath(url, bucket)) ===
-    normalizeResourcePath(path)
+    decodeResourceUrl(toRelativePath(url, bucket)) === stripTrailingSlash(path)
   );
 };

--- a/apps/chat-api/src/files/folder/files-folder.service.ts
+++ b/apps/chat-api/src/files/folder/files-folder.service.ts
@@ -7,10 +7,12 @@ import {
 import { ConfigService } from '@nestjs/config';
 import { handleDialSdkError } from '../../common/dial/dial-error.mapper';
 import { getBearerAuthHeaders } from '../../common/utils/auth-header';
-import { encodeDialResourcePath } from '../../common/utils/encode-dial-path';
 import type { EnvironmentVariables } from '../../config/environment.config';
 import { DialClientService } from '../../dial/dial-client.service';
-import { buildDialFileUrl } from '../dial-resource-path.util';
+import {
+  buildDialFileUrl,
+  encodeDialFilePath,
+} from '../dial-resource-path.util';
 import type { CreateFolderResponseDto } from '../dto/create-folder.dto';
 import { FOLDER_NODE_TYPE, MARKER_NAME } from '../files.constants';
 import { markerMetadataMatches } from '../marker-metadata';
@@ -58,7 +60,7 @@ export class FilesFolderService {
         response: metaResponse,
       } = await this.dialClient.client.getFileMetadata(
         bucket,
-        encodeDialResourcePath(markerPath),
+        encodeDialFilePath(markerPath),
         {
           headers: getBearerAuthHeaders(at),
           signal: AbortSignal.timeout(this.getTimeoutMs()),

--- a/apps/chat-api/src/files/listing/files-listing.service.ts
+++ b/apps/chat-api/src/files/listing/files-listing.service.ts
@@ -3,11 +3,10 @@ import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { handleDialSdkError } from '../../common/dial/dial-error.mapper';
 import { getBearerAuthHeaders } from '../../common/utils/auth-header';
-import { encodeDialResourcePath } from '../../common/utils/encode-dial-path';
 import { safeDecodeURIComponent } from '../../common/utils/uri';
 import type { EnvironmentVariables } from '../../config/environment.config';
 import { DialClientService } from '../../dial/dial-client.service';
-import { toRelativePath } from '../dial-resource-path.util';
+import { encodeDialFilePath, toRelativePath } from '../dial-resource-path.util';
 import type { FileMetadataResponseDto } from '../dto/file-metadata-response.dto';
 import type { ListFilesResponseDto } from '../dto/list-files.dto';
 import { RESERVED_ROOT_FOLDER_NAMES } from '../files.constants';
@@ -25,8 +24,17 @@ export interface ExpandedFile {
 
 const FULL_FILE_LIST_PAGE_LIMIT = 1000;
 
-const safeDecodePathForCompare = (path: string): string =>
-  path.split('/').map(safeDecodeURIComponent).join('/');
+/**
+ * Decodes a percent-encoded DIAL Core `url` into the plain path space every
+ * other path in the files domain uses. Only `url` is encoded — `name` and
+ * `parentPath` already come back decoded — so this must never be applied to a
+ * path that is already plain.
+ */
+const decodeDialResourceUrl = (path: string): string =>
+  path
+    .split('/')
+    .map((segment) => safeDecodeURIComponent(segment))
+    .join('/');
 
 const isReservedRootFolder = (item: DialFileItem): boolean => {
   const nodeType = (item.nodeType ?? '').toLowerCase();
@@ -69,7 +77,7 @@ export class FilesListingService {
     const { data, error, response } =
       await this.dialClient.client.getFileMetadata(
         bucket,
-        encodeDialResourcePath(normalizedPath),
+        encodeDialFilePath(normalizedPath),
         {
           headers: getBearerAuthHeaders(at),
           params: {
@@ -308,7 +316,7 @@ export class FilesListingService {
       const { data, error, response } =
         await this.dialClient.client.getFileMetadata(
           bucket,
-          encodeDialResourcePath(path),
+          encodeDialFilePath(path),
           {
             headers: getBearerAuthHeaders(token),
             signal: AbortSignal.timeout(this.getTimeoutMs()),
@@ -381,7 +389,7 @@ export class FilesListingService {
       const { data, error, response } =
         await this.dialClient.client.getFileMetadata(
           bucket,
-          encodeDialResourcePath(relFolderPath),
+          encodeDialFilePath(relFolderPath),
           {
             headers: getBearerAuthHeaders(at),
             params: {
@@ -426,9 +434,17 @@ export class FilesListingService {
           continue;
         }
 
-        // item.url may be a full resource path or already relative — normalise to relative
-        const rawUrl = item.url ?? item.name ?? '';
-        const relItemPath = toRelativePath(rawUrl, bucket);
+        /*
+         * item.url may be a full resource path or already relative — normalise
+         * to relative, then decode it: `url` is the one percent-encoded field
+         * DIAL Core returns, while `name` and the paths this service is called
+         * with are plain.
+         */
+        const rawUrl = item.url;
+        const relItemPath =
+          rawUrl != null
+            ? decodeDialResourceUrl(toRelativePath(rawUrl, bucket))
+            : toRelativePath(item.name ?? '', bucket);
 
         const relative = this.getRelativeChildPath(
           relItemPath,
@@ -484,14 +500,13 @@ export class FilesListingService {
     const folderPrefix = folderPath.endsWith('/')
       ? folderPath
       : `${folderPath}/`;
+    /*
+     * Both sides are plain paths — `childPath` was decoded from the DIAL Core
+     * url by the caller — so a direct prefix comparison is exact. Decoding
+     * either side again here would make `a%20b` and `a b` compare equal.
+     */
     if (childPath.startsWith(folderPrefix)) {
       return childPath.slice(folderPrefix.length);
-    }
-
-    const comparableChildPath = safeDecodePathForCompare(childPath);
-    const comparableFolderPrefix = safeDecodePathForCompare(folderPrefix);
-    if (comparableChildPath.startsWith(comparableFolderPrefix)) {
-      return comparableChildPath.slice(comparableFolderPrefix.length);
     }
 
     return fallback;

--- a/apps/chat-api/src/files/tests/dial-resource-path.util.spec.ts
+++ b/apps/chat-api/src/files/tests/dial-resource-path.util.spec.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildDialFileResourceUrl,
+  buildDialFileUrl,
+  encodeDialFilePath,
+  toRelativePath,
+} from '../dial-resource-path.util';
+
+describe('encodeDialFilePath', () => {
+  it('percent-encodes each segment while keeping separators', () => {
+    expect(encodeDialFilePath('New folder/a b.pdf')).toBe(
+      'New%20folder/a%20b.pdf',
+    );
+  });
+
+  it('preserves a trailing slash', () => {
+    expect(encodeDialFilePath('New folder/')).toBe('New%20folder/');
+  });
+
+  it('does not decode first, so a percent escape in a name survives', () => {
+    expect(encodeDialFilePath('a%20b.pdf')).toBe('a%2520b.pdf');
+    expect(encodeDialFilePath('a%2Fb.txt')).toBe('a%252Fb.txt');
+  });
+
+  it('returns an empty string unchanged', () => {
+    expect(encodeDialFilePath('')).toBe('');
+  });
+});
+
+describe('buildDialFileUrl', () => {
+  it('prefixes the relative path with files/{bucket}', () => {
+    expect(buildDialFileUrl('user-bucket', 'reports/q1.pdf')).toBe(
+      'files/user-bucket/reports/q1.pdf',
+    );
+  });
+});
+
+describe('buildDialFileResourceUrl', () => {
+  it('percent-encodes the path without decoding it first', () => {
+    expect(
+      buildDialFileResourceUrl('user-bucket', 'New folder/a%20b.pdf'),
+    ).toBe('files/user-bucket/New%20folder/a%2520b.pdf');
+  });
+});
+
+describe('toRelativePath', () => {
+  it('strips the files/{bucket}/ prefix', () => {
+    expect(
+      toRelativePath('files/user-bucket/reports/q1.pdf', 'user-bucket'),
+    ).toBe('reports/q1.pdf');
+  });
+
+  it('returns the path unchanged when the bucket does not match', () => {
+    expect(toRelativePath('files/other/reports/q1.pdf', 'user-bucket')).toBe(
+      'files/other/reports/q1.pdf',
+    );
+  });
+});

--- a/apps/chat-api/src/files/tests/file-metadata-match.spec.ts
+++ b/apps/chat-api/src/files/tests/file-metadata-match.spec.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { fileMetadataMatchesPath } from '../file-metadata-match';
+
+describe('fileMetadataMatchesPath', () => {
+  it('matches a plain path against the percent-encoded url DIAL Core echoes', () => {
+    expect(
+      fileMetadataMatchesPath(
+        { url: 'files/user-bucket/New%20folder/a.pdf' },
+        'user-bucket',
+        'New folder/a.pdf',
+      ),
+    ).toBe(true);
+  });
+
+  it('ignores a trailing slash on either side', () => {
+    expect(
+      fileMetadataMatchesPath(
+        { url: 'files/user-bucket/New%20folder/' },
+        'user-bucket',
+        'New folder',
+      ),
+    ).toBe(true);
+  });
+
+  it('does not match a name whose percent escape is part of the name', () => {
+    expect(
+      fileMetadataMatchesPath(
+        { url: 'files/user-bucket/a%20b.pdf' },
+        'user-bucket',
+        'a%20b.pdf',
+      ),
+    ).toBe(false);
+  });
+
+  it('matches a name whose percent escape is part of the name when the url is double-encoded', () => {
+    expect(
+      fileMetadataMatchesPath(
+        { url: 'files/user-bucket/a%2520b.pdf' },
+        'user-bucket',
+        'a%20b.pdf',
+      ),
+    ).toBe(true);
+  });
+
+  it('returns false when the metadata carries no url', () => {
+    expect(fileMetadataMatchesPath({}, 'user-bucket', 'a.pdf')).toBe(false);
+  });
+
+  it('returns false for a non-object payload', () => {
+    expect(fileMetadataMatchesPath(null, 'user-bucket', 'a.pdf')).toBe(false);
+  });
+});

--- a/apps/chat-api/src/files/upload/files-upload.service.ts
+++ b/apps/chat-api/src/files/upload/files-upload.service.ts
@@ -24,11 +24,13 @@ import {
   mapDialHttpStatus,
 } from '../../common/dial/dial-error.mapper';
 import { getBearerAuthHeaders } from '../../common/utils/auth-header';
-import { encodeDialResourcePath } from '../../common/utils/encode-dial-path';
 import { StringUtils } from '../../common/utils/string-utils';
 import type { EnvironmentVariables } from '../../config/environment.config';
 import { DialClientService } from '../../dial/dial-client.service';
-import { buildDialFileUrl } from '../dial-resource-path.util';
+import {
+  buildDialFileUrl,
+  encodeDialFilePath,
+} from '../dial-resource-path.util';
 import type {
   UploadArchiveEntryResultDto,
   UploadArchiveResponseDto,
@@ -163,7 +165,7 @@ export class FilesUploadService {
       const { data, error, response } =
         (await this.dialClient.client.uploadFile(
           bucket,
-          encodeDialResourcePath(path),
+          encodeDialFilePath(path),
           {
             headers: {
               ...getBearerAuthHeaders(token),
@@ -621,7 +623,7 @@ export class FilesUploadService {
 
   private buildDialUploadUrl(bucket: string, path: string): string {
     const baseUrl = this.dialClient.baseUrl.replace(/\/+$/, '');
-    return `${baseUrl}/v1/files/${encodeURIComponent(bucket)}/${encodeDialResourcePath(path)}`;
+    return `${baseUrl}/v1/files/${encodeURIComponent(bucket)}/${encodeDialFilePath(path)}`;
   }
 
   private async removeArchiveUploadTempDirectory(

--- a/libs/chat-hooks/src/catalog/usePublishFolders/usePublishFolders.ts
+++ b/libs/chat-hooks/src/catalog/usePublishFolders/usePublishFolders.ts
@@ -10,7 +10,6 @@ import {
   type PublishFolderNode,
 } from '@epam/ai-dial-publish-panel';
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { safeDecodeURI } from '../../shared/string-utils';
 
 /**
  * Folder paths that deny publish write access under the current heuristic.
@@ -37,7 +36,8 @@ const buildFolderNodes = (
   return items
     .filter((item) => item.nodeType === ListFilesItemDtoNodeTypeEnum.Folder)
     .map((item): PublishFolderNode => {
-      const name = safeDecodeURI(item.name);
+      // DIAL Core returns `name` already decoded; only `url` is percent-encoded.
+      const name = item.name;
       const path = [...parentPath, name];
       const childApiPath = `${apiPath}${item.name}/`;
       const children = cache.has(childApiPath)

--- a/libs/chat-hooks/src/files/dial-file-manager-mapping.util.ts
+++ b/libs/chat-hooks/src/files/dial-file-manager-mapping.util.ts
@@ -14,8 +14,10 @@ import {
   DialFileManagerTabs,
   DialFileNodeType,
 } from '@epam/ai-dial-react-file-manager';
-import { safeDecodeURI } from '../shared/string-utils';
-import { dialCorePathToRelative } from './dial-file-manager-path.util';
+import {
+  buildSharedItemVirtualPath,
+  dialCorePathToRelative,
+} from './dial-file-manager-path.util';
 import {
   CORE_PERMISSION_MAP,
   type PreparedCopyMoveItem,
@@ -81,7 +83,13 @@ export const buildFromCache = (
 
   return flat.map((item): DialFile => {
     const isFolder = item.nodeType === ListFilesItemDtoNodeTypeEnum.Folder;
-    const name = safeDecodeURI(item.name);
+    /*
+     * DIAL Core returns `name` already decoded (only `url` is percent-encoded).
+     * Decoding it again corrupts names that legitimately contain percent
+     * escapes — `a%2Fb.txt` would split into a phantom folder and the row would
+     * vanish, `a%20b.pdf` would resolve to a path DIAL Core does not have.
+     */
+    const name = item.name;
     const virtualPath = isFolder
       ? `${parentPathBase}/${name}/`
       : `${parentPathBase}/${name}`;
@@ -273,7 +281,8 @@ export const mapSearchItem = (
   rootLabel: string,
 ): DialFile => {
   const isFolder = item.nodeType === ListFilesItemDtoNodeTypeEnum.Folder;
-  const name = safeDecodeURI(item.name);
+  // `name` arrives decoded from DIAL Core — see the note in `buildFromCache`.
+  const name = item.name;
   const itemBucket = item.bucket ?? fallbackBucket;
   const dialCorePath = item.url ?? item.path ?? '';
   const relativePath = dialCorePathToRelative(dialCorePath, itemBucket);
@@ -281,9 +290,16 @@ export const mapSearchItem = (
   const lastSlash = relativeStripped.lastIndexOf('/');
   const parentRelative =
     lastSlash > 0 ? relativeStripped.slice(0, lastSlash) : '';
-  const virtualParentPath = parentRelative
-    ? `/${rootLabel}/${parentRelative}`
-    : `/${rootLabel}`;
+  /*
+   * The parent path is derived from the percent-encoded DIAL Core url, so its
+   * segments have to be decoded to land in the same virtual-path space as the
+   * rows `buildFromCache` produces.
+   */
+  const virtualParentPath = buildSharedItemVirtualPath(
+    parentRelative,
+    rootLabel,
+    false,
+  );
   const virtualPath = isFolder
     ? `${virtualParentPath}/${name}/`
     : `${virtualParentPath}/${name}`;

--- a/libs/chat-hooks/src/files/dial-file-manager-path.util.ts
+++ b/libs/chat-hooks/src/files/dial-file-manager-path.util.ts
@@ -28,12 +28,17 @@ export const normalizeVirtualPath = (value: string): string => {
   return trimmed || '/';
 };
 
+/*
+ * Virtual and API paths are already in the decoded space, so the last segment
+ * is the resource name verbatim — decoding it again would turn a name that
+ * legitimately contains a percent escape into a different name.
+ */
 export const getVirtualPathName = (
   virtualPath: string,
   fallback: string,
 ): string => {
   const segments = virtualPath.split('/').filter(Boolean);
-  return safeDecodeURI(segments[segments.length - 1] ?? fallback);
+  return segments[segments.length - 1] ?? fallback;
 };
 
 export const formatOperationFolderName = (
@@ -130,8 +135,9 @@ export const dialCorePathToRelative = (
  * DialFile.path format ("/My files/reports/q1.pdf") that ui-kit compares
  * row items against for `sharedByMePaths`/`sharedWithMeIds` gating — the
  * DIAL Core resource path ("files/{bucket}/...") is a different identifier
- * space and never matches. Decodes each path segment independently, matching
- * how buildFromCache derives virtual paths.
+ * space and never matches. The input comes from a percent-encoded DIAL Core
+ * url, so each segment is decoded independently to reach the same decoded
+ * space the listing rows live in.
  */
 export const buildSharedItemVirtualPath = (
   relativePath: string,

--- a/libs/chat-hooks/src/files/tests/dial-file-manager-mapping.util.spec.ts
+++ b/libs/chat-hooks/src/files/tests/dial-file-manager-mapping.util.spec.ts
@@ -176,6 +176,61 @@ describe('buildFromCache', () => {
       buildFromCache(new Map(), new Map(), 'missing/', '/My files', 'root'),
     ).toEqual([]);
   });
+
+  it('keeps percent escapes that are part of the name from DIAL Core', () => {
+    const cache = new Map<string, ListFilesItemDto[]>([
+      [
+        '',
+        [
+          {
+            name: 'a%20b.pdf',
+            path: 'files/user-bucket/a%2520b.pdf',
+            folderId: 'user-bucket',
+            nodeType: ListFilesItemDtoNodeTypeEnum.Item,
+            bucket: 'user-bucket',
+          },
+        ],
+      ],
+    ]);
+
+    const [file] = buildFromCache(cache, new Map(), '', '/My files', 'root');
+    expect(file.name).toBe('a%20b.pdf');
+    expect(file.path).toBe('/My files/a%20b.pdf');
+  });
+
+  it('derives the child cache key from the undecoded folder name', () => {
+    const cache = new Map<string, ListFilesItemDto[]>([
+      [
+        '',
+        [
+          {
+            name: 'a%2Fb',
+            path: 'files/user-bucket/a%252Fb/',
+            folderId: 'user-bucket',
+            nodeType: ListFilesItemDtoNodeTypeEnum.Folder,
+            bucket: 'user-bucket',
+          },
+        ],
+      ],
+      [
+        'a%2Fb/',
+        [
+          {
+            name: 'q1.pdf',
+            path: 'files/user-bucket/a%252Fb/q1.pdf',
+            folderId: 'user-bucket',
+            nodeType: ListFilesItemDtoNodeTypeEnum.Item,
+            bucket: 'user-bucket',
+          },
+        ],
+      ],
+    ]);
+
+    const [folder] = buildFromCache(cache, new Map(), '', '/My files', 'root');
+    expect(folder.name).toBe('a%2Fb');
+    expect(folder.items).toHaveLength(1);
+    expect(folder.items?.[0].path).toBe('/My files/a%2Fb/q1.pdf');
+  });
 });
 
 describe('mergeCreatedFolderIntoCache', () => {
@@ -286,6 +341,20 @@ describe('mapSearchItem', () => {
     const result = mapSearchItem(item, 'user-bucket', 'My files');
     expect(result.parentPath).toBe('/My files');
     expect(result.path).toBe('/My files/report.pdf');
+  });
+
+  it('decodes the url-derived parent path while keeping the name verbatim', () => {
+    const item: ListFilesItemDto = {
+      name: 'a%20b.pdf',
+      path: 'files/user-bucket/New%20folder/a%2520b.pdf',
+      folderId: 'user-bucket',
+      nodeType: ListFilesItemDtoNodeTypeEnum.Item,
+      bucket: 'user-bucket',
+      url: 'files/user-bucket/New%20folder/a%2520b.pdf',
+    };
+    const result = mapSearchItem(item, 'user-bucket', 'My files');
+    expect(result.parentPath).toBe('/My files/New folder');
+    expect(result.path).toBe('/My files/New folder/a%20b.pdf');
   });
 });
 

--- a/libs/chat-hooks/src/files/tests/dial-file-manager-path.util.spec.ts
+++ b/libs/chat-hooks/src/files/tests/dial-file-manager-path.util.spec.ts
@@ -10,6 +10,7 @@ import {
   findDialFileByPath,
   findFolderByVirtualPath,
   formatOperationFolderName,
+  getVirtualPathName,
   hasDialFileWritePermission,
   hasForbiddenNameSymbols,
   isCopyMoveDuplicateAllowed,
@@ -223,6 +224,24 @@ describe('dialCorePathToRelative', () => {
         'user-bucket',
       ),
     ).toBe('files/other-bucket/reports/q1.pdf');
+  });
+});
+
+describe('getVirtualPathName', () => {
+  it('returns the last segment of a virtual path', () => {
+    expect(getVirtualPathName('/My files/reports/q1.pdf', 'fallback')).toBe(
+      'q1.pdf',
+    );
+  });
+
+  it('keeps a percent escape that is part of the name', () => {
+    expect(getVirtualPathName('/My files/reports/a%20b.pdf', 'fallback')).toBe(
+      'a%20b.pdf',
+    );
+  });
+
+  it('falls back when the path has no segments', () => {
+    expect(getVirtualPathName('', 'fallback')).toBe('fallback');
   });
 });
 

--- a/libs/chat-hooks/src/files/useDialFileListing/useDialFileListing.ts
+++ b/libs/chat-hooks/src/files/useDialFileListing/useDialFileListing.ts
@@ -11,7 +11,6 @@ import {
 import { NotificationVariant } from '@epam/ai-dial-ui-kit';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { getApiErrorStatus } from '../../api-error/api-error';
-import { safeDecodeURI } from '../../shared/string-utils';
 import {
   buildFromCache,
   fetchByTab,
@@ -238,7 +237,7 @@ export const useDialFileListing = ({
           );
           sharedRootMetaRef.current = new Map(
             flat.map((item) => [
-              safeDecodeURI(item.name),
+              item.name,
               { bucket: item.bucket ?? '', dialCorePath: item.path },
             ]),
           );
@@ -650,7 +649,7 @@ export const useDialFileListing = ({
           setIsSearching(true);
           const rootItems = cache.get('') ?? [];
           const matched = rootItems.filter((item) =>
-            safeDecodeURI(item.name).toLowerCase().includes(lowerQuery),
+            item.name.toLowerCase().includes(lowerQuery),
           );
           setSearchResults(
             matched.map((item) =>
@@ -677,7 +676,7 @@ export const useDialFileListing = ({
             );
             if (cancelled) return;
             const matched = searchItems.filter((item) =>
-              safeDecodeURI(item.name).toLowerCase().includes(lowerQuery),
+              item.name.toLowerCase().includes(lowerQuery),
             );
             setSearchResults(
               matched.map((item) =>


### PR DESCRIPTION
## Description of changes

Port of #7849 to the new chat. The old chat's `mapFileToDial` / `buildFileTree` no longer exist, but the same defect lives in the BFF-backed file manager: DIAL Core returns `name` and `parentPath` **already decoded** and percent-encodes only `url`, so decoding the name a second time corrupts every resource whose name legitimately contains a percent escape.

- `a%2Fb.txt` split into a phantom folder and vanished from the tree
- `a%20b.pdf` resolved to a path DIAL Core does not have and failed to download

### Frontend (`libs/chat-hooks`)

- `buildFromCache` / `mapSearchItem` take `item.name` verbatim. `mapSearchItem` additionally decodes the url-derived parent path, so search rows land in the same virtual-path space as listing rows.
- `getVirtualPathName` no longer decodes — its inputs are virtual/API paths that are already plain. This fixes the `name` field sent in rename/copy/move/delete DTOs.
- `useDialFileListing`: shared-root meta keys and search filtering.
- `usePublishFolders`: `name` and `childApiPath` no longer disagree (the former was decoded, the latter was not).

### BFF (`apps/chat-api/src/files`)

- New `encodeDialFilePath` encodes segment by segment **without** the decode-then-encode normalization of the shared `encodeDialResourcePath`, which rewrote `a%20b.pdf` to `a b.pdf` on the wire. Listing, download, upload, folder, batch and archive now use it.
- `expandFolderContents` decodes the DIAL Core url once and emits plain paths, so `getRelativeChildPath` compares prefixes exactly instead of decoding both sides again.
- `fileMetadataMatchesPath` decodes only the url side; previously `a%20b.pdf` matched `a b.pdf`.

### Deliberately out of scope

- `encodeDialResourcePath` for the other domains (conversations, prompts, skills, publish) still pre-decodes. There the ids often arrive already encoded, so the pre-decode acts as normalization — changing it globally is a separate change.
- `buildDialFileUrl` in the upload response returns an unencoded url while listing returns encoded ones. Same class of inconsistency, not part of this fix.

## Verification

- `nx test @epam/ai-dial-chat-hooks` — 1475 passed
- `nx test chat-api` (files domain) — 311 passed, including new `dial-resource-path.util.spec.ts` and `file-metadata-match.spec.ts`
- `nx test chat` (`DialFileManager`) — 128 passed
- `nx lint` on both projects — clean
- `nx build chat-api` and the `chat-hooks` build — pass

New regression tests cover `%20` and `%2F` in names across the mapping utils, the path utils, the new encoder and the metadata matcher.

## Applicable issues

Ports the fix from #7849 (which closed #7808, #7807, #7787 for the old chat).

## Checklist

- [x] I confirm that I don't share any confidential information like API keys or any other secrets and private URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)