### PR TITLE
fix(chat-api): use canonical discovered OIDC issuer

### DIFF
--- a/apps/chat-api/README.md
+++ b/apps/chat-api/README.md
@@ -251,6 +251,12 @@ Every `AUTH_{PROVIDER_TYPE}_HOST` variable (`AUTH_AUTH0_HOST`, `AUTH_GITLAB_HOST
 
 A trailing slash is normalised away. A scheme other than `http` or `https` fails boot with an error naming the variable.
 
+The configured host is used as the OIDC discovery location. After discovery,
+Chat uses the canonical `issuer` returned by the provider metadata for callback
+and token issuer validation. This allows an in-cluster discovery URL to return
+the provider's externally advertised issuer without causing a false issuer
+mismatch; the canonical issuer remains subject to strict validation.
+
 **Auth0** (`id: auth0`)
 
 | Variable                      | Required | Default                               |

--- a/apps/chat-api/src/auth/providers/provider-registry.service.spec.ts
+++ b/apps/chat-api/src/auth/providers/provider-registry.service.spec.ts
@@ -41,10 +41,14 @@ describe('ProviderRegistryService', () => {
   let discoverSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
-    discoverSpy = vi.spyOn(Issuer, 'discover').mockResolvedValue({
-      Client: class {},
-      metadata: {},
-    } as unknown as Issuer<never>);
+    discoverSpy = vi
+      .spyOn(Issuer, 'discover')
+      .mockImplementation(async (discoveryUrl: string) => {
+        return {
+          Client: class {},
+          metadata: { issuer: discoveryUrl },
+        } as unknown as Issuer<never>;
+      });
   });
 
   afterEach(() => {
@@ -279,6 +283,29 @@ describe('ProviderRegistryService', () => {
       // eslint-disable-next-line testing-library/await-async-queries -- ProviderRegistryService.findByIssuer is synchronous, not an async testing-library query
       const entry = svc.findByIssuer(config.issuer);
       expect(entry?.config.id).toBe('keycloak');
+    });
+
+    it('matches the canonical issuer returned by discovery when the discovery URL is internal', async () => {
+      const internalDiscoveryUrl = 'http://keycloak.internal:8080/realms/test';
+      const canonicalIssuer = 'https://login.example.com/auth/realms/test';
+      discoverSpy.mockResolvedValueOnce({
+        Client: class {},
+        metadata: { issuer: canonicalIssuer },
+      } as unknown as Issuer<never>);
+
+      const module = await buildModule({
+        ...KEYCLOAK_ENV,
+        AUTH_KEYCLOAK_HOST: internalDiscoveryUrl,
+      });
+      await module.init();
+      const svc = module.get(ProviderRegistryService);
+
+      expect(discoverSpy).toHaveBeenCalledWith(internalDiscoveryUrl);
+      expect(svc.getProvider('keycloak').config.issuer).toBe(canonicalIssuer);
+      // eslint-disable-next-line testing-library/await-async-queries -- ProviderRegistryService.findByIssuer is synchronous, not an async testing-library query
+      expect(svc.findByIssuer(canonicalIssuer)?.config.id).toBe('keycloak');
+      // eslint-disable-next-line testing-library/await-async-queries -- ProviderRegistryService.findByIssuer is synchronous, not an async testing-library query
+      expect(svc.findByIssuer(internalDiscoveryUrl)).toBeUndefined();
     });
 
     it('resolves an Azure AD v1 issuer to the registered v2 provider for the same tenant', async () => {

--- a/apps/chat-api/src/auth/providers/provider-registry.service.ts
+++ b/apps/chat-api/src/auth/providers/provider-registry.service.ts
@@ -128,6 +128,13 @@ export class ProviderRegistryService implements OnModuleInit {
           `Discovering OIDC metadata for provider: ${providerConfig.id}`,
         );
         const issuer = await Issuer.discover(providerConfig.issuer);
+        /*
+         * The configured URL is the discovery location and may be an internal
+         * cluster address. The metadata's `issuer` is the canonical identity
+         * that appears in authorization responses and tokens, so retain that
+         * value for all subsequent issuer checks.
+         */
+        providerConfig.issuer = issuer.metadata.issuer;
         const client = new issuer.Client({
           client_id: providerConfig.clientId,
           client_secret: providerConfig.clientSecret,

--- a/docs/auth/auth-bff-encrypted-cookie.md
+++ b/docs/auth/auth-bff-encrypted-cookie.md
@@ -109,6 +109,13 @@ type ProviderConfig = {
 };
 ```
 
+For providers configured with a host URL, that URL is the OIDC discovery
+location. The registry replaces the provisional configured issuer with the
+canonical `issuer` from the discovered provider metadata before validating
+authorization callbacks or bearer tokens. Consequently, an internal cluster
+discovery URL may safely resolve metadata whose canonical issuer is the
+externally advertised identity, while RFC 9207 issuer matching remains exact.
+
 Login URLs become `/auth/login/:providerId?callbackUrl=<app-url>`. The active provider is encoded in the session, so refresh and logout always use the correct IdP; the validated `callbackUrl` is encoded in the short-lived transaction cookie so the callback can return the browser to the correct SPA origin/page.
 
 ---


### PR DESCRIPTION
## Description of changes

Use the canonical issuer returned by OIDC discovery for callback and bearer-token issuer validation. This supports deployments that access Keycloak discovery through an internal cluster URL while Keycloak advertises a different canonical issuer, without weakening strict RFC 9207 validation.

Verification: auth provider and controller tests, chat-api lint and build, and documentation validation all pass.

## Applicable issues

None.

## UI changes

No UI changes.

## Checklist

- [ ] the pull request name ends with (Issue #ISSUE_ID) (comma-separated list of issues)
- [x] I confirm that I do not share any confidential information like API keys or any other secrets and private URLs