### PR TITLE
fix(chat): show the Upload skill popup before the file picker (#8654)

### DIFF
--- a/apps/chat/src/components/CatalogView/CatalogView.tsx
+++ b/apps/chat/src/components/CatalogView/CatalogView.tsx
@@ -28,7 +28,6 @@ import {
   FavoritesI18nKeys,
   NavigationI18nKeys,
   PublishI18nKeys,
-  SkillArchiveImportI18nKeys,
   ToolsetEditorI18nKeys,
 } from '../../constants/translation-keys';
 import { useAppConfig } from '../../context/AppConfigContext';
@@ -68,6 +67,7 @@ import { getCatalogSearchPlaceholder } from '../../utils/catalog';
 import { resolveCatalogItemEntity } from '../../utils/entity-notification';
 import { getAccessRulesLabels } from '../../utils/publish';
 import SharePopoverContainer from '../SharePopoverContainer/SharePopoverContainer';
+import SkillArchiveUploadDialog from '../SkillArchiveUploadDialog/SkillArchiveUploadDialog';
 
 /** Entity types shown in the catalog picker modal: models and agents only. */
 const PICKER_VISIBLE_TYPES = new Set<CatalogEntityType>([
@@ -200,10 +200,13 @@ const CatalogView: FC<Props> = ({
   } = useSkills();
 
   const {
-    fileInputRef: skillArchiveFileInputRef,
+    isDialogOpen: isSkillArchiveDialogOpen,
     statusMessage: skillArchiveStatusMessage,
-    triggerFilePicker: triggerSkillArchivePicker,
-    handleFileChange: handleSkillArchiveFileChange,
+    selectionError: skillArchiveSelectionError,
+    openDialog: openSkillArchiveDialog,
+    closeDialog: closeSkillArchiveDialog,
+    handleFilesSelected: handleSkillArchiveFilesSelected,
+    handleFilesRejected: handleSkillArchiveFilesRejected,
   } = useSkillArchiveImport();
 
   const isLoading =
@@ -498,7 +501,7 @@ const CatalogView: FC<Props> = ({
       ),
     labels: catalogEditNavigationLabels,
     onNotify: showErrorNotification,
-    triggerSkillArchivePicker,
+    onSkillUploadClick: openSkillArchiveDialog,
   });
 
   if (!isCatalogEnabled && !isSelectorMode) {
@@ -507,14 +510,12 @@ const CatalogView: FC<Props> = ({
 
   return (
     <>
-      <input
-        ref={skillArchiveFileInputRef}
-        type="file"
-        accept=".zip,.md"
-        className="sr-only"
-        tabIndex={-1}
-        aria-label={t(SkillArchiveImportI18nKeys.FileInputAriaLabel)}
-        onChange={handleSkillArchiveFileChange}
+      <SkillArchiveUploadDialog
+        isOpen={isSkillArchiveDialogOpen}
+        errorText={skillArchiveSelectionError}
+        onClose={closeSkillArchiveDialog}
+        onFilesSelected={handleSkillArchiveFilesSelected}
+        onFilesRejected={handleSkillArchiveFilesRejected}
       />
       <span role="status" aria-live="polite" className="sr-only">
         {skillArchiveStatusMessage}

--- a/apps/chat/src/components/SkillArchiveUploadDialog/SkillArchiveUploadDialog.tsx
+++ b/apps/chat/src/components/SkillArchiveUploadDialog/SkillArchiveUploadDialog.tsx
@@ -1,0 +1,70 @@
+import { FileDropzone, Popup, PopupSize } from '@epam/ai-dial-ui-kit';
+import { memo, type FC } from 'react';
+import { useTranslation } from 'react-i18next';
+import { SKILL_ARCHIVE_ACCEPT } from '../../constants/skills';
+import {
+  ButtonsI18nKeys,
+  SkillArchiveImportI18nKeys,
+} from '../../constants/translation-keys';
+
+/** Props for `SkillArchiveUploadDialog`. */
+interface Props {
+  /** Whether the dialog is open. */
+  isOpen: boolean;
+  /** Rejection message rendered under the drop area; omit when nothing was rejected. */
+  errorText?: string;
+  /** Called on Escape, the close button, or an outside click. */
+  onClose: () => void;
+  /** Called with the picked or dropped files that `accept` allowed through. */
+  onFilesSelected: (files: File[]) => void;
+  /** Called when a drop carried files that `accept` excluded. */
+  onFilesRejected: () => void;
+}
+
+/**
+ * Dialog the Catalog's "Create → Skill → Upload" action opens, so the user
+ * sees the drop area and the supported formats before the file picker
+ * appears rather than landing straight in the OS dialog.
+ */
+const SkillArchiveUploadDialog: FC<Props> = ({
+  isOpen,
+  errorText,
+  onClose,
+  onFilesSelected,
+  onFilesRejected,
+}) => {
+  const { t } = useTranslation();
+
+  return (
+    <Popup
+      open={isOpen}
+      size={PopupSize.Sm}
+      header={t(SkillArchiveImportI18nKeys.DialogTitle)}
+      closeAriaLabel={t(ButtonsI18nKeys.Close)}
+      onClose={onClose}
+    >
+      <div className="px-6 py-4">
+        <FileDropzone
+          label={
+            <>
+              <span className="desktop:hidden">
+                {t(SkillArchiveImportI18nKeys.DialogDropZoneMobileLabel)}
+              </span>
+              <span className="hidden desktop:inline">
+                {t(SkillArchiveImportI18nKeys.DialogDropZoneLabel)}
+              </span>
+            </>
+          }
+          description={t(SkillArchiveImportI18nKeys.DialogFormats)}
+          ariaLabel={t(SkillArchiveImportI18nKeys.FileInputAriaLabel)}
+          accept={SKILL_ARCHIVE_ACCEPT}
+          errorText={errorText}
+          onChange={onFilesSelected}
+          onReject={onFilesRejected}
+        />
+      </div>
+    </Popup>
+  );
+};
+
+export default memo(SkillArchiveUploadDialog);

--- a/apps/chat/src/components/SkillArchiveUploadDialog/tests/SkillArchiveUploadDialog.spec.tsx
+++ b/apps/chat/src/components/SkillArchiveUploadDialog/tests/SkillArchiveUploadDialog.spec.tsx
@@ -1,0 +1,88 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { SKILL_ARCHIVE_ACCEPT } from '../../../constants/skills';
+import {
+  ButtonsI18nKeys,
+  SkillArchiveImportI18nKeys,
+} from '../../../constants/translation-keys';
+import SkillArchiveUploadDialog from '../SkillArchiveUploadDialog';
+
+const renderDialog = (
+  props?: Partial<React.ComponentProps<typeof SkillArchiveUploadDialog>>,
+) =>
+  render(
+    <SkillArchiveUploadDialog
+      isOpen
+      onClose={vi.fn()}
+      onFilesSelected={vi.fn()}
+      onFilesRejected={vi.fn()}
+      {...props}
+    />,
+  );
+
+const getFileInput = (): HTMLInputElement =>
+  screen.getByLabelText(
+    SkillArchiveImportI18nKeys.FileInputAriaLabel,
+  ) as HTMLInputElement;
+
+describe('SkillArchiveUploadDialog', () => {
+  it('renders nothing while closed', () => {
+    renderDialog({ isOpen: false });
+
+    expect(
+      screen.queryByText(SkillArchiveImportI18nKeys.DialogTitle),
+    ).toBeNull();
+  });
+
+  it('renders the title, the drop zone and the supported formats', () => {
+    renderDialog();
+
+    expect(
+      screen.getByText(SkillArchiveImportI18nKeys.DialogTitle),
+    ).toBeTruthy();
+    expect(
+      screen.getByText(SkillArchiveImportI18nKeys.DialogDropZoneLabel),
+    ).toBeTruthy();
+    expect(
+      screen.getByText(SkillArchiveImportI18nKeys.DialogFormats),
+    ).toBeTruthy();
+  });
+
+  it('limits the file picker to the formats the import endpoint accepts', () => {
+    renderDialog();
+
+    expect(getFileInput().accept).toBe(SKILL_ARCHIVE_ACCEPT);
+  });
+
+  it('reports the picked file instead of uploading on open', () => {
+    const onFilesSelected = vi.fn();
+    renderDialog({ onFilesSelected });
+    const file = new File(['zip bytes'], 'skill.zip');
+
+    fireEvent.change(getFileInput(), { target: { files: [file] } });
+
+    expect(onFilesSelected).toHaveBeenCalledWith([file]);
+  });
+
+  it('renders the rejection message under the drop zone', () => {
+    renderDialog({
+      errorText: SkillArchiveImportI18nKeys.ErrorUnsupportedFilename,
+    });
+
+    expect(
+      screen.getByText(SkillArchiveImportI18nKeys.ErrorUnsupportedFilename),
+    ).toBeTruthy();
+  });
+
+  it('closes on the close button', async () => {
+    const onClose = vi.fn();
+    renderDialog({ onClose });
+
+    await userEvent.click(
+      screen.getByRole('button', { name: ButtonsI18nKeys.Close }),
+    );
+
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/apps/chat/src/constants/skills.ts
+++ b/apps/chat/src/constants/skills.ts
@@ -1,0 +1,9 @@
+/** Required manifest filename, matching the BFF's exact, case-sensitive check. */
+export const SKILL_MANIFEST_FILE = 'SKILL.md';
+
+/**
+ * `accept` tokens for the skill upload drop zone. The BFF dispatches on the
+ * uploaded filename — a ZIP archive, or a file named exactly `SKILL.md` — so
+ * these are the only two extensions it can take.
+ */
+export const SKILL_ARCHIVE_ACCEPT = '.zip,.md';

--- a/apps/chat/src/constants/translation-keys.ts
+++ b/apps/chat/src/constants/translation-keys.ts
@@ -1025,6 +1025,10 @@ export enum SkillEditorI18nKeys {
 
 export enum SkillArchiveImportI18nKeys {
   FileInputAriaLabel = 'skillArchiveImport.fileInputAriaLabel',
+  DialogTitle = 'skillArchiveImport.dialog.title',
+  DialogDropZoneLabel = 'skillArchiveImport.dialog.dropZoneLabel',
+  DialogDropZoneMobileLabel = 'skillArchiveImport.dialog.dropZoneMobileLabel',
+  DialogFormats = 'skillArchiveImport.dialog.formats',
   StatusUploading = 'skillArchiveImport.status.uploading',
   StatusSuccess = 'skillArchiveImport.status.success',
   StatusError = 'skillArchiveImport.status.error',

--- a/apps/chat/src/hooks/skills/tests/useSkillArchiveImport.spec.ts
+++ b/apps/chat/src/hooks/skills/tests/useSkillArchiveImport.spec.ts
@@ -1,7 +1,6 @@
 import type { SkillImportResponseDto } from '@epam/ai-dial-chat-api-client';
 import { NotificationVariant } from '@epam/ai-dial-ui-kit';
 import { act, renderHook } from '@testing-library/react';
-import { ChangeEvent } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   EntityNotificationsI18nKeys,
@@ -32,16 +31,6 @@ const IMPORT_RESPONSE: SkillImportResponseDto = {
   etag: '"abc123"',
 };
 
-const makeChangeEvent = (
-  file: File | undefined,
-): ChangeEvent<HTMLInputElement> => {
-  const target = {
-    files: file ? [file] : [],
-    value: 'C:\\fakepath\\skill.zip',
-  } as unknown as HTMLInputElement;
-  return { target } as unknown as ChangeEvent<HTMLInputElement>;
-};
-
 describe('useSkillArchiveImport', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -59,21 +48,50 @@ describe('useSkillArchiveImport', () => {
     });
   });
 
-  it('starts idle with no status message', () => {
+  it('starts idle with the dialog closed and no status message', () => {
     const { result } = renderHook(() => useSkillArchiveImport());
 
+    expect(result.current.isDialogOpen).toBe(false);
     expect(result.current.status).toBe(SkillArchiveImportStatus.Idle);
     expect(result.current.statusMessage).toBeUndefined();
+    expect(result.current.selectionError).toBeUndefined();
+  });
+
+  it('opens the dialog instead of uploading anything', () => {
+    const { result } = renderHook(() => useSkillArchiveImport());
+
+    act(() => {
+      result.current.openDialog();
+    });
+
+    expect(result.current.isDialogOpen).toBe(true);
+    expect(mockImportSkillArchive).not.toHaveBeenCalled();
+  });
+
+  it('closes the dialog and clears the rejection message', () => {
+    const { result } = renderHook(() => useSkillArchiveImport());
+
+    act(() => {
+      result.current.openDialog();
+    });
+    act(() => {
+      result.current.handleFilesRejected();
+    });
+    act(() => {
+      result.current.closeDialog();
+    });
+
+    expect(result.current.isDialogOpen).toBe(false);
+    expect(result.current.selectionError).toBeUndefined();
   });
 
   it('uploads the selected file, notifies success, and refetches skills', async () => {
     mockImportSkillArchive.mockResolvedValue(IMPORT_RESPONSE);
     const { result } = renderHook(() => useSkillArchiveImport());
     const file = new File(['zip bytes'], 'skill.zip');
-    const event = makeChangeEvent(file);
 
     await act(async () => {
-      result.current.handleFileChange(event);
+      result.current.handleFilesSelected([file]);
       await Promise.resolve();
     });
 
@@ -87,18 +105,22 @@ describe('useSkillArchiveImport', () => {
     expect(result.current.status).toBe(SkillArchiveImportStatus.Success);
   });
 
-  it('resets the input value before invoking the import so re-selecting the same file re-triggers it', async () => {
+  it('closes the dialog once an accepted file starts uploading', async () => {
     mockImportSkillArchive.mockResolvedValue(IMPORT_RESPONSE);
     const { result } = renderHook(() => useSkillArchiveImport());
-    const file = new File(['zip bytes'], 'skill.zip');
-    const event = makeChangeEvent(file);
+
+    act(() => {
+      result.current.openDialog();
+    });
 
     await act(async () => {
-      result.current.handleFileChange(event);
+      result.current.handleFilesSelected([
+        new File(['zip bytes'], 'skill.zip'),
+      ]);
       await Promise.resolve();
     });
 
-    expect(event.target.value).toBe('');
+    expect(result.current.isDialogOpen).toBe(false);
   });
 
   it('ends in the error state, shows an error toast, and skips the success notification/refetch on failure', async () => {
@@ -108,11 +130,11 @@ describe('useSkillArchiveImport', () => {
       response: new Response(null, { status: 409 }),
     });
     const { result } = renderHook(() => useSkillArchiveImport());
-    const file = new File(['zip bytes'], 'skill.zip');
-    const event = makeChangeEvent(file);
 
     await act(async () => {
-      result.current.handleFileChange(event);
+      result.current.handleFilesSelected([
+        new File(['zip bytes'], 'skill.zip'),
+      ]);
       await Promise.resolve();
       await Promise.resolve();
     });
@@ -145,11 +167,11 @@ describe('useSkillArchiveImport', () => {
       },
     });
     const { result } = renderHook(() => useSkillArchiveImport());
-    const file = new File(['zip bytes'], 'skill.zip');
-    const event = makeChangeEvent(file);
 
     await act(async () => {
-      result.current.handleFileChange(event);
+      result.current.handleFilesSelected([
+        new File(['zip bytes'], 'skill.zip'),
+      ]);
       await Promise.resolve();
       await Promise.resolve();
       await Promise.resolve();
@@ -166,34 +188,30 @@ describe('useSkillArchiveImport', () => {
     });
   });
 
-  it('does not start a second import while one is already in flight', () => {
+  it('does not reopen the dialog while an import is already in flight', () => {
     const { result } = renderHook(() => useSkillArchiveImport());
-    const clickSpy = vi.fn();
-    Object.defineProperty(result.current.fileInputRef, 'current', {
-      value: { click: clickSpy },
-      writable: true,
-    });
 
     act(() => {
-      const file = new File(['zip bytes'], 'skill.zip');
       mockImportSkillArchive.mockImplementation(
         () => new Promise(() => undefined),
       );
-      result.current.handleFileChange(makeChangeEvent(file));
+      result.current.handleFilesSelected([
+        new File(['zip bytes'], 'skill.zip'),
+      ]);
     });
 
     act(() => {
-      result.current.triggerFilePicker();
+      result.current.openDialog();
     });
 
-    expect(clickSpy).not.toHaveBeenCalled();
+    expect(result.current.isDialogOpen).toBe(false);
   });
 
   it('does nothing when no file is selected', () => {
     const { result } = renderHook(() => useSkillArchiveImport());
 
     act(() => {
-      result.current.handleFileChange(makeChangeEvent(undefined));
+      result.current.handleFilesSelected([]);
     });
 
     expect(mockImportSkillArchive).not.toHaveBeenCalled();
@@ -204,10 +222,9 @@ describe('useSkillArchiveImport', () => {
     mockImportSkillArchive.mockResolvedValue(IMPORT_RESPONSE);
     const { result } = renderHook(() => useSkillArchiveImport());
     const file = new File(['---\nname: docs-helper\n---\n'], 'SKILL.md');
-    const event = makeChangeEvent(file);
 
     await act(async () => {
-      result.current.handleFileChange(event);
+      result.current.handleFilesSelected([file]);
       await Promise.resolve();
     });
 
@@ -215,53 +232,65 @@ describe('useSkillArchiveImport', () => {
     expect(result.current.status).toBe(SkillArchiveImportStatus.Success);
   });
 
-  it('rejects a wrong-case Markdown filename locally without calling the API', () => {
+  it('rejects a wrong-case Markdown filename inline, keeping the dialog open', () => {
     const { result } = renderHook(() => useSkillArchiveImport());
-    const file = new File(['content'], 'skill.md');
-    const event = makeChangeEvent(file);
 
     act(() => {
-      result.current.handleFileChange(event);
+      result.current.openDialog();
+    });
+    act(() => {
+      result.current.handleFilesSelected([new File(['content'], 'skill.md')]);
+    });
+
+    expect(mockImportSkillArchive).not.toHaveBeenCalled();
+    expect(result.current.isDialogOpen).toBe(true);
+    expect(result.current.status).toBe(SkillArchiveImportStatus.Error);
+    expect(result.current.selectionError).toBe(
+      SkillArchiveImportI18nKeys.ErrorUnsupportedFilename,
+    );
+    expect(result.current.statusMessage).toBe(
+      SkillArchiveImportI18nKeys.ErrorUnsupportedFilename,
+    );
+    expect(mockShowNotification).not.toHaveBeenCalled();
+  });
+
+  it('rejects any other Markdown filename without calling the API', () => {
+    const { result } = renderHook(() => useSkillArchiveImport());
+
+    act(() => {
+      result.current.handleFilesSelected([new File(['content'], 'readme.md')]);
     });
 
     expect(mockImportSkillArchive).not.toHaveBeenCalled();
     expect(result.current.status).toBe(SkillArchiveImportStatus.Error);
-    expect(result.current.statusMessage).toBe(
-      SkillArchiveImportI18nKeys.ErrorUnsupportedFilename,
-    );
-    expect(mockShowNotification).toHaveBeenCalledWith({
-      variant: NotificationVariant.Error,
-      title: SkillArchiveImportI18nKeys.ErrorTitle,
-      message: SkillArchiveImportI18nKeys.ErrorUnsupportedFilename,
-    });
-  });
-
-  it('rejects any other Markdown filename locally without calling the API', () => {
-    const { result } = renderHook(() => useSkillArchiveImport());
-    const file = new File(['content'], 'readme.md');
-    const event = makeChangeEvent(file);
-
-    act(() => {
-      result.current.handleFileChange(event);
-    });
-
-    expect(mockImportSkillArchive).not.toHaveBeenCalled();
-    expect(result.current.status).toBe(SkillArchiveImportStatus.Error);
-    expect(result.current.statusMessage).toBe(
+    expect(result.current.selectionError).toBe(
       SkillArchiveImportI18nKeys.ErrorUnsupportedFilename,
     );
   });
 
-  it('resets the input value even when the local filename check rejects the file', () => {
+  it('reports a drop the drop zone excluded by extension', () => {
     const { result } = renderHook(() => useSkillArchiveImport());
-    const file = new File(['content'], 'skill.md');
-    const event = makeChangeEvent(file);
 
     act(() => {
-      result.current.handleFileChange(event);
+      result.current.handleFilesRejected();
     });
 
-    expect(event.target.value).toBe('');
+    expect(result.current.selectionError).toBe(
+      SkillArchiveImportI18nKeys.ErrorUnsupportedFilename,
+    );
+  });
+
+  it('clears a stale rejection message when the dialog is reopened', () => {
+    const { result } = renderHook(() => useSkillArchiveImport());
+
+    act(() => {
+      result.current.handleFilesRejected();
+    });
+    act(() => {
+      result.current.openDialog();
+    });
+
+    expect(result.current.selectionError).toBeUndefined();
   });
 });
 

--- a/apps/chat/src/hooks/skills/useSkillArchiveImport.ts
+++ b/apps/chat/src/hooks/skills/useSkillArchiveImport.ts
@@ -2,8 +2,9 @@ import {
   getApiErrorDetails,
   getApiErrorStatus,
 } from '@epam/ai-dial-chat-hooks';
-import { ChangeEvent, useCallback, useRef, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { SKILL_MANIFEST_FILE } from '../../constants/skills';
 import { SkillArchiveImportI18nKeys } from '../../constants/translation-keys';
 import { useNotification } from '../../context/NotificationContext';
 import { useSkills } from '../../context/SkillsContext';
@@ -14,13 +15,10 @@ import {
 } from '../../types/entity-notification';
 import { useOperationNotification } from '../useOperationNotification';
 
-/** Required manifest filename, matching the BFF's exact, case-sensitive check. */
-const SKILL_MANIFEST_FILE = 'SKILL.md';
-
 /**
  * Client-side UX shortcut only — the BFF is the actual authority on what it
  * accepts. Flags a `.md`-named file that isn't exactly `SKILL.md` so the
- * picker can reject it locally instead of round-tripping to the server for
+ * dialog can reject it locally instead of round-tripping to the server for
  * an outcome the client can already predict.
  */
 const isUnsupportedMarkdownFilename = (fileName: string): boolean =>
@@ -62,21 +60,27 @@ export const mapSkillArchiveImportErrorKey = (
 };
 
 interface UseSkillArchiveImportResult {
-  /** Attach to the hidden `<input type="file">` the Catalog's "Upload" action opens. */
-  fileInputRef: React.RefObject<HTMLInputElement | null>;
+  /** Whether the "Upload skill" dialog is open. */
+  isDialogOpen: boolean;
   /** Current phase of the import — drives loading/success/error UI. */
   status: SkillArchiveImportStatus;
   /** Localized status sentence for an `aria-live` region; `undefined` while idle. */
   statusMessage: string | undefined;
-  /** Opens the file picker, unless an import is already in flight. */
-  triggerFilePicker: () => void;
-  /** Wire directly to the hidden input's `onChange`. */
-  handleFileChange: (event: ChangeEvent<HTMLInputElement>) => void;
+  /** Localized rejection message for the drop zone; `undefined` when nothing was rejected. */
+  selectionError: string | undefined;
+  /** Opens the upload dialog, unless an import is already in flight. */
+  openDialog: () => void;
+  /** Closes the upload dialog and clears any rejection message. */
+  closeDialog: () => void;
+  /** Wire to the dialog drop zone's `onChange`. */
+  handleFilesSelected: (files: File[]) => void;
+  /** Wire to the dialog drop zone's `onReject`. */
+  handleFilesRejected: () => void;
 }
 
 /**
- * Owns the Catalog "Upload" action's whole workflow: opening the hidden file
- * picker, uploading the selected archive to `POST /api/v1/skills/import`,
+ * Owns the Catalog "Upload" action's whole workflow: opening the upload
+ * dialog, uploading the selected archive to `POST /api/v1/skills/import`,
  * raising the "Skill created" notification, and refreshing `SkillsContext`
  * so the new Skill appears without a manual reload — kept out of
  * `CatalogView` so that already-large component doesn't absorb a full async
@@ -92,7 +96,8 @@ export const useSkillArchiveImport = (): UseSkillArchiveImportResult => {
     SkillArchiveImportStatus.Idle,
   );
   const [statusMessage, setStatusMessage] = useState<string>();
-  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const [selectionError, setSelectionError] = useState<string>();
   const isUploadingRef = useRef(false);
 
   const importArchive = useCallback(
@@ -140,41 +145,53 @@ export const useSkillArchiveImport = (): UseSkillArchiveImportResult => {
     [notifyOperationSuccess, refetchSkills, showErrorNotification, t],
   );
 
-  const triggerFilePicker = useCallback(() => {
+  const openDialog = useCallback(() => {
     if (isUploadingRef.current) return;
-    fileInputRef.current?.click();
+    setSelectionError(undefined);
+    setIsDialogOpen(true);
   }, []);
 
+  const closeDialog = useCallback(() => {
+    setIsDialogOpen(false);
+    setSelectionError(undefined);
+  }, []);
+
+  /*
+   * Rejections are surfaced inline under the drop zone rather than as a
+   * toast: the dialog stays open so the user can pick another file without
+   * reopening it, and a toast on top of the visible error would say the same
+   * thing twice.
+   */
   const rejectUnsupportedFilename = useCallback(() => {
     setStatus(SkillArchiveImportStatus.Error);
     const message = t(SkillArchiveImportI18nKeys.ErrorUnsupportedFilename);
     setStatusMessage(message);
-    showErrorNotification({
-      title: t(SkillArchiveImportI18nKeys.ErrorTitle),
-      message,
-    });
-  }, [showErrorNotification, t]);
+    setSelectionError(message);
+  }, [t]);
 
-  const handleFileChange = useCallback(
-    (event: ChangeEvent<HTMLInputElement>) => {
-      const file = event.target.files?.[0];
-      /* Reset so selecting the same file again re-triggers onChange. */
-      event.target.value = '';
+  const handleFilesSelected = useCallback(
+    (files: File[]) => {
+      const file = files[0];
       if (!file) return;
       if (isUnsupportedMarkdownFilename(file.name)) {
         rejectUnsupportedFilename();
         return;
       }
+      setSelectionError(undefined);
+      setIsDialogOpen(false);
       void importArchive(file);
     },
     [importArchive, rejectUnsupportedFilename],
   );
 
   return {
-    fileInputRef,
+    isDialogOpen,
     status,
     statusMessage,
-    triggerFilePicker,
-    handleFileChange,
+    selectionError,
+    openDialog,
+    closeDialog,
+    handleFilesSelected,
+    handleFilesRejected: rejectUnsupportedFilename,
   };
 };

--- a/apps/chat/src/i18n/locales/en.json
+++ b/apps/chat/src/i18n/locales/en.json
@@ -1316,6 +1316,12 @@
   },
   "skillArchiveImport": {
     "fileInputAriaLabel": "Upload a skill ZIP archive or a SKILL.md file",
+    "dialog": {
+      "title": "Upload skill",
+      "dropZoneLabel": "Drag and drop it or click here to upload",
+      "dropZoneMobileLabel": "Click here to upload",
+      "formats": "File formats .zip and SKILL.md"
+    },
     "status": {
       "uploading": "Uploading skill…",
       "success": "Skill uploaded successfully.",

--- a/libs/chat-hooks/README.md
+++ b/libs/chat-hooks/README.md
@@ -727,7 +727,7 @@ const VoiceComposer = ({
 
 ### useConversationExport / useConversationImport
 
-A shared conversation-transfer capability: `useConversationExport` downloads one or all conversations as a JSON (`.json`) or `.dial`/`.zip` archive; `useConversationImport` parses a selected file and re-persists its conversations, re-uploading any archive attachments and rewriting their references. Both share the same job-queue semantics — `jobs`, `cancelJob`, `dismissJob`, `retryJob`, `dismissAll` — and report determinate per-job progress plus outcomes through structured, translation-free `onSuccess`/`onWarning`/`onError` callbacks instead of calling a notification system themselves. A transfer that delivers its file but skips some attachments settles at `Warning` carrying a `warningCode`, so a partial result is distinguishable from a clean one without reading the event stream. Job identity is always structured data (`ConversationTransferSubject`), never pre-rendered text. `cancelJob` and `dismissJob` differ: both abort the job's in-flight requests, but `cancelJob` leaves the job in `jobs` with status `Canceled` so the UI can keep showing it, while `dismissJob` removes it.
+A shared conversation-transfer capability: `useConversationExport` downloads one or all conversations as a JSON (`.json`) or `.dial`/`.zip` archive; `useConversationImport` parses a selected file and re-persists its conversations, re-uploading any archive attachments and rewriting their references. Each imported conversation is stored under a fresh `{deploymentId}__{title}__{uuid}` path — collision-free, and with the conversation's own `name` (sanitized to what DIAL Core accepts in a resource name, and reported back that way in `onSuccess`) as the title segment rather than the first-message title the export file embedded. Both share the same job-queue semantics — `jobs`, `cancelJob`, `dismissJob`, `retryJob`, `dismissAll` — and report determinate per-job progress plus outcomes through structured, translation-free `onSuccess`/`onWarning`/`onError` callbacks instead of calling a notification system themselves. A transfer that delivers its file but skips some attachments settles at `Warning` carrying a `warningCode`, so a partial result is distinguishable from a clean one without reading the event stream. Job identity is always structured data (`ConversationTransferSubject`), never pre-rendered text. `cancelJob` and `dismissJob` differ: both abort the job's in-flight requests, but `cancelJob` leaves the job in `jobs` with status `Canceled` so the UI can keep showing it, while `dismissJob` removes it.
 
 ```tsx
 import { ConversationTransferErrorCode } from '@epam/ai-dial-chat-shared';
@@ -2610,7 +2610,7 @@ Owns the catalog's edit/delete/create-menu navigation: routing the details panel
 | `onDeleteSuccess`                                                             | `(item: CatalogItem) => void`                               | Called after a successful delete, so the host can notify with its own entity/operation vocabulary. |
 | `labels`                                                                      | `CatalogEditNavigationLabels`                               | Localized notification and Create-menu copy, resolved by the host.                                 |
 | `onNotify`                                                                    | `(notification: CatalogEditNavigationNotification) => void` | Called to surface a host notification when a delete fails.                                         |
-| `triggerSkillArchivePicker`                                                   | `() => void`                                                | Opens the file picker used to upload a skill archive from the Create menu.                         |
+| `onSkillUploadClick`                                                          | `() => void`                                                | Called when the Create menu's Skill → Upload option is picked.                                     |
 
 `CatalogEditNavigationUrls` has one URL-builder pair per item kind — `buildPromptEditUrl(promptId)` / `buildPromptCreateUrl()`, and the same edit/create pair for `Skill`, `Toolset`, and `CustomApp` — plus `buildQuickAppEditUrl(schemaId, appId)` / `buildQuickAppCreateUrl(schemaId)`.
 
@@ -2668,7 +2668,7 @@ const { handleEdit, handleDelete, createOptions } = useCatalogEditNavigation({
   onDeleteSuccess: (item) => notifyOperationSuccess(item),
   labels,
   onNotify: showErrorNotification,
-  triggerSkillArchivePicker,
+  onSkillUploadClick: openSkillUploadDialog,
 });
 ```
 

--- a/libs/chat-hooks/src/catalog/useCatalogEditNavigation/tests/useCatalogEditNavigation.spec.ts
+++ b/libs/chat-hooks/src/catalog/useCatalogEditNavigation/tests/useCatalogEditNavigation.spec.ts
@@ -61,7 +61,7 @@ const renderEditNavigation = (
   const refetchDeployments = vi.fn().mockResolvedValue(undefined);
   const onDeleteSuccess = vi.fn();
   const onNotify = vi.fn();
-  const triggerSkillArchivePicker = vi.fn();
+  const onSkillUploadClick = vi.fn();
   const view = renderHook(() =>
     useCatalogEditNavigation({
       deployments: [],
@@ -84,7 +84,7 @@ const renderEditNavigation = (
       onDeleteSuccess,
       labels,
       onNotify,
-      triggerSkillArchivePicker,
+      onSkillUploadClick,
       ...overrides,
     }),
   );
@@ -101,7 +101,7 @@ const renderEditNavigation = (
     refetchDeployments,
     onDeleteSuccess,
     onNotify,
-    triggerSkillArchivePicker,
+    onSkillUploadClick,
   };
 };
 
@@ -479,7 +479,7 @@ describe('useCatalogEditNavigation', () => {
     });
 
     it('offers no nested children other than Write instructions and Upload under Skill', () => {
-      const { result, triggerSkillArchivePicker } = renderEditNavigation();
+      const { result, onSkillUploadClick } = renderEditNavigation();
 
       const skillOption = result.current.createOptions.find(
         (option) => option.key === 'skill',
@@ -493,7 +493,7 @@ describe('useCatalogEditNavigation', () => {
         (child) => child.key === 'skill-upload',
       );
       uploadOption?.onClick?.({ key: 'skill-upload', domEvent: {} as never });
-      expect(triggerSkillArchivePicker).toHaveBeenCalledOnce();
+      expect(onSkillUploadClick).toHaveBeenCalledOnce();
     });
   });
 });

--- a/libs/chat-hooks/src/catalog/useCatalogEditNavigation/useCatalogEditNavigation.ts
+++ b/libs/chat-hooks/src/catalog/useCatalogEditNavigation/useCatalogEditNavigation.ts
@@ -85,8 +85,8 @@ export interface UseCatalogEditNavigationParams {
   labels: CatalogEditNavigationLabels;
   /** Called to surface a host notification when a delete fails. */
   onNotify: (notification: CatalogEditNavigationNotification) => void;
-  /** Opens the file picker used to upload a skill archive from the Create menu. */
-  triggerSkillArchivePicker: () => void;
+  /** Called when the Create menu's Skill → Upload option is picked. */
+  onSkillUploadClick: () => void;
 }
 
 /** Return value of {@link useCatalogEditNavigation}. */
@@ -123,7 +123,7 @@ export const useCatalogEditNavigation = ({
   onDeleteSuccess,
   labels,
   onNotify,
-  triggerSkillArchivePicker,
+  onSkillUploadClick,
 }: UseCatalogEditNavigationParams): UseCatalogEditNavigationResult => {
   const handleEdit = useCallback(
     (item: CatalogItem) => {
@@ -248,7 +248,7 @@ export const useCatalogEditNavigation = ({
         {
           key: 'skill-upload',
           label: labels.createSkillUpload,
-          onClick: triggerSkillArchivePicker,
+          onClick: onSkillUploadClick,
         },
       ],
     });
@@ -272,7 +272,7 @@ export const useCatalogEditNavigation = ({
     isHideCustomAppCreationEnabled,
     isToolsetsEnabled,
     isCustomAppsEnabled,
-    triggerSkillArchivePicker,
+    onSkillUploadClick,
   ]);
 
   return {


### PR DESCRIPTION
Closes #8654

## Problem

Catalog **Create → Skill → Upload** called `.click()` on a hidden `<input type="file">`, so the OS file dialog opened immediately. The user never saw the drop area, the click-to-browse affordance, or the supported formats.

## Change

**New `SkillArchiveUploadDialog`** (`apps/chat/src/components/SkillArchiveUploadDialog/`) — the kit's `Popup` (`PopupSize.Sm`) around `FileDropzone`: an "Upload skill" title, a drag-and-drop area that opens the picker on click, the accepted formats, an inline rejection message, and a close button. The hidden input is gone; the OS picker now opens only from inside the popup.

**`useSkillArchiveImport`** swaps `triggerFilePicker` / `handleFileChange` for `isDialogOpen` / `openDialog` / `closeDialog` / `handleFilesSelected` / `handleFilesRejected` / `selectionError`. A rejected file renders inline under the drop zone and leaves the dialog open, so the user can pick another without reopening it — previously this was a toast, which would now duplicate the visible error. An accepted file closes the dialog and runs the existing import → notification → `refetchSkills` flow unchanged. The in-flight guard still blocks reopening during an upload.

**`useCatalogEditNavigation`**: `triggerSkillArchivePicker` → `onSkillUploadClick`. The old name described a picker that no longer exists; the param is required, so any external consumer gets a compile error rather than a silent behaviour change. README updated.

## Note on the accepted formats

The issue lists `.md, .zip, .skill`. `.skill` does not exist anywhere in this repo: `skills-import.service.ts` dispatches on the uploaded filename and accepts only a ZIP archive or a file named exactly `SKILL.md`. The popup therefore reads **"File formats .zip and SKILL.md"** with `accept=".zip,.md"` — advertising `.skill` would be a promise the backend breaks. Real `.skill` support is a separate change spanning the BFF.

## Verification

`typecheck:affected`, `lint:affected` and `validate:docs` pass. New spec for the dialog (5 cases), rewritten spec for the hook; `CatalogView`, `useCatalogEditNavigation` and the full `chat-hooks` suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
