### PR TITLE
feat(chat-api): add runtime memory diagnostics

### DIFF
--- a/apps/chat-api/README.md
+++ b/apps/chat-api/README.md
@@ -180,7 +180,7 @@ setting is read at Core startup, so restart DIAL Core after changing it.
 | `SKILL_TRANSFER_TIMEOUT_MS`             | `60000`                        | Timeout for all skills-domain DIAL Core requests (milliseconds)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
 | `SKILL_ARCHIVE_UPLOAD_MAX_BYTES`        | `20971520`                     | Maximum size (bytes) of the compressed ZIP archive accepted by `POST /api/v1/skills/import` before extraction (default 20 MB); rejected with 413. Distinct from `SKILL_UPLOAD_MAX_TOTAL_BYTES`, which bounds decompressed content                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
 | `ASR_MODEL`                             | —                              | Deployment ID of a dedicated speech-to-text model. When set (together with the `voice-input` feature), the mic button is always shown and recorded audio is transcribed by this model via `POST /api/v1/transcription`. When absent, the mic button is shown only for deployments whose `inputAttachmentTypes` include an audio MIME type, and transcription is handled by the selected chat deployment.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
-| `TRANSCRIBE_SIZE_LIMIT_BYTES`           | `5242880`                      | Maximum audio file size (in bytes) accepted for transcription. The frontend applies this limit to the complete recording before upload. Default is 5 MB.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| `TRANSCRIBE_SIZE_LIMIT_BYTES`           | `5242880`                      | Maximum audio file size (in bytes) accepted for transcription. The frontend applies this limit to the complete recording before upload. Default is 5 MB.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
 | `UTILITY_MODEL`                         | —                              | Deployment ID of a utility model for server-side tasks (e.g. LLM conversation naming). Not exposed to the frontend. Required together with `DIAL_API_KEY` and `LLM_CONVERSATION_NAMING_ENABLED=true` to enable automatic title generation after the first assistant reply.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
 | `LLM_CONVERSATION_NAMING_ENABLED`       | `false`                        | When `true` and `UTILITY_MODEL` is set, the backend asynchronously renames conversations after the first assistant reply using the utility model.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
 | `UTILITY_NAMING_TIMEOUT_MS`             | `10000`                        | Timeout in milliseconds for utility-model conversation naming requests.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
@@ -696,6 +696,8 @@ processors, no additional listening port, and no outbound network calls for tele
   response status code. `MetricsInterceptor` records exactly one data point per request, except
   `GET /api/health` (still logged, never recorded) — see `telemetry/excluded-paths.ts`, the same
   exclusion list `otel-sdk.ts` uses for tracing.
+  Runtime gauges report the serving Node.js process's memory, active SSE operations, and
+  generation registry size; see [Runtime memory diagnostics](#runtime-memory-diagnostics).
 - **Prometheus endpoint**: when the `prometheus` metrics exporter is selected, a dedicated,
   unauthenticated HTTP listener starts (default `127.0.0.1:9464`, path `/metrics`), entirely
   independent of the main application port — no new business-API route, no interaction with
@@ -707,7 +709,7 @@ processors, no additional listening port, and no outbound network calls for tele
 - **Shutdown**: `main.ts` calls `app.enableShutdownHooks()`; `TelemetryShutdownService` (a Nest
   `OnApplicationShutdown` provider) flushes and shuts down all telemetry processors, bounded by
   an internal timeout (default 5s) so a hung exporter or unreachable collector can never block
-  container termination.
+  container termination. Runtime metric collection callbacks are removed on shutdown.
 - **Failure mode**: an unreachable OTLP collector never crashes the process, blocks a response,
   or fails a request — it surfaces only as exporter-level warning logs from the OpenTelemetry
   SDK's own retry/backoff logic.
@@ -738,6 +740,83 @@ validator schema only covers application-owned configuration; these are read in
 
 **Not supported**: `OTEL_EXPORTER_OTLP_PROTOCOL` (and per-signal variants) is not read — the
 protocol is fixed to `http/protobuf` in code via the `*-otlp-http` exporter packages.
+
+### Runtime memory diagnostics
+
+To collect memory and active-operation metrics without enabling trace or log export, set these
+existing environment variables on the backend process and restart it:
+
+```dotenv
+OTEL_SDK_DISABLED=false
+OTEL_METRICS_EXPORTER=prometheus
+OTEL_TRACES_EXPORTER=none
+OTEL_LOGS_EXPORTER=none
+```
+
+Scrape the existing `http://127.0.0.1:9464/metrics` listener from the pod's network namespace.
+For a Prometheus scraper outside the pod, also set `OTEL_EXPORTER_PROMETHEUS_HOST=0.0.0.0`,
+configure its scrape target for port `9464`, path `/metrics`, and restrict access with the
+deployment's NetworkPolicy. This unauthenticated listener remains separate from the application
+port. Metrics can also be sent through the existing `otlp` exporter configuration.
+
+| OpenTelemetry instrument              | Prometheus series              | Meaning                                                                                                                                                        |
+| ------------------------------------- | ------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `dial.chat.process.memory` (unit `B`) | `dial_chat_process_memory`     | Bytes from one `process.memoryUsage()` call in the Node.js process serving Nest requests, once per metric collection. Each memory `kind` is a separate series. |
+| `dial.chat.sse.active`                | `dial_chat_sse_active`         | Outstanding SSE operations for each `kind`, including setup and cleanup as described below.                                                                    |
+| `dial.chat.generations.active`        | `dial_chat_generations_active` | Number of entries physically retained in the process's generation registry. No application labels.                                                             |
+
+Memory `kind` values are `rss`, `heap_used`, `heap_total`, `external`, and `array_buffers`,
+corresponding to Node.js's `rss`, `heapUsed`, `heapTotal`, `external`, and `arrayBuffers` fields.
+`heap_used` measures used JavaScript heap; `heap_total` measures allocated
+JavaScript heap; `external` includes native memory associated with JavaScript objects;
+`array_buffers` includes `ArrayBuffer`/`SharedArrayBuffer` allocations and Node.js `Buffer`
+storage. **`array_buffers` is already included in `external`**. RSS describes resident memory
+for the whole process, and these series overlap: do not sum them into a total. A pod memory
+panel may also include other containers or memory outside this process.
+
+`client_channel` and `conversation_watch` start counting before the asynchronous subscribe/watch
+setup and stop when the handler settles. If the client has already disconnected but upstream
+work has not finished, the operation remains counted. `generation_attach` counts the attached
+subscription until its cleanup runs, even after its handler returns. These counts are not a
+count of open browser connections. Ordinary completion-response delivery is not part of the
+SSE gauge; registered generations have their own gauge. On application shutdown, registered
+generations emit a stopped terminal event so attached subscriptions can run their cleanup.
+
+The generation gauge includes stopped or aborted entries while persistence is still pending.
+Entries stop contributing when they are removed on completion, error, stale eviction,
+replacement, or shutdown. It measures the registry, not every upstream task that might still
+be running after its entry was removed. Neither operation gauge includes user, conversation,
+or deployment identifiers.
+
+Runtime collection callbacks are registered after SDK startup only when a metrics exporter is
+enabled, and removed on shutdown. They sample during exporter collection rather than starting
+another sampling timer. Disabling the SDK or setting `OTEL_METRICS_EXPORTER=none` disables these
+runtime observations. These metrics help correlate retained memory with active work; adding
+them does not itself fix memory leaks.
+
+For Grafana, the following PromQL keeps each pod and memory kind separate. These examples
+assume the Prometheus scrape configuration adds a `pod` label and the dashboard has a `$pod`
+variable; the application does not add Kubernetes labels. Add your deployment's `job`,
+`namespace`, or `cluster` selectors as needed.
+
+```promql
+dial_chat_process_memory{pod=~"$pod"}
+```
+
+Use the panel's bytes unit and legend `{{pod}} {{kind}}`. Compare it with two count panels:
+
+```promql
+dial_chat_sse_active{pod=~"$pod"}
+```
+
+```promql
+dial_chat_generations_active{pod=~"$pod"}
+```
+
+Use legends `{{pod}} {{kind}}` and `{{pod}}`, respectively. Growing `heap_used` with stable
+operation counts directs investigation toward retained JavaScript objects; growing `external`
+or `array_buffers` directs it toward buffers. A rising RSS alone cannot establish a JavaScript
+heap leak.
 
 ### Local verification
 

--- a/apps/chat-api/src/client-channel/client-channel.controller.ts
+++ b/apps/chat-api/src/client-channel/client-channel.controller.ts
@@ -16,6 +16,10 @@ import { FeatureGuard } from '../app-config/feature-flags/feature.guard';
 import { RequireFeature } from '../app-config/feature-flags/require-feature.decorator';
 import type { SessionUser } from '../auth/session/session.types';
 import { startSseResponse } from '../common/utils/sse';
+import {
+  SseSubscriptionKind,
+  trackSseSubscription,
+} from '../telemetry/runtime-metrics';
 import { ClientChannelService } from './client-channel.service';
 import {
   assertValidChannelId,
@@ -78,56 +82,63 @@ export class ClientChannelController {
     const validReconnectChannelId =
       assertValidOptionalChannelId(reconnectChannelId);
     const abortController = new AbortController();
-
-    this.logger.debug('[timing] subscribe request received by BFF');
-    const { stream, channelId } = await this.clientChannelService.subscribe(
-      at,
-      validReconnectChannelId,
-      abortController.signal,
+    const finishSubscription = trackSseSubscription(
+      SseSubscriptionKind.ClientChannel,
     );
-    this.logger.debug(
-      `[timing] subscribe request headers about to flush — channelId: ${channelId}`,
-    );
-
-    res.setHeader(CHANNEL_ID_HEADER, channelId);
-    startSseResponse(res);
-
-    const reader = stream.getReader();
-    let isClientAborted = false;
-    let isReaderReleased = false;
-
-    const handleClose = () => {
-      isClientAborted = true;
-      abortController.abort();
-      if (!isReaderReleased) {
-        void reader.cancel().catch(() => undefined);
-      }
-    };
-    res.on('close', handleClose);
 
     try {
-      while (true) {
-        if (isClientAborted) break;
+      this.logger.debug('[timing] subscribe request received by BFF');
+      const { stream, channelId } = await this.clientChannelService.subscribe(
+        at,
+        validReconnectChannelId,
+        abortController.signal,
+      );
+      this.logger.debug(
+        `[timing] subscribe request headers about to flush — channelId: ${channelId}`,
+      );
 
-        const { done, value } = await reader.read();
-        if (done) break;
+      res.setHeader(CHANNEL_ID_HEADER, channelId);
+      startSseResponse(res);
 
-        res.write(value);
-      }
-    } catch (err) {
-      if (!isClientAborted) {
-        this.logger.error(
-          'Error while relaying client-channel events to browser',
-          err,
-        );
+      const reader = stream.getReader();
+      let isClientAborted = false;
+      let isReaderReleased = false;
+
+      const handleClose = () => {
+        isClientAborted = true;
+        abortController.abort();
+        if (!isReaderReleased) {
+          void reader.cancel().catch(() => undefined);
+        }
+      };
+      res.on('close', handleClose);
+
+      try {
+        while (true) {
+          if (isClientAborted) break;
+
+          const { done, value } = await reader.read();
+          if (done) break;
+
+          res.write(value);
+        }
+      } catch (err) {
+        if (!isClientAborted) {
+          this.logger.error(
+            'Error while relaying client-channel events to browser',
+            err,
+          );
+        }
+      } finally {
+        res.off('close', handleClose);
+        isReaderReleased = true;
+        reader.releaseLock();
+        if (!res.writableEnded) {
+          res.end();
+        }
       }
     } finally {
-      res.off('close', handleClose);
-      isReaderReleased = true;
-      reader.releaseLock();
-      if (!res.writableEnded) {
-        res.end();
-      }
+      finishSubscription();
     }
   }
 

--- a/apps/chat-api/src/conversations/conversation-generation.service.ts
+++ b/apps/chat-api/src/conversations/conversation-generation.service.ts
@@ -1,7 +1,13 @@
 import { EventEmitter } from 'node:events';
-import { ConflictException, Injectable, Logger } from '@nestjs/common';
+import {
+  ConflictException,
+  Injectable,
+  Logger,
+  OnModuleDestroy,
+} from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import type { EnvironmentVariables } from '../config/environment.config';
+import { trackGeneration } from '../telemetry/runtime-metrics';
 import {
   ConversationMessageDto,
   ConversationMessageRole,
@@ -68,10 +74,12 @@ interface GenerationEntry {
    * normal-speed generation never triggers it.
    */
   maxDurationTimer: NodeJS.Timeout;
+  /** Released when this entry is no longer retained by the registry. */
+  finishTracking: () => void;
 }
 
 @Injectable()
-export class ConversationGenerationService {
+export class ConversationGenerationService implements OnModuleDestroy {
   private readonly logger = new Logger(ConversationGenerationService.name);
   private readonly registry = new Map<string, GenerationEntry>();
   private readonly maxGenerationDurationMs: number;
@@ -86,13 +94,47 @@ export class ConversationGenerationService {
     return `${sessionId}::${path}`;
   }
 
+  private removeEntry(key: string, entry: GenerationEntry): void {
+    clearTimeout(entry.maxDurationTimer);
+    if (this.registry.get(key) === entry) {
+      this.registry.delete(key);
+    }
+    entry.finishTracking();
+  }
+
+  onModuleDestroy(): void {
+    for (const [key, entry] of this.registry) {
+      clearTimeout(entry.maxDurationTimer);
+      entry.status = GenerationStatus.Stopped;
+      /*
+       * Every attachment must get a terminal event to release its response and
+       * keepalive. Isolate subscribers so one failing callback cannot prevent
+       * the others from closing; raw listeners preserve EventEmitter.once.
+       */
+      for (const listener of entry.emitter.rawListeners('terminal')) {
+        try {
+          listener.call(entry.emitter, {
+            type: 'stopped',
+          } satisfies GenerationTerminalEvent);
+        } catch (error) {
+          this.logger.error(
+            'Failed to notify generation subscriber during shutdown',
+            error instanceof Error ? error.stack : undefined,
+          );
+        }
+      }
+      entry.emitter.removeAllListeners();
+      this.removeEntry(key, entry);
+      entry.abortController.abort();
+    }
+  }
+
   private evictStale(): void {
     const cutoff = Date.now() - STALE_ENTRY_TTL_MS;
     for (const [key, entry] of this.registry) {
       if (entry.startedAt < cutoff) {
         this.logger.warn(`Evicting stale generation entry: ${key}`);
-        clearTimeout(entry.maxDurationTimer);
-        this.registry.delete(key);
+        this.removeEntry(key, entry);
       }
     }
   }
@@ -110,6 +152,9 @@ export class ConversationGenerationService {
       throw new ConflictException(
         `A generation is already active for this conversation. Stop it before starting a new one.`,
       );
+    }
+    if (existing) {
+      this.removeEntry(key, existing);
     }
 
     const abortController = new AbortController();
@@ -137,6 +182,7 @@ export class ConversationGenerationService {
       assembledMessage: createPlaceholderMessage(),
       emitter,
       maxDurationTimer,
+      finishTracking: trackGeneration(),
     });
     return abortController;
   }
@@ -222,7 +268,7 @@ export class ConversationGenerationService {
         type: 'done',
       } satisfies GenerationTerminalEvent);
       entry.emitter.removeAllListeners();
-      this.registry.delete(key);
+      this.removeEntry(key, entry);
     }
   }
 
@@ -251,7 +297,7 @@ export class ConversationGenerationService {
           : { type: 'error', message }) satisfies GenerationTerminalEvent,
       );
       entry.emitter.removeAllListeners();
-      this.registry.delete(key);
+      this.removeEntry(key, entry);
     }
   }
 }

--- a/apps/chat-api/src/conversations/conversation.controller.ts
+++ b/apps/chat-api/src/conversations/conversation.controller.ts
@@ -27,6 +27,10 @@ import {
   ConversationResponseDto,
 } from '../openapi/openapi-response.dto';
 import {
+  SseSubscriptionKind,
+  trackSseSubscription,
+} from '../telemetry/runtime-metrics';
+import {
   ConversationGenerationService,
   type GenerationTerminalEvent,
 } from './conversation-generation.service';
@@ -400,6 +404,9 @@ export class ConversationController {
     const keepaliveTimer = setInterval(() => {
       if (!res.writableEnded) res.write(SSE_KEEPALIVE_PAYLOAD);
     }, SSE_KEEPALIVE_INTERVAL_MS);
+    const finishSubscription = trackSseSubscription(
+      SseSubscriptionKind.GenerationAttach,
+    );
 
     let isCleanedUp = false;
     const onChunk = (rawChunk: unknown): void => {
@@ -415,6 +422,7 @@ export class ConversationController {
     const cleanup = (): void => {
       if (isCleanedUp) return;
       isCleanedUp = true;
+      finishSubscription();
       clearInterval(keepaliveTimer);
       attachment.emitter.off('chunk', onChunk);
       attachment.emitter.off('terminal', onTerminal);
@@ -451,60 +459,70 @@ export class ConversationController {
     @Body() dto: WatchConversationBodyDto,
   ) {
     const { at, bucket } = req.user as SessionUser;
-    const stream = await this.conversationService.watchConversation(
-      dto.path,
-      at,
-      bucket,
+    const finishSubscription = trackSseSubscription(
+      SseSubscriptionKind.ConversationWatch,
     );
-
-    startSseResponse(res);
-
-    const reader = stream.getReader();
-
-    let isClientAborted = false;
-    let isReaderReleased = false;
-    let isCancelRequested = false;
-
-    const handleClose = () => {
-      isClientAborted = true;
-      if (isReaderReleased || isCancelRequested) {
-        return;
-      }
-
-      isCancelRequested = true;
-      void reader.cancel().catch(() => undefined);
-    };
-
-    res.on('close', handleClose);
-
-    let keepaliveTimer: ReturnType<typeof setInterval> | null = null;
     try {
-      keepaliveTimer = setInterval(() => {
-        if (!isClientAborted && !res.writableEnded) {
-          res.write(SSE_KEEPALIVE_PAYLOAD);
+      const stream = await this.conversationService.watchConversation(
+        dto.path,
+        at,
+        bucket,
+      );
+
+      startSseResponse(res);
+
+      const reader = stream.getReader();
+
+      let isClientAborted = false;
+      let isReaderReleased = false;
+      let isCancelRequested = false;
+
+      const handleClose = () => {
+        isClientAborted = true;
+        if (isReaderReleased || isCancelRequested) {
+          return;
         }
-      }, SSE_KEEPALIVE_INTERVAL_MS);
 
-      while (true) {
-        if (isClientAborted) break;
+        isCancelRequested = true;
+        void reader.cancel().catch(() => undefined);
+      };
 
-        const { done, value } = await reader.read();
-        if (done) break;
+      res.on('close', handleClose);
 
-        res.write(value);
-      }
-    } catch (err) {
-      if (!isClientAborted) {
-        this.logger.error('Error while streaming watch events to client', err);
+      let keepaliveTimer: ReturnType<typeof setInterval> | null = null;
+      try {
+        keepaliveTimer = setInterval(() => {
+          if (!isClientAborted && !res.writableEnded) {
+            res.write(SSE_KEEPALIVE_PAYLOAD);
+          }
+        }, SSE_KEEPALIVE_INTERVAL_MS);
+
+        while (true) {
+          if (isClientAborted) break;
+
+          const { done, value } = await reader.read();
+          if (done) break;
+
+          res.write(value);
+        }
+      } catch (err) {
+        if (!isClientAborted) {
+          this.logger.error(
+            'Error while streaming watch events to client',
+            err,
+          );
+        }
+      } finally {
+        if (keepaliveTimer) clearInterval(keepaliveTimer);
+        res.off('close', handleClose);
+        isReaderReleased = true;
+        reader.releaseLock();
+        if (!res.writableEnded) {
+          res.end();
+        }
       }
     } finally {
-      if (keepaliveTimer) clearInterval(keepaliveTimer);
-      res.off('close', handleClose);
-      isReaderReleased = true;
-      reader.releaseLock();
-      if (!res.writableEnded) {
-        res.end();
-      }
+      finishSubscription();
     }
   }
 

--- a/apps/chat-api/src/conversations/tests/conversation-generation.service.spec.ts
+++ b/apps/chat-api/src/conversations/tests/conversation-generation.service.spec.ts
@@ -1,7 +1,9 @@
-import { ConflictException } from '@nestjs/common';
+import { ConflictException, Logger } from '@nestjs/common';
 import type { ConfigService } from '@nestjs/config';
+import { MeterProvider, MetricReader } from '@opentelemetry/sdk-metrics';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { EnvironmentVariables } from '../../config/environment.config';
+import { initializeRuntimeMetrics } from '../../telemetry/runtime-metrics';
 import {
   ConversationGenerationService,
   GenerationStatus,
@@ -14,6 +16,16 @@ import {
 const SESSION = 'session-1';
 const PATH = 'gpt-4o__Test Chat';
 const GENERATION_ID = 'gen-1';
+
+class TestMetricReader extends MetricReader {
+  protected async onForceFlush(): Promise<void> {
+    /* Metrics are collected directly in assertions. */
+  }
+
+  protected async onShutdown(): Promise<void> {
+    /* This reader owns no resources. */
+  }
+}
 
 const makeMessage = (content: string): ConversationMessageDto => ({
   role: ConversationMessageRole.Assistant,
@@ -33,6 +45,10 @@ describe('ConversationGenerationService', () => {
 
   beforeEach(() => {
     service = new ConversationGenerationService(makeConfigService());
+  });
+
+  afterEach(() => {
+    service.onModuleDestroy();
   });
 
   describe('register', () => {
@@ -251,6 +267,211 @@ describe('ConversationGenerationService', () => {
         expect(onWarning).not.toHaveBeenCalled();
       } finally {
         process.off('warning', onWarning);
+      }
+    });
+  });
+
+  describe('generation memory diagnostics', () => {
+    let reader: TestMetricReader;
+    let meterProvider: MeterProvider;
+    let stopMetrics: () => void;
+
+    beforeEach(() => {
+      vi.useFakeTimers();
+      reader = new TestMetricReader();
+      meterProvider = new MeterProvider({ readers: [reader] });
+      stopMetrics = initializeRuntimeMetrics(meterProvider.getMeter('test'));
+    });
+
+    afterEach(async () => {
+      service.onModuleDestroy();
+      stopMetrics();
+      await meterProvider.shutdown();
+      vi.useRealTimers();
+    });
+
+    const collectGenerationCount = async () => {
+      const { resourceMetrics } = await reader.collect();
+      const dataPoints = resourceMetrics.scopeMetrics.flatMap((scope) =>
+        scope.metrics
+          .filter(
+            (metric) =>
+              metric.descriptor.name === 'dial.chat.generations.active',
+          )
+          .flatMap((metric) => metric.dataPoints),
+      );
+      expect(dataPoints).toHaveLength(1);
+      expect(dataPoints[0].attributes).toEqual({});
+      return dataPoints[0].value;
+    };
+
+    const getAttachment = (sessionId = SESSION) => {
+      const attachment = service.attach(sessionId, PATH);
+      if (!attachment) {
+        throw new Error('Expected an attachment for the registered generation');
+      }
+      return attachment;
+    };
+
+    it('counts concurrent retained generations until each completes or errors', async () => {
+      expect(await collectGenerationCount()).toBe(0);
+
+      service.register(SESSION, PATH, GENERATION_ID);
+      service.register('session-2', PATH, 'gen-2');
+      expect(await collectGenerationCount()).toBe(2);
+
+      service.complete(SESSION, PATH, GENERATION_ID);
+      expect(await collectGenerationCount()).toBe(1);
+
+      service.error('session-2', PATH, 'gen-2', 'upstream failed');
+      service.error('session-2', PATH, 'gen-2');
+      service.complete(SESSION, PATH, GENERATION_ID);
+      expect(await collectGenerationCount()).toBe(0);
+    });
+
+    it('does not count conflicting registrations or finish a mismatched generation', async () => {
+      service.register(SESSION, PATH, GENERATION_ID);
+      expect(() => service.register(SESSION, PATH, 'gen-2')).toThrow(
+        ConflictException,
+      );
+      service.complete(SESSION, PATH, 'gen-2');
+      service.error(SESSION, PATH, 'gen-2');
+
+      expect(await collectGenerationCount()).toBe(1);
+    });
+
+    it('keeps a stopped generation counted while final persistence is pending', async () => {
+      service.register(SESSION, PATH, GENERATION_ID);
+      service.abort(SESSION, PATH, GENERATION_ID);
+
+      expect(await collectGenerationCount()).toBe(1);
+      service.error(SESSION, PATH, GENERATION_ID);
+      expect(await collectGenerationCount()).toBe(0);
+    });
+
+    it('keeps a timed-out generation counted until it leaves the registry', async () => {
+      service = new ConversationGenerationService(makeConfigService(1000));
+      const controller = service.register(SESSION, PATH, GENERATION_ID);
+      vi.advanceTimersByTime(1000);
+
+      expect(controller.signal.aborted).toBe(true);
+      expect(await collectGenerationCount()).toBe(1);
+      service.error(SESSION, PATH, GENERATION_ID);
+      expect(await collectGenerationCount()).toBe(0);
+    });
+
+    it('does not depend on whether a browser remains attached', async () => {
+      service.register(SESSION, PATH, GENERATION_ID);
+      const attachment = getAttachment();
+      const onChunk = vi.fn();
+      attachment.emitter.on('chunk', onChunk);
+      attachment.emitter.off('chunk', onChunk);
+
+      expect(await collectGenerationCount()).toBe(1);
+    });
+
+    it('stops counting a stale entry when a later registration evicts it', async () => {
+      service.register(SESSION, PATH, GENERATION_ID);
+      vi.setSystemTime(Date.now() + 30 * 60 * 1000 + 1);
+
+      service.register('session-2', PATH, 'gen-2');
+
+      expect(service.getStatus(SESSION, PATH)).toBeUndefined();
+      expect(await collectGenerationCount()).toBe(1);
+      service.complete(SESSION, PATH, GENERATION_ID);
+      expect(await collectGenerationCount()).toBe(1);
+    });
+
+    it('counts a replacement once when a stopped generation is overwritten', async () => {
+      service.register(SESSION, PATH, GENERATION_ID);
+      service.abort(SESSION, PATH, GENERATION_ID);
+      service.register(SESSION, PATH, 'gen-2');
+
+      expect(await collectGenerationCount()).toBe(1);
+      service.error(SESSION, PATH, GENERATION_ID);
+      expect(await collectGenerationCount()).toBe(1);
+      service.complete(SESSION, PATH, 'gen-2');
+      expect(await collectGenerationCount()).toBe(0);
+    });
+
+    it('releases retained generations, timers, and listeners on module shutdown', async () => {
+      const controller = service.register(SESSION, PATH, GENERATION_ID);
+      const secondController = service.register('session-2', PATH, 'gen-2');
+      service.abort('session-2', PATH, 'gen-2');
+      const attachment = getAttachment();
+      const onTerminal = vi.fn(() => service.attach(SESSION, PATH));
+      const secondOnTerminal = vi.fn();
+      attachment.emitter.on('chunk', vi.fn());
+      attachment.emitter.on('terminal', onTerminal);
+      getAttachment('session-2').emitter.on('terminal', secondOnTerminal);
+
+      service.onModuleDestroy();
+      service.onModuleDestroy();
+
+      expect(controller.signal.aborted).toBe(true);
+      expect(secondController.signal.aborted).toBe(true);
+      expect(onTerminal).toHaveBeenCalledExactlyOnceWith({ type: 'stopped' });
+      expect(onTerminal.mock.results[0].value).toBeDefined();
+      expect(secondOnTerminal).toHaveBeenCalledExactlyOnceWith({
+        type: 'stopped',
+      });
+      expect(service.attach(SESSION, PATH)).toBeUndefined();
+      expect(service.attach('session-2', PATH)).toBeUndefined();
+      expect(attachment.emitter.eventNames()).toEqual([]);
+      expect(vi.getTimerCount()).toBe(0);
+      expect(await collectGenerationCount()).toBe(0);
+    });
+
+    it('notifies and cleans up every shutdown attachment even when one subscriber throws', async () => {
+      const controller = service.register(SESSION, PATH, GENERATION_ID);
+      const secondController = service.register('session-2', PATH, 'gen-2');
+      const attachment = getAttachment();
+      const secondAttachment = getAttachment('session-2');
+      const subscriberError = new Error('Subscriber failed');
+      const throwingSubscriber = vi.fn(() => {
+        throw subscriberError;
+      });
+      const healthySubscriber = vi.fn(() =>
+        attachment.emitter.listeners('terminal').includes(throwingSubscriber),
+      );
+      const otherGenerationSubscriber = vi.fn();
+      attachment.emitter.once('terminal', throwingSubscriber);
+      attachment.emitter.once('terminal', healthySubscriber);
+      secondAttachment.emitter.on('terminal', otherGenerationSubscriber);
+      const logError = vi
+        .spyOn(Logger.prototype, 'error')
+        .mockImplementation(() => {
+          /* Assert the failure is logged without emitting expected test noise. */
+        });
+
+      try {
+        expect(() => service.onModuleDestroy()).not.toThrow();
+        service.onModuleDestroy();
+
+        expect(throwingSubscriber).toHaveBeenCalledExactlyOnceWith({
+          type: 'stopped',
+        });
+        expect(healthySubscriber).toHaveBeenCalledExactlyOnceWith({
+          type: 'stopped',
+        });
+        expect(healthySubscriber.mock.results[0].value).toBe(false);
+        expect(otherGenerationSubscriber).toHaveBeenCalledExactlyOnceWith({
+          type: 'stopped',
+        });
+        expect(logError).toHaveBeenCalledExactlyOnceWith(
+          'Failed to notify generation subscriber during shutdown',
+          subscriberError.stack,
+        );
+        expect(controller.signal.aborted).toBe(true);
+        expect(secondController.signal.aborted).toBe(true);
+        expect(attachment.emitter.eventNames()).toEqual([]);
+        expect(secondAttachment.emitter.eventNames()).toEqual([]);
+        expect(service.attach(SESSION, PATH)).toBeUndefined();
+        expect(service.attach('session-2', PATH)).toBeUndefined();
+        expect(vi.getTimerCount()).toBe(0);
+        expect(await collectGenerationCount()).toBe(0);
+      } finally {
+        logError.mockRestore();
       }
     });
   });

--- a/apps/chat-api/src/telemetry/otel-sdk.ts
+++ b/apps/chat-api/src/telemetry/otel-sdk.ts
@@ -30,6 +30,7 @@ import packageJson from '../../package.json';
 import { isExcludedFromTelemetry } from './excluded-paths';
 import type { MetricsExporter, SingleSignalExporter } from './otel-config';
 import { parseOtelConfig } from './otel-config';
+import { initializeRuntimeMetrics } from './runtime-metrics';
 
 /*
  * `main.ts` imports this module first, before `reflect-metadata`, Nest, Express, or any DIAL
@@ -101,6 +102,7 @@ export const buildMetricReaders = (
   });
 
 let sdk: NodeSDK | undefined;
+let stopRuntimeMetrics: (() => void) | undefined;
 
 export const initializeOpenTelemetry = (
   env: NodeJS.ProcessEnv = process.env,
@@ -116,6 +118,10 @@ export const initializeOpenTelemetry = (
     metricReaders: buildMetricReaders(config.metricsExporters, env),
   });
   sdk.start();
+  if (config.metricsExporters.length > 0) {
+    stopRuntimeMetrics?.();
+    stopRuntimeMetrics = initializeRuntimeMetrics();
+  }
 };
 
 /*
@@ -128,6 +134,8 @@ export const shutdownOpenTelemetry = async (
   timeoutMs = 5000,
   shutdownFn: () => Promise<void> = () => sdk?.shutdown() ?? Promise.resolve(),
 ): Promise<void> => {
+  stopRuntimeMetrics?.();
+  stopRuntimeMetrics = undefined;
   await Promise.race([
     shutdownFn(),
     new Promise<void>((resolve) => {

--- a/apps/chat-api/src/telemetry/runtime-metrics.ts
+++ b/apps/chat-api/src/telemetry/runtime-metrics.ts
@@ -1,0 +1,85 @@
+import {
+  metrics,
+  type BatchObservableCallback,
+  type Meter,
+} from '@opentelemetry/api';
+import packageJson from '../../package.json';
+
+export enum SseSubscriptionKind {
+  ClientChannel = 'client_channel',
+  ConversationWatch = 'conversation_watch',
+  GenerationAttach = 'generation_attach',
+}
+
+const activeSubscriptions: Record<SseSubscriptionKind, number> = {
+  [SseSubscriptionKind.ClientChannel]: 0,
+  [SseSubscriptionKind.ConversationWatch]: 0,
+  [SseSubscriptionKind.GenerationAttach]: 0,
+};
+let activeGenerations = 0;
+
+/*
+ * Only fixed counters live here. An operation owns its completion callback, so
+ * instrumentation never retains requests, credentials, streams, or per-user keys.
+ */
+export const trackSseSubscription = (
+  kind: SseSubscriptionKind,
+): (() => void) => {
+  activeSubscriptions[kind] += 1;
+  let finished = false;
+
+  return () => {
+    if (finished) return;
+    finished = true;
+    activeSubscriptions[kind] -= 1;
+  };
+};
+
+export const trackGeneration = (): (() => void) => {
+  activeGenerations += 1;
+  let finished = false;
+
+  return () => {
+    if (finished) return;
+    finished = true;
+    activeGenerations -= 1;
+  };
+};
+
+export const initializeRuntimeMetrics = (
+  meter: Meter = metrics.getMeter('dial-chat-api', packageJson.version),
+): (() => void) => {
+  const memory = meter.createObservableGauge('dial.chat.process.memory', {
+    description: 'Memory used or reserved by the NestJS Node.js process.',
+    unit: 'B',
+  });
+  const subscriptions = meter.createObservableGauge('dial.chat.sse.active', {
+    description: 'Active SSE subscriptions, including pending upstream setup.',
+  });
+  const generations = meter.createObservableGauge(
+    'dial.chat.generations.active',
+    {
+      description:
+        'Conversation generations retained by the process until registry removal.',
+    },
+  );
+  const observables = [memory, subscriptions, generations];
+
+  const collect: BatchObservableCallback = (result) => {
+    const usage = process.memoryUsage();
+    result.observe(memory, usage.rss, { kind: 'rss' });
+    result.observe(memory, usage.heapUsed, { kind: 'heap_used' });
+    result.observe(memory, usage.heapTotal, { kind: 'heap_total' });
+    result.observe(memory, usage.external, { kind: 'external' });
+    result.observe(memory, usage.arrayBuffers, { kind: 'array_buffers' });
+
+    for (const kind of Object.values(SseSubscriptionKind)) {
+      result.observe(subscriptions, activeSubscriptions[kind], { kind });
+    }
+    result.observe(generations, activeGenerations);
+  };
+
+  meter.addBatchObservableCallback(collect, observables);
+
+  return () => meter.removeBatchObservableCallback(collect, observables);
+};

--- a/apps/chat-api/src/telemetry/tests/otel-sdk-runtime.spec.ts
+++ b/apps/chat-api/src/telemetry/tests/otel-sdk-runtime.spec.ts
@@ -1,0 +1,76 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { initializeOpenTelemetry, shutdownOpenTelemetry } from '../otel-sdk';
+
+const { start, shutdown, stopRuntimeMetrics, initializeRuntimeMetrics } =
+  vi.hoisted(() => {
+    const stopRuntimeMetrics = vi.fn();
+    return {
+      start: vi.fn(),
+      shutdown: vi.fn().mockResolvedValue(undefined),
+      stopRuntimeMetrics,
+      initializeRuntimeMetrics: vi.fn().mockReturnValue(stopRuntimeMetrics),
+    };
+  });
+
+vi.mock('@opentelemetry/sdk-node', () => ({
+  NodeSDK: class {
+    start = start;
+    shutdown = shutdown;
+  },
+}));
+vi.mock('../runtime-metrics', () => ({ initializeRuntimeMetrics }));
+
+const metricsOnlyEnv = {
+  OTEL_SDK_DISABLED: 'false',
+  OTEL_TRACES_EXPORTER: 'none',
+  OTEL_LOGS_EXPORTER: 'none',
+  OTEL_METRICS_EXPORTER: 'otlp',
+};
+
+describe('runtime metric SDK lifecycle', () => {
+  afterEach(async () => {
+    await shutdownOpenTelemetry(0);
+    vi.clearAllMocks();
+  });
+
+  it('registers runtime observations only after the SDK installs its meter provider', () => {
+    initializeOpenTelemetry(metricsOnlyEnv);
+
+    expect(start).toHaveBeenCalledOnce();
+    expect(initializeRuntimeMetrics).toHaveBeenCalledOnce();
+    expect(start.mock.invocationCallOrder[0]).toBeLessThan(
+      initializeRuntimeMetrics.mock.invocationCallOrder[0],
+    );
+  });
+
+  it.each(['none', 'prometheus,none', 'unsupported'])(
+    'does not register runtime observations with metrics exporter %s',
+    (exporter) => {
+      initializeOpenTelemetry({
+        ...metricsOnlyEnv,
+        OTEL_METRICS_EXPORTER: exporter,
+      });
+
+      expect(start).toHaveBeenCalledOnce();
+      expect(initializeRuntimeMetrics).not.toHaveBeenCalled();
+    },
+  );
+
+  it('does not register runtime observations when the SDK is disabled', () => {
+    initializeOpenTelemetry({ ...metricsOnlyEnv, OTEL_SDK_DISABLED: 'true' });
+
+    expect(start).not.toHaveBeenCalled();
+    expect(initializeRuntimeMetrics).not.toHaveBeenCalled();
+  });
+
+  it('removes runtime callbacks once before shutting down exporters', async () => {
+    initializeOpenTelemetry(metricsOnlyEnv);
+    await shutdownOpenTelemetry(0);
+    await shutdownOpenTelemetry(0);
+
+    expect(stopRuntimeMetrics).toHaveBeenCalledOnce();
+    expect(stopRuntimeMetrics.mock.invocationCallOrder[0]).toBeLessThan(
+      shutdown.mock.invocationCallOrder[0],
+    );
+  });
+});

--- a/apps/chat-api/src/telemetry/tests/prometheus-endpoint.spec.ts
+++ b/apps/chat-api/src/telemetry/tests/prometheus-endpoint.spec.ts
@@ -4,6 +4,12 @@ import type { PrometheusExporter } from '@opentelemetry/exporter-prometheus';
 import { MeterProvider } from '@opentelemetry/sdk-metrics';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { buildMetricReaders } from '../otel-sdk';
+import {
+  initializeRuntimeMetrics,
+  SseSubscriptionKind,
+  trackGeneration,
+  trackSseSubscription,
+} from '../runtime-metrics';
 
 /*
  * `PrometheusExporter`'s own `port` option treats `0` as "not provided" (`config.port ||
@@ -24,6 +30,9 @@ const getFreePort = (): Promise<number> =>
 describe('Prometheus scrape endpoint', () => {
   let exporter: PrometheusExporter;
   let port: number;
+  let stopRuntimeMetrics: (() => void) | undefined;
+  let finishSubscription: (() => void) | undefined;
+  let finishGeneration: (() => void) | undefined;
 
   beforeAll(async () => {
     port = await getFreePort();
@@ -39,13 +48,21 @@ describe('Prometheus scrape endpoint', () => {
     await exporter.startServer();
 
     const meter = metrics.getMeter('prometheus-endpoint-test');
+    stopRuntimeMetrics = initializeRuntimeMetrics(meter);
+    finishSubscription = trackSseSubscription(
+      SseSubscriptionKind.ClientChannel,
+    );
+    finishGeneration = trackGeneration();
     meter
       .createHistogram('http.server.request.duration', { unit: 's' })
       .record(0.1, { 'http.request.method': 'GET' });
   });
 
   afterAll(async () => {
-    await exporter.shutdown();
+    finishSubscription?.();
+    finishGeneration?.();
+    stopRuntimeMetrics?.();
+    await exporter?.shutdown();
     /*
      * Deregister the global MeterProvider this spec installed — see `http-metrics.spec.ts` for
      * why every OTel-global-mutating spec cleans up after itself.
@@ -67,5 +84,36 @@ describe('Prometheus scrape endpoint', () => {
 
     const body = await response.text();
     expect(body).toContain('http_server_request_duration');
+  });
+
+  it('exports runtime gauge names and fixed labels through the actual Prometheus exporter', async () => {
+    const response = await fetch(`http://127.0.0.1:${port}/metrics`);
+    const body = await response.text();
+
+    expect(body).toContain('# TYPE dial_chat_process_memory gauge');
+    expect(body).toContain('# UNIT dial_chat_process_memory B');
+    for (const kind of [
+      'rss',
+      'heap_used',
+      'heap_total',
+      'external',
+      'array_buffers',
+    ]) {
+      expect(body).toMatch(
+        new RegExp(
+          `dial_chat_process_memory\\{[^\\n]*kind="${kind}"[^\\n]*\\} \\d+`,
+        ),
+      );
+    }
+    expect(body).toMatch(
+      /dial_chat_sse_active\{[^\n]*kind="client_channel"[^\n]*\} 1/,
+    );
+    expect(body).toMatch(
+      /dial_chat_sse_active\{[^\n]*kind="conversation_watch"[^\n]*\} 0/,
+    );
+    expect(body).toMatch(
+      /dial_chat_sse_active\{[^\n]*kind="generation_attach"[^\n]*\} 0/,
+    );
+    expect(body).toMatch(/dial_chat_generations_active\{[^\n]*\} 1/);
   });
 });

--- a/apps/chat-api/src/telemetry/tests/runtime-metrics.spec.ts
+++ b/apps/chat-api/src/telemetry/tests/runtime-metrics.spec.ts
@@ -1,0 +1,202 @@
+import { MeterProvider, MetricReader } from '@opentelemetry/sdk-metrics';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  initializeRuntimeMetrics,
+  SseSubscriptionKind,
+  trackGeneration,
+  trackSseSubscription,
+} from '../runtime-metrics';
+
+class TestMetricReader extends MetricReader {
+  protected async onForceFlush(): Promise<void> {
+    /* Collection is driven explicitly by each assertion. */
+  }
+
+  protected async onShutdown(): Promise<void> {
+    /* This reader owns no external resources. */
+  }
+}
+
+const memoryUsage: NodeJS.MemoryUsage = {
+  rss: 500,
+  heapUsed: 100,
+  heapTotal: 200,
+  external: 80,
+  arrayBuffers: 40,
+};
+
+describe('runtime metrics', () => {
+  let reader: TestMetricReader;
+  let provider: MeterProvider;
+  let stopCollecting: () => void;
+  let finishOperations: (() => void)[];
+
+  beforeEach(() => {
+    reader = new TestMetricReader();
+    provider = new MeterProvider({ readers: [reader] });
+    finishOperations = [];
+    vi.spyOn(process, 'memoryUsage').mockReturnValue(memoryUsage);
+    stopCollecting = initializeRuntimeMetrics(
+      provider.getMeter('test-runtime'),
+    );
+  });
+
+  afterEach(async () => {
+    for (const finish of finishOperations) finish();
+    stopCollecting();
+    await provider.shutdown();
+    vi.restoreAllMocks();
+  });
+
+  const collectMetrics = async () => {
+    const { resourceMetrics } = await reader.collect();
+    return resourceMetrics.scopeMetrics.flatMap((scope) => scope.metrics);
+  };
+
+  const collectValues = async (name: string) => {
+    const collected = await collectMetrics();
+    return collected
+      .find((metric) => metric.descriptor.name === name)
+      ?.dataPoints.map(({ value, attributes }) => ({ value, attributes }));
+  };
+
+  it('samples all memory fields once per collection with only fixed kind labels', async () => {
+    expect(process.memoryUsage).not.toHaveBeenCalled();
+
+    const collected = await collectMetrics();
+    const memory = collected.find(
+      (metric) => metric.descriptor.name === 'dial.chat.process.memory',
+    );
+
+    expect(process.memoryUsage).toHaveBeenCalledOnce();
+    expect(memory?.descriptor.unit).toBe('B');
+    expect(
+      memory?.dataPoints.map(({ value, attributes }) => ({
+        value,
+        attributes,
+      })),
+    ).toEqual([
+      { value: 500, attributes: { kind: 'rss' } },
+      { value: 100, attributes: { kind: 'heap_used' } },
+      { value: 200, attributes: { kind: 'heap_total' } },
+      { value: 80, attributes: { kind: 'external' } },
+      { value: 40, attributes: { kind: 'array_buffers' } },
+    ]);
+
+    vi.mocked(process.memoryUsage).mockReturnValue({
+      ...memoryUsage,
+      heapUsed: 150,
+    });
+    expect(await collectValues('dial.chat.process.memory')).toContainEqual({
+      value: 150,
+      attributes: { kind: 'heap_used' },
+    });
+    expect(process.memoryUsage).toHaveBeenCalledTimes(2);
+  });
+
+  it('exports explicit zero series before any subscriptions or generations exist', async () => {
+    expect(await collectValues('dial.chat.sse.active')).toEqual(
+      Object.values(SseSubscriptionKind).map((kind) => ({
+        value: 0,
+        attributes: { kind },
+      })),
+    );
+    expect(await collectValues('dial.chat.generations.active')).toEqual([
+      { value: 0, attributes: {} },
+    ]);
+  });
+
+  it('counts concurrent subscriptions independently by kind and ignores repeated completion', async () => {
+    const finishClient = trackSseSubscription(
+      SseSubscriptionKind.ClientChannel,
+    );
+    const finishOtherClient = trackSseSubscription(
+      SseSubscriptionKind.ClientChannel,
+    );
+    const finishWatch = trackSseSubscription(
+      SseSubscriptionKind.ConversationWatch,
+    );
+    const finishAttach = trackSseSubscription(
+      SseSubscriptionKind.GenerationAttach,
+    );
+    finishOperations.push(
+      finishClient,
+      finishOtherClient,
+      finishWatch,
+      finishAttach,
+    );
+
+    expect(await collectValues('dial.chat.sse.active')).toEqual([
+      { value: 2, attributes: { kind: SseSubscriptionKind.ClientChannel } },
+      { value: 1, attributes: { kind: SseSubscriptionKind.ConversationWatch } },
+      { value: 1, attributes: { kind: SseSubscriptionKind.GenerationAttach } },
+    ]);
+
+    finishClient();
+    finishClient();
+    finishWatch();
+    finishAttach();
+
+    expect(await collectValues('dial.chat.sse.active')).toEqual([
+      { value: 1, attributes: { kind: SseSubscriptionKind.ClientChannel } },
+      { value: 0, attributes: { kind: SseSubscriptionKind.ConversationWatch } },
+      { value: 0, attributes: { kind: SseSubscriptionKind.GenerationAttach } },
+    ]);
+  });
+
+  it('counts active generations independently of attached clients without operation labels', async () => {
+    const finishFirst = trackGeneration();
+    const finishSecond = trackGeneration();
+    const finishAttach = trackSseSubscription(
+      SseSubscriptionKind.GenerationAttach,
+    );
+    finishOperations.push(finishFirst, finishSecond, finishAttach);
+    finishAttach();
+
+    expect(await collectValues('dial.chat.generations.active')).toEqual([
+      { value: 2, attributes: {} },
+    ]);
+    finishFirst();
+    finishFirst();
+    expect(await collectValues('dial.chat.generations.active')).toEqual([
+      { value: 1, attributes: {} },
+    ]);
+    finishSecond();
+    expect(await collectValues('dial.chat.generations.active')).toEqual([
+      { value: 0, attributes: {} },
+    ]);
+  });
+
+  it('stops memory sampling when callbacks are removed and preserves live counts on reinitialization', async () => {
+    const finish = trackGeneration();
+    finishOperations.push(finish);
+    await collectMetrics();
+    vi.mocked(process.memoryUsage).mockClear();
+
+    stopCollecting();
+    stopCollecting();
+    await collectMetrics();
+    expect(process.memoryUsage).not.toHaveBeenCalled();
+
+    stopCollecting = initializeRuntimeMetrics(
+      provider.getMeter('test-runtime'),
+    );
+    expect(await collectValues('dial.chat.generations.active')).toEqual([
+      { value: 1, attributes: {} },
+    ]);
+    expect(process.memoryUsage).toHaveBeenCalledOnce();
+  });
+
+  it('tracks operation lifetimes without sampling memory when collection is disabled', () => {
+    stopCollecting();
+    const finishSubscription = trackSseSubscription(
+      SseSubscriptionKind.ClientChannel,
+    );
+    const finishGeneration = trackGeneration();
+    finishOperations.push(finishSubscription, finishGeneration);
+    finishSubscription();
+    finishGeneration();
+
+    expect(process.memoryUsage).not.toHaveBeenCalled();
+  });
+});

--- a/apps/chat-api/src/telemetry/tests/sse-subscription-metrics.spec.ts
+++ b/apps/chat-api/src/telemetry/tests/sse-subscription-metrics.spec.ts
@@ -1,0 +1,281 @@
+import { EventEmitter } from 'node:events';
+import { ConfigService } from '@nestjs/config';
+import { Test, type TestingModule } from '@nestjs/testing';
+import { MeterProvider, MetricReader } from '@opentelemetry/sdk-metrics';
+import type { Request, Response } from 'express';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { FeatureGuard } from '../../app-config/feature-flags/feature.guard';
+import { ClientChannelController } from '../../client-channel/client-channel.controller';
+import { ClientChannelService } from '../../client-channel/client-channel.service';
+import { ConversationGenerationService } from '../../conversations/conversation-generation.service';
+import { ConversationController } from '../../conversations/conversation.controller';
+import { ConversationService } from '../../conversations/conversation.service';
+import {
+  initializeRuntimeMetrics,
+  SseSubscriptionKind,
+} from '../runtime-metrics';
+
+class TestMetricReader extends MetricReader {
+  protected async onForceFlush(): Promise<void> {
+    /* Assertions collect observations directly. */
+  }
+
+  protected async onShutdown(): Promise<void> {
+    /* This reader owns no external resources. */
+  }
+}
+
+class TestResponse extends EventEmitter {
+  writableEnded = false;
+  setHeader = vi.fn();
+  flushHeaders = vi.fn();
+  write = vi.fn().mockReturnValue(true);
+  end = vi.fn(() => {
+    this.writableEnded = true;
+    return this;
+  });
+}
+
+const request = {
+  user: { at: 'test-token', bucket: 'test-bucket', sid: 'test-session' },
+} as unknown as Request;
+
+describe('SSE subscription metrics', () => {
+  let module: TestingModule;
+  let reader: TestMetricReader;
+  let provider: MeterProvider;
+  let stopMetrics: () => void;
+  let response: TestResponse;
+  let clientChannel: ClientChannelController;
+  let conversations: ConversationController;
+  const subscribe = vi.fn();
+  const watch = vi.fn();
+  const attach = vi.fn();
+
+  beforeEach(async () => {
+    vi.resetAllMocks();
+    reader = new TestMetricReader();
+    provider = new MeterProvider({ readers: [reader] });
+    stopMetrics = initializeRuntimeMetrics(
+      provider.getMeter('sse-metrics-test'),
+    );
+    response = new TestResponse();
+    module = await Test.createTestingModule({
+      controllers: [ClientChannelController, ConversationController],
+      providers: [
+        { provide: ClientChannelService, useValue: { subscribe } },
+        {
+          provide: ConversationService,
+          useValue: { watchConversation: watch },
+        },
+        { provide: ConversationGenerationService, useValue: { attach } },
+      ],
+    })
+      .overrideGuard(FeatureGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
+    clientChannel = module.get(ClientChannelController);
+    conversations = module.get(ConversationController);
+  });
+
+  afterEach(async () => {
+    response.emit('close');
+    stopMetrics();
+    await provider.shutdown();
+    await module.close();
+  });
+
+  const activeSubscriptions = async (kind: SseSubscriptionKind) => {
+    const { resourceMetrics } = await reader.collect();
+    return resourceMetrics.scopeMetrics
+      .flatMap((scope) => scope.metrics)
+      .find((metric) => metric.descriptor.name === 'dial.chat.sse.active')
+      ?.dataPoints.find((point) => point.attributes.kind === kind)?.value;
+  };
+
+  describe.each([
+    SseSubscriptionKind.ClientChannel,
+    SseSubscriptionKind.ConversationWatch,
+  ])('%s relay', (kind) => {
+    const upstream = () =>
+      kind === SseSubscriptionKind.ClientChannel ? subscribe : watch;
+    const result = (stream: ReadableStream<Uint8Array>) =>
+      kind === SseSubscriptionKind.ClientChannel
+        ? { stream, channelId: 'test-channel' }
+        : stream;
+    const invoke = () =>
+      kind === SseSubscriptionKind.ClientChannel
+        ? clientChannel.subscribe(
+            request,
+            response as unknown as Response,
+            undefined,
+          )
+        : conversations.watchConversation(
+            request,
+            response as unknown as Response,
+            {
+              path: 'test-path',
+            },
+          );
+
+    it('counts opening and streaming work until upstream completes', async () => {
+      let resolveOpening!: (value: unknown) => void;
+      upstream().mockReturnValue(
+        new Promise((resolve) => {
+          resolveOpening = resolve;
+        }),
+      );
+      let streamController!: ReadableStreamDefaultController<Uint8Array>;
+      const stream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          streamController = controller;
+        },
+      });
+
+      const pending = invoke();
+      expect(await activeSubscriptions(kind)).toBe(1);
+      resolveOpening(result(stream));
+      await vi.waitFor(() =>
+        expect(response.flushHeaders).toHaveBeenCalledOnce(),
+      );
+      expect(await activeSubscriptions(kind)).toBe(1);
+
+      streamController.close();
+      await pending;
+      expect(await activeSubscriptions(kind)).toBe(0);
+    });
+
+    it('releases the count when opening upstream fails', async () => {
+      upstream().mockRejectedValue(new Error('upstream unavailable'));
+
+      await expect(invoke()).rejects.toThrow('upstream unavailable');
+
+      expect(await activeSubscriptions(kind)).toBe(0);
+    });
+
+    it('releases the count after disconnect cancels a pending upstream read', async () => {
+      const cancel = vi.fn();
+      upstream().mockResolvedValue(result(new ReadableStream({ cancel })));
+      const pending = invoke();
+      await vi.waitFor(() =>
+        expect(response.flushHeaders).toHaveBeenCalledOnce(),
+      );
+      expect(await activeSubscriptions(kind)).toBe(1);
+
+      response.emit('close');
+      response.emit('close');
+      await pending;
+
+      expect(cancel).toHaveBeenCalledOnce();
+      expect(await activeSubscriptions(kind)).toBe(0);
+    });
+
+    it('keeps unfinished upstream setup visible after an early client close', async () => {
+      let rejectOpening!: (reason: Error) => void;
+      upstream().mockReturnValue(
+        new Promise((_resolve, reject) => {
+          rejectOpening = reject;
+        }),
+      );
+      const pending = invoke();
+
+      response.emit('close');
+      expect(await activeSubscriptions(kind)).toBe(1);
+
+      const rejected = expect(pending).rejects.toThrow('upstream unavailable');
+      rejectOpening(new Error('upstream unavailable'));
+      await rejected;
+      expect(await activeSubscriptions(kind)).toBe(0);
+    });
+  });
+
+  describe('generation attachment', () => {
+    const invoke = () =>
+      conversations.attachToGeneration(
+        request,
+        response as unknown as Response,
+        {
+          path: 'test-path',
+        },
+      );
+
+    it('counts the live subscription after the controller returns and releases on terminal', async () => {
+      const emitter = new EventEmitter();
+      attach.mockReturnValue({ emitter, assembledMessage: { content: '' } });
+
+      await invoke();
+      expect(
+        await activeSubscriptions(SseSubscriptionKind.GenerationAttach),
+      ).toBe(1);
+
+      emitter.emit('terminal', { type: 'done' });
+      response.emit('close');
+      expect(
+        await activeSubscriptions(SseSubscriptionKind.GenerationAttach),
+      ).toBe(0);
+      expect(emitter.listenerCount('chunk')).toBe(0);
+      expect(emitter.listenerCount('terminal')).toBe(0);
+    });
+
+    it('releases on client close without waiting for generation completion', async () => {
+      const emitter = new EventEmitter();
+      attach.mockReturnValue({ emitter, assembledMessage: { content: '' } });
+      await invoke();
+
+      response.emit('close');
+      response.emit('close');
+
+      expect(
+        await activeSubscriptions(SseSubscriptionKind.GenerationAttach),
+      ).toBe(0);
+      expect(emitter.listenerCount('terminal')).toBe(0);
+    });
+
+    it('does not count a missing generation as a subscription', async () => {
+      attach.mockReturnValue(null);
+
+      await expect(invoke()).rejects.toThrow('No active generation');
+
+      expect(
+        await activeSubscriptions(SseSubscriptionKind.GenerationAttach),
+      ).toBe(0);
+    });
+
+    it('closes live attachments and releases their count when the generation module shuts down', async () => {
+      const generationModule = await Test.createTestingModule({
+        controllers: [ConversationController],
+        providers: [
+          ConversationGenerationService,
+          { provide: ConfigService, useValue: { get: () => 1_800_000 } },
+          { provide: ConversationService, useValue: {} },
+        ],
+      }).compile();
+
+      try {
+        const service = generationModule.get(ConversationGenerationService);
+        service.register('test-session', 'test-path', 'test-generation');
+        await generationModule
+          .get(ConversationController)
+          .attachToGeneration(request, response as unknown as Response, {
+            path: 'test-path',
+          });
+        expect(
+          await activeSubscriptions(SseSubscriptionKind.GenerationAttach),
+        ).toBe(1);
+
+        await generationModule.close();
+
+        expect(response.write).toHaveBeenCalledWith(
+          'data: {"type":"stopped"}\n\n',
+        );
+        expect(response.writableEnded).toBe(true);
+        expect(response.listenerCount('close')).toBe(0);
+        expect(
+          await activeSubscriptions(SseSubscriptionKind.GenerationAttach),
+        ).toBe(0);
+      } finally {
+        await generationModule.close();
+      }
+    });
+  });
+});

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -279,8 +279,10 @@ Configured at startup:
 - OpenTelemetry SDK bootstrap (`telemetry/otel-sdk.ts`, imported first, before `reflect-metadata`)
   — off by default (`OTEL_SDK_DISABLED=true`); when enabled, adds a `traceparent` response header
   on traced routes and an optional dedicated Prometheus scrape listener (default `:9464/metrics`,
-  independent of the main application port) — see `apps/chat-api/README.md`'s Observability
-  section
+  independent of the main application port). Metrics include process memory, outstanding SSE
+  operations, and generation registry size, collected in the serving process; see
+  [backend observability](../apps/chat-api/README.md#observability) and
+  [runtime memory diagnostics](../apps/chat-api/README.md#runtime-memory-diagnostics).
 
 NestJS conventions (domain structure, thin controllers, Swagger decorators, Logger, ConfigService, DTO validation) are defined in `apps/chat-api/AGENTS.md` — read it before implementing anything in `apps/chat-api/**`.
 

--- a/openspec/specs/observability-telemetry/spec.md
+++ b/openspec/specs/observability-telemetry/spec.md
@@ -242,3 +242,88 @@ histogram.
 - **WHEN** metrics are enabled
 - **THEN** `MetricsInterceptor`'s histogram is the only emitter of HTTP server request duration
   data points for the application
+
+### Requirement: Runtime gauges follow metrics enablement and lifecycle
+The telemetry bootstrap SHALL register runtime memory and active-operation collection callbacks
+after SDK startup only when at least one metrics exporter is enabled. Runtime gauges SHALL use
+the existing metric readers and SHALL NOT introduce a separate sampling timer, environment
+variable, or HTTP endpoint. Shutdown SHALL remove the collection callbacks.
+
+#### Scenario: Metrics enabled independently of traces and logs
+- **WHEN** the application starts with `OTEL_SDK_DISABLED=false`,
+  `OTEL_METRICS_EXPORTER=prometheus`, `OTEL_TRACES_EXPORTER=none`, and `OTEL_LOGS_EXPORTER=none`
+- **THEN** the existing Prometheus listener exposes the runtime gauges
+- **AND** trace and log export remain disabled
+
+#### Scenario: Runtime observations disabled
+- **WHEN** the SDK is disabled or `OTEL_METRICS_EXPORTER=none`
+- **THEN** runtime collection callbacks are not registered
+- **AND** metric collection does not sample process memory
+
+#### Scenario: Runtime collection stops on shutdown
+- **WHEN** the telemetry shutdown routine runs
+- **THEN** runtime collection callbacks are removed
+
+### Requirement: Memory observed inside the serving Node.js process
+The application SHALL expose the observable gauge `dial.chat.process.memory` with unit `B`,
+exported by Prometheus as `dial_chat_process_memory`. Each collection SHALL call
+`process.memoryUsage()` once in the Node.js process serving Nest requests and observe five
+points using the fixed `kind` values `rss`, `heap_used`, `heap_total`, `external`, and
+`array_buffers`, respectively mapped to `rss`, `heapUsed`, `heapTotal`, `external`, and
+`arrayBuffers`. The values SHALL be reported independently without summation because
+`arrayBuffers` is included in `external` and the memory categories overlap.
+
+#### Scenario: One consistent memory sample per collection
+- **WHEN** a metric reader collects runtime gauges
+- **THEN** all five memory points come from one `process.memoryUsage()` result
+- **AND** each point reports the corresponding byte value with its fixed `kind` attribute
+
+### Requirement: Outstanding SSE operations observed by lifecycle
+The application SHALL expose the observable gauge `dial.chat.sse.active`, exported by Prometheus
+as `dial_chat_sse_active`, with only the fixed `kind` values `client_channel`,
+`conversation_watch`, and `generation_attach`. Client-channel subscribe and conversation-watch
+operations SHALL count from before asynchronous setup until their handlers settle. Generation
+attach operations SHALL count until subscription cleanup, including after the handler returns.
+Cleanup SHALL release each operation's contribution at most once. Ordinary completion-response
+delivery SHALL NOT contribute to this SSE gauge.
+
+#### Scenario: Subscribe or watch setup is pending
+- **WHEN** a client-channel subscription or conversation watch is awaiting upstream setup
+- **THEN** its kind's gauge includes the operation
+- **AND** a client disconnect alone does not remove it while the asynchronous handler is pending
+
+#### Scenario: Subscribe or watch settles
+- **WHEN** the asynchronous handler completes or fails
+- **THEN** its contribution is removed exactly once
+
+#### Scenario: Attached generation outlives the handler
+- **WHEN** a generation attach handler returns with its subscription still active
+- **THEN** `generation_attach` continues to include that subscription
+- **AND** its contribution is removed exactly once when subscription cleanup runs
+
+#### Scenario: Shutdown releases attached generation subscriptions
+- **WHEN** the application shuts down with registered generations and attached subscriptions
+- **THEN** the generations emit a stopped terminal event
+- **AND** the attached subscriptions run their cleanup and release their gauge contributions
+
+### Requirement: Generation gauge reflects the physical registry
+The application SHALL expose the observable gauge `dial.chat.generations.active`, exported by
+Prometheus as `dial_chat_generations_active`, with no application attributes. It SHALL report
+the number of entries physically retained in the generation registry, including stopped or
+aborted entries awaiting persistence. Entry insertion, removal, replacement, and shutdown SHALL
+keep the gauge consistent with registry ownership. The gauge SHALL NOT claim to count upstream
+tasks that outlive their registry entries.
+
+#### Scenario: Generation remains registered during persistence
+- **WHEN** a stopped or aborted generation is still registered while persistence is pending
+- **THEN** it continues to contribute to the generation gauge
+
+#### Scenario: Registry entry released or replaced
+- **WHEN** an entry is removed on completion, error, stale eviction, replacement, or shutdown
+- **THEN** the removed entry no longer contributes to the gauge
+- **AND** replacement with a new entry for the same registry key does not double count the key
+
+#### Scenario: Runtime metrics do not contain unbounded identifiers
+- **WHEN** runtime memory and active-operation gauges are collected
+- **THEN** their application attributes contain only the specified fixed `kind` values, where applicable
+- **AND** they contain no user, conversation, deployment, or Kubernetes pod identifiers


### PR DESCRIPTION
## Description of changes

Add opt-in OpenTelemetry runtime gauges for the Nest process's RSS, V8 heap, external memory, and ArrayBuffer memory, together with outstanding SSE operations and retained generation registry entries. The metrics use fixed labels only and sample memory during collection, so they retain no request data and add no timer, endpoint, dependency, or environment variable.

Track pending subscribe/watch setup and generation attachments through their cleanup paths, making stuck work visible even after a browser disconnects. Application shutdown now sends a terminal event to generation attachments so their SSE responses and keepalive timers are released.

## Validation

- `npm exec nx test chat-api`: 181 test files and 3,054 tests passed.
- `npm exec nx lint chat-api` and `npm exec nx build chat-api` passed.
- Verified actual Prometheus scrape names and labels: `dial_chat_process_memory`, `dial_chat_sse_active`, and `dial_chat_generations_active`.
- `npm run validate:docs` and strict validation of `observability-telemetry` OpenSpec passed.

## UI changes

No UI changes.

## Checklist

- [ ] the pull request name ends with a linked issue number (no linked issue provided)
- [x] I confirm that I don't share any confidential information like API keys or any other secrets and private URLs
