### PR TITLE
fix(chat): file manager modification time, Organization root label, resizable field caps, markdown preview lists, stopped-generation re-submit (Issue #8653, #8704, #8652, #8690, #8687)

### DIFF
--- a/.claude/rules/all-tsx.md
+++ b/.claude/rules/all-tsx.md
@@ -40,7 +40,7 @@ className={mergeClasses(nameClassName, styles.nameText)}
 | **2.0** (use)   | no prefix — `Button`, `Input`, `Select` | current design system             |
 | **1.0** (avoid) | `Dial*` — `DialButton`, `DialInput`     | legacy, kept for back-compat only |
 
-**Always import the 2.0 component.** Reach for a `Dial*` component only when the MCP lookup shows it has no 2.0 replacement (e.g. `DialPagination`, `DialSlider`, `DialGrid`, `DialNoDataContent`, `DialFileManager` currently have none). `DialTooltip`, `DialEllipsisTooltip`, `DialCheckbox`, `DialRadioButton`, `DialRadioGroup` and `DialSegmentedControl` gained 2.0 counterparts in ui-kit 0.14 — use `Tooltip`, `EllipsisTooltip`, `Checkbox`, `Radio`, `RadioGroup`, `SegmentedControl`. `DialFormPopup` is likewise superseded: `Popup` builds the Cancel/Submit footer from `mainButtons`/`additionalButtons`.
+**Always import the 2.0 component.** Reach for a `Dial*` component only when the MCP lookup shows it has no 2.0 replacement (e.g. `DialPagination`, `DialFileManager`, `DialFileName`, `DialInputPopup` currently have none). `DialTooltip`, `DialEllipsisTooltip`, `DialCheckbox`, `DialRadioButton`, `DialRadioGroup` and `DialSegmentedControl` gained 2.0 counterparts in ui-kit 0.14 — use `Tooltip`, `EllipsisTooltip`, `Checkbox`, `Radio`, `RadioGroup`, `SegmentedControl`. `DialNoDataContent`, `DialSlider`, `DialGrid` and `DialConditionalResizableContainer` are likewise superseded — use `NoDataContent`, `Slider`, `Grid`, `ConditionalResizableContainer`. `DialFormPopup` is likewise superseded: `Popup` builds the Cancel/Submit footer from `mainButtons`/`additionalButtons`.
 
 ```tsx
 // Correct — generation 2.0

--- a/apps/chat/src/components/CatalogView/CatalogView.tsx
+++ b/apps/chat/src/components/CatalogView/CatalogView.tsx
@@ -22,6 +22,7 @@ import { ToolsetEditorQuery } from '../../constants/toolsets';
 import {
   ApiI18nKeys,
   AuthI18nKeys,
+  BasicI18nKeys,
   ButtonsI18nKeys,
   CatalogI18nKeys,
   DialFileManagerI18nKeys,
@@ -582,6 +583,7 @@ const CatalogView: FC<Props> = ({
           historyLoadingLabel: t(CatalogI18nKeys.PublishHistoryLoading),
           historyErrorLabel: t(CatalogI18nKeys.PublishHistoryError),
           submitError: t(PublishI18nKeys.SubmitErrorCallout),
+          rootFolderLabel: t(BasicI18nKeys.Organization),
           accessRulesLabels: getAccessRulesLabels(t),
         }}
         shareOverlay={(item, onClose) => (

--- a/apps/chat/src/components/ConversationPanel/ConversationPanelView.tsx
+++ b/apps/chat/src/components/ConversationPanel/ConversationPanelView.tsx
@@ -125,6 +125,7 @@ import {
 } from '../../utils/conversation-transfer';
 import { resolveCatalogIconUrl } from '../../utils/icon-path';
 import { resolveLocalizedText } from '../../utils/locale';
+import { getPublishFolderLabel } from '../../utils/publish';
 import ShareConversationPopoverContainer from '../ShareConversationPopoverContainer/ShareConversationPopoverContainer';
 import ConversationPanelMenu from './ConversationPanelMenu';
 
@@ -1145,7 +1146,7 @@ const ConversationPanelView: FC<ConversationPanelViewProps> = ({
         notifyOperationSuccess(
           NotifiableEntity.Conversation,
           EntityOperation.UnpublishRequested,
-          { name: title, folder: folderPath.split('/').pop() ?? folderPath },
+          { name: title, folder: getPublishFolderLabel(folderPath, t) },
         );
       },
       () => '',
@@ -1156,6 +1157,7 @@ const ConversationPanelView: FC<ConversationPanelViewProps> = ({
     selectedUnpublishFolder,
     showPublishError,
     notifyOperationSuccess,
+    t,
   ]);
 
   const handleConfirmRevoke = useCallback(async () => {

--- a/apps/chat/src/components/ConversationView/ConversationView.tsx
+++ b/apps/chat/src/components/ConversationView/ConversationView.tsx
@@ -9,9 +9,9 @@ import {
   dialFolderPathToAttachment,
   findDeploymentByIdOrReference,
   getQuickAppConversationStarters,
-  isMessageChanged,
   isQuickAppSchema,
   referenceAttachmentToPdfCanvasContent,
+  shouldRerunGenerationOnEdit,
   useAttachmentValidation,
   useChatSettingsFormConfig,
 } from '@epam/ai-dial-chat-hooks';
@@ -633,15 +633,20 @@ const ConversationView: FC<Props> = ({
       newAttachments: Attachment[],
     ) => {
       /*
-       * handleEditMessage no-ops if a generation is in flight or the text is
-       * unchanged (isMessageChanged mirrors that same check) — skip arming
-       * in either case so a later, unrelated update can't consume a stale index.
+       * handleEditMessage no-ops if a generation is in flight, or if nothing
+       * changed and the existing answer is complete (shouldRerunGenerationOnEdit
+       * mirrors that same check) — skip arming in either case so a later,
+       * unrelated update can't consume a stale index.
        */
-      const originalMessage = messages[messageIndex];
       if (
         !isAssistantTyping &&
-        originalMessage != null &&
-        isMessageChanged(originalMessage, text, keptAttachments, newAttachments)
+        shouldRerunGenerationOnEdit(
+          messages,
+          messageIndex,
+          text,
+          keptAttachments,
+          newAttachments,
+        )
       ) {
         armAnchor(messageIndex);
       }

--- a/apps/chat/src/components/PublishConversationPanelContainer/PublishConversationPanelContainer.tsx
+++ b/apps/chat/src/components/PublishConversationPanelContainer/PublishConversationPanelContainer.tsx
@@ -8,6 +8,7 @@ import type { FC, RefObject } from 'react';
 import { memo, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
+  BasicI18nKeys,
   ButtonsI18nKeys,
   ConversationPublishI18nKeys,
   PublishI18nKeys,
@@ -22,7 +23,10 @@ import {
   EntityOperation,
   NotifiableEntity,
 } from '../../types/entity-notification';
-import { getAccessRulesLabels } from '../../utils/publish';
+import {
+  getAccessRulesLabels,
+  getPublishFolderLabel,
+} from '../../utils/publish';
 
 const EMPTY_HISTORY: PublishHistoryEntry[] = [];
 
@@ -104,7 +108,7 @@ const PublishConversationPanelContainer: FC<Props> = ({
         EntityOperation.PublishRequested,
         {
           name: conversationTitle,
-          folder: folderPath[folderPath.length - 1],
+          folder: getPublishFolderLabel(folderPath, t),
         },
       );
     },
@@ -173,6 +177,7 @@ const PublishConversationPanelContainer: FC<Props> = ({
           ConversationPublishI18nKeys.DuplicateFolderNameError,
         ),
         submitError: t(PublishI18nKeys.SubmitErrorCallout),
+        rootFolderLabel: t(BasicI18nKeys.Organization),
         accessRulesLabels: getAccessRulesLabels(t),
       }}
       labels={{

--- a/apps/chat/src/hooks/useCatalogPublishing/tests/useCatalogPublishing.spec.ts
+++ b/apps/chat/src/hooks/useCatalogPublishing/tests/useCatalogPublishing.spec.ts
@@ -4,6 +4,7 @@ import { CatalogEntityType } from '@epam/ai-dial-chat-shared';
 import type { PublicationRule } from '@epam/ai-dial-publish-panel';
 import { renderHook } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { BasicI18nKeys } from '../../../constants/translation-keys';
 import { getPublishRules } from '../../../server-api/publish-rules.api';
 import {
   CatalogPublishEntityType,
@@ -153,6 +154,22 @@ describe('useCatalogPublishing', () => {
         expect.anything(),
         EntityOperation.PublishRequested,
         { name: 'My toolset', folder: 'Data Science' },
+      );
+    });
+
+    /*
+     * The public root has no path segments, so naming its leaf produced
+     * `folder ""` in the confirmation (GH #8704).
+     */
+    it('names the root label when the target folder is the public root', () => {
+      const { result, notifyOperationSuccess } = renderPublishing();
+
+      result.current.handlePublishSuccess(makeCatalogItem(), []);
+
+      expect(notifyOperationSuccess).toHaveBeenCalledWith(
+        expect.anything(),
+        EntityOperation.PublishRequested,
+        { name: 'My toolset', folder: BasicI18nKeys.Organization },
       );
     });
 
@@ -346,6 +363,18 @@ describe('useCatalogPublishing', () => {
         expect.anything(),
         EntityOperation.UnpublishRequested,
         { name: 'My toolset', folder: 'Data Science' },
+      );
+    });
+
+    it('names the root label when the published copy sits in the public root', async () => {
+      const { result, notifyOperationSuccess } = renderPublishing();
+
+      await result.current.handleUnpublish(makeCatalogItem(), []);
+
+      expect(notifyOperationSuccess).toHaveBeenCalledWith(
+        expect.anything(),
+        EntityOperation.UnpublishRequested,
+        { name: 'My toolset', folder: BasicI18nKeys.Organization },
       );
     });
 

--- a/apps/chat/src/hooks/useCatalogPublishing/useCatalogPublishing.ts
+++ b/apps/chat/src/hooks/useCatalogPublishing/useCatalogPublishing.ts
@@ -13,6 +13,7 @@ import type {
   PublishHistoryEntry,
 } from '@epam/ai-dial-publish-panel';
 import { useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
 import { getPublishRules } from '../../server-api/publish-rules.api';
 import {
   getCatalogPublishHistory,
@@ -21,6 +22,7 @@ import {
 } from '../../server-api/publish.api';
 import { EntityOperation } from '../../types/entity-notification';
 import { resolveCatalogItemEntity } from '../../utils/entity-notification';
+import { getPublishFolderLabel } from '../../utils/publish';
 import type { useOperationNotification } from '../useOperationNotification';
 
 interface UseCatalogPublishingParams {
@@ -70,6 +72,8 @@ export const useCatalogPublishing = ({
   isAdmin,
   hasPublishWriteAccess,
 }: UseCatalogPublishingParams): UseCatalogPublishingResult => {
+  const { t } = useTranslation();
+
   /*
    * Publish and Unpublish act on two different items, and each is offered
    * only on the one it applies to (GH #8691, where both landed on the wrong
@@ -200,11 +204,11 @@ export const useCatalogPublishing = ({
         EntityOperation.UnpublishRequested,
         {
           name: item.name,
-          folder: folderPath[folderPath.length - 1],
+          folder: getPublishFolderLabel(folderPath, t),
         },
       );
     },
-    [deployments, notifyOperationSuccess, showPublishError],
+    [deployments, notifyOperationSuccess, showPublishError, t],
   );
 
   const handlePublishSuccess = useCallback(
@@ -218,11 +222,11 @@ export const useCatalogPublishing = ({
         EntityOperation.PublishRequested,
         {
           name: item.name,
-          folder: folderPath[folderPath.length - 1],
+          folder: getPublishFolderLabel(folderPath, t),
         },
       );
     },
-    [deployments, rememberPublishFolder, notifyOperationSuccess],
+    [deployments, rememberPublishFolder, notifyOperationSuccess, t],
   );
 
   const handlePublishError = useCallback(

--- a/apps/chat/src/utils/publish.ts
+++ b/apps/chat/src/utils/publish.ts
@@ -1,9 +1,31 @@
 import { PublishAccessRulesLabels } from '@epam/ai-dial-publish-panel';
 import type { TFunction } from 'i18next';
 import {
+  BasicI18nKeys,
   ButtonsI18nKeys,
   PublishAccessRulesI18nKeys,
 } from '../constants/translation-keys';
+
+/**
+ * Display name of a publish target folder, for notification copy.
+ *
+ * The Organization root is the whole public bucket and so has no path segments;
+ * taking the last segment of its path yields an empty string, which rendered as
+ * `folder ""` in the confirmation. It falls back to the same root label the
+ * publish panel's folder tree shows for that node.
+ *
+ * Accepts either the `string[]` segments the publish panel hands its callbacks
+ * or the already-joined path kept in publish history.
+ */
+export const getPublishFolderLabel = (
+  folderPath: string | string[],
+  t: TFunction,
+): string => {
+  const segments = Array.isArray(folderPath)
+    ? folderPath
+    : folderPath.split('/');
+  return segments[segments.length - 1] || t(BasicI18nKeys.Organization);
+};
 
 /** Builds the translated `accessRulesLabels` overrides shared by every publish panel host (catalog, conversation). */
 export const getAccessRulesLabels = (

--- a/apps/chat/src/utils/tests/publish.spec.ts
+++ b/apps/chat/src/utils/tests/publish.spec.ts
@@ -1,0 +1,32 @@
+import type { TFunction } from 'i18next';
+import { describe, expect, it } from 'vitest';
+import { BasicI18nKeys } from '../../constants/translation-keys';
+import { getPublishFolderLabel } from '../publish';
+
+const t = ((key: string) => key) as unknown as TFunction;
+
+describe('getPublishFolderLabel', () => {
+  it('names the leaf segment of a nested folder path', () => {
+    expect(getPublishFolderLabel(['Organization', 'Data Science'], t)).toBe(
+      'Data Science',
+    );
+  });
+
+  it('names the leaf segment of a joined folder path', () => {
+    expect(getPublishFolderLabel('Organization/Data Science', t)).toBe(
+      'Data Science',
+    );
+  });
+
+  /*
+   * The Organization root has no path segments, so its leaf is the empty
+   * string — GH #8704, where the confirmation read `folder ""`.
+   */
+  it('falls back to the root label for the segment-less public root', () => {
+    expect(getPublishFolderLabel([], t)).toBe(BasicI18nKeys.Organization);
+  });
+
+  it('falls back to the root label for an empty joined path', () => {
+    expect(getPublishFolderLabel('', t)).toBe(BasicI18nKeys.Organization);
+  });
+});

--- a/libs/attachment-canvas/src/components/AttachmentCanvas/AttachmentCanvas.tsx
+++ b/libs/attachment-canvas/src/components/AttachmentCanvas/AttachmentCanvas.tsx
@@ -31,6 +31,7 @@ const AttachmentCanvasBase: FC<AttachmentCanvasProps> = ({
   labels: {
     ariaLabel,
     closeLabel = 'Close',
+    resizeLabel = 'Resize panel',
     downloadLabel = 'Download',
     copyTextLabel = 'Copy text',
     copiedTextLabel = 'Copied!',
@@ -173,7 +174,7 @@ const AttachmentCanvasBase: FC<AttachmentCanvasProps> = ({
       isOpen={isOpen}
       orientation={SidebarOrientation.Right}
       title={fileName}
-      labels={{ ariaLabel, closeLabel }}
+      labels={{ ariaLabel, closeLabel, resizeLabel }}
       onClose={onClose}
       resizable={!isMobile}
       defaultWidth={defaultWidth}

--- a/libs/attachment-canvas/src/models/attachment-canvas.ts
+++ b/libs/attachment-canvas/src/models/attachment-canvas.ts
@@ -282,6 +282,8 @@ export interface AttachmentCanvasLabels {
   ariaLabel: string;
   /** Accessible label for the close button. Defaults to `'Close'`. */
   closeLabel?: string;
+  /** Accessible label for the panel's drag-to-resize handle. Defaults to `'Resize panel'`. */
+  resizeLabel?: string;
   /** Message shown in the canvas body when the content type is `Unsupported`. Defaults to `'Preview is not supported for this file'`. */
   unsupportedLabel?: string;
   /** Message shown in the canvas body when content type is `Error` with `errorType: LoadFailed`. Defaults to `'Failed to load file'`. */

--- a/libs/catalog/src/components/ListView/tests/ListView.spec.tsx
+++ b/libs/catalog/src/components/ListView/tests/ListView.spec.tsx
@@ -10,7 +10,7 @@ vi.mock('@epam/ai-dial-ui-kit', () => ({
   DIAL_ICON_SIZE: { SM: 16, MD: 20, LG: 24 },
   mergeClasses: (...args: (string | undefined)[]) =>
     args.filter(Boolean).join(' '),
-  DialNoDataContent: ({ title }: { title?: string }) => <span>{title}</span>,
+  NoDataContent: ({ title }: { title?: string }) => <span>{title}</span>,
 }));
 
 vi.mock('@epam/ai-dial-ui-kit/grid', () => ({

--- a/libs/chat-hooks/README.md
+++ b/libs/chat-hooks/README.md
@@ -935,7 +935,7 @@ const ChatPage = ({
 state updater, so a host may update its own state from it — for example dropping
 the deleted conversation from a list it renders.
 
-Also exports the standalone `attachmentsToDtos`/`attachmentToDto`, `createMessagePair`, `hasActiveToolConfig`/`isMessageChanged`, and `getStarterConversationText`/`getStarterSubmitText` (the pure functions the hook is built on) for hosts that need the same logic outside the hook.
+Also exports the standalone `attachmentsToDtos`/`attachmentToDto`, `createMessagePair`, `hasActiveToolConfig`/`isMessageChanged`/`isAnswerIncomplete`/`shouldRerunGenerationOnEdit`, and `getStarterConversationText`/`getStarterSubmitText` (the pure functions the hook is built on) for hosts that need the same logic outside the hook.
 
 ### useAttachmentValidation
 

--- a/libs/chat-hooks/src/conversation/useConversationHandlers/message-utils.ts
+++ b/libs/chat-hooks/src/conversation/useConversationHandlers/message-utils.ts
@@ -1,7 +1,8 @@
-import type {
-  Attachment,
-  DisplayAttachment,
-  Message,
+import {
+  type Attachment,
+  type DisplayAttachment,
+  type Message,
+  MessageRole,
 } from '@epam/ai-dial-chat-shared';
 
 /** Whether at least one tool toggle in `value` is active. */
@@ -29,4 +30,43 @@ export const isMessageChanged = (
   const originalAttachmentCount =
     originalMessage.custom_content?.attachments?.length ?? 0;
   return keptDisplayAttachments.length !== originalAttachmentCount;
+};
+
+/**
+ * Whether the assistant answer that follows an edited user message is missing
+ * or incomplete: no message at all, a non-assistant message, an answer the
+ * user stopped, or one that ended with a stream error.
+ */
+export const isAnswerIncomplete = (answer: Message | undefined): boolean =>
+  answer == null ||
+  answer.role !== MessageRole.Assistant ||
+  !!answer.wasStoppedByUser ||
+  answer.streamErrorMessage != null;
+
+/**
+ * Whether submitting an edit has to re-run the generation.
+ *
+ * True whenever the message itself changed, and also when it is unchanged but
+ * its answer never completed — after stopping a generation the user submits
+ * the same message precisely to get a full answer, so treating that as "no
+ * change" would leave the conversation stuck with the partial one.
+ */
+export const shouldRerunGenerationOnEdit = (
+  messages: Message[],
+  messageIndex: number,
+  newText: string,
+  keptDisplayAttachments: DisplayAttachment[],
+  newAttachments: Attachment[],
+): boolean => {
+  const originalMessage = messages[messageIndex];
+  if (!originalMessage) return false;
+
+  return (
+    isMessageChanged(
+      originalMessage,
+      newText,
+      keptDisplayAttachments,
+      newAttachments,
+    ) || isAnswerIncomplete(messages[messageIndex + 1])
+  );
 };

--- a/libs/chat-hooks/src/conversation/useConversationHandlers/tests/message-utils.spec.ts
+++ b/libs/chat-hooks/src/conversation/useConversationHandlers/tests/message-utils.spec.ts
@@ -7,7 +7,12 @@ import {
   type Message,
 } from '@epam/ai-dial-chat-shared';
 import { describe, expect, it } from 'vitest';
-import { hasActiveToolConfig, isMessageChanged } from '../message-utils';
+import {
+  hasActiveToolConfig,
+  isAnswerIncomplete,
+  isMessageChanged,
+  shouldRerunGenerationOnEdit,
+} from '../message-utils';
 
 const userMessage = (content = 'hello'): Message => ({
   role: MessageRole.User,
@@ -109,5 +114,80 @@ describe('hasActiveToolConfig', () => {
 
   it('returns true when at least one entry is present', () => {
     expect(hasActiveToolConfig({ web: true })).toBe(true);
+  });
+});
+
+describe('isAnswerIncomplete', () => {
+  const answer = (overrides: Partial<Message> = {}): Message => ({
+    role: MessageRole.Assistant,
+    content: 'answer',
+    timestamp: '2024-01-01T00:00:00.000Z',
+    ...overrides,
+  });
+
+  it('returns false for a completed answer', () => {
+    expect(isAnswerIncomplete(answer())).toBe(false);
+  });
+
+  it('returns true when there is no answer at all', () => {
+    expect(isAnswerIncomplete(undefined)).toBe(true);
+  });
+
+  it('returns true when the answer is not an assistant message', () => {
+    expect(isAnswerIncomplete(userMessage())).toBe(true);
+  });
+
+  it('returns true when the user stopped the answer', () => {
+    expect(isAnswerIncomplete(answer({ wasStoppedByUser: true }))).toBe(true);
+  });
+
+  it('returns true when the answer ended with a stream error', () => {
+    expect(isAnswerIncomplete(answer({ streamErrorMessage: '' }))).toBe(true);
+  });
+});
+
+describe('shouldRerunGenerationOnEdit', () => {
+  const stoppedAnswer: Message = {
+    role: MessageRole.Assistant,
+    content: 'Partial',
+    timestamp: '2024-01-01T00:00:00.000Z',
+    wasStoppedByUser: true,
+  };
+
+  const completedAnswer: Message = {
+    role: MessageRole.Assistant,
+    content: 'Full answer',
+    timestamp: '2024-01-01T00:00:00.000Z',
+  };
+
+  it('returns false when nothing changed and the answer is complete', () => {
+    const messages = [userMessage('hello'), completedAnswer];
+    expect(shouldRerunGenerationOnEdit(messages, 0, 'hello', [], [])).toBe(
+      false,
+    );
+  });
+
+  it('returns true when the text changed', () => {
+    const messages = [userMessage('hello'), completedAnswer];
+    expect(shouldRerunGenerationOnEdit(messages, 0, 'world', [], [])).toBe(
+      true,
+    );
+  });
+
+  it('returns true when nothing changed but the answer was stopped', () => {
+    const messages = [userMessage('hello'), stoppedAnswer];
+    expect(shouldRerunGenerationOnEdit(messages, 0, 'hello', [], [])).toBe(
+      true,
+    );
+  });
+
+  it('returns true when the edited message has no answer yet', () => {
+    expect(
+      shouldRerunGenerationOnEdit([userMessage('hello')], 0, 'hello', [], []),
+    ).toBe(true);
+  });
+
+  it('returns false when the index holds no message', () => {
+    expect(shouldRerunGenerationOnEdit([], 0, 'hello', [], [])).toBe(false);
   });
 });

--- a/libs/chat-hooks/src/conversation/useConversationHandlers/tests/useConversationHandlers.spec.ts
+++ b/libs/chat-hooks/src/conversation/useConversationHandlers/tests/useConversationHandlers.spec.ts
@@ -564,6 +564,70 @@ describe('useConversationHandlers', () => {
       expect(result.current.handlers.editingMessageIndexes.has(0)).toBe(false);
     });
 
+    it('re-runs the generation when nothing changed but the answer was stopped', async () => {
+      const conversation = makeConversation({
+        messages: [
+          {
+            role: 'user' as never,
+            content: 'Original question',
+            timestamp: 't',
+          },
+          {
+            role: 'assistant' as never,
+            content: 'Partial answer',
+            timestamp: 't',
+            wasStoppedByUser: true,
+          },
+        ],
+      });
+      const { result } = renderHook(() => useHarness({ conversation }));
+      act(() => result.current.handlers.handleStartEdit(0));
+
+      await act(() =>
+        result.current.handlers.handleEditMessage(
+          0,
+          'Original question',
+          [],
+          [],
+        ),
+      );
+
+      expect(result.current.startStream).toHaveBeenCalledWith(
+        conversation.id,
+        'Original question',
+        1,
+        'selected-model',
+        undefined,
+        expect.any(String),
+        'edit',
+      );
+      expect(result.current.handlers.editingMessageIndexes.has(0)).toBe(false);
+    });
+
+    it('updates conversationRef before starting the stream', async () => {
+      const conversation = editableConversation();
+      const { result } = renderHook(() =>
+        useHarness({ conversation }, { keepRefInSync: false }),
+      );
+      /* startStream seeds its live-message buffer from the ref, so the edit has
+         to be visible there by the time it runs. */
+      const refMessagesAtStreamStart: unknown[] = [];
+      result.current.startStream.mockImplementation(() => {
+        refMessagesAtStreamStart.push(
+          result.current.conversationRef.current?.messages,
+        );
+      });
+
+      await act(() =>
+        result.current.handlers.handleEditMessage(0, 'Edited question', [], []),
+      );
+
+      expect(refMessagesAtStreamStart[0]).toEqual([
+        expect.objectContaining({ content: 'Edited question' }),
+        expect.objectContaining({ role: 'assistant', content: '' }),
+      ]);
+    });
+
     it('does nothing while streaming', async () => {
       const conversation = editableConversation();
       const { result } = renderHook(() =>

--- a/libs/chat-hooks/src/conversation/useConversationHandlers/useConversationHandlers.ts
+++ b/libs/chat-hooks/src/conversation/useConversationHandlers/useConversationHandlers.ts
@@ -22,7 +22,10 @@ import { getConversationPath } from '../useConversationStream/conversation-path'
 import type { ConversationStateAccessor } from '../useConversationStream/useConversationStream';
 import { attachmentsToDtos } from './attachment-to-dto';
 import { createMessagePair } from './message-factory';
-import { hasActiveToolConfig, isMessageChanged } from './message-utils';
+import {
+  hasActiveToolConfig,
+  shouldRerunGenerationOnEdit,
+} from './message-utils';
 import { getStarterSubmitText } from './starter-option';
 
 /** The exact `startStream` shape `useConversationStream` returns. */
@@ -514,8 +517,9 @@ export const useConversationHandlers = ({
       const originalMessage = conversation.messages[idx];
 
       if (
-        !isMessageChanged(
-          originalMessage,
+        !shouldRerunGenerationOnEdit(
+          conversation.messages,
+          idx,
           text,
           keptDisplayAttachments,
           newAttachments,
@@ -571,10 +575,12 @@ export const useConversationHandlers = ({
 
       const updated = { ...conversation, messages: updatedMessages };
 
-      setConversation(() => {
-        conversationRef.current = updated;
-        return updated;
-      });
+      /* The ref is assigned outside the updater because startStream reads it
+       * synchronously below to seed its live-message buffer: React may defer a
+       * function updater to the next render, which would seed the buffer with
+       * the answer this edit replaces. */
+      conversationRef.current = updated;
+      setConversation(updated);
 
       const modelId = resolveModelId();
 

--- a/libs/chat-hooks/src/conversation/useConversationStream/tests/useConversationStream.spec.ts
+++ b/libs/chat-hooks/src/conversation/useConversationStream/tests/useConversationStream.spec.ts
@@ -510,6 +510,103 @@ describe('useConversationStream', () => {
     );
   });
 
+  it('ignores a superseded generation completing on the same path', async () => {
+    const { result } = renderHook(() =>
+      useHookHarness({
+        transport,
+        conversationId: 'bucket/conv',
+        initialConversation: makeConversation({
+          messages: [
+            { role: MessageRole.User, content: 'edited', timestamp: 't' },
+            { role: MessageRole.Assistant, content: '', timestamp: 't' },
+          ],
+        }),
+      }),
+    );
+
+    await act(async () => {
+      result.current.stream.startStream(
+        'bucket/conv',
+        'hi',
+        1,
+        'gpt-4o',
+        undefined,
+        'gen-1',
+      );
+    });
+    /* The stopped generation's own callbacks, captured before the re-submit
+     * replaces the harness's capturedOptions. */
+    const stoppedOptions = capturedOptions;
+
+    await act(async () => {
+      result.current.stream.startStream(
+        'bucket/conv',
+        'edited',
+        1,
+        'gpt-4o',
+        undefined,
+        'gen-2',
+        SendCompletionDtoModeEnum.Edit,
+      );
+    });
+
+    await act(async () => {
+      await stoppedOptions?.onComplete();
+    });
+
+    expect(result.current.stream.isStreaming).toBe(true);
+    expect(transport.getConversation).not.toHaveBeenCalled();
+    expect(result.current.conversation?.messages[0]?.content).toBe('edited');
+  });
+
+  it('does not write a superseded generation error onto the new answer', async () => {
+    const { result } = renderHook(() =>
+      useHookHarness({
+        transport,
+        conversationId: 'bucket/conv',
+        initialConversation: makeConversation({
+          messages: [
+            { role: MessageRole.User, content: 'edited', timestamp: 't' },
+            { role: MessageRole.Assistant, content: '', timestamp: 't' },
+          ],
+        }),
+      }),
+    );
+
+    await act(async () => {
+      result.current.stream.startStream(
+        'bucket/conv',
+        'hi',
+        1,
+        'gpt-4o',
+        undefined,
+        'gen-1',
+      );
+    });
+    const stoppedOptions = capturedOptions;
+
+    await act(async () => {
+      result.current.stream.startStream(
+        'bucket/conv',
+        'edited',
+        1,
+        'gpt-4o',
+        undefined,
+        'gen-2',
+        SendCompletionDtoModeEnum.Edit,
+      );
+    });
+
+    act(() => {
+      stoppedOptions?.onError(new Error('generation failed'));
+    });
+
+    expect(result.current.stream.isStreaming).toBe(true);
+    expect(result.current.conversation?.messages[1]?.streamErrorMessage).toBe(
+      undefined,
+    );
+  });
+
   it('reports an error only on the currently displayed conversation', () => {
     const { result } = renderHook(() =>
       useHookHarness({ transport, conversationId: 'bucket/conv' }),

--- a/libs/chat-hooks/src/conversation/useConversationStream/useConversationStream.ts
+++ b/libs/chat-hooks/src/conversation/useConversationStream/useConversationStream.ts
@@ -185,6 +185,8 @@ export const useConversationStream = ({
   /* Generation ids stopped by the user — onComplete emits notifyStopGenerating's
    * counterpart (nothing) instead of notifyGenerationEnd for these. */
   const stoppedGenerationIdsRef = useRef<Set<string>>(new Set());
+  /** Newest generation id started for each path — see `isSuperseded` in `startStream`. */
+  const latestGenerationIdsRef = useRef<Map<string, string>>(new Map());
 
   /*
    * The host component isn't necessarily remounted when navigating between
@@ -241,6 +243,7 @@ export const useConversationStream = ({
       const conversationPath = getConversationPath(currentConversationId);
       activeGenerationIdRef.current = genId;
       activeGenerationPathRef.current = conversationPath;
+      latestGenerationIdsRef.current.set(conversationPath, genId);
       setStoppablePath(conversationPath);
 
       /*
@@ -255,6 +258,17 @@ export const useConversationStream = ({
       } else if (mode === SendCompletionDtoModeEnum.Edit) {
         serverMessageIndex = messageIndex - 1;
       }
+
+      /*
+       * True once a newer generation has been started on this path: the user
+       * stopped this one and immediately re-submitted (Stop re-enables
+       * edit/regenerate as soon as the stopped stream closes, while this
+       * generation's conversation reload is still in flight). A superseded
+       * generation must not clear the new one's streaming state, report its
+       * end, or overwrite the conversation with the answer it had fetched.
+       */
+      const isSuperseded = (): boolean =>
+        latestGenerationIdsRef.current.get(conversationPath) !== genId;
 
       const controller = startGeneration(conversationPath, genId);
       const initialMessage = conversationRef.current?.messages[messageIndex];
@@ -320,7 +334,7 @@ export const useConversationStream = ({
           ) {
             bufferedGenerationsRef.current.delete(conversationPath);
           }
-          removeStreamingPath(conversationPath);
+          if (!isSuperseded()) removeStreamingPath(conversationPath);
           if (activeGenerationIdRef.current === genId) {
             activeGenerationIdRef.current = null;
             activeGenerationPathRef.current = null;
@@ -330,9 +344,12 @@ export const useConversationStream = ({
           channel?.notifyGenerationSettled?.();
           if (stoppedGenerationIdsRef.current.has(genId)) {
             stoppedGenerationIdsRef.current.delete(genId);
-          } else {
+          } else if (!isSuperseded()) {
             overlay?.notifyGenerationEnd?.();
           }
+          /* The generation that superseded this one owns the displayed state
+           * and reloads it when it settles. */
+          if (isSuperseded()) return;
           /*
            * Only refresh displayed state if the user is still viewing this
            * conversation; otherwise leave the currently-shown chat untouched.
@@ -352,7 +369,9 @@ export const useConversationStream = ({
             const refreshed = await transport.getConversation(
               safeDecodeURI(currentConversationId),
             );
-            if (!isPathDisplayed(conversationPath)) return;
+            /* Re-checked after the round trip: a re-submit during it makes this
+             * reload stale — it would restore the answer the user just replaced. */
+            if (isSuperseded() || !isPathDisplayed(conversationPath)) return;
             setConversation(refreshed);
             conversationRef.current = refreshed;
           } catch {
@@ -365,7 +384,7 @@ export const useConversationStream = ({
           const buffered =
             currentBuffer?.generationId === genId ? currentBuffer : undefined;
           if (buffered) bufferedGenerationsRef.current.delete(conversationPath);
-          removeStreamingPath(conversationPath);
+          if (!isSuperseded()) removeStreamingPath(conversationPath);
           if (activeGenerationIdRef.current === genId) {
             activeGenerationIdRef.current = null;
             activeGenerationPathRef.current = null;
@@ -373,8 +392,9 @@ export const useConversationStream = ({
           }
           completeGeneration(conversationPath, genId);
           channel?.notifyGenerationSettled?.();
-          // Surface the error only on the conversation the user is viewing.
-          if (!isPathDisplayed(conversationPath)) return;
+          /* Surface the error only on the conversation the user is viewing,
+           * and never over the generation that superseded this one. */
+          if (isSuperseded() || !isPathDisplayed(conversationPath)) return;
           setConversation((prev) => {
             if (!prev) return prev;
             const restored =

--- a/libs/chat-hooks/src/entry-points/conversation.ts
+++ b/libs/chat-hooks/src/entry-points/conversation.ts
@@ -28,7 +28,9 @@ export {
 } from '../conversation/useConversationHandlers/message-factory';
 export {
   hasActiveToolConfig,
+  isAnswerIncomplete,
   isMessageChanged,
+  shouldRerunGenerationOnEdit,
 } from '../conversation/useConversationHandlers/message-utils';
 export {
   getStarterConversationText,

--- a/libs/chat-hooks/src/files/dial-file-manager.model.ts
+++ b/libs/chat-hooks/src/files/dial-file-manager.model.ts
@@ -12,10 +12,19 @@ export const RESERVED_MARKER_NAME = HIDDEN_FILE;
 
 export const PATH_SEPARATOR_REGEXP = /[/\\]/;
 
+/*
+ * Modified-date cells and the file metadata popup render the full modification
+ * timestamp, not just the calendar day, so files touched on the same date stay
+ * distinguishable. The clock is pinned to 24-hour form (`hour12: false`) so the
+ * time reads the same way regardless of the active locale's default cycle.
+ */
 export const DATE_OPTIONS: Intl.DateTimeFormatOptions = {
   year: 'numeric',
   month: 'short',
   day: '2-digit',
+  hour: '2-digit',
+  minute: '2-digit',
+  hour12: false,
 };
 
 export const COLUMNS_WITHOUT_AUTHOR: FileManagerColumnKey[] = [

--- a/libs/chat-hooks/src/files/useDialFileManager/tests/useDialFileManager.spec.tsx
+++ b/libs/chat-hooks/src/files/useDialFileManager/tests/useDialFileManager.spec.tsx
@@ -1403,6 +1403,38 @@ describe('useDialFileManager', () => {
       });
     });
 
+    describe('dateOptions', () => {
+      it('formats the modification timestamp with both date and 24-hour time', async () => {
+        const { result } = renderHook(() =>
+          useDialFileManager(buildOptions({ bucket: BUCKET })),
+        );
+        await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+        const formatted = new Intl.DateTimeFormat('en-GB', {
+          ...result.current.dateOptions,
+          timeZone: 'UTC',
+        }).format(new Date(Date.UTC(2026, 8, 7, 14, 35)));
+
+        /* The month abbreviation ("Sep" vs "Sept") varies by ICU version. */
+        expect(formatted).toMatch(/^07 \w+\.? 2026, 14:35$/);
+      });
+
+      it('keeps the clock 24-hour in a locale that defaults to AM/PM', async () => {
+        const { result } = renderHook(() =>
+          useDialFileManager(buildOptions({ bucket: BUCKET })),
+        );
+        await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+        const formatted = new Intl.DateTimeFormat('en-US', {
+          ...result.current.dateOptions,
+          timeZone: 'UTC',
+        }).format(new Date(Date.UTC(2026, 8, 7, 14, 35)));
+
+        expect(formatted).toContain('14:35');
+        expect(formatted).not.toMatch(/[AP]M/);
+      });
+    });
+
     describe('actionLabels', () => {
       it('includes Delete on MyFiles tab', async () => {
         const { result } = renderHook(() =>

--- a/libs/chat-hooks/src/index.ts
+++ b/libs/chat-hooks/src/index.ts
@@ -86,7 +86,9 @@ export {
 } from './conversation/useConversationHandlers/message-factory';
 export {
   hasActiveToolConfig,
+  isAnswerIncomplete,
   isMessageChanged,
+  shouldRerunGenerationOnEdit,
 } from './conversation/useConversationHandlers/message-utils';
 export {
   getStarterConversationText,

--- a/libs/chat-shared/README.md
+++ b/libs/chat-shared/README.md
@@ -461,6 +461,32 @@ still accepted; new consumers should use `styles.colors`.
 
 ## Hooks
 
+### useAvailableHeightCap
+
+Measures the height still available below an element inside its nearest
+scrollable ancestor and writes it to a CSS custom property, so a user-resizable
+control can be capped at the room its form actually has instead of a fixed
+fraction of the viewport. Returns the ref to attach; the property inherits, so
+the class that reads it may target a descendant.
+
+```tsx
+import {
+  MARKDOWN_EDITOR_MAX_HEIGHT_CLASS_NAME,
+  useAvailableHeightCap,
+} from '@epam/ai-dial-chat-shared';
+
+const editorCapRef = useAvailableHeightCap<HTMLDivElement>();
+
+<div ref={editorCapRef} className={MARKDOWN_EDITOR_MAX_HEIGHT_CLASS_NAME}>
+  <MarkdownEditor value={value} onChange={setValue} />
+</div>;
+```
+
+Options: `bottomGap` (pixels kept below the element, default `16`),
+`minHeight` (smallest cap written, default `200`, so a field below the
+fold stays usable) and `cssVariable` (default
+`RESIZABLE_FIELD_MAX_HEIGHT_CSS_VARIABLE`).
+
 ### useIsMobile
 
 Returns `true` when the viewport matches the mobile breakpoint.
@@ -571,25 +597,29 @@ import {
   ENTITY_TYPE_BG_COLOR,
   TAG_INPUT_TAG_CLASS_NAME,
   RESIZABLE_TEXTAREA_CLASS_NAME,
+  RESIZABLE_FIELD_MAX_HEIGHT_CSS_VARIABLE,
   MARKDOWN_EDITOR_MAX_HEIGHT_CLASS_NAME,
+  MARKDOWN_EDITOR_PREVIEW_LIST_CLASS_NAME,
   SELECT_LIST_MAX_HEIGHT_PX,
   SELECT_LIST_MAX_HEIGHT_CLASS_NAME,
 } from '@epam/ai-dial-chat-shared';
 ```
 
-| Constant                                     | Purpose                                                                 |
-| -------------------------------------------- | ----------------------------------------------------------------------- |
-| `MIME_TYPE_EXT_MAP`                          | MIME type → file extension, for labels and download file names          |
-| `MIME_TYPE_WILDCARD`                         | `*/*`, the "any type accepted" sentinel in attachment allowlists        |
-| `MIME_TYPE_AUDIO_PREFIX`                     | `audio/`, used to detect transcription-capable attachment types         |
-| `HIDDEN_FILE`                                | `.dial_folder`, the marker file DIAL Core writes into folders           |
-| `BASE_MD_ICON_PROPS` / `BASE_LG_ICON_PROPS`  | Default `size`/`stroke` pairs for Tabler icons at each scale step       |
-| `ENTITY_TYPE_COLOR` / `ENTITY_TYPE_BG_COLOR` | `CatalogEntityType` → text and surface color tokens                     |
-| `TAG_INPUT_TAG_CLASS_NAME`                   | `tagClassName` for `TagInput`, so its tags stay visible in the field    |
-| `RESIZABLE_TEXTAREA_CLASS_NAME`              | `className` for a resizable `Textarea`, capping drag height at `50vh`   |
-| `MARKDOWN_EDITOR_MAX_HEIGHT_CLASS_NAME`      | `className` for `MarkdownEditor`, capping its drag-bar height at `70vh` |
-| `SELECT_LIST_MAX_HEIGHT_PX`                  | `344`, the design's maximum select-list length, for a measured cap      |
-| `SELECT_LIST_MAX_HEIGHT_CLASS_NAME`          | `max-h-[344px]`, the same cap for an options scroll box                 |
+| Constant                                     | Purpose                                                               |
+| -------------------------------------------- | --------------------------------------------------------------------- |
+| `MIME_TYPE_EXT_MAP`                          | MIME type → file extension, for labels and download file names        |
+| `MIME_TYPE_WILDCARD`                         | `*/*`, the "any type accepted" sentinel in attachment allowlists      |
+| `MIME_TYPE_AUDIO_PREFIX`                     | `audio/`, used to detect transcription-capable attachment types       |
+| `HIDDEN_FILE`                                | `.dial_folder`, the marker file DIAL Core writes into folders         |
+| `BASE_MD_ICON_PROPS` / `BASE_LG_ICON_PROPS`  | Default `size`/`stroke` pairs for Tabler icons at each scale step     |
+| `ENTITY_TYPE_COLOR` / `ENTITY_TYPE_BG_COLOR` | `CatalogEntityType` → text and surface color tokens                   |
+| `TAG_INPUT_TAG_CLASS_NAME`                   | `tagClassName` for `TagInput`, so its tags stay visible in the field  |
+| `RESIZABLE_TEXTAREA_CLASS_NAME`              | `className` for a resizable `Textarea`, capping drag height at `50vh` |
+| `RESIZABLE_FIELD_MAX_HEIGHT_CSS_VARIABLE`    | Custom property `useAvailableHeightCap` writes the measured cap to    |
+| `MARKDOWN_EDITOR_MAX_HEIGHT_CLASS_NAME`      | `className` capping `MarkdownEditor`'s drag bar at that measured cap  |
+| `MARKDOWN_EDITOR_PREVIEW_LIST_CLASS_NAME`    | `className` restoring list markers in the `MarkdownEditor` preview    |
+| `SELECT_LIST_MAX_HEIGHT_PX`                  | `344`, the design's maximum select-list length, for a measured cap    |
+| `SELECT_LIST_MAX_HEIGHT_CLASS_NAME`          | `max-h-[344px]`, the same cap for an options scroll box               |
 
 ## Stylesheet
 

--- a/libs/chat-shared/src/components/PanelEmptyState/PanelEmptyState.tsx
+++ b/libs/chat-shared/src/components/PanelEmptyState/PanelEmptyState.tsx
@@ -1,4 +1,4 @@
-import { DialNoDataContent } from '@epam/ai-dial-ui-kit';
+import { NoDataContent } from '@epam/ai-dial-ui-kit';
 import { memo, type FC, type ReactNode } from 'react';
 import { buildCssVars } from '../../utils/build-css-vars';
 import { mergeClasses } from '../../utils/merge-class';
@@ -42,11 +42,11 @@ export const PanelEmptyState: FC<PanelEmptyStateProps> = memo(
 
     return (
       <div style={cssVars}>
-        <DialNoDataContent
+        <NoDataContent
           title={label}
           icon={icon && <span className={styles.icon}>{icon}</span>}
           titleClassName={mergeClasses(styles.label, labelClassName)}
-          containerClassName={containerClassName}
+          className={containerClassName}
         />
       </div>
     );

--- a/libs/chat-shared/src/constants/markdown-editor.ts
+++ b/libs/chat-shared/src/constants/markdown-editor.ts
@@ -1,0 +1,14 @@
+/*
+ * Tailwind's preflight zeroes `list-style` on every `ul`/`ol`, and
+ * `@uiw/react-markdown-preview`'s stylesheet only re-declares
+ * `list-style-type` for *nested* lists — it leaves top-level ones on the
+ * browser default that preflight just removed. The result is a preview where
+ * bullets and numbers are missing entirely. Restore the markers the preview
+ * expects: `disc`/`circle`/`square` down the `ul` nesting chain, and `decimal`
+ * for a top-level `ol` only, so the vendor's `lower-roman`/`lower-alpha` rules
+ * for deeper ordered lists still win. Pass it as the `className` of
+ * `MarkdownEditor` or of any element wrapping it — the class only has to sit on
+ * an ancestor of the `.wmde-markdown` preview.
+ */
+export const MARKDOWN_EDITOR_PREVIEW_LIST_CLASS_NAME =
+  '[&_.wmde-markdown>ol]:list-decimal [&_.wmde-markdown_ul]:list-disc [&_.wmde-markdown_ul_ul]:list-[circle] [&_.wmde-markdown_ul_ul_ul]:list-[square]';

--- a/libs/chat-shared/src/constants/resizable-fields.ts
+++ b/libs/chat-shared/src/constants/resizable-fields.ts
@@ -8,12 +8,24 @@
 export const RESIZABLE_TEXTAREA_CLASS_NAME = 'max-h-[50vh]';
 
 /*
+ * The custom property `useAvailableHeightCap` writes the measured cap to, and
+ * that `MARKDOWN_EDITOR_MAX_HEIGHT_CLASS_NAME` reads back. Kept next to the
+ * class because the two have to name the same property: Tailwind only sees
+ * class-name literals, so the name cannot be interpolated into the class.
+ */
+export const RESIZABLE_FIELD_MAX_HEIGHT_CSS_VARIABLE =
+  '--resizable-field-max-height';
+
+/*
  * `MarkdownEditor` grows through `@uiw/react-md-editor`'s own drag bar, whose
  * ceiling is that package's 1200px default — taller than most viewports, and
  * not overridable through the kit's prop surface. Cap the inner editor box
- * instead so the drag stops at the viewport edge. Pass it as `MarkdownEditor`'s
- * `className`; the class it lands on wraps the `.w-md-editor` box that carries
- * the dragged height.
+ * instead, at the height still available below the field.
+ *
+ * Pass it as the `className` of the element carrying `useAvailableHeightCap`'s
+ * ref, wrapped around the editor; custom properties inherit, so the cap reaches
+ * the `.w-md-editor` box that carries the dragged height. The `70vh` fallback
+ * only applies before the first measurement, or if the ref is left unattached.
  */
 export const MARKDOWN_EDITOR_MAX_HEIGHT_CLASS_NAME =
-  '[&_.w-md-editor]:max-h-[70vh]';
+  '[&_.w-md-editor]:max-h-[var(--resizable-field-max-height,70vh)]';

--- a/libs/chat-shared/src/hooks/tests/useAvailableHeightCap.spec.tsx
+++ b/libs/chat-shared/src/hooks/tests/useAvailableHeightCap.spec.tsx
@@ -1,0 +1,189 @@
+import { render, screen } from '@testing-library/react';
+import { type FC } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { RESIZABLE_FIELD_MAX_HEIGHT_CSS_VARIABLE } from '../../constants/resizable-fields';
+import {
+  useAvailableHeightCap,
+  type UseAvailableHeightCapOptions,
+} from '../useAvailableHeightCap';
+
+let resizeObserverCallback: ResizeObserverCallback | undefined;
+
+class ResizeObserverMock {
+  constructor(callback: ResizeObserverCallback) {
+    resizeObserverCallback = callback;
+  }
+
+  observe() {
+    // No-op in JSDOM.
+  }
+  unobserve() {
+    // No-op in JSDOM.
+  }
+  disconnect() {
+    // No-op in JSDOM.
+  }
+}
+
+const CAPPED_FIELD_LABEL = 'capped field';
+const SCROLL_CONTAINER_LABEL = 'scroll container';
+
+const TestAvailableHeightCap: FC<{
+  options?: UseAvailableHeightCapOptions;
+}> = ({ options }) => {
+  const capRef = useAvailableHeightCap<HTMLDivElement>(options);
+
+  return (
+    <div
+      role="region"
+      aria-label={SCROLL_CONTAINER_LABEL}
+      style={{ overflowY: 'auto' }}
+    >
+      <div ref={capRef} role="group" aria-label={CAPPED_FIELD_LABEL} />
+    </div>
+  );
+};
+
+/**
+ * JSDOM reports every box as 0×0, so both the container geometry and the
+ * element's position have to be stubbed for the measurement to mean anything.
+ */
+const stubGeometry = ({
+  containerClientHeight,
+  containerScrollTop = 0,
+  containerTop = 0,
+  elementTop,
+}: {
+  containerClientHeight: number;
+  containerScrollTop?: number;
+  containerTop?: number;
+  elementTop: number;
+}) => {
+  vi.spyOn(HTMLElement.prototype, 'clientHeight', 'get').mockImplementation(
+    function (this: HTMLElement) {
+      return this.getAttribute('aria-label') === SCROLL_CONTAINER_LABEL
+        ? containerClientHeight
+        : 0;
+    },
+  );
+  vi.spyOn(HTMLElement.prototype, 'scrollTop', 'get').mockImplementation(
+    function (this: HTMLElement) {
+      return this.getAttribute('aria-label') === SCROLL_CONTAINER_LABEL
+        ? containerScrollTop
+        : 0;
+    },
+  );
+  vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(
+    function (this: HTMLElement) {
+      const top =
+        this.getAttribute('aria-label') === SCROLL_CONTAINER_LABEL
+          ? containerTop
+          : elementTop;
+
+      return { top } as DOMRect;
+    },
+  );
+};
+
+const getCappedField = (): HTMLElement =>
+  screen.getByRole('group', { name: CAPPED_FIELD_LABEL });
+
+const readCap = (): string =>
+  getCappedField().style.getPropertyValue(
+    RESIZABLE_FIELD_MAX_HEIGHT_CSS_VARIABLE,
+  );
+
+describe('useAvailableHeightCap', () => {
+  beforeEach(() => {
+    resizeObserverCallback = undefined;
+    vi.stubGlobal('ResizeObserver', ResizeObserverMock);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('caps the field at the space left below it in the scroll container', () => {
+    stubGeometry({ containerClientHeight: 900, elementTop: 400 });
+
+    render(<TestAvailableHeightCap />);
+
+    /* 900 visible − 400 taken by the fields above − the 16px default gap. */
+    expect(readCap()).toBe('484px');
+  });
+
+  it('ignores how far the form happens to be scrolled', () => {
+    stubGeometry({
+      containerClientHeight: 900,
+      containerScrollTop: 250,
+      elementTop: 150,
+    });
+
+    render(<TestAvailableHeightCap />);
+
+    /* The element sits 150 + 250 = 400 into the content, as in the case above. */
+    expect(readCap()).toBe('484px');
+  });
+
+  it('measures the element relative to the container, not the viewport', () => {
+    stubGeometry({
+      containerClientHeight: 900,
+      containerTop: 120,
+      elementTop: 400,
+    });
+
+    render(<TestAvailableHeightCap />);
+
+    expect(readCap()).toBe('604px');
+  });
+
+  it('falls back to the minimum height for a field below the fold', () => {
+    stubGeometry({ containerClientHeight: 400, elementTop: 380 });
+
+    render(<TestAvailableHeightCap />);
+
+    expect(readCap()).toBe('200px');
+  });
+
+  it('honours the bottom gap and minimum height passed by the caller', () => {
+    stubGeometry({ containerClientHeight: 900, elementTop: 400 });
+
+    render(
+      <TestAvailableHeightCap options={{ bottomGap: 40, minHeight: 500 }} />,
+    );
+
+    /* 900 − 400 − 40 = 460, below the caller's own floor of 500. */
+    expect(readCap()).toBe('500px');
+  });
+
+  it('re-measures when the scroll container resizes', () => {
+    stubGeometry({ containerClientHeight: 900, elementTop: 400 });
+
+    render(<TestAvailableHeightCap />);
+
+    expect(readCap()).toBe('484px');
+
+    vi.restoreAllMocks();
+    stubGeometry({ containerClientHeight: 600, elementTop: 400 });
+    resizeObserverCallback?.([], {} as ResizeObserver);
+
+    expect(readCap()).toBe('200px');
+  });
+
+  it('re-measures before a drag starts, when content above may have moved it', () => {
+    stubGeometry({ containerClientHeight: 900, elementTop: 400 });
+
+    render(<TestAvailableHeightCap />);
+
+    expect(readCap()).toBe('484px');
+
+    vi.restoreAllMocks();
+    stubGeometry({ containerClientHeight: 900, elementTop: 600 });
+    getCappedField().dispatchEvent(
+      new MouseEvent('pointerdown', { bubbles: true }),
+    );
+
+    expect(readCap()).toBe('284px');
+  });
+});

--- a/libs/chat-shared/src/hooks/useAvailableHeightCap.ts
+++ b/libs/chat-shared/src/hooks/useAvailableHeightCap.ts
@@ -1,0 +1,130 @@
+import type { RefObject } from 'react';
+import { useCallback, useLayoutEffect, useRef } from 'react';
+import { RESIZABLE_FIELD_MAX_HEIGHT_CSS_VARIABLE } from '../constants/resizable-fields';
+
+/** Space kept between the capped element and the bottom edge of its scroller. */
+const DEFAULT_BOTTOM_GAP = 16;
+
+/*
+ * Lower bound for the cap. A field that starts below the fold — a long form on
+ * a short viewport — would otherwise be capped to nothing, which is worse than
+ * overflowing: the control becomes unusable rather than merely too tall.
+ */
+const DEFAULT_MIN_HEIGHT = 200;
+
+const SCROLLABLE_OVERFLOW_VALUES = new Set(['auto', 'scroll', 'overlay']);
+
+/** Options for `useAvailableHeightCap`. */
+export interface UseAvailableHeightCapOptions {
+  /** Pixels left between the element's bottom and the scroller's bottom edge. Defaults to `16`. */
+  bottomGap?: number;
+  /** Smallest cap to write, so a field below the fold stays usable. Defaults to `200`. */
+  minHeight?: number;
+  /** Custom property the cap is written to. Defaults to `RESIZABLE_FIELD_MAX_HEIGHT_CSS_VARIABLE`. */
+  cssVariable?: string;
+}
+
+/**
+ * Nearest ancestor that scrolls vertically, or the document scroller when the
+ * element sits in an unconstrained page.
+ */
+const findScrollContainer = (element: HTMLElement): HTMLElement => {
+  for (
+    let ancestor = element.parentElement;
+    ancestor;
+    ancestor = ancestor.parentElement
+  ) {
+    const { overflowY } = getComputedStyle(ancestor);
+
+    if (SCROLLABLE_OVERFLOW_VALUES.has(overflowY)) return ancestor;
+  }
+
+  return document.documentElement;
+};
+
+/**
+ * Writes the height still available below an element into a CSS custom
+ * property, so a user-resizable control inside it can be capped at the space
+ * its form actually has rather than at a fixed fraction of the viewport.
+ *
+ * A `vh` ceiling only bounds a field against the height of the screen, not
+ * against the room left underneath it: a field that starts 40% down a form can
+ * be dragged to its full `70vh` and still run past the bottom of the page. The
+ * cap here is measured instead — the scroller's visible height minus the space
+ * the fields above occupy — and normalised by `scrollTop`, so it describes the
+ * worst case (the form scrolled to its top) and does not shift while the user
+ * scrolls or drags.
+ *
+ * Attach the returned ref to the element that wraps the resizable control and
+ * give it a class that reads the property, e.g.
+ * `MARKDOWN_EDITOR_MAX_HEIGHT_CLASS_NAME`; custom properties inherit, so the
+ * class may target a descendant.
+ */
+export const useAvailableHeightCap = <TElement extends HTMLElement>({
+  bottomGap = DEFAULT_BOTTOM_GAP,
+  minHeight = DEFAULT_MIN_HEIGHT,
+  cssVariable = RESIZABLE_FIELD_MAX_HEIGHT_CSS_VARIABLE,
+}: UseAvailableHeightCapOptions = {}): RefObject<TElement | null> => {
+  const elementRef = useRef<TElement>(null);
+
+  const measureAvailableHeight = useCallback(() => {
+    const element = elementRef.current;
+
+    if (!element) return;
+
+    const scrollContainer = findScrollContainer(element);
+    const isDocumentScroller = scrollContainer === document.documentElement;
+    const elementTop = element.getBoundingClientRect().top;
+    /*
+     * A scroll container keeps its own box in place while its content moves, so
+     * the element's offset inside that content is its viewport offset relative
+     * to the container plus how far the container is scrolled. The document
+     * scroller is the exception: its box translates with the scroll, so its
+     * rect is already accounted for by `scrollTop` alone.
+     */
+    const offsetWithinContent = isDocumentScroller
+      ? elementTop + scrollContainer.scrollTop
+      : elementTop -
+        scrollContainer.getBoundingClientRect().top +
+        scrollContainer.scrollTop;
+    const availableHeight =
+      scrollContainer.clientHeight - offsetWithinContent - bottomGap;
+    const cap = `${Math.round(Math.max(availableHeight, minHeight))}px`;
+
+    /* Writing the same value again would keep the ResizeObserver below busy. */
+    if (element.style.getPropertyValue(cssVariable) === cap) return;
+
+    element.style.setProperty(cssVariable, cap);
+  }, [bottomGap, minHeight, cssVariable]);
+
+  useLayoutEffect(() => {
+    measureAvailableHeight();
+
+    const element = elementRef.current;
+
+    if (!element) return;
+
+    /*
+     * A resize of the scroller changes the cap directly. Content appearing
+     * above the element moves it without resizing either one, and no observer
+     * reports that, so re-measure when a drag is about to start as well — by
+     * then the layout above has settled.
+     */
+    const resizeObserver =
+      typeof ResizeObserver === 'undefined'
+        ? undefined
+        : new ResizeObserver(measureAvailableHeight);
+
+    resizeObserver?.observe(findScrollContainer(element));
+    element.addEventListener('pointerdown', measureAvailableHeight, true);
+    window.addEventListener('resize', measureAvailableHeight);
+
+    return () => {
+      resizeObserver?.disconnect();
+      element.removeEventListener('pointerdown', measureAvailableHeight, true);
+      window.removeEventListener('resize', measureAvailableHeight);
+    };
+  }, [measureAvailableHeight]);
+
+  return elementRef;
+};

--- a/libs/chat-shared/src/index.ts
+++ b/libs/chat-shared/src/index.ts
@@ -37,6 +37,7 @@ export * from './constants/icon';
 export * from './constants/dial';
 export * from './constants/tag-input';
 export * from './constants/resizable-fields';
+export * from './constants/markdown-editor';
 export * from './constants/select-list';
 
 export * from './components/DeploymentIcon/DeploymentIcon';
@@ -52,6 +53,7 @@ export * from './components/EntityHeader/EntityHeader';
 export * from './components/ResourceSummary/ResourceSummary';
 export * from './components/MarkdownRenderer/Table/TableHeader';
 export * from './entry-points/markdown';
+export * from './hooks/useAvailableHeightCap';
 export * from './hooks/useIsMobile';
 
 /*

--- a/libs/chat-shared/src/models/chat.ts
+++ b/libs/chat-shared/src/models/chat.ts
@@ -119,6 +119,8 @@ export interface Message {
   deploymentId?: string;
   /* Human-readable error text from a failed stream. Present when generation ended in error — absence means generation succeeded or is still in progress. Used for both resume detection and UI error display. */
   streamErrorMessage?: string;
+  /** Set on an assistant message whose generation the user stopped; the content is whatever had streamed by then. */
+  wasStoppedByUser?: boolean;
   /** Allows extra SDK-level properties to pass through when serializing to DIAL Core. */
   [key: string]: unknown;
 }

--- a/libs/prompt-editor/src/components/PromptEditor/PromptEditor.tsx
+++ b/libs/prompt-editor/src/components/PromptEditor/PromptEditor.tsx
@@ -1,7 +1,9 @@
 import {
   buildCssVars,
   MARKDOWN_EDITOR_MAX_HEIGHT_CLASS_NAME,
+  MARKDOWN_EDITOR_PREVIEW_LIST_CLASS_NAME,
   mergeClasses,
+  useAvailableHeightCap,
 } from '@epam/ai-dial-chat-shared';
 import { EditorLayout } from '@epam/ai-dial-editor-builder';
 import {
@@ -92,6 +94,7 @@ export const PromptEditor: FC<PromptEditorProps> = ({
   });
   const contentLabelId = useId();
   const contentEditorId = useId();
+  const contentEditorCapRef = useAvailableHeightCap<HTMLDivElement>();
 
   /* Hosts that load asynchronously re-seed the form through `initialValues`. */
   useEffect(() => {
@@ -250,27 +253,35 @@ export const PromptEditor: FC<PromptEditorProps> = ({
               required
               className={contentLabelClassName}
             />
-            <Suspense
-              fallback={
-                <Spinner
-                  ariaLabel={
-                    labels?.contentLoadingAriaLabel ?? 'Loading prompt editor'
-                  }
-                />
-              }
+            <div
+              ref={contentEditorCapRef}
+              className={mergeClasses(
+                MARKDOWN_EDITOR_MAX_HEIGHT_CLASS_NAME,
+                MARKDOWN_EDITOR_PREVIEW_LIST_CLASS_NAME,
+              )}
             >
-              <MarkdownEditor
-                id={contentEditorId}
-                value={values.content}
-                onChange={(value) => setField('content', value)}
-                height={480}
-                className={MARKDOWN_EDITOR_MAX_HEIGHT_CLASS_NAME}
-                placeholder={
-                  labels?.contentPlaceholder ?? 'Write the prompt instructions'
+              <Suspense
+                fallback={
+                  <Spinner
+                    ariaLabel={
+                      labels?.contentLoadingAriaLabel ?? 'Loading prompt editor'
+                    }
+                  />
                 }
-                theme={markdownEditorTheme}
-              />
-            </Suspense>
+              >
+                <MarkdownEditor
+                  id={contentEditorId}
+                  value={values.content}
+                  onChange={(value) => setField('content', value)}
+                  height={480}
+                  placeholder={
+                    labels?.contentPlaceholder ??
+                    'Write the prompt instructions'
+                  }
+                  theme={markdownEditorTheme}
+                />
+              </Suspense>
+            </div>
             {errors?.content != null && (
               <p
                 className={mergeClasses(

--- a/libs/scheduled-tasks/src/components/ScheduledTaskCreateForm/ScheduledTaskCreateForm.tsx
+++ b/libs/scheduled-tasks/src/components/ScheduledTaskCreateForm/ScheduledTaskCreateForm.tsx
@@ -2,7 +2,9 @@ import { BuilderFormContainer } from '@epam/ai-dial-builder-form';
 import {
   buildCssVars,
   MARKDOWN_EDITOR_MAX_HEIGHT_CLASS_NAME,
+  MARKDOWN_EDITOR_PREVIEW_LIST_CLASS_NAME,
   mergeClasses,
+  useAvailableHeightCap,
 } from '@epam/ai-dial-chat-shared';
 import {
   Input,
@@ -67,6 +69,7 @@ export const ScheduledTaskCreateForm: FC<ScheduledTaskCreateFormProps> = ({
   styles: formStyles,
 }) => {
   const instructionsEditorId = useId();
+  const instructionsCapRef = useAvailableHeightCap<HTMLDivElement>();
   const { colors, typography } = formStyles ?? {};
   const titleClassName = typography?.titleClassName ?? 'dial-h1-text';
   const sectionTitleClassName =
@@ -407,16 +410,23 @@ export const ScheduledTaskCreateForm: FC<ScheduledTaskCreateFormProps> = ({
           >
             {labels.instructionsLabel}
           </label>
-          <Suspense fallback={<Spinner />}>
-            <MarkdownEditor
-              id={instructionsEditorId}
-              value={values.prompt}
-              onChange={(value) => onFieldChange('prompt', value)}
-              height={480}
-              className={MARKDOWN_EDITOR_MAX_HEIGHT_CLASS_NAME}
-              theme={markdownEditorTheme}
-            />
-          </Suspense>
+          <div
+            ref={instructionsCapRef}
+            className={mergeClasses(
+              MARKDOWN_EDITOR_MAX_HEIGHT_CLASS_NAME,
+              MARKDOWN_EDITOR_PREVIEW_LIST_CLASS_NAME,
+            )}
+          >
+            <Suspense fallback={<Spinner />}>
+              <MarkdownEditor
+                id={instructionsEditorId}
+                value={values.prompt}
+                onChange={(value) => onFieldChange('prompt', value)}
+                height={480}
+                theme={markdownEditorTheme}
+              />
+            </Suspense>
+          </div>
           {errors.prompt && (
             <p
               className={mergeClasses(

--- a/libs/scheduled-tasks/src/components/ScheduledTasks/tests/ScheduledTasks.spec.tsx
+++ b/libs/scheduled-tasks/src/components/ScheduledTasks/tests/ScheduledTasks.spec.tsx
@@ -79,7 +79,7 @@ vi.mock('@epam/ai-dial-ui-kit', async (importOriginal) => ({
     text: ReactNode;
     className?: string;
   }) => <span className={className}>{text}</span>,
-  DialNoDataContent: ({ title, icon }: { title: string; icon?: ReactNode }) => (
+  NoDataContent: ({ title, icon }: { title: string; icon?: ReactNode }) => (
     <div>
       {icon}
       <span>{title}</span>

--- a/libs/sidebar/src/components/SidebarPanel/SidebarPanel.tsx
+++ b/libs/sidebar/src/components/SidebarPanel/SidebarPanel.tsx
@@ -2,7 +2,7 @@ import { buildCssVars, mergeClasses } from '@epam/ai-dial-chat-shared';
 import {
   DIAL_ICON_SIZE,
   DIAL_KIT_ICON_STROKE,
-  DialConditionalResizableContainer,
+  ConditionalResizableContainer,
   GhostIconButton,
   ResizableContainerSide,
 } from '@epam/ai-dial-ui-kit';
@@ -211,9 +211,10 @@ export const SidebarPanel: FC<SidebarPanelProps> = ({
         styles.panel,
       )}
     >
-      <DialConditionalResizableContainer
+      <ConditionalResizableContainer
         enabled={(resizable ?? false) && isOpen}
         side={resizableSide}
+        ariaLabel={labels.resizeLabel ?? 'Resize panel'}
         width={
           isOpen ? animationMaxWidth || currentWidthRef.current : undefined
         }
@@ -257,7 +258,7 @@ export const SidebarPanel: FC<SidebarPanelProps> = ({
             {children}
           </div>
         </aside>
-      </DialConditionalResizableContainer>
+      </ConditionalResizableContainer>
     </div>
   );
 };

--- a/libs/sidebar/src/components/SidebarPanel/tests/SidebarPanel.spec.tsx
+++ b/libs/sidebar/src/components/SidebarPanel/tests/SidebarPanel.spec.tsx
@@ -20,7 +20,7 @@ vi.mock('@epam/ai-dial-ui-kit', () => ({
     Left: 'left',
     Right: 'right',
   },
-  DialConditionalResizableContainer: ({
+  ConditionalResizableContainer: ({
     children,
   }: {
     children: React.ReactNode;

--- a/libs/sidebar/src/models/panel-props.ts
+++ b/libs/sidebar/src/models/panel-props.ts
@@ -25,6 +25,8 @@ export interface SidebarPanelLabels {
   ariaLabel: string;
   /** Accessible label and tooltip for the close button. Required when `onClose` is provided. */
   closeLabel?: string;
+  /** Accessible label for the drag-to-resize handle, used when `resizable` is true. Defaults to `'Resize panel'`. */
+  resizeLabel?: string;
 }
 
 /** Combined style overrides (colors and typography) for the `SidebarPanel` component. */

--- a/libs/skill-editor/src/components/SkillEditor/SkillEditor.tsx
+++ b/libs/skill-editor/src/components/SkillEditor/SkillEditor.tsx
@@ -1,7 +1,9 @@
 import {
   buildCssVars,
   MARKDOWN_EDITOR_MAX_HEIGHT_CLASS_NAME,
+  MARKDOWN_EDITOR_PREVIEW_LIST_CLASS_NAME,
   mergeClasses,
+  useAvailableHeightCap,
 } from '@epam/ai-dial-chat-shared';
 import { EditorLayout } from '@epam/ai-dial-editor-builder';
 import type { DialFile } from '@epam/ai-dial-react-file-manager';
@@ -104,6 +106,7 @@ export const SkillEditor: FC<SkillEditorProps> = ({
     description: initialValues?.description ?? '',
     instructions: initialValues?.instructions ?? '',
   });
+  const instructionsCapRef = useAvailableHeightCap<HTMLDivElement>();
   const seededInitialValuesRef = useRef(initialValues);
   const isReseeding = seededInitialValuesRef.current !== initialValues;
   const seededFilesRef = useRef<SkillFileTreeNode[]>(files);
@@ -496,29 +499,38 @@ export const SkillEditor: FC<SkillEditorProps> = ({
                     </span>
                     <span className="dial-tiny-text text-error">*</span>
                   </span>
-                  <Suspense
-                    fallback={
-                      <Spinner
-                        ariaLabel={t.instructionsLoadingAriaLabel ?? 'Loading'}
-                      />
-                    }
+                  <div
+                    ref={instructionsCapRef}
+                    className={mergeClasses(
+                      MARKDOWN_EDITOR_MAX_HEIGHT_CLASS_NAME,
+                      MARKDOWN_EDITOR_PREVIEW_LIST_CLASS_NAME,
+                    )}
                   >
-                    <LazyMarkdown
-                      value={values.instructions}
-                      onChange={(value) =>
-                        setValues((prev) => ({
-                          ...prev,
-                          instructions: value,
-                        }))
+                    <Suspense
+                      fallback={
+                        <Spinner
+                          ariaLabel={
+                            t.instructionsLoadingAriaLabel ?? 'Loading'
+                          }
+                        />
                       }
-                      className={MARKDOWN_EDITOR_MAX_HEIGHT_CLASS_NAME}
-                      theme={instructionsEditorTheme}
-                      placeholder={
-                        t.instructionsPlaceholder ??
-                        'Write the skill instructions in Markdown'
-                      }
-                    />
-                  </Suspense>
+                    >
+                      <LazyMarkdown
+                        value={values.instructions}
+                        onChange={(value) =>
+                          setValues((prev) => ({
+                            ...prev,
+                            instructions: value,
+                          }))
+                        }
+                        theme={instructionsEditorTheme}
+                        placeholder={
+                          t.instructionsPlaceholder ??
+                          'Write the skill instructions in Markdown'
+                        }
+                      />
+                    </Suspense>
+                  </div>
                   {errors?.instructions != null && (
                     <ErrorText text={errors.instructions} />
                   )}

--- a/libs/source-panel/src/components/ConversationSourcesPanel/ConversationSourcesPanel.tsx
+++ b/libs/source-panel/src/components/ConversationSourcesPanel/ConversationSourcesPanel.tsx
@@ -4,11 +4,7 @@ import {
   SidebarOrientation,
   SidebarPanel,
 } from '@epam/ai-dial-sidebar';
-import {
-  DialNoDataContent,
-  GhostIconButton,
-  Search,
-} from '@epam/ai-dial-ui-kit';
+import { GhostIconButton, NoDataContent, Search } from '@epam/ai-dial-ui-kit';
 import { IconDownload } from '@tabler/icons-react';
 import {
   memo,
@@ -105,7 +101,7 @@ const ConversationSourcesPanel: FC<ConversationSourcesPanelProps> = ({
   if (isGloballyEmpty) {
     bodyContent = (
       <div className="flex h-full items-center justify-center">
-        <DialNoDataContent title={labels.noDataLabel} />
+        <NoDataContent title={labels.noDataLabel} />
       </div>
     );
   } else {

--- a/libs/source-panel/src/components/ConversationSourcesPanel/tests/ConversationSourcesPanel.spec.tsx
+++ b/libs/source-panel/src/components/ConversationSourcesPanel/tests/ConversationSourcesPanel.spec.tsx
@@ -60,7 +60,7 @@ vi.mock('@epam/ai-dial-ui-kit', () => ({
       onClick={onClick}
     />
   ),
-  DialNoDataContent: ({ title }: { title: string }) => <div>{title}</div>,
+  NoDataContent: ({ title }: { title: string }) => <div>{title}</div>,
   EllipsisTooltip: ({ text }: { text: ReactNode }) => <span>{text}</span>,
   Search: ({
     placeholder,

--- a/libs/source-panel/src/models/conversation-sources-panel-props.ts
+++ b/libs/source-panel/src/models/conversation-sources-panel-props.ts
@@ -8,6 +8,8 @@ export interface ConversationSourcesPanelLabels {
   ariaLabel: string;
   /** Label for the close button. */
   closeLabel: string;
+  /** Accessible label for the panel's drag-to-resize handle. Defaults to `'Resize panel'`. */
+  resizeLabel?: string;
   /** Placeholder text shown inside the search input. */
   searchPlaceholder: string;
   /** Accessible label for the search input clear button. */

--- a/openspec/specs/chat-hooks-conversation-stream/spec.md
+++ b/openspec/specs/chat-hooks-conversation-stream/spec.md
@@ -85,6 +85,27 @@ backend's save) fires.
 - **THEN** no reload happens until the transport's own completion signal
   fires afterward
 
+### Requirement: A superseded generation never touches shared state
+Once a newer generation has been started for a path, the terminal callbacks of
+the older generation on that path SHALL NOT clear the path's streaming state,
+report a generation end to the overlay, write a stream error into the
+conversation, or replace conversation state with the reload they fetched. The
+reload is re-checked after its round trip, because the newer generation can
+start while that reload is in flight.
+
+#### Scenario: Stopped generation completes after the user re-submitted
+- **WHEN** the user stops a generation and — while the stopped generation's
+  post-completion reload is still in flight — submits an edit that starts a
+  new generation on the same path
+- **THEN** the stopped generation's completion leaves `isStreaming` true for
+  the path and does not restore the answer it had fetched over the edited
+  messages
+
+#### Scenario: Superseded generation errors
+- **WHEN** a superseded generation's `onError` fires
+- **THEN** no `streamErrorMessage` is written onto the newer generation's
+  answer and the path stays marked as streaming
+
 ### Requirement: Optional client-channel and overlay capabilities
 The hook SHALL accept `channel` and `overlay` as independently optional
 parameters; a consumer that supplies neither SHALL NOT be required to pass

--- a/openspec/specs/conversation-sources-sidebar/spec.md
+++ b/openspec/specs/conversation-sources-sidebar/spec.md
@@ -155,7 +155,7 @@ The panel SHALL be considered empty when `uploaded.length === 0` AND `generated.
 When the panel is empty (per the updated definition above):
 
 - The header SHALL contain only the built-in close button; `leftActions` and `rightActions` SHALL not render search or download-all buttons.
-- The body SHALL render `DialNoDataContent` from `@epam/ai-dial-ui-kit`, centred horizontally and vertically, with `title` set to the i18n value of `basic.noData` (`"No data"`). No `icon` prop is supplied, so `DialNoDataContent` uses its default icon.
+- The body SHALL render `NoDataContent` from `@epam/ai-dial-ui-kit`, centred horizontally and vertically, with `title` set to the i18n value of `basic.noData` (`"No data"`). No `icon` prop is supplied, so `NoDataContent` uses its default icon.
 - No section headings SHALL be rendered.
 
 When the panel is not empty:
@@ -180,14 +180,14 @@ For both states:
 #### Scenario: Global empty state when no files exist and no scheduled task is active
 
 - **WHEN** `ConversationSourcesPanel` derives empty `uploaded`, `generated`, and `sources` lists AND the active conversation is not a scheduled-task conversation
-- **THEN** the body shows centred `DialNoDataContent` with the `basic.noData` title and default icon
+- **THEN** the body shows centred `NoDataContent` with the `basic.noData` title and default icon
 - **AND** no section heading is rendered
 - **AND** no search or download-all button is rendered
 
 #### Scenario: Scheduled-task conversation is never shown the global empty state
 
 - **WHEN** the active conversation is a scheduled-task conversation AND `uploaded`, `generated`, and `sources` are all empty
-- **THEN** the panel does not render `DialNoDataContent`
+- **THEN** the panel does not render `NoDataContent`
 - **AND** the History and Details sections render with their own loading/empty/error states
 
 #### Scenario: Any derived file or source switches the panel to section content

--- a/openspec/specs/dial-file-manager-attach-ui/spec.md
+++ b/openspec/specs/dial-file-manager-attach-ui/spec.md
@@ -30,7 +30,7 @@ RTL: tab bar direction is handled by the ui-kit; no physical direction classes o
 - `visibleColumns` changes per tab (see `file-manager-tabs` spec).
 - `actionLabels` includes `Delete` only when `activeTab === DialFileManagerTabs.MyFiles`.
 - `dateLocale` is `i18n.language`.
-- `dateOptions` is `{ year: 'numeric', month: 'short', day: '2-digit' }`.
+- `dateOptions` is `{ year: 'numeric', month: 'short', day: '2-digit', hour: '2-digit', minute: '2-digit', hour12: false }`.
 - `selectionMode`, `additionalGridOptions`, and row-selectability logic are unchanged from current implementation.
 
 `gridOptions` SHALL be recomputed (via `useMemo`) whenever `activeTab`, `downloadLabel`, or `deleteLabel` changes.

--- a/openspec/specs/edit-message/spec.md
+++ b/openspec/specs/edit-message/spec.md
@@ -110,6 +110,18 @@ Clicking Save & Submit (or pressing Enter in the textarea) SHALL update the mess
 - **THEN** the AI is re-triggered with the updated message and attachments
 - **THEN** a new streaming assistant response begins
 
+#### Scenario: Unchanged message whose answer never completed
+- **WHEN** the user submits an edit without changing the text or attachments,
+  and the answer below it is missing, was stopped by the user, or ended with a
+  stream error
+- **THEN** the generation is re-run for that message, because the point of
+  re-submitting an unchanged message is to replace the incomplete answer
+
+#### Scenario: Unchanged message whose answer is complete
+- **WHEN** the user submits an edit without changing the text or attachments
+  and the answer below it completed normally
+- **THEN** edit mode is exited and no new generation starts
+
 #### Scenario: Other edits silently cancelled on submit
 - **WHEN** the user submits an edit while other messages are also in edit mode
 - **THEN** all other edit areas are silently exited without any confirmation or notification

--- a/openspec/specs/file-manager-attach-modal-polish/spec.md
+++ b/openspec/specs/file-manager-attach-modal-polish/spec.md
@@ -6,37 +6,67 @@ Attach-modal refinements: auto-selecting uploaded items, tab-specific empty stat
 
 ## Requirements
 
-### Requirement: autoSelectUploadedItems adds uploaded paths to selectedPaths
+### Requirement: autoSelectUploadedItems auto-selects newly uploaded items
 
-`DialFileManagerModal` SHALL accept an `autoSelectUploadedItems?: boolean` prop (default `true`). When `true`, after the current upload batch reaches `status: 'done'` (as tracked by `uploadBatchState` from `useDialFileManager`), the modal SHALL add the successfully uploaded file paths to `selectedPaths` using `setSelectedPaths`.
+`DialFileManagerModal` SHALL accept an `autoSelectUploadedItems?: boolean` prop (default `true`) and SHALL forward it unchanged through `FileManagerAttachModal` and `DialFileManagerShell` to the ui-kit `DialFileManager`, whose own default is `false`. The host SHALL NOT implement auto-selection itself — the behaviour is owned by the ui-kit `FileManagerProvider`, and the host contract is the prop passthrough plus the `selectedPaths` / `onSelectedPathsChange` pair.
 
-The selection update SHALL use `Set` deduplication to avoid double-entries if the same file is uploaded twice within a session.
+When `true`, the ui-kit records the item names and the destination folder at the moment `onUploadFiles`, `onUploadArchive`, or `onCreateFolder` fires, and applies that pending record once `items` refreshes and the destination folder's children contain the matching names. Auto-selection therefore covers uploaded files, uploaded archives, and newly created folders — not only uploaded files.
 
-When `autoSelectUploadedItems` is `false`, `selectedPaths` SHALL NOT be modified automatically after upload; behavior is identical to current (no auto-select).
+The recorded names are the names after `sanitizeFileName`, because `useDialFileUploadBatch` rewrites `DialUploadFileItem.name` inside `onValidateUpload`, which the ui-kit awaits before calling `onUploadFiles`.
 
-State ownership: `DialFileManagerModal` — existing `selectedPaths` state; effect triggered by `uploadBatchState`.
+Auto-selection SHALL be skipped when either:
+
+- the current path is no longer the upload's destination folder — the pending record is discarded, and a later return to that folder does not revive it; or
+- the item fails the ui-kit's `isFileSelectable` check against `allowedFileTypes` / `maxSelectableFileSize`. The host's own `isRowSelectable` predicate is **not** consulted here, so a folder row that the host blocks for selection can still be auto-selected after creation.
+
+`selectedPaths` is a `Set` of paths, so a name uploaded twice into the same folder resolves to a single entry.
+
+When `autoSelectUploadedItems` is `false`, `selectedPaths` SHALL NOT be modified automatically after upload.
+
+**Divergence from the original intent (ui-kit owned):** the ui-kit *replaces* the selection with the matched paths (`setSelectedPaths(matchedPaths)`) instead of merging them into the existing selection, so a row selected before the upload is dropped when auto-selection fires. This requirement originally specified add-and-dedupe; the replace semantics are recorded here as current behaviour, not endorsed. Closing the gap requires a `@epam/ai-dial-ui-kit` change, not a host change.
+
+State ownership: `DialFileManagerModal` owns the `selectedPaths` state; the ui-kit drives every update through `onSelectedPathsChange`, and the host filters hidden paths out of each update before storing it.
 Feature flag: none — controlled by the prop.
 RTL: none.
-Memoisation: the `useEffect` dependency array MUST include `uploadBatchState.status` and `autoSelectUploadedItems`.
 
 #### Scenario: Uploaded files auto-selected when prop is true
 
-- **WHEN** `autoSelectUploadedItems={true}` and an upload batch completes with two files
+- **WHEN** `autoSelectUploadedItems={true}` and an upload of two files into the current folder settles
 - **THEN** both uploaded file paths appear in `selectedPaths`
 
-#### Scenario: Previously selected paths preserved after upload
+#### Scenario: Newly created folder auto-selected when prop is true
 
-- **WHEN** user had already selected `file_a.pdf` and then uploads `file_b.png` with `autoSelectUploadedItems={true}`
-- **THEN** `selectedPaths` contains both `file_a.pdf` and `file_b.png`
+- **WHEN** `autoSelectUploadedItems={true}` and the user creates a folder in the current folder
+- **THEN** the new folder's path appears in `selectedPaths`
+
+#### Scenario: Previously selected path is replaced, not preserved
+
+- **WHEN** the user has `file_a.pdf` selected and then uploads `file_b.png` by dropping it on the grid
+- **THEN** `selectedPaths` contains `file_b.png` only, and `file_a.pdf` is dropped
+
+#### Scenario: New toolbar is unavailable while a selection is active
+
+- **WHEN** at least one row is selected
+- **THEN** the ui-kit renders the bulk-actions toolbar in place of the New toolbar, so drag & drop onto the grid is the only route to starting an upload while a selection exists
+
+#### Scenario: Pending auto-selection discarded after navigating away
+
+- **WHEN** an upload into `folder_a` settles after the user has navigated to `folder_b`
+- **THEN** the pending record is discarded and `selectedPaths` is unchanged
+
+#### Scenario: Uploaded file rejected by the type filter is not selected
+
+- **WHEN** `allowedFileTypes` excludes the uploaded file's type
+- **THEN** the file is listed but its path is not added to `selectedPaths`
 
 #### Scenario: No auto-select when prop is false
 
-- **WHEN** `autoSelectUploadedItems={false}` and an upload batch completes
+- **WHEN** `autoSelectUploadedItems={false}` and an upload settles
 - **THEN** `selectedPaths` is unchanged
 
-#### Scenario: Duplicate upload does not double-add path
+#### Scenario: Same name uploaded twice yields one entry
 
-- **WHEN** `file_a.pdf` is already in `selectedPaths` and user uploads `file_a.pdf` again (replace mode)
+- **WHEN** `file_a.pdf` is uploaded again into the folder that already holds it (replace mode)
 - **THEN** `selectedPaths` contains `file_a.pdf` exactly once
 
 ---
@@ -52,8 +82,15 @@ i18n keys:
 
 All six keys SHALL be added to `apps/chat/src/i18n/locales/en.json` and to `DialFileManagerI18nKeys`.
 
+Two contexts SHALL override the tab-specific copy, in this precedence order:
+
+1. a settled search with no matches → `labels.searchEmptyStateTitle`;
+2. an empty subfolder (a path more than one segment deep) → `labels.folderEmptyStateTitle`.
+
+Both overrides render an empty description; the tab-specific copy is used only at a tab's root with no active search.
+
 RTL: none — text direction is inherited from the `dir` attribute on `<html>`.
-Memoisation: empty state props in `useMemo` keyed on active tab.
+Memoisation: empty state props in `useMemo` keyed on the active tab, the search state, and the current path.
 
 #### Scenario: My Files empty state shown when My Files tab is empty
 
@@ -74,9 +111,9 @@ Memoisation: empty state props in `useMemo` keyed on active tab.
 
 ### Requirement: trimFileNameToByteLimit caps file name byte length on upload
 
-`apps/chat/src/utils/file.ts` SHALL export `trimFileNameToByteLimit(name: string, limit = 255): string`. The function SHALL measure the UTF-8 byte length of `name` using `TextEncoder`. If the byte length exceeds `limit`, it SHALL trim on a character boundary (not a byte boundary) such that the result's UTF-8 byte length is ≤ `limit`, preserving the file extension.
+`libs/chat-hooks/src/files/file-name.ts` SHALL export `trimFileNameToByteLimit(name: string, limit = 255): string`, re-exported from `@epam/ai-dial-chat-hooks`. The function SHALL measure the UTF-8 byte length of `name` via `getUtf8ByteLength` from `@epam/ai-dial-chat-shared`. If the byte length exceeds `limit`, it SHALL trim on a character boundary (not a byte boundary) using `truncateToUtf8Bytes` such that the result's UTF-8 byte length is ≤ `limit`, preserving the file extension. When the extension alone consumes the whole limit, the full name is truncated instead.
 
-`sanitizeFileName` SHALL apply `trimFileNameToByteLimit` as its final step.
+`sanitizeFileName` SHALL apply `trimFileNameToByteLimit` as its final step, and SHALL return the original name unchanged when the base name is empty after sanitization. `useDialFileUploadBatch` SHALL apply `sanitizeFileName` to each `DialUploadFileItem.name` during upload validation, so the ui-kit's conflict detection and the auto-selection record both see the sanitized name.
 
 RTL: none — utility is direction-agnostic.
 Feature flag: none.

--- a/openspec/specs/file-manager-tabs/spec.md
+++ b/openspec/specs/file-manager-tabs/spec.md
@@ -85,19 +85,26 @@ RTL: tab rendering and label alignment are handled by the ui-kit; no physical di
 
 ### Requirement: Locale-aware UpdatedAt column
 
-`DialFileManagerShell` SHALL pass `gridOptions.dateLocale` and `gridOptions.dateOptions` to format the UpdatedAt column. `dateLocale` SHALL be sourced from `i18n.language` (via `useTranslation`). `dateOptions` SHALL be fixed as `{ year: 'numeric', month: 'short', day: '2-digit' }`. These options SHALL be applied regardless of the active tab.
+`DialFileManagerShell` SHALL pass `gridOptions.dateLocale` and `gridOptions.dateOptions` to format the UpdatedAt column. `dateLocale` SHALL be sourced from `i18n.language` (via `useTranslation`). `dateOptions` SHALL be fixed as `{ year: 'numeric', month: 'short', day: '2-digit', hour: '2-digit', minute: '2-digit', hour12: false }`, so the cell carries the modification time alongside the calendar date and the clock stays 24-hour in every locale. These options SHALL be applied regardless of the active tab, and the same options SHALL format the modified date in the file metadata popup.
 
 Items with a missing `updatedAt` SHALL display an empty cell; no error or fallback string is rendered.
+
+Sorting the UpdatedAt column SHALL order rows by the underlying `updatedAt` timestamp, not by the formatted string, so files modified on the same calendar day keep their true chronological order.
 
 #### Scenario: UpdatedAt formatted in en-US locale
 
 - **WHEN** `i18n.language` is `'en'` or `'en-US'` and a file has `updatedAt` set
-- **THEN** the UpdatedAt cell displays a date in the form "Jun 19, 2026"
+- **THEN** the UpdatedAt cell displays a date and time in the form "Jun 19, 2026, 14:35"
 
 #### Scenario: UpdatedAt formatted in Arabic locale
 
 - **WHEN** `i18n.language` is `'ar'` and a file has `updatedAt` set
-- **THEN** the UpdatedAt cell displays the date using the Arabic locale with the same format options (year numeric, month short, day 2-digit); layout follows RTL direction inherited from `<html dir="rtl">`
+- **THEN** the UpdatedAt cell displays the date and time using the Arabic locale with the same format options (year numeric, month short, day 2-digit, hour and minute 2-digit, 24-hour clock); layout follows RTL direction inherited from `<html dir="rtl">`
+
+#### Scenario: Same-day files ordered by time
+
+- **WHEN** two files were modified on the same calendar day at different times and the UpdatedAt column is sorted ascending
+- **THEN** the file with the earlier modification time is listed first
 
 #### Scenario: Missing updatedAt renders empty cell
 


### PR DESCRIPTION
## Description of changes

Six commits on the branch, four of them user-facing.

### File manager: show modification time (#8653)

`DATE_OPTIONS` in the file manager gains `hour` and `minute`, so the **Modified Date** column and the file metadata popup render the full modification timestamp instead of only the calendar day. `hour12` is pinned to `false` so the clock stays 24-hour in locales that would otherwise render AM/PM.

The constant flows from `useDialFileManager` through `DialFileManagerShell` into both the grid column and the metadata popup, so My Files, Shared with Me, Organization and the attach modal all pick it up. Sorting already ordered rows by the raw ISO-8601 `updatedAt`, so same-day files were ordered correctly before this change — only the display was lossy.

### Publish confirmations: name the Organization root (#8704)

The publish/unpublish notifications derived the folder name as the last segment of the target path. The Organization root is the public bucket itself and has no path segments, so the name resolved to an empty string and the confirmation read ``folder ""``.

Adds `getPublishFolderLabel`, which falls back to the localized root label, and wires it into all four call sites with the same bug: catalog publish and unpublish, and conversation publish and unpublish. Both publish-panel hosts now also pass `rootFolderLabel`, so the folder tree stops falling back to the lib's hardcoded English default and says the same translated thing as the notification.

### Resizable text fields: cap them at the height their form actually has (#8652)

The `70vh` ceiling added earlier does apply — the Tailwind utility reaches the app's CSS and the class lands on the wrapper the kit puts around `.w-md-editor` — but `vh` only bounds a field against the height of the *screen*, not against the room left *underneath* it. Skill's and Prompt's Instructions start roughly 40% down their form, so a fully capped field still runs past the bottom of the page. That is what the issue's expected result forbids, and what the retest on dev reported.

The cap is measured instead. The new `useAvailableHeightCap` hook (in `chat-shared`) finds the nearest vertically scrolling ancestor and writes the space left below the element into `--resizable-field-max-height`: the scroller's visible height minus the offset the fields above occupy, normalised by `scrollTop` so the value describes the worst case (the form scrolled to its top) and does not shift while the user scrolls or drags. A 200px floor keeps a field that starts below the fold on a short viewport usable rather than collapsed.

It re-measures on mount, on a `ResizeObserver` over the scroller, on `window.resize`, and on `pointerdown` — content appearing above the element moves it without resizing either one, and no observer reports that, but by the time a drag starts the layout above has settled.

The class moves from `MarkdownEditor`'s own `className` onto a wrapper carrying the ref, since the kit does not forward a ref; custom properties inherit, so the cap still reaches the box that carries the dragged height. `70vh` stays as the fallback until the first measurement. Applied to all three markdown editors: Skill Instructions, Prompt Instructions and New task Instructions. The `Textarea` call sites keep their `50vh` cap, which the retest accepted.

### Markdown preview: restore list markers (#8690)

Numbered and bulleted lists rendered as unmarked plain text in the Instructions preview (the eye icon). Not a serialization bug: the toolbar writes correct markdown (`- ` / `1. `) and `react-markdown` produces correct `<ul>`/`<ol>`. The markers were removed by a CSS interaction between two stylesheets:

1. Tailwind's preflight sets `list-style: none` on every `ul`/`ol`.
2. `@uiw/react-markdown-preview`'s stylesheet only re-declares `list-style-type` for **nested** lists (`ol ol` / `ul ol` → `lower-roman`, third level → `lower-alpha`). It leaves top-level lists on the browser default — which preflight had just removed.

So top-level bullets and numbers disappeared entirely, while the preview's own `padding-left: 2em` stayed, which is why the text still looked indented but unmarked.

The new `MARKDOWN_EDITOR_PREVIEW_LIST_CLASS_NAME` constant (in `chat-shared`, next to the height cap) restores the markers the preview expects: `disc`/`circle`/`square` down the `ul` nesting chain, and `decimal` for a top-level `ol` only — the `ol` rule uses a child combinator so the vendor's `lower-roman`/`lower-alpha` rules for deeper ordered lists keep winning, and task-list items keep `list-style: none` from their own `li` rule. Applied to the same three editors, on the wrapper the height cap already uses.

Verified in a browser against the real stylesheets, with preflight loaded *before* the vendor CSS (the worst case for cascade order). Computed `list-style-type`, before → after: top-level `ol` `none` → `decimal`; top-level `ul` `none` → `disc`; nested `ul` `none` → `circle`/`square`; nested `ol` `lower-roman` → unchanged; task-list item `none` → unchanged. The "before" column reproduces the reported bug exactly.

The proper long-term home for this fix is `@epam/ai-dial-ui-kit`, which ships `MarkdownEditor` and owns the vendor CSS import — worth raising there so the three consumers do not each need the class.

### Stopped generation does not restart after re-submitting the message (#8687)

Stop a generation, open the pencil on the user message, click **Save & Submit** — the conversation stayed on the stopped partial answer. Three separate client-side causes, each of which alone reproduces some part of the report:

**1. An unchanged message was a silent no-op.** `handleEditMessage` skipped the whole submit path whenever `isMessageChanged` was false — closing the edit area and starting nothing. After a stop that is precisely the case the user needs re-run: the message is the same, the *answer* is what has to be replaced. The shortcut now goes through `shouldRerunGenerationOnEdit`, which keeps the no-op only when the answer below the edited message actually completed, and re-runs when it is missing, was stopped by the user, or ended with a stream error (`isAnswerIncomplete`). `ConversationView` arms its scroll anchor off the same predicate, so the two cannot drift apart.

**2. A superseded generation stomped the new one.** The edit button is gated on `isAssistantTyping`, so it unlocks the moment the stopped stream closes — while that generation's `onComplete` is still awaiting `transport.getConversation`. A re-submit inside that window started a second generation, and then the older callback ran `removeStreamingPath` and `setConversation(refreshed)` against it: streaming state cleared, and the pre-edit messages (the stopped answer) restored over the edit. `useConversationStream` now tracks the newest generation id per path; the terminal callbacks of a superseded generation clear no streaming state, report no generation end, write no `streamErrorMessage`, and skip the reload — re-checked *after* the round trip, since the new generation can start while it is in flight.

**3. The live-message buffer was seeded from a stale ref.** `handleEditMessage` assigned `conversationRef.current` inside a `setConversation` updater, which React may defer past the synchronous `startStream` call that reads it to seed the buffer. When it did, the buffer held the answer being replaced, and the new tokens appended to the stopped partial text (`Part` + `New` rendered as one answer). The ref is now assigned directly before `setConversation`, matching `handleConfirmDelete`.

Covered by regression tests at both levels: the handler test (unchanged text over a `wasStoppedByUser` answer re-runs in `edit` mode) and two stream-hook tests (a superseded completion leaves `isStreaming` true and issues no reload; a superseded error writes nothing onto the new answer). Both stream tests were confirmed to fail against the unfixed hook. `openspec/specs/edit-message/spec.md` and `openspec/specs/chat-hooks-conversation-stream/spec.md` record the two new rules.

The backend needed no change: `buildConversationHistory` already truncates correctly for `edit` mode, and the generation registry releases a stopped entry before the client's stream closes.

### Accessible labels for resize and empty-state controls (chore)

Adds the missing label props — a `resizeLabel` for `SidebarPanel`'s drag-to-resize handle, and the equivalents on `AttachmentCanvas`, `PanelEmptyState` and `ConversationSourcesPanel` — so the hosts translate them instead of leaving the libs on hardcoded English defaults.

### Attach-modal auto-select spec: record the shipped behaviour (docs, #7501)

Answers the two open review comments on #7501 by reconciling `openspec/specs/file-manager-attach-modal-polish/spec.md` with the code. No behaviour change — spec text only.

The `autoSelectUploadedItems` requirement described a host-side `useEffect` on `uploadBatchState` that does not exist. `DialFileManagerModal` defaults the prop to `true` and passes it through `FileManagerAttachModal` and `DialFileManagerShell` to the ui-kit `DialFileManager` (kit default `false`); the behaviour lives in the kit's `FileManagerProvider`, which records the item names and destination folder when `onUploadFiles`, `onUploadArchive` or `onCreateFolder` fires and applies that record once `items` refreshes. The spec now says so, and adds the parts it never covered: created folders and uploaded archives are auto-selected too, the recorded names are the post-`sanitizeFileName` ones (`useDialFileUploadBatch` rewrites them inside `onValidateUpload`, which the kit awaits first), and auto-selection is skipped when the user has navigated away from the destination folder or when the item fails the kit's `isFileSelectable` check — the host's own `isRowSelectable` is not consulted there.

The reviewer's spec question is answered in the spec rather than left open. The toolbar swap is intended kit behaviour: `FileManager` renders the bulk-actions toolbar in place of the New toolbar whenever `selectedPaths.size > 0`, so the New → Upload route is genuinely unavailable while a selection exists. But the state the two scenarios needed is still reachable — `onDrop` sits on the grid section and is not gated on selection, so dropping a file with a row already selected exercises exactly that path. Along it the clause fails for a substantive reason, not for unreachability: the kit calls `setSelectedPaths(matchedPaths)`, replacing the selection instead of merging into it, so the previously selected row is dropped. That divergence is now recorded in the spec as current-but-not-endorsed, with a note that closing it needs a change in `@epam/ai-dial-ui-kit`, not here. The "previously selected paths preserved" scenario is rewritten to match, and the toolbar swap gets its own scenario.

Two stale spots in the same file fixed while there: the tab empty-state requirement omitted the search and empty-subfolder overrides that take precedence over the per-tab copy, and the filename utilities have moved from `apps/chat/src/utils/file.ts` to `libs/chat-hooks/src/files/file-name.ts` (they also measure bytes through `getUtf8ByteLength` / `truncateToUtf8Bytes` from `chat-shared` rather than `TextEncoder` directly).

The bug in the first review comment — a file uploaded inside the attach modal is listed but unchecked — is **not** closed by this commit. The prop chain and the kit's auto-select logic are both intact in the current code (kit `0.14.0-dev.46`; the logic has not changed since kit `0.9.0`), so the report needs runtime verification rather than a spec edit.

## Applicable issues

- fixes #8653
- #8704
- fixes #8652
- fixes #8690
- fixes #8687
- #7501

## UI changes

No new UI surfaces. The visible differences are: a time appended to the file manager's Modified Date values, the Organization root's name in publish/unpublish confirmations instead of an empty pair of quotes, an upper bound on how far the Instructions editors can be dragged, bullets/numbers reappearing in the markdown preview, and a new response actually starting when a stopped message is re-submitted from the edit area. Repro steps and before-screenshots are in the linked issues. The spec commit changes no UI.

## Checklist

- [x] the pull request name ends with `(Issue #<ISSUE_ID>)` (comma-separated list of issues)
- [x] I confirm that I don't share any confidential information like API keys or any other secrets and private URLs


