### PR TITLE
fix(chat-api): close SSE stream lifecycle leaks in client-channel, watch, completions, and attach

### DIFF
--- a/apps/chat-api/README.md
+++ b/apps/chat-api/README.md
@@ -590,6 +590,9 @@ property so a client failure can be correlated with server traces and logs.
 - **Cache-Control Headers**: HTTP caching directives for browser/CDN caching
 - **Request Timeouts**: Configurable timeouts for external service calls with AbortController
 - **Metrics Logging**: Request duration and status tracking for monitoring
+- **SSE stream lifecycle**: All four SSE-writing handlers share the backpressure helper in `common/utils/sse.ts` (`writeSseChunk`/`waitForDrain`) instead of ignoring `res.write()`'s return value.
+  - `client-channel/subscribe` and `conversations/watch` relay an upstream DIAL Core stream. Each constructs its `AbortController` and registers `res.on('close', ...)` **before** the first `await` of upstream setup, so a browser disconnect during that await aborts the pending upstream call immediately instead of only being observed once it resolves. While relaying, a `res.write()` that returns `false` pauses further upstream reads until `'drain'`, the response closing, an upstream error, or `SSE_DRAIN_TIMEOUT_MS` (5000ms) elapses — whichever comes first. If the timeout elapses first, the connection is treated as stalled: the upstream reader is cancelled and the response ends, the same as an explicit disconnect.
+  - `conversations/completions` (`streamCompletion`) and `conversations/completions/attach` (`attachToGeneration`) never pause or abort their backend-owned generation for a slow client. After each write, if the response's buffered bytes (`res.writableLength`) exceed `SSE_COMPLETION_MAX_BUFFERED_BYTES` / `SSE_ATTACH_MAX_BUFFERED_BYTES` (1 MiB each), the handler stops writing to that one response (marking it detached / running its existing cleanup) while the generation keeps running and persists normally — see `docs/` for the generation-independent-of-connection guarantee.
 
 ## Testing
 

--- a/apps/chat-api/src/client-channel/client-channel.controller.ts
+++ b/apps/chat-api/src/client-channel/client-channel.controller.ts
@@ -15,7 +15,12 @@ import { FeatureKey } from '../app-config/feature-flags/feature-key.enum';
 import { FeatureGuard } from '../app-config/feature-flags/feature.guard';
 import { RequireFeature } from '../app-config/feature-flags/require-feature.decorator';
 import type { SessionUser } from '../auth/session/session.types';
-import { startSseResponse } from '../common/utils/sse';
+import {
+  SSE_DRAIN_TIMEOUT_MS,
+  startSseResponse,
+  waitForDrain,
+  writeSseChunk,
+} from '../common/utils/sse';
 import {
   SseSubscriptionKind,
   trackSseSubscription,
@@ -86,6 +91,19 @@ export class ClientChannelController {
       SseSubscriptionKind.ClientChannel,
     );
 
+    let isClientAborted = false;
+    let isReaderReleased = false;
+    let reader: ReadableStreamDefaultReader<Uint8Array> | undefined;
+
+    const handleClose = () => {
+      isClientAborted = true;
+      abortController.abort();
+      if (reader && !isReaderReleased) {
+        void reader.cancel().catch(() => undefined);
+      }
+    };
+    res.on('close', handleClose);
+
     try {
       this.logger.debug('[timing] subscribe request received by BFF');
       const { stream, channelId } = await this.clientChannelService.subscribe(
@@ -97,21 +115,15 @@ export class ClientChannelController {
         `[timing] subscribe request headers about to flush — channelId: ${channelId}`,
       );
 
+      if (isClientAborted) {
+        await stream.cancel().catch(() => undefined);
+        return;
+      }
+
       res.setHeader(CHANNEL_ID_HEADER, channelId);
       startSseResponse(res);
 
-      const reader = stream.getReader();
-      let isClientAborted = false;
-      let isReaderReleased = false;
-
-      const handleClose = () => {
-        isClientAborted = true;
-        abortController.abort();
-        if (!isReaderReleased) {
-          void reader.cancel().catch(() => undefined);
-        }
-      };
-      res.on('close', handleClose);
+      reader = stream.getReader();
 
       try {
         while (true) {
@@ -120,7 +132,20 @@ export class ClientChannelController {
           const { done, value } = await reader.read();
           if (done) break;
 
-          res.write(value);
+          const { needsDrain } = writeSseChunk(res, value);
+          if (needsDrain) {
+            const outcome = await waitForDrain(
+              res,
+              abortController.signal,
+              SSE_DRAIN_TIMEOUT_MS,
+            );
+            if (outcome === 'timeout') {
+              isClientAborted = true;
+              void reader.cancel().catch(() => undefined);
+              break;
+            }
+            if (outcome === 'aborted') break;
+          }
         }
       } catch (err) {
         if (!isClientAborted) {
@@ -130,7 +155,6 @@ export class ClientChannelController {
           );
         }
       } finally {
-        res.off('close', handleClose);
         isReaderReleased = true;
         reader.releaseLock();
         if (!res.writableEnded) {
@@ -138,6 +162,7 @@ export class ClientChannelController {
         }
       }
     } finally {
+      res.off('close', handleClose);
       finishSubscription();
     }
   }

--- a/apps/chat-api/src/client-channel/tests/client-channel.controller.spec.ts
+++ b/apps/chat-api/src/client-channel/tests/client-channel.controller.spec.ts
@@ -1,3 +1,4 @@
+import { EventEmitter } from 'node:events';
 import {
   BadGatewayException,
   INestApplication,
@@ -5,11 +6,23 @@ import {
   VersioningType,
 } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
+import type { Request, Response } from 'express';
 import request from 'supertest';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { FeatureGuard } from '../../app-config/feature-flags/feature.guard';
 import { ClientChannelController } from '../client-channel.controller';
 import { ClientChannelService } from '../client-channel.service';
+
+class TestResponse extends EventEmitter {
+  writableEnded = false;
+  setHeader = vi.fn();
+  flushHeaders = vi.fn();
+  write = vi.fn().mockReturnValue(true);
+  end = vi.fn(() => {
+    this.writableEnded = true;
+    return this;
+  });
+}
 
 const TEST_USER = { at: 'test-access-token' };
 
@@ -150,6 +163,95 @@ describe('ClientChannelController (integration)', () => {
         .set('X-DIAL-CLIENT-CHANNEL-ID', 'bad;channel')
         .expect(400);
       expect(service.subscribe).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('subscribe — early close and backpressure (direct controller)', () => {
+    const request_ = {
+      user: { at: 'test-access-token' },
+    } as unknown as Request;
+    let controller: ClientChannelController;
+    let response: TestResponse;
+    let subscribe: ReturnType<typeof vi.fn>;
+
+    beforeEach(async () => {
+      response = new TestResponse();
+      subscribe = vi.fn();
+      const module: TestingModule = await Test.createTestingModule({
+        controllers: [ClientChannelController],
+        providers: [{ provide: ClientChannelService, useValue: { subscribe } }],
+      })
+        .overrideGuard(FeatureGuard)
+        .useValue({ canActivate: () => true })
+        .compile();
+      controller = module.get(ClientChannelController);
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('aborts the pending upstream call and never starts a reader when the client disconnects during setup', async () => {
+      let capturedSignal: AbortSignal | undefined;
+      const cancel = vi.fn();
+      subscribe.mockImplementation(
+        (_at: string, _channelId: string | undefined, signal: AbortSignal) => {
+          capturedSignal = signal;
+          return new Promise((resolve) => {
+            signal.addEventListener('abort', () => {
+              resolve({
+                stream: new ReadableStream({ cancel }),
+                channelId: 'channel-1',
+              });
+            });
+          });
+        },
+      );
+
+      const pending = controller.subscribe(
+        request_,
+        response as unknown as Response,
+        undefined,
+      );
+
+      response.emit('close');
+      await pending;
+
+      expect(capturedSignal?.aborted).toBe(true);
+      expect(response.setHeader).not.toHaveBeenCalled();
+      expect(response.flushHeaders).not.toHaveBeenCalled();
+      expect(cancel).toHaveBeenCalledOnce();
+    });
+
+    it('closes a stalled connection after the drain timeout and cancels the upstream reader', async () => {
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+      response.write = vi.fn().mockReturnValue(false);
+      const cancel = vi.fn().mockResolvedValue(undefined);
+      let pullCount = 0;
+      const stream = new ReadableStream<Uint8Array>({
+        pull(streamController) {
+          pullCount += 1;
+          streamController.enqueue(new TextEncoder().encode('data: x\n\n'));
+        },
+        cancel,
+      });
+      subscribe.mockResolvedValue({ stream, channelId: 'channel-1' });
+
+      const pending = controller.subscribe(
+        request_,
+        response as unknown as Response,
+        undefined,
+      );
+
+      await vi.waitFor(() =>
+        expect(response.write.mock.calls.length).toBeGreaterThanOrEqual(2),
+      );
+      await vi.advanceTimersByTimeAsync(5000);
+      await pending;
+
+      expect(cancel).toHaveBeenCalledOnce();
+      expect(response.end).toHaveBeenCalledOnce();
+      expect(pullCount).toBeGreaterThanOrEqual(1);
     });
   });
 

--- a/apps/chat-api/src/common/utils/sse.ts
+++ b/apps/chat-api/src/common/utils/sse.ts
@@ -36,3 +36,76 @@ export const startSseResponse = (res: Response): void => {
   res.flushHeaders();
   res.write(SSE_INIT_PAYLOAD);
 };
+
+/**
+ * How long an upstream-relaying SSE handler (client-channel subscribe,
+ * conversation watch) waits for `'drain'` after `res.write()` signals
+ * backpressure before treating the connection as stalled and closing it —
+ * the same as an explicit client disconnect.
+ */
+export const SSE_DRAIN_TIMEOUT_MS = 5000;
+
+export interface SseWriteResult {
+  /** False only when the response was already ended/detached. */
+  written: boolean;
+  /** True when `res.write()` returned `false` — the caller must wait for `'drain'` before writing more. */
+  needsDrain: boolean;
+}
+
+/**
+ * Wraps `res.write()` so every SSE handler shares the same backpressure
+ * signal instead of four bespoke checks of its boolean return value.
+ */
+export const writeSseChunk = (
+  res: Response,
+  chunk: Uint8Array | string,
+): SseWriteResult => {
+  if (res.writableEnded) {
+    return { written: false, needsDrain: false };
+  }
+
+  const needsDrain = !res.write(chunk);
+  return { written: true, needsDrain };
+};
+
+/**
+ * Resolves on whichever comes first: the response's `'drain'` event, the
+ * given `signal` aborting (connection closed / upstream error), or
+ * `timeoutMs` elapsing. Always tears down its own listeners/timer before
+ * resolving, on every branch, so a caller can safely call this repeatedly
+ * across a long-lived relay loop without leaking listeners.
+ */
+export const waitForDrain = (
+  res: Response,
+  signal: AbortSignal,
+  timeoutMs: number,
+): Promise<'drained' | 'timeout' | 'aborted'> =>
+  new Promise((resolve) => {
+    let isSettled = false;
+
+    const cleanup = (): void => {
+      clearTimeout(timer);
+      res.off('drain', onDrain);
+      signal.removeEventListener('abort', onAbort);
+    };
+
+    const settle = (result: 'drained' | 'timeout' | 'aborted'): void => {
+      if (isSettled) return;
+      isSettled = true;
+      cleanup();
+      resolve(result);
+    };
+
+    const onDrain = (): void => settle('drained');
+    const onAbort = (): void => settle('aborted');
+
+    const timer = setTimeout(() => settle('timeout'), timeoutMs);
+
+    if (signal.aborted) {
+      settle('aborted');
+      return;
+    }
+
+    res.once('drain', onDrain);
+    signal.addEventListener('abort', onAbort);
+  });

--- a/apps/chat-api/src/common/utils/tests/sse.spec.ts
+++ b/apps/chat-api/src/common/utils/tests/sse.spec.ts
@@ -1,0 +1,119 @@
+import { Writable } from 'node:stream';
+import type { Response } from 'express';
+import { describe, expect, it } from 'vitest';
+import { waitForDrain, writeSseChunk } from '../sse';
+
+/**
+ * A real Node `Writable` with a tiny `highWaterMark` and a `write` that
+ * withholds its callback until `flush()` is called, so `write()` genuinely
+ * returns `false` and a later `'drain'` genuinely fires — not a mocked
+ * boolean.
+ */
+const createStalledWritable = (): {
+  writable: Writable;
+  flush: () => void;
+} => {
+  const pendingCallbacks: Array<() => void> = [];
+  const writable = new Writable({
+    highWaterMark: 1,
+    write(_chunk, _encoding, callback) {
+      pendingCallbacks.push(callback);
+    },
+  });
+  return {
+    writable,
+    flush: () => {
+      const callbacks = pendingCallbacks.splice(0);
+      callbacks.forEach((callback) => callback());
+    },
+  };
+};
+
+describe('writeSseChunk', () => {
+  it('reports needsDrain: true when the underlying Writable returns false', () => {
+    const { writable } = createStalledWritable();
+    const res = writable as unknown as Response;
+
+    const first = writeSseChunk(res, 'a'.repeat(10));
+
+    expect(first.written).toBe(true);
+    expect(first.needsDrain).toBe(true);
+  });
+
+  it('reports needsDrain: false when the Writable accepts the chunk immediately', () => {
+    const writable = new Writable({
+      write(_chunk, _encoding, callback) {
+        callback();
+      },
+    });
+    const res = writable as unknown as Response;
+
+    const result = writeSseChunk(res, 'small');
+
+    expect(result.written).toBe(true);
+    expect(result.needsDrain).toBe(false);
+  });
+
+  it('reports written: false without writing when the response already ended', async () => {
+    const writable = new Writable({
+      write(_chunk, _encoding, callback) {
+        callback();
+      },
+    });
+    const res = writable as unknown as Response;
+    writable.end();
+    await new Promise((resolve) => writable.once('finish', resolve));
+
+    const result = writeSseChunk(res, 'chunk');
+
+    expect(result).toEqual({ written: false, needsDrain: false });
+  });
+});
+
+describe('waitForDrain', () => {
+  it('resolves "drained" on a real drain event', async () => {
+    const { writable, flush } = createStalledWritable();
+    const res = writable as unknown as Response;
+    writeSseChunk(res, 'a'.repeat(10));
+
+    const pending = waitForDrain(res, new AbortController().signal, 1000);
+    flush();
+
+    await expect(pending).resolves.toBe('drained');
+  });
+
+  it('resolves "aborted" when the signal fires before drain or timeout', async () => {
+    const { writable } = createStalledWritable();
+    const res = writable as unknown as Response;
+    writeSseChunk(res, 'a'.repeat(10));
+
+    const controller = new AbortController();
+    const pending = waitForDrain(res, controller.signal, 1000);
+    controller.abort();
+
+    await expect(pending).resolves.toBe('aborted');
+  });
+
+  it('resolves "timeout" when neither drain nor abort happens in time', async () => {
+    const { writable } = createStalledWritable();
+    const res = writable as unknown as Response;
+    writeSseChunk(res, 'a'.repeat(10));
+
+    const result = await waitForDrain(res, new AbortController().signal, 10);
+
+    expect(result).toBe('timeout');
+  });
+
+  it('removes its drain/abort/timer listeners once settled', async () => {
+    const { writable, flush } = createStalledWritable();
+    const res = writable as unknown as Response;
+    writeSseChunk(res, 'a'.repeat(10));
+
+    const controller = new AbortController();
+    const pending = waitForDrain(res, controller.signal, 1000);
+    flush();
+    await pending;
+
+    expect(writable.listenerCount('drain')).toBe(0);
+  });
+});

--- a/apps/chat-api/src/conversations/conversation.controller.ts
+++ b/apps/chat-api/src/conversations/conversation.controller.ts
@@ -21,7 +21,13 @@ import {
   getJobTitleClaim,
   type SessionUser,
 } from '../auth/session/session.types';
-import { SSE_KEEPALIVE_PAYLOAD, startSseResponse } from '../common/utils/sse';
+import {
+  SSE_DRAIN_TIMEOUT_MS,
+  SSE_KEEPALIVE_PAYLOAD,
+  startSseResponse,
+  waitForDrain,
+  writeSseChunk,
+} from '../common/utils/sse';
 import {
   ConversationMetadataDto,
   ConversationResponseDto,
@@ -64,6 +70,23 @@ import {
 } from './utils/timezone-header';
 
 const SSE_KEEPALIVE_INTERVAL_MS = 15_000;
+
+/**
+ * Bounds per-connection buffered output for `streamCompletion`. Past this
+ * many bytes buffered in `res`, the handler stops writing to that response
+ * (marking it detached, the same as a client disconnect) without pausing or
+ * aborting the backend-owned generation loop. See
+ * `backend-owned-generation-persistence`.
+ */
+const SSE_COMPLETION_MAX_BUFFERED_BYTES = 1024 * 1024;
+
+/**
+ * Bounds per-subscriber buffered output for `attachToGeneration`. Past this
+ * many bytes buffered in a subscriber's `res`, that subscriber is detached
+ * (its own cleanup runs) without affecting the generation or any other
+ * concurrently attached subscriber. See `generation-live-replay`.
+ */
+const SSE_ATTACH_MAX_BUFFERED_BYTES = 1024 * 1024;
 
 @ApiTags('conversations')
 @Controller({ path: 'conversations', version: '1' })
@@ -313,7 +336,10 @@ export class ConversationController {
       for await (const chunk of stream) {
         if (isResponseDetached) continue;
         try {
-          res.write(chunk);
+          writeSseChunk(res, chunk);
+          if (res.writableLength > SSE_COMPLETION_MAX_BUFFERED_BYTES) {
+            isResponseDetached = true;
+          }
         } catch {
           isResponseDetached = true;
         }
@@ -394,21 +420,32 @@ export class ConversationController {
 
     startSseResponse(res);
 
-    const writeEvent = (payload: unknown): void => {
-      if (res.writableEnded) return;
-      res.write(`data: ${JSON.stringify(payload)}\n\n`);
-    };
-
-    writeEvent({ type: 'snapshot', message: attachment.assembledMessage });
-
-    const keepaliveTimer = setInterval(() => {
-      if (!res.writableEnded) res.write(SSE_KEEPALIVE_PAYLOAD);
-    }, SSE_KEEPALIVE_INTERVAL_MS);
     const finishSubscription = trackSseSubscription(
       SseSubscriptionKind.GenerationAttach,
     );
 
     let isCleanedUp = false;
+    const timers: { keepalive?: ReturnType<typeof setInterval> } = {};
+
+    const cleanup = (): void => {
+      if (isCleanedUp) return;
+      isCleanedUp = true;
+      finishSubscription();
+      if (timers.keepalive) clearInterval(timers.keepalive);
+      attachment.emitter.off('chunk', onChunk);
+      attachment.emitter.off('terminal', onTerminal);
+      res.off('close', handleClose);
+      if (!res.writableEnded) res.end();
+    };
+
+    const writeEvent = (payload: unknown): void => {
+      if (isCleanedUp || res.writableEnded) return;
+      writeSseChunk(res, `data: ${JSON.stringify(payload)}\n\n`);
+      if (res.writableLength > SSE_ATTACH_MAX_BUFFERED_BYTES) {
+        cleanup();
+      }
+    };
+
     const onChunk = (rawChunk: unknown): void => {
       writeEvent({ type: 'chunk', chunk: rawChunk });
     };
@@ -419,16 +456,13 @@ export class ConversationController {
     const handleClose = (): void => {
       cleanup();
     };
-    const cleanup = (): void => {
-      if (isCleanedUp) return;
-      isCleanedUp = true;
-      finishSubscription();
-      clearInterval(keepaliveTimer);
-      attachment.emitter.off('chunk', onChunk);
-      attachment.emitter.off('terminal', onTerminal);
-      res.off('close', handleClose);
-      if (!res.writableEnded) res.end();
-    };
+
+    writeEvent({ type: 'snapshot', message: attachment.assembledMessage });
+    if (isCleanedUp) return;
+
+    timers.keepalive = setInterval(() => {
+      writeSseChunk(res, SSE_KEEPALIVE_PAYLOAD);
+    }, SSE_KEEPALIVE_INTERVAL_MS);
 
     /*
      * Subscribing here — synchronously, right after `attach()` read the
@@ -462,38 +496,48 @@ export class ConversationController {
     const finishSubscription = trackSseSubscription(
       SseSubscriptionKind.ConversationWatch,
     );
+
+    const abortController = new AbortController();
+    let isClientAborted = false;
+    let isReaderReleased = false;
+    let isCancelRequested = false;
+    let reader: ReadableStreamDefaultReader<Uint8Array> | undefined;
+
+    const handleClose = () => {
+      isClientAborted = true;
+      abortController.abort();
+      if (isReaderReleased || isCancelRequested || !reader) {
+        return;
+      }
+
+      isCancelRequested = true;
+      void reader.cancel().catch(() => undefined);
+    };
+
+    res.on('close', handleClose);
+
     try {
       const stream = await this.conversationService.watchConversation(
         dto.path,
         at,
         bucket,
+        abortController.signal,
       );
+
+      if (isClientAborted) {
+        await stream.cancel().catch(() => undefined);
+        return;
+      }
 
       startSseResponse(res);
 
-      const reader = stream.getReader();
-
-      let isClientAborted = false;
-      let isReaderReleased = false;
-      let isCancelRequested = false;
-
-      const handleClose = () => {
-        isClientAborted = true;
-        if (isReaderReleased || isCancelRequested) {
-          return;
-        }
-
-        isCancelRequested = true;
-        void reader.cancel().catch(() => undefined);
-      };
-
-      res.on('close', handleClose);
+      reader = stream.getReader();
 
       let keepaliveTimer: ReturnType<typeof setInterval> | null = null;
       try {
         keepaliveTimer = setInterval(() => {
           if (!isClientAborted && !res.writableEnded) {
-            res.write(SSE_KEEPALIVE_PAYLOAD);
+            writeSseChunk(res, SSE_KEEPALIVE_PAYLOAD);
           }
         }, SSE_KEEPALIVE_INTERVAL_MS);
 
@@ -503,7 +547,20 @@ export class ConversationController {
           const { done, value } = await reader.read();
           if (done) break;
 
-          res.write(value);
+          const { needsDrain } = writeSseChunk(res, value);
+          if (needsDrain) {
+            const outcome = await waitForDrain(
+              res,
+              abortController.signal,
+              SSE_DRAIN_TIMEOUT_MS,
+            );
+            if (outcome === 'timeout') {
+              isClientAborted = true;
+              void reader.cancel().catch(() => undefined);
+              break;
+            }
+            if (outcome === 'aborted') break;
+          }
         }
       } catch (err) {
         if (!isClientAborted) {
@@ -514,7 +571,6 @@ export class ConversationController {
         }
       } finally {
         if (keepaliveTimer) clearInterval(keepaliveTimer);
-        res.off('close', handleClose);
         isReaderReleased = true;
         reader.releaseLock();
         if (!res.writableEnded) {
@@ -522,6 +578,7 @@ export class ConversationController {
         }
       }
     } finally {
+      res.off('close', handleClose);
       finishSubscription();
     }
   }

--- a/apps/chat-api/src/conversations/streaming/conversation-streaming.service.ts
+++ b/apps/chat-api/src/conversations/streaming/conversation-streaming.service.ts
@@ -143,6 +143,7 @@ export class ConversationStreamingService {
     conversationPath: string,
     token: string,
     sessionBucket: string,
+    signal: AbortSignal,
   ): Promise<ReadableStream<Uint8Array>> {
     const { bucket, subPath } = resolveConversationLocation(
       qualifySessionConversationPath(conversationPath, sessionBucket),
@@ -164,6 +165,7 @@ export class ConversationStreamingService {
           Accept: 'text/event-stream',
         },
         parseAs: 'stream',
+        signal,
       })) as { response: globalThis.Response; error?: unknown };
 
       if (!result.response.ok || !result.response.body) {

--- a/apps/chat-api/src/conversations/tests/attach-generation-backpressure.spec.ts
+++ b/apps/chat-api/src/conversations/tests/attach-generation-backpressure.spec.ts
@@ -1,0 +1,119 @@
+import { EventEmitter } from 'node:events';
+import type { ConfigService } from '@nestjs/config';
+import type { Request, Response } from 'express';
+import { describe, expect, it, vi } from 'vitest';
+import { ConversationGenerationService } from '../conversation-generation.service';
+import { ConversationController } from '../conversation.controller';
+import { ConversationService } from '../conversation.service';
+import {
+  ConversationMessageDto,
+  ConversationMessageRole,
+} from '../dto/conversation-message.dto';
+
+/**
+ * A minimal `Response`-shaped `EventEmitter` whose `writableLength` is
+ * driven manually per instance: `drains: true` resets it to 0 after every
+ * write (a well-behaved subscriber), `drains: false` accumulates it (a
+ * subscriber whose connection cannot keep up), mirroring how a real
+ * `Writable` would behave under those two conditions.
+ */
+class FakeAttachResponse extends EventEmitter {
+  writableEnded = false;
+  writableLength = 0;
+  setHeader = vi.fn();
+  flushHeaders = vi.fn();
+  end = vi.fn(() => {
+    this.writableEnded = true;
+    return this;
+  });
+  write = vi.fn((chunk: unknown) => {
+    if (this.writableEnded) return false;
+    if (this.drains) {
+      this.writableLength = 0;
+    } else {
+      this.writableLength += Buffer.byteLength(String(chunk));
+    }
+    return true;
+  });
+
+  constructor(private readonly drains: boolean) {
+    super();
+  }
+}
+
+const SID = 'test-sid';
+const PATH = 'test-bucket/gpt-4o__Hello__uuid';
+const GEN_ID = 'aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaaa';
+
+const makeMessage = (content: string): ConversationMessageDto => ({
+  role: ConversationMessageRole.Assistant,
+  content,
+  timestamp: '2026-01-01T00:00:00.000Z',
+});
+
+const makeController = (): {
+  controller: ConversationController;
+  generationService: ConversationGenerationService;
+} => {
+  const generationService = new ConversationGenerationService({
+    get: () => undefined,
+  } as unknown as ConfigService);
+  const controller = new ConversationController(
+    {} as unknown as ConversationService,
+    generationService,
+  );
+  return { controller, generationService };
+};
+
+describe('attachToGeneration — per-subscriber backpressure', () => {
+  it('detaches a slow subscriber once its buffered output exceeds the limit, while a well-behaved concurrent subscriber and the generation continue unaffected', async () => {
+    const { controller, generationService } = makeController();
+    generationService.register(SID, PATH, GEN_ID);
+    generationService.seedAssembledMessage(SID, PATH, GEN_ID, makeMessage(''));
+
+    const slowRes = new FakeAttachResponse(false);
+    const fastRes = new FakeAttachResponse(true);
+    const req = { user: { sid: SID } } as unknown as Request;
+
+    await Promise.all([
+      controller.attachToGeneration(req, slowRes as unknown as Response, {
+        path: PATH,
+      }),
+      controller.attachToGeneration(req, fastRes as unknown as Response, {
+        path: PATH,
+      }),
+    ]);
+
+    // 12 * 100 KiB = 1.17 MiB, past the 1 MiB per-subscriber limit.
+    const bigChunk = 'x'.repeat(100 * 1024);
+    for (let i = 0; i < 12; i += 1) {
+      generationService.applyChunk(
+        SID,
+        PATH,
+        GEN_ID,
+        { choices: [{ delta: { content: bigChunk } }] },
+        makeMessage(bigChunk),
+      );
+    }
+
+    expect(slowRes.writableEnded).toBe(true);
+    expect(slowRes.end).toHaveBeenCalledOnce();
+    expect(fastRes.writableEnded).toBe(false);
+
+    generationService.complete(SID, PATH, GEN_ID);
+
+    expect(fastRes.writableEnded).toBe(true);
+    expect(
+      fastRes.write.mock.calls.some(([chunk]) =>
+        String(chunk).includes('"type":"done"'),
+      ),
+    ).toBe(true);
+    // The detached slow subscriber never received the terminal event — its
+    // listener was removed before `complete()` emitted it.
+    expect(
+      slowRes.write.mock.calls.some(([chunk]) =>
+        String(chunk).includes('"type":"done"'),
+      ),
+    ).toBe(false);
+  });
+});

--- a/apps/chat-api/src/conversations/tests/completions.integration.spec.ts
+++ b/apps/chat-api/src/conversations/tests/completions.integration.spec.ts
@@ -1,4 +1,6 @@
+import { EventEmitter } from 'node:events';
 import http from 'node:http';
+import { Writable } from 'node:stream';
 import {
   ConflictException,
   INestApplication,
@@ -18,6 +20,7 @@ import {
 } from '../conversation-generation.service';
 import { ConversationController } from '../conversation.controller';
 import { ConversationService } from '../conversation.service';
+import type { SendCompletionDto } from '../dto/send-completion.dto';
 
 const TEST_USER = {
   sid: 'test-sid',
@@ -354,6 +357,106 @@ describe('POST /conversations/completions (integration)', () => {
     expect(mockGenerationService.abort).not.toHaveBeenCalled();
     expect(mockGenerationService.error).not.toHaveBeenCalled();
     expect(mockGenerationService.complete).not.toHaveBeenCalled();
+  });
+
+  /*
+   * Regression check: the disconnect-during-setup path (before
+   * `onReadyToStream`/headers are sent) must keep draining the generator to
+   * completion exactly like the mid-stream disconnect above — the
+   * `writeSseChunk` swap must not change this refactor-safety guarantee.
+   */
+  it('keeps draining the generator to completion when the client disconnects before onReadyToStream fires', async () => {
+    const res = new EventEmitter() as unknown as ExpressResponse;
+    Object.assign(res, {
+      writableEnded: false,
+      setHeader: vi.fn(),
+      flushHeaders: vi.fn(),
+      write: vi.fn().mockReturnValue(true),
+      end: vi.fn(),
+    });
+
+    let reachedNaturalEnd = false;
+    mockService.streamCompletion.mockImplementation(async function* (
+      ...args: unknown[]
+    ) {
+      // Simulates the browser closing before setup finishes — no headers
+      // have been sent yet.
+      res.emit('close');
+      (args[10] as () => void)();
+      yield Buffer.from('data: [DONE]\n\n');
+      reachedNaturalEnd = true;
+    });
+
+    await new ConversationController(
+      mockService as unknown as ConversationService,
+      mockGenerationService as unknown as ConversationGenerationService,
+    ).streamCompletion(
+      { user: TEST_USER } as unknown as ExpressRequest,
+      res,
+      VALID_COMPLETION_BODY as unknown as SendCompletionDto,
+      undefined,
+    );
+
+    expect(reachedNaturalEnd).toBe(true);
+    expect(mockGenerationService.abort).not.toHaveBeenCalled();
+  });
+});
+
+describe('POST /conversations/completions — backpressure-driven detachment (direct controller)', () => {
+  const TEST_REQUEST = { user: TEST_USER } as unknown as ExpressRequest;
+
+  it('detaches the response once buffered output exceeds SSE_COMPLETION_MAX_BUFFERED_BYTES, while the generator keeps running to completion', async () => {
+    const pendingCallbacks: Array<() => void> = [];
+    const res = new Writable({
+      highWaterMark: 1024,
+      write(_chunk, _encoding, callback) {
+        // Never calls back — simulates a browser that stopped reading, so
+        // writes pile up in the internal buffer and `writableLength` grows
+        // past the threshold instead of ever draining.
+        pendingCallbacks.push(callback);
+      },
+    }) as unknown as ExpressResponse;
+    Object.assign(res, { setHeader: vi.fn(), flushHeaders: vi.fn() });
+
+    const chunkSize = 64 * 1024;
+    const totalChunks = 20; // 20 * 64 KiB = 1.25 MiB, past the 1 MiB limit
+    let reachedNaturalEnd = false;
+    const mockService = {
+      streamCompletion: vi.fn().mockImplementation(async function* (
+        ...args: unknown[]
+      ) {
+        (args[10] as () => void)();
+        for (let i = 0; i < totalChunks; i += 1) {
+          yield Buffer.alloc(chunkSize, 'x');
+        }
+        reachedNaturalEnd = true;
+      }),
+    };
+    const mockGenerationService = {
+      register: vi.fn().mockReturnValue(new AbortController()),
+      abort: vi.fn().mockReturnValue(true),
+      complete: vi.fn(),
+      error: vi.fn(),
+      getStatus: vi.fn().mockReturnValue(GenerationStatus.Active),
+    };
+
+    const controller = new ConversationController(
+      mockService as unknown as ConversationService,
+      mockGenerationService as unknown as ConversationGenerationService,
+    );
+
+    await controller.streamCompletion(
+      TEST_REQUEST,
+      res,
+      VALID_COMPLETION_BODY as unknown as SendCompletionDto,
+      undefined,
+    );
+
+    expect(reachedNaturalEnd).toBe(true);
+    // Fewer writes actually reached the underlying stream than were yielded
+    // (plus the init comment) — proof that the response was detached instead
+    // of continuing to buffer every chunk without bound.
+    expect(pendingCallbacks.length).toBeLessThan(totalChunks + 1);
   });
 });
 

--- a/apps/chat-api/src/conversations/tests/conversation-watch.controller.spec.ts
+++ b/apps/chat-api/src/conversations/tests/conversation-watch.controller.spec.ts
@@ -1,0 +1,104 @@
+import { EventEmitter } from 'node:events';
+import type { Request, Response } from 'express';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ConversationController } from '../conversation.controller';
+
+class TestResponse extends EventEmitter {
+  writableEnded = false;
+  setHeader = vi.fn();
+  flushHeaders = vi.fn();
+  write = vi.fn().mockReturnValue(true);
+  end = vi.fn(() => {
+    this.writableEnded = true;
+    return this;
+  });
+}
+
+const request = {
+  user: { at: 'test-token', bucket: 'test-bucket' },
+} as unknown as Request;
+
+describe('ConversationController.watchConversation — early close and backpressure', () => {
+  let controller: ConversationController;
+  let response: TestResponse;
+  let watchConversation: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    response = new TestResponse();
+    watchConversation = vi.fn();
+    controller = new ConversationController(
+      { watchConversation } as never,
+      {} as never,
+    );
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('propagates the AbortSignal to ConversationService.watchConversation and aborts it on early close', async () => {
+    let capturedSignal: AbortSignal | undefined;
+    const cancel = vi.fn();
+    watchConversation.mockImplementation(
+      (_path: string, _at: string, _bucket: string, signal: AbortSignal) => {
+        capturedSignal = signal;
+        return new Promise((resolve) => {
+          signal.addEventListener('abort', () => {
+            resolve(new ReadableStream({ cancel }));
+          });
+        });
+      },
+    );
+
+    const pending = controller.watchConversation(
+      request,
+      response as unknown as Response,
+      { path: 'test-path' },
+    );
+
+    response.emit('close');
+    await pending;
+
+    expect(capturedSignal?.aborted).toBe(true);
+    expect(watchConversation).toHaveBeenCalledWith(
+      'test-path',
+      'test-token',
+      'test-bucket',
+      expect.any(AbortSignal),
+    );
+    expect(response.flushHeaders).not.toHaveBeenCalled();
+    expect(cancel).toHaveBeenCalledOnce();
+  });
+
+  it('closes a stalled watch connection after the drain timeout, clearing the keepalive timer and cancelling the reader', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    response.write = vi.fn().mockReturnValue(false);
+    const cancel = vi.fn().mockResolvedValue(undefined);
+    const stream = new ReadableStream<Uint8Array>({
+      pull(streamController) {
+        streamController.enqueue(
+          new TextEncoder().encode('data: {"action":"UPDATE"}\n\n'),
+        );
+      },
+      cancel,
+    });
+    watchConversation.mockResolvedValue(stream);
+    const clearIntervalSpy = vi.spyOn(global, 'clearInterval');
+
+    const pending = controller.watchConversation(
+      request,
+      response as unknown as Response,
+      { path: 'test-path' },
+    );
+
+    await vi.waitFor(() =>
+      expect(response.write.mock.calls.length).toBeGreaterThanOrEqual(2),
+    );
+    await vi.advanceTimersByTimeAsync(5000);
+    await pending;
+
+    expect(cancel).toHaveBeenCalledOnce();
+    expect(response.end).toHaveBeenCalledOnce();
+    expect(clearIntervalSpy).toHaveBeenCalled();
+  });
+});

--- a/apps/chat-api/src/telemetry/tests/sse-subscription-metrics.spec.ts
+++ b/apps/chat-api/src/telemetry/tests/sse-subscription-metrics.spec.ts
@@ -27,6 +27,7 @@ class TestMetricReader extends MetricReader {
 
 class TestResponse extends EventEmitter {
   writableEnded = false;
+  writableLength = 0;
   setHeader = vi.fn();
   flushHeaders = vi.fn();
   write = vi.fn().mockReturnValue(true);
@@ -35,6 +36,8 @@ class TestResponse extends EventEmitter {
     return this;
   });
 }
+
+const SSE_ATTACH_MAX_BUFFERED_BYTES = 1024 * 1024;
 
 const request = {
   user: { at: 'test-token', bucket: 'test-bucket', sid: 'test-session' },
@@ -187,6 +190,28 @@ describe('SSE subscription metrics', () => {
       await rejected;
       expect(await activeSubscriptions(kind)).toBe(0);
     });
+
+    it('aborts the upstream call signal on an early close during pending setup, and still settles the gauge exactly once', async () => {
+      let capturedSignal: AbortSignal | undefined;
+      let rejectOpening!: (reason: Error) => void;
+      upstream().mockImplementation((...args: unknown[]) => {
+        capturedSignal = args[args.length - 1] as AbortSignal;
+        return new Promise((_resolve, reject) => {
+          rejectOpening = reject;
+        });
+      });
+
+      const pending = invoke();
+      expect(await activeSubscriptions(kind)).toBe(1);
+
+      response.emit('close');
+      expect(capturedSignal?.aborted).toBe(true);
+
+      const rejected = expect(pending).rejects.toThrow('aborted');
+      rejectOpening(new Error('aborted'));
+      await rejected;
+      expect(await activeSubscriptions(kind)).toBe(0);
+    });
   });
 
   describe('generation attachment', () => {
@@ -228,6 +253,47 @@ describe('SSE subscription metrics', () => {
       expect(
         await activeSubscriptions(SseSubscriptionKind.GenerationAttach),
       ).toBe(0);
+      expect(emitter.listenerCount('terminal')).toBe(0);
+    });
+
+    it('releases the count when a subscriber is detached for backpressure, not just on close/terminal', async () => {
+      const emitter = new EventEmitter();
+      attach.mockReturnValue({ emitter, assembledMessage: { content: '' } });
+      await invoke();
+      expect(
+        await activeSubscriptions(SseSubscriptionKind.GenerationAttach),
+      ).toBe(1);
+
+      response.writableLength = SSE_ATTACH_MAX_BUFFERED_BYTES + 1;
+      emitter.emit('chunk', { choices: [{ delta: { content: 'x' } }] });
+
+      expect(
+        await activeSubscriptions(SseSubscriptionKind.GenerationAttach),
+      ).toBe(0);
+      expect(response.writableEnded).toBe(true);
+      expect(emitter.listenerCount('chunk')).toBe(0);
+      expect(emitter.listenerCount('terminal')).toBe(0);
+    });
+
+    it('runs cleanup exactly once when a backpressure-triggered detach races with a terminal event in the same tick', async () => {
+      const emitter = new EventEmitter();
+      attach.mockReturnValue({ emitter, assembledMessage: { content: '' } });
+      await invoke();
+      expect(
+        await activeSubscriptions(SseSubscriptionKind.GenerationAttach),
+      ).toBe(1);
+
+      // The terminal event's own write is what pushes buffered bytes over
+      // the limit, so `writeEvent`'s internal backpressure check and
+      // `onTerminal`'s own explicit cleanup call both fire in this one tick.
+      response.writableLength = SSE_ATTACH_MAX_BUFFERED_BYTES + 1;
+      emitter.emit('terminal', { type: 'done' });
+
+      expect(
+        await activeSubscriptions(SseSubscriptionKind.GenerationAttach),
+      ).toBe(0);
+      expect(response.end).toHaveBeenCalledOnce();
+      expect(emitter.listenerCount('chunk')).toBe(0);
       expect(emitter.listenerCount('terminal')).toBe(0);
     });
 

--- a/openspec/changes/archive/2026-09-11-fix-sse-stream-lifecycle-leaks/.openspec.yaml
+++ b/openspec/changes/archive/2026-09-11-fix-sse-stream-lifecycle-leaks/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-11

--- a/openspec/changes/archive/2026-09-11-fix-sse-stream-lifecycle-leaks/design.md
+++ b/openspec/changes/archive/2026-09-11-fix-sse-stream-lifecycle-leaks/design.md
@@ -1,0 +1,222 @@
+## Context
+
+Four handlers in `apps/chat-api` open an SSE response and relay bytes from
+either a DIAL Core upstream stream or an in-process `EventEmitter`:
+
+| Handler | File | Upstream source | Client-owned lifecycle? |
+|---|---|---|---|
+| `subscribe` | `client-channel/client-channel.controller.ts` | DIAL Core fetch stream | Yes — aborts upstream on disconnect |
+| `watchConversation` | `conversations/conversation.controller.ts` | DIAL Core fetch stream | Yes — aborts upstream on disconnect |
+| `streamCompletion` | `conversations/conversation.controller.ts` | `ConversationStreamingService`'s async generator | No — generation is backend-owned (`backend-owned-generation-persistence`); disconnect only stops writes |
+| `attachToGeneration` | `conversations/conversation.controller.ts` | `ConversationGenerationService`'s per-generation `EventEmitter` | Partial — the *subscription* is client-owned, the *generation* it observes is not |
+
+All four share two defects, confirmed by reading the current code (not
+assumed): (1) the two upstream-owning handlers construct their
+`AbortController`/register `res.on('close', ...)` *after* the `await` that
+opens the upstream call, so a disconnect during that await has nothing to
+cancel; (2) all four call `res.write(value)` without checking its boolean
+return, so a client that reads slower than bytes are produced (or a
+completely stalled `Writable`) has its output buffered by Node without bound.
+`dial_chat_sse_active`/`dial_chat_generations_active` (already merged on this
+branch, see `observability-telemetry`) give visibility into the first defect
+class (subscriptions outliving their justification) but do not themselves
+bound the second (per-connection buffered bytes), which is why the change
+adds an explicit, measured limit rather than relying on the gauges alone.
+
+The two client-owned handlers (`subscribe`, `watchConversation`) already
+close their own upstream work — the fix is *timing* (attach the cancellation
+path earlier) and, for `watchConversation`, *plumbing* (no `AbortSignal`
+reaches `subscribeToResources` today at all). The two generation-owning
+handlers (`streamCompletion`, `attachToGeneration`) must never cancel the
+generation on a slow/closed client — the fix there is purely about bounding
+buffered output and stopping writes, mirroring the existing
+`isResponseDetached` pattern `streamCompletion` already uses for disconnect.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Close the two confirmed retention paths without changing SSE framing,
+  auth, feature flags, or the documented backend-owned-generation guarantee.
+- Share the backpressure-handling logic across all four handlers instead of
+  writing four bespoke copies of "check `res.write()`'s return value."
+- Keep the runtime gauges (`dial_chat_sse_active`, `dial_chat_generations_active`)
+  accurate under every new code path — settle-exactly-once must still hold.
+- Make the fix independently verifiable: real Node `Writable`/`ReadableStream`
+  primitives in tests, not full HTTP integration, so backpressure and
+  early-abort behavior are exercised deterministically.
+
+**Non-Goals:**
+- Changing the wire format of any SSE event, or any DTO/OpenAPI contract.
+- Introducing reconnection/resume logic on the frontend — this is a backend
+  resource-lifecycle fix only.
+- Solving unrelated retention findings from the local memory-leak
+  investigation that are not confirmed defects (tracked as follow-ups per
+  the proposal's scope).
+- A general-purpose stream-piping abstraction; the shared helper here is
+  scoped to this repo's four SSE call sites, not a public utility.
+
+## Decisions
+
+### 1. Attach `res.on('close', ...)` and construct the `AbortController` before the first `await`
+
+For `subscribe` and `watchConversation`, move the existing
+`new AbortController()` + `res.on('close', handleClose)` lines to the top of
+the handler, before calling `clientChannelService.subscribe(...)` /
+`conversationService.watchConversation(...)`. `handleClose` already calls
+`abortController.abort()`; the only change is *when* the listener starts
+existing, not its body. This makes the already-passed `AbortSignal` (for
+`subscribe`) actually useful for the setup-phase window, and — combined with
+Decision 2 — extends the same coverage to `watchConversation`.
+
+No alternative was considered here: this is a straightforward reordering
+with no behavioral trade-off, confirmed safe because `res` exists (Express
+already supplied it) before either upstream call is made.
+
+### 2. Thread an `AbortSignal` through `watchConversation`
+
+`ConversationStreamingService.watchConversation(conversationPath, token, sessionBucket)`
+gains a fourth parameter, `signal: AbortSignal`, passed straight to
+`this.dialClient.client.subscribeToResources({ ..., signal })` (the SDK's
+underlying `fetch` already accepts `signal` — `relayModelCompletion` in the
+same file does exactly this for the completions call). `ConversationController.watchConversation`
+passes its own `AbortController`'s signal. `ConversationService.watchConversation`
+needs no change — it is a bound property re-export
+(`this.streamingService.watchConversation.bind(...)`), so the new parameter
+flows through automatically.
+
+**Alternative considered:** give `ConversationStreamingService` its own
+internal `AbortController` and only expose a `cancel()` method. Rejected —
+every other upstream call in this service (`relayModelCompletion`) already
+takes the caller's `AbortSignal` directly; introducing a second pattern for
+one method adds inconsistency for no benefit.
+
+### 3. A shared SSE backpressure helper in `common/utils/sse.ts`
+
+Add one function used by all four handlers instead of four ad hoc
+backpressure implementations:
+
+```ts
+export interface SseWriteResult {
+  written: boolean; // false only when the response was already ended/detached
+  needsDrain: boolean; // true when res.write() returned false
+}
+
+export const writeSseChunk = (res: Response, chunk: Uint8Array | string): SseWriteResult => { ... };
+
+export const waitForDrain = (
+  res: Response,
+  signal: AbortSignal, // aborts the wait early: connection closed / upstream errored
+  timeoutMs: number,
+): Promise<'drained' | 'timeout' | 'aborted'> => { ... };
+```
+
+`writeSseChunk` wraps `res.write()` and reports whether the caller must now
+wait for `'drain'`. `waitForDrain` resolves on the response's `'drain'`
+event, the given `AbortSignal` firing, or `timeoutMs` elapsing — whichever
+comes first — and always removes its own listeners before resolving (a
+`Promise.race` over three cleanly-torn-down listeners, not a bare
+`once('drain')` that could leak if the signal fires instead).
+
+The two upstream-relay loops (`subscribe`, `watchConversation`) use both
+functions: on `needsDrain`, they `await waitForDrain(...)` (bounded by the
+existing `AbortController`'s signal plus a new 5000ms
+`SSE_DRAIN_TIMEOUT_MS`) before issuing the next `reader.read()`. A `'timeout'`
+result is treated exactly like a disconnect: cancel the reader, clear any
+keepalive timer, end the response.
+
+The two generation-owning handlers (`streamCompletion`, `attachToGeneration`)
+use only `writeSseChunk` plus a synchronous `res.writableLength` check (no
+`waitForDrain` — they must never block the generation loop on a slow
+client). Immediately after each write, if `res.writableLength` exceeds the
+relevant constant (`SSE_COMPLETION_MAX_BUFFERED_BYTES` /
+`SSE_ATTACH_MAX_BUFFERED_BYTES`, both 1 MiB — see Decision 4), the handler
+sets its existing detach flag (`isResponseDetached` for `streamCompletion`,
+the existing `cleanup()` path for `attachToGeneration`) and stops writing,
+without awaiting anything. This is a check, not a wait, so it adds no
+latency to the generation's own progress.
+
+**Alternative considered:** use a `stream.pipeline`/`Writable` wrapper
+(Node's `Readable.pipe(res)`) instead of manual `read()`/`write()` loops for
+the two upstream relays, letting Node's own backpressure handling apply
+automatically. Rejected for this change: it would require restructuring the
+existing reader loops (which also parse SSE frames inline for
+`watchConversation`'s keepalive interleaving and `client-channel`'s
+pass-through), a larger refactor than this fix's scope, and it would not
+help the two generation-owning handlers at all, since those write from an
+async generator / `EventEmitter` callback, not a `Readable`. A shared
+small helper keeps both families of handler on the same drain-detection
+logic without restructuring either.
+
+### 4. Concrete limits
+
+| Constant | Value | Applies to | Rationale |
+|---|---|---|---|
+| `SSE_DRAIN_TIMEOUT_MS` | 5000 | `subscribe`, `watchConversation` | Matches the existing 15s keepalive cadence with margin — a connection that can't drain in 5s is failing, not momentarily slow, and holding the upstream Core connection open past that point produces exactly the retention this change targets. |
+| `SSE_COMPLETION_MAX_BUFFERED_BYTES` | 1 MiB (`1024 * 1024`) | `streamCompletion` | The local reproduction accumulated ~16 MiB against a 1 KiB `highWaterMark`; 1 MiB bounds worst-case per-connection buffering to roughly the size of a large single assistant turn while being generous enough that no normal client trips it. |
+| `SSE_ATTACH_MAX_BUFFERED_BYTES` | 1 MiB | `attachToGeneration` | Same reasoning; attach mirrors completion delivery's chunk shape. |
+
+These are internal constants (`apps/chat-api/src/common/utils/sse.ts` and/or
+each domain's controller), not environment variables — they are a safety
+bound on an implementation detail, not an operator-tunable setting, matching
+how `SSE_KEEPALIVE_INTERVAL_MS` is already handled today.
+
+**Alternative considered:** count buffered *chunks* instead of bytes.
+Rejected — chunk size varies enormously (a keepalive comment vs. a large
+tool-call argument delta), so a byte bound is the only one that actually
+caps memory.
+
+### 5. Detaching for backpressure reuses each handler's existing disconnect path exactly
+
+`streamCompletion` already has `isResponseDetached`/`handleClose`;
+`attachToGeneration` already has `cleanup()`. Backpressure detection calls
+into these same functions rather than introducing a parallel "detached for
+backpressure" state, so `backend-owned-generation-persistence` and
+`generation-live-replay`'s existing "no writes to a closed response"
+guarantees apply unchanged to the new trigger.
+
+## Risks / Trade-offs
+
+- **[Risk]** A legitimately large single completion (very long assistant
+  turn plus large `stages`/tool-call payloads) could exceed 1 MiB of
+  buffered output on a merely slow-but-not-broken connection, causing a
+  premature detach → **Mitigation**: detachment only stops *delivery* to
+  that one response; generation and persistence are unaffected (per
+  `backend-owned-generation-persistence`), and the frontend's existing
+  disconnect/resume path (`generation-live-replay`'s attach endpoint) already
+  handles a client that needs to pick the stream back up. The 1 MiB bound is
+  also revisitable via the same constant if production metrics show it
+  firing on healthy connections.
+- **[Risk]** `SSE_DRAIN_TIMEOUT_MS` too aggressive for a genuinely slow but
+  recovering mobile connection → **Mitigation**: 5s only starts counting
+  once `res.write()` has already signaled backpressure (not from connection
+  start), and hitting it only closes that one relay (client-channel or
+  watch), both of which the frontend already reconnects/retries by design
+  (`client-channel-protocol`'s reconnect header, `conversation-watch-sse`'s
+  timeout-and-silent-completion scenario).
+- **[Risk]** Sharing one helper across four call sites could couple unrelated
+  handlers → **Mitigation**: the helper is two small pure-ish functions
+  (`writeSseChunk`, `waitForDrain`) with no shared state between calls; each
+  handler still owns its own loop, flags, and cleanup.
+- **[Trade-off]** This does not eliminate every theoretical retention path
+  in the SSE stack (e.g. pathological upstream behavior beyond what was
+  reproduced) — scope is the two confirmed defects; anything else surfaces
+  through the PR #8738 gauges for a follow-up.
+
+## Migration Plan
+
+No data migration. Deploy behind the normal release process; the change is
+backend-only and behaviorally additive (existing well-behaved clients never
+observe the new timeout/byte-limit paths). Verification after deploy: watch
+`dial_chat_process_memory{kind="rss"}` and `dial_chat_sse_active` over a
+comparable load window to 1.0.15's post-deploy period; a fix that works
+shows RSS plateauing instead of climbing, and `dial_chat_sse_active` gauges
+returning to baseline between load spikes instead of trending upward.
+Rollback is a plain revert — no schema or persisted-state change to unwind.
+
+## Open Questions
+
+- None outstanding for this slice. The two remaining "confirmed defects
+  reproduced locally, contribution to production growth not yet measured"
+  framing in the proposal stays true after this fix ships — the metrics
+  comparison above is how that gets answered, not something this design can
+  resolve in advance.

--- a/openspec/changes/archive/2026-09-11-fix-sse-stream-lifecycle-leaks/proposal.md
+++ b/openspec/changes/archive/2026-09-11-fix-sse-stream-lifecycle-leaks/proposal.md
@@ -1,0 +1,109 @@
+## Why
+
+Production pod memory kept climbing after 1.0.15 (PR #8683's bounded Keyv
+cache) shipped, and the new runtime gauges from PR #8738
+(`dial_chat_process_memory`, `dial_chat_sse_active`,
+`dial_chat_generations_active`) give us the instruments to see why but do not
+themselves fix anything. Local reproduction against the exact 1.0.15 code
+found two remaining retention paths in the SSE-serving controllers:
+
+1. `ClientChannelController.subscribe` and `ConversationController.watchConversation`
+   attach their `res.on('close', ...)` listener only after `await`ing the
+   upstream DIAL Core subscribe call. A browser disconnect that happens during
+   that await is invisible to the handler — the upstream fetch, its eventual
+   reader, and (for watch) a keepalive timer are still started once the await
+   resolves, with nothing left listening for the close that already happened.
+2. Every SSE writer in these controllers (`res.write(value)`) ignores a
+   `false` return, i.e. it never respects Node's backpressure signal. A
+   reproduction using the real 1.0.15 `subscribe` method against a genuinely
+   stalled `Writable` (1 KiB `highWaterMark`) accumulated ~16 MiB of buffered
+   output for a single connection.
+
+Both defects hold a connection's resources (upstream reader, timers, buffered
+bytes) alive longer than the browser connection that justified them, which is
+the retention shape a stalled/discarded client produces under real network
+conditions (slow mobile networks, backgrounded tabs, proxies that hold sockets
+half-open). Fixing them is the next concrete step after 1.0.15's cache fix,
+using the observability PR #8738 just merged as the way to confirm the fix
+actually reduces retained memory in production.
+
+## What Changes
+
+- Move each SSE handler's `res.on('close', ...)` registration to before the
+  first `await` of upstream setup (client-channel subscribe, conversation
+  watch), and make that early-close path actually abort the in-flight setup
+  call rather than only being available for cleanup after the fact.
+- Thread an `AbortSignal` into `ConversationStreamingService.watchConversation`
+  and the underlying `subscribeToResources` call — today `watchConversation`
+  accepts no signal at all, so a disconnect during its upstream await cannot
+  cancel anything upstream.
+- Add bounded SSE write backpressure handling shared by every SSE-writing
+  handler (client-channel subscribe, conversation watch, completion delivery,
+  generation attach): stop reading further upstream bytes / further chunks
+  while `res.write()` returns `false`, wait for `'drain'` bounded by the
+  connection closing, an upstream error, or a fixed timeout, and — for
+  completion delivery and generation attach specifically, where the
+  generation itself must keep running and persist regardless of a slow
+  browser — detach the response (stop writing to it) once an explicit,
+  documented buffered-byte/time limit is exceeded, without pausing or
+  aborting the generation.
+- Keep the existing runtime gauges (`dial_chat_sse_active`,
+  `dial_chat_generations_active`) accurate under the new cleanup paths: a
+  cancelled-during-setup subscription still settles its count exactly once,
+  and a detached-for-backpressure completion/attach releases its listeners
+  and timers the same way a normal close does.
+- No change to SSE event framing, authentication, feature-flag gating, or the
+  documented generation-independent-of-connection guarantee
+  (`backend-owned-generation-persistence`) — a browser disconnecting or being
+  detached for backpressure must not stop or corrupt generation or its
+  eventual persistence.
+
+## Capabilities
+
+### New Capabilities
+
+(none — this hardens existing SSE transport behavior; no new endpoint or
+externally observable capability is introduced)
+
+### Modified Capabilities
+
+- `client-channel-protocol`: the "Browser disconnects mid-stream" behavior is
+  tightened to cover a disconnect that happens *before* the upstream Core
+  subscribe call resolves, and a new bounded-backpressure requirement is
+  added for the relay loop.
+- `conversation-watch-sse`: the "Client disconnect closes the DIAL Core
+  subscription" behavior is tightened the same way, plus the previously
+  unstated fact that upstream subscribe accepts no cancellation signal is
+  fixed (an `AbortSignal` now flows from the controller through
+  `ConversationService`/`ConversationStreamingService` to the DIAL Core SDK
+  call), plus the same bounded-backpressure requirement.
+- `generation-live-replay`: adds an explicit, documented buffered-output limit
+  for a slow attach subscriber, past which the backend detaches that
+  subscriber's response (stops writing, removes its listeners) without
+  affecting the generation or other subscribers.
+- `backend-owned-generation-persistence`: adds the same explicit backpressure
+  limit for the primary completion-delivery response, clarifying that a
+  detached-for-backpressure response is handled identically to a
+  disconnected one — the generation and its final persistence proceed
+  unaffected.
+
+## Impact
+
+- Code: `apps/chat-api/src/client-channel/client-channel.controller.ts`,
+  `apps/chat-api/src/client-channel/client-channel.service.ts`,
+  `apps/chat-api/src/conversations/conversation.controller.ts`,
+  `apps/chat-api/src/conversations/streaming/conversation-streaming.service.ts`,
+  `apps/chat-api/src/conversations/conversation.service.ts` (facade
+  passthrough for the new `watchConversation` signal parameter), and a new
+  shared SSE-writing helper in `apps/chat-api/src/common/utils/sse.ts` used by
+  all four handlers so the backpressure logic is not duplicated four times.
+- Tests: new/updated specs under `apps/chat-api/src/client-channel/tests/`,
+  `apps/chat-api/src/conversations/tests/`, and
+  `apps/chat-api/src/common/utils/tests/`, plus the existing
+  `apps/chat-api/src/telemetry/tests/sse-subscription-metrics.spec.ts` gains
+  cases for the now-earlier abort and for backpressure-driven detachment.
+- Docs: `apps/chat-api/README.md` (SSE handling section, if one documents the
+  close/backpressure contract) and the four specs listed above.
+- No frontend changes — SSE event formats, headers, and authentication are
+  unchanged; this is purely backend resource-lifecycle hardening.
+- No OpenAPI/DTO changes.

--- a/openspec/changes/archive/2026-09-11-fix-sse-stream-lifecycle-leaks/specs/backend-owned-generation-persistence/spec.md
+++ b/openspec/changes/archive/2026-09-11-fix-sse-stream-lifecycle-leaks/specs/backend-owned-generation-persistence/spec.md
@@ -1,0 +1,46 @@
+## MODIFIED Requirements
+
+### Requirement: A closed downstream response does not alter generation persistence or outcome
+
+Closing, refreshing, or navigating away from the browser connection that opened `POST /api/v1/conversations/completions` SHALL have no effect on the generation's outcome or persistence. `ConversationController.streamCompletion` SHALL continue consuming `ConversationStreamingService.streamCompletion`'s async generator to its natural terminal outcome after the downstream HTTP response closes; it MUST NOT abort the generation's `AbortController` and MUST NOT stop iterating merely because the response closed. It SHALL stop writing to the closed response (and MUST NOT attempt any further `res.write`/`res.end` calls against it) but otherwise treats the generation exactly as if the original client were still connected.
+
+The same "stop writing but keep generating" treatment SHALL apply when the response is not closed but cannot keep up with output: after each `res.write(chunk)`, the handler SHALL check `res.writableLength`; if it exceeds `SSE_COMPLETION_MAX_BUFFERED_BYTES` (1 MiB), the handler SHALL mark the response detached (setting the same `isResponseDetached` flag used for a closed connection) and stop calling `res.write`/`res.end` against it for the remainder of the generation, without pausing, slowing, or aborting the generation loop itself.
+
+When the upstream stream subsequently reaches a normal terminal event (`[DONE]`, a provider error, or an explicit Stop received before the disconnect), the backend persists the outcome per the existing outcome table in "Backend persists the conversation across the generation lifecycle" — a disconnect or a backpressure-driven detachment never substitutes a different, disconnect-specific outcome. Reopening the conversation (in the same or a different browser tab/session) after the generation finishes SHALL show the complete persisted response, not a truncated or error-marked one caused by the earlier disconnect or detachment.
+
+This requirement applies only to `POST /api/v1/conversations/completions`. It does not apply to `POST /api/v1/client-channel/subscribe` (an ephemeral client subscription with no independent backend-owned lifecycle — see `client-channel-protocol`) or to `POST /api/v1/conversations/completions/attach` (an observer of an existing generation — see `generation-live-replay`), both of which correctly abort their own upstream work on disconnect because nothing else depends on that work continuing.
+
+#### Scenario: Browser tab closes before the upstream reaches a terminal event
+
+- **GIVEN** a generation is actively streaming and has received at least one chunk
+- **WHEN** the client's HTTP connection to `POST /conversations/completions` closes (tab closed, navigation to another page, refresh) before the upstream reaches `[DONE]`, an error, or an explicit Stop
+- **THEN** the backend keeps consuming the upstream stream unaffected, and no `AbortController` tied to the generation is aborted because of the closed response
+
+#### Scenario: No writes are attempted against a closed response
+
+- **GIVEN** the downstream response has closed while the generation is still streaming
+- **WHEN** further chunks are produced by the upstream relay
+- **THEN** the backend does not call `res.write` or `res.end` against the closed response for those chunks
+
+#### Scenario: The complete response is persisted and visible after disconnect
+
+- **GIVEN** the browser disconnected mid-stream as in the scenario above
+- **WHEN** the upstream subsequently reaches `[DONE]`
+- **THEN** the backend persists the full assembled assistant message (no `streamErrorMessage`, no `wasStoppedByUser`), releases the registry entry as `Done`, and reopening the conversation shows the complete response
+
+#### Scenario: Navigating between conversations does not stop a completion
+
+- **WHEN** a generation is active for conversation A and the user navigates to conversation B and back, or to an unrelated page in the SPA, before the generation finishes
+- **THEN** the generation for conversation A continues unaffected and completes normally
+
+#### Scenario: A slow browser connection is detached without pausing generation
+
+- **GIVEN** a generation is actively streaming to a connected browser that reads slower than chunks are produced
+- **WHEN** `res.writableLength` exceeds `SSE_COMPLETION_MAX_BUFFERED_BYTES` after a write
+- **THEN** the backend stops writing further chunks to that response (marking it detached, the same as a closed connection) while the generation continues unaffected until its natural terminal outcome
+
+#### Scenario: The complete response is persisted after a backpressure-driven detachment
+
+- **GIVEN** the response was detached for backpressure as in the scenario above
+- **WHEN** the upstream subsequently reaches `[DONE]`
+- **THEN** the backend persists the full assembled assistant message exactly as it would for a client disconnect, and reopening the conversation shows the complete response

--- a/openspec/changes/archive/2026-09-11-fix-sse-stream-lifecycle-leaks/specs/client-channel-protocol/spec.md
+++ b/openspec/changes/archive/2026-09-11-fix-sse-stream-lifecycle-leaks/specs/client-channel-protocol/spec.md
@@ -1,0 +1,45 @@
+## MODIFIED Requirements
+
+### Requirement: BFF proxies DIAL Core client-channel subscribe as an SSE relay
+
+The backend SHALL expose `POST /api/v1/client-channel/subscribe` (NestJS domain `apps/chat-api/src/client-channel/`, `ClientChannelController`, `@Controller({ path: 'client-channel', version: '1' })`). The endpoint SHALL call `@epam/ai-dial-typescript-sdk`'s `subscribeClientChannel` using the bearer access token from the caller's encrypted BFF session (never a value supplied by the browser), and SHALL relay the upstream `text/event-stream` response body to the browser without buffering it in memory. The response SHALL echo the `X-DIAL-CLIENT-CHANNEL-ID` header returned by Core. If the browser already holds a channel id (reconnect), the frontend SHALL send it as a request header and the backend SHALL forward it to Core unchanged so Core can attempt to resume the same channel. The relayed SSE body MAY carry RPC events of different `method` values (e.g. `toolset/signin`, `external-service/signin`) — the backend SHALL relay every event body-for-body without inspecting or filtering on `method`; method-specific handling is entirely a frontend concern.
+
+The handler SHALL register its `res.on('close', ...)` listener, and construct the `AbortController` whose signal is passed to `ClientChannelService.subscribe`, before making that call — i.e. before the first `await` of upstream setup — so a browser disconnect that happens while the upstream subscribe call is still in flight aborts that call immediately instead of being observed only once the call resolves. The `dial_chat_sse_active{kind="client_channel"}` gauge contribution (see `observability-telemetry`) SHALL start before this call and be released exactly once when the handler settles, unchanged by this requirement.
+
+While relaying, the handler SHALL respect `res.write()`'s return value: when it returns `false`, the handler SHALL stop issuing further upstream reads until the response emits `'drain'`, bounded by the response closing, the upstream stream erroring, or an internal drain timeout (`SSE_DRAIN_TIMEOUT_MS`, 5000ms) — whichever happens first. If the drain timeout elapses without a `'drain'` event, the handler SHALL treat the connection as stalled: cancel the upstream reader and end the response, identical to a client disconnect.
+
+Request: no body. Optional request header `X-DIAL-CLIENT-CHANNEL-ID` (reconnect case).
+Response: `200 text/event-stream`, response header `X-DIAL-CLIENT-CHANNEL-ID`, SSE body of `RpcRequest` events framed as `data: <json>\n\n`.
+Generated-client impact: this endpoint is **not** exposed through the generated `@epam/chat-api-client` (SSE streaming is a documented generator gap, matching the existing `chat-stream.api.ts` precedent); the frontend calls it with a raw `fetch` in a new `apps/chat/src/server-api/client-channel.ts` adapter, same pattern as `streamCompletion`.
+
+#### Scenario: Fresh subscribe returns a new channel id
+- **WHEN** the frontend calls `POST /api/v1/client-channel/subscribe` with no `X-DIAL-CLIENT-CHANNEL-ID` header
+- **THEN** the backend opens a new upstream Core subscription and streams back `200 text/event-stream` with a fresh `X-DIAL-CLIENT-CHANNEL-ID` response header
+
+#### Scenario: Reconnect forwards the existing channel id
+- **WHEN** the frontend calls subscribe with an `X-DIAL-CLIENT-CHANNEL-ID` header from a previous session
+- **THEN** the backend forwards that header value to Core's subscribe call unchanged
+
+#### Scenario: Browser disconnects mid-stream
+- **WHEN** the browser closes the connection to `/api/v1/client-channel/subscribe` while events are streaming
+- **THEN** the backend aborts the upstream Core reader/fetch and releases any associated resources within the same request lifecycle, without waiting for a subsequent request to clean it up
+
+#### Scenario: Browser disconnects while the upstream subscribe call is still pending
+- **WHEN** the browser closes the connection to `/api/v1/client-channel/subscribe` before the upstream `subscribeClientChannel` call has resolved
+- **THEN** the backend's `AbortController` is aborted immediately (not only after the call eventually resolves), the pending `subscribeClientChannel` fetch is cancelled, and no reader, response headers, or keepalive work is started for the now-closed connection
+
+#### Scenario: Upstream Core connection fails
+- **WHEN** the upstream `subscribeClientChannel` call to Core fails or the upstream stream errors
+- **THEN** the backend closes the response stream to the browser so the frontend's `EventSource`/`fetch` reader observes the failure and can apply its own reconnect policy
+
+#### Scenario: Stream carries a mix of event methods
+- **WHEN** the relayed SSE body contains both a `toolset/signin` frame and an `external-service/signin` frame for the same channel
+- **THEN** the backend relays both frames unmodified and in order, leaving method-based dispatch entirely to the frontend
+
+#### Scenario: A slow browser applies backpressure
+- **WHEN** `res.write()` on the relayed response returns `false` because the browser is not reading fast enough
+- **THEN** the backend stops reading further bytes from the upstream Core stream until the response drains, an error occurs, the response closes, or `SSE_DRAIN_TIMEOUT_MS` elapses
+
+#### Scenario: A stalled browser connection is closed after the drain timeout
+- **WHEN** `res.write()` returns `false` and no `'drain'` event, close, or upstream error occurs within `SSE_DRAIN_TIMEOUT_MS`
+- **THEN** the backend cancels the upstream reader and ends the response, the same as it would for an explicit client disconnect

--- a/openspec/changes/archive/2026-09-11-fix-sse-stream-lifecycle-leaks/specs/conversation-watch-sse/spec.md
+++ b/openspec/changes/archive/2026-09-11-fix-sse-stream-lifecycle-leaks/specs/conversation-watch-sse/spec.md
@@ -1,10 +1,4 @@
-# Spec: conversation-watch-sse
-
-## Purpose
-
-BFF endpoint and frontend integration that lets the browser subscribe to DIAL Core resource-update events for a single conversation, enabling the LLM naming detection to be push-based instead of polled.
-
-## Requirements
+## MODIFIED Requirements
 
 ### Requirement: POST /api/v1/conversations/watch proxies DIAL Core resource subscription as SSE
 
@@ -85,50 +79,3 @@ No i18n keys, no RTL impact, no caching, no analytics events for this endpoint.
 
 - **WHEN** `res.write()` returns `false` and no `'drain'` event, close, or upstream error occurs within `SSE_DRAIN_TIMEOUT_MS`
 - **THEN** the backend cancels the upstream reader and keepalive timer and ends the response, the same as it would for an explicit client disconnect
-
----
-
-### Requirement: Frontend subscribes to conversation watch and replaces polling
-
-`watchForDisplayNameUpdate` in `ConversationsContext` SHALL:
-
-1. Call `conversationsApi.watchConversationRaw({ watchConversationBodyDto: { path } })` (generated client Raw variant) to get the `Response`, where `path` is the bucket-stripped, decode-normalized conversation path (`getConversationPath`).
-2. Read the SSE body via `response.body.getReader()` and a `TextDecoder`, splitting on `\n`.
-3. On each `data:` line: parse JSON `{ url, action, timestamp }`.
-4. On an `UPDATE` action for the subscribed URL: call `getConversation(fullConversationId)` once, where `fullConversationId` is `safeDecodeURIComponent(conversationId)` (`apps/chat/src/utils/string-utils.ts`) — the **bucket-included**, decode-normalized id — NOT the bucket-stripped `path` used in step 1. `getConversation`'s `path` query param must include the bucket to resolve correctly (see `conversations-api` spec); passing the bucket-stripped path caused a 400 from DIAL Core for Quick App conversations, whose deployment-id segment itself contains a slash (`applications/{bucket}/{appName}`).
-5. If `result.llmNamingDone === true` or `result.name?.trim() !== previousName.trim()`: call `updateConversationTitle`, `onUpdated(result.name)`, `silentRefreshConversations()`, then close the connection.
-6. On any other action or a `data:` line that does not match: continue reading.
-7. Abort the connection after `DISPLAY_NAME_WATCH_TIMEOUT_MS = 120_000` using an `AbortController` passed to the fetch.
-8. Cancel the connection when the returned cleanup function is called (component unmount).
-9. If the SSE stream ends unexpectedly before a qualifying event (e.g. server-side close): exit the read loop and complete silently — the title stays message-derived. Reconnect on network interruption is **out of scope**.
-
-The frontend SHALL NOT poll `getConversation` on an interval. Constants `DISPLAY_NAME_POLL_INTERVAL_MS` and `DISPLAY_NAME_POLL_MAX_ATTEMPTS` SHALL be removed.
-
-State ownership: `watchForDisplayNameUpdate` remains a method on `ConversationsContext`, unchanged contract (`(conversationId, previousName, onUpdated) => () => void`).
-
-No new i18n keys. No RTL impact. No analytics events. No memoisation changes beyond the existing `useCallback`.
-
-#### Scenario: Name update via SSE triggers title refresh
-
-- **WHEN** DIAL Core emits an `UPDATE` event for the watched conversation and the subsequent `getConversation` returns `llmNamingDone: true`
-- **THEN** `updateConversationTitle` is called with the new name, `onUpdated` fires, and the SSE connection is closed
-
-#### Scenario: Non-UPDATE events are ignored
-
-- **WHEN** a `CREATE` or `DELETE` event arrives on the SSE stream
-- **THEN** the frontend continues reading without calling `getConversation`
-
-#### Scenario: Timeout closes the connection
-
-- **WHEN** 120 seconds elapse without a qualifying UPDATE event
-- **THEN** the AbortController aborts the fetch and the cleanup completes silently
-
-#### Scenario: Component unmount cancels the watch
-
-- **WHEN** the `Conversation` page unmounts while a watch is open
-- **THEN** the cleanup function aborts the SSE fetch and no further state updates occur
-
-#### Scenario: getConversation on UPDATE uses the full, bucket-included id for a Quick App conversation
-
-- **WHEN** the watched conversation id is `bucket/applications/bucket/My%20App__0.0.1__title__uuid` and an `UPDATE` event arrives
-- **THEN** `watchConversationRaw` was called with the bucket-stripped, decoded path (`applications/bucket/My App__0.0.1__title__uuid`), and the subsequent `getConversation` call receives the full, bucket-included, decoded id (`bucket/applications/bucket/My App__0.0.1__title__uuid`) — not the bucket-stripped path

--- a/openspec/changes/archive/2026-09-11-fix-sse-stream-lifecycle-leaks/specs/generation-live-replay/spec.md
+++ b/openspec/changes/archive/2026-09-11-fix-sse-stream-lifecycle-leaks/specs/generation-live-replay/spec.md
@@ -1,0 +1,24 @@
+## MODIFIED Requirements
+
+### Requirement: Attach subscribers are cleaned up on client disconnect
+
+Unlike `ConversationController.streamCompletion` (which has no client-disconnect handling, by design, so a closed tab does not stop generation), the attach endpoint SHALL detect client disconnect (`res.on('close', ...)`) and remove its listener from the generation's emitter, so listener count reflects only currently-connected subscribers.
+
+The attach endpoint SHALL also detach a subscriber whose response cannot keep up with generation output, without pausing or slowing the generation itself (the generation continues to run and to update the retained assembled message regardless of any attached subscriber's write speed). On each `chunk`/terminal write, the handler SHALL check `res.writableLength` (Node's count of bytes currently buffered for that response) after calling `res.write()`; if it exceeds `SSE_ATTACH_MAX_BUFFERED_BYTES` (1 MiB), the handler SHALL treat the subscriber as unable to keep up and run the same cleanup as a client disconnect (remove its `chunk`/`terminal` listeners, clear its keepalive timer, end its response, release its `dial_chat_sse_active{kind="generation_attach"}` contribution) without emitting further chunks to it.
+
+#### Scenario: Client disconnects mid-attach
+
+- **WHEN** an attached client's connection closes before the generation reaches a terminal state
+- **THEN** the backend removes that subscriber's listener and performs no further writes to its (closed) response, and the generation itself continues unaffected
+
+#### Scenario: A slow attach subscriber is detached without affecting the generation
+
+- **GIVEN** an attach subscriber whose response cannot drain as fast as chunks are produced
+- **WHEN** that subscriber's buffered output (`res.writableLength`) exceeds `SSE_ATTACH_MAX_BUFFERED_BYTES` after a write
+- **THEN** the backend detaches that subscriber (removes its listeners, clears its keepalive timer, ends its response) while the generation and any other concurrently attached subscriber continue receiving chunks and the eventual terminal event unaffected
+
+#### Scenario: A well-behaved attach subscriber is never detached for backpressure
+
+- **GIVEN** an attach subscriber whose response reads chunks promptly (buffered output stays under `SSE_ATTACH_MAX_BUFFERED_BYTES`)
+- **WHEN** the generation produces any number of chunks before reaching a terminal state
+- **THEN** the subscriber receives every chunk and the terminal event, and is never detached for backpressure

--- a/openspec/changes/archive/2026-09-11-fix-sse-stream-lifecycle-leaks/tasks.md
+++ b/openspec/changes/archive/2026-09-11-fix-sse-stream-lifecycle-leaks/tasks.md
@@ -1,0 +1,42 @@
+## 1. Shared SSE backpressure helper
+
+- [x] 1.1 In `apps/chat-api/src/common/utils/sse.ts`, add `writeSseChunk(res, chunk)` returning `{ written, needsDrain }`, and `waitForDrain(res, signal, timeoutMs)` returning `'drained' | 'timeout' | 'aborted'`, per design.md Decision 3. Ensure `waitForDrain` always removes its own `'drain'`/`abort`/timer listeners before resolving, on every branch.
+- [x] 1.2 Add `SSE_DRAIN_TIMEOUT_MS = 5000`, `SSE_COMPLETION_MAX_BUFFERED_BYTES = 1024 * 1024`, and `SSE_ATTACH_MAX_BUFFERED_BYTES = 1024 * 1024` as exported constants alongside the helper (or in the domain files that use them, matching the existing `SSE_KEEPALIVE_INTERVAL_MS` placement pattern).
+- [x] 1.3 Add `apps/chat-api/src/common/utils/tests/sse.spec.ts` covering: `writeSseChunk` reports `needsDrain: true` when the underlying `Writable` returns `false`; `waitForDrain` resolves `'drained'` on a real `'drain'` event, `'aborted'` when the signal fires first, and `'timeout'` when neither happens within the timeout — use a real Node `Writable` with a small `highWaterMark` and manually withheld reads to force backpressure, not a mocked boolean return.
+
+## 2. Client-channel subscribe: early-close + backpressure
+
+- [x] 2.1 In `client-channel.controller.ts`'s `subscribe`, move `new AbortController()` and `res.on('close', handleClose)` registration to before `await this.clientChannelService.subscribe(...)`, so `handleClose` exists and can abort during that await. Keep `trackSseSubscription` counting from the same point it does today.
+- [x] 2.2 Replace the relay loop's raw `res.write(value)` with `writeSseChunk`; on `needsDrain`, `await waitForDrain(res, abortController.signal, SSE_DRAIN_TIMEOUT_MS)` before the next `reader.read()`. On `'timeout'`, treat it as a disconnect: set `isClientAborted = true`, cancel the reader, end the response.
+- [x] 2.3 Update `apps/chat-api/src/client-channel/tests/client-channel.controller.spec.ts` (or create it if it does not yet cover this): a disconnect fired while `clientChannelService.subscribe` is still pending aborts that call's signal and never starts a reader; a slow `Writable` that never drains is closed after the timeout with the upstream reader cancelled.
+- [x] 2.4 Extend `apps/chat-api/src/telemetry/tests/sse-subscription-metrics.spec.ts`'s `client_channel` cases: an early close during pending setup now results in the upstream call actually receiving an aborted signal (not just the gauge staying at 1), and the gauge still returns to 0 exactly once.
+
+## 3. Conversation watch: signal plumbing + early-close + backpressure
+
+- [x] 3.1 Add a `signal: AbortSignal` parameter to `ConversationStreamingService.watchConversation` and pass it to `this.dialClient.client.subscribeToResources({ ..., signal })`. Confirm `ConversationService.watchConversation` needs no edit (bound property re-export).
+- [x] 3.2 In `conversation.controller.ts`'s `watchConversation`, construct the `AbortController` and register `res.on('close', handleClose)` before calling `this.conversationService.watchConversation(dto.path, at, bucket, abortController.signal)`; keep `trackSseSubscription` counting from the same point.
+- [x] 3.3 Replace the relay loop's `res.write(value)` and the keepalive `res.write(SSE_KEEPALIVE_PAYLOAD)` with `writeSseChunk`; on `needsDrain` from the main relay write, `await waitForDrain(...)` bounded by `abortController.signal` and `SSE_DRAIN_TIMEOUT_MS` before the next `reader.read()`, same timeout-as-disconnect handling as client-channel. Keepalive writes only need the `written` check (skip when already detached), not a drain wait.
+- [x] 3.4 Add/extend `apps/chat-api/src/conversations/tests/conversation.controller.spec.ts` (or the relevant streaming test file) with: `subscribeToResources` receives the propagated signal and observes it aborting on early close; a stalled watch connection is closed after the drain timeout with the keepalive timer cleared and the reader cancelled.
+- [x] 3.5 Extend `sse-subscription-metrics.spec.ts`'s `conversation_watch` cases the same way as task 2.4.
+
+## 4. Completion delivery: bounded backpressure without pausing generation
+
+- [x] 4.1 In `conversation.controller.ts`'s `streamCompletion`, replace `res.write(chunk)` with `writeSseChunk`; immediately after, if `res.writableLength > SSE_COMPLETION_MAX_BUFFERED_BYTES`, set `isResponseDetached = true` (reusing the existing flag/finally cleanup — no new code path). Do not await drain here — the generator loop must keep running regardless of the response's write speed.
+- [x] 4.2 Add a test (in `apps/chat-api/src/conversations/tests/`, alongside `completions.integration.spec.ts`) using a real `Writable`-backed mock response with a small `highWaterMark`: feed chunks fast enough to exceed `SSE_COMPLETION_MAX_BUFFERED_BYTES`, assert the response stops receiving further writes (detached) while the generator is driven to completion and `finalize()` still persists the full assembled message — mirroring the existing "closed response" persistence assertions in that spec.
+- [x] 4.3 Add a regression test for the existing "closed downstream response" scenarios (disconnect before/around `onReadyToStream`, disconnect mid-stream) to confirm they still pass unchanged after the `writeSseChunk` swap — this is a refactor-safety check, not new behavior.
+
+## 5. Generation attach: bounded backpressure per subscriber
+
+- [x] 5.1 In `conversation.controller.ts`'s `attachToGeneration`, replace both `writeEvent`'s `res.write(...)` call and the keepalive `res.write(SSE_KEEPALIVE_PAYLOAD)` with `writeSseChunk`. After each event write (snapshot, chunk, terminal), if `res.writableLength > SSE_ATTACH_MAX_BUFFERED_BYTES`, call the existing `cleanup()` instead of continuing to write to that subscriber.
+- [x] 5.2 Verify `cleanup()`'s idempotency guard (`isCleanedUp`) correctly short-circuits when backpressure-triggered cleanup races with a `terminal` event or a `close` event arriving around the same time — add a test forcing that race (emit `terminal` and trigger the buffered-bytes threshold in the same tick) and assert listeners are removed exactly once and `finishSubscription()` runs exactly once.
+- [x] 5.3 Add a test with two concurrent attach subscribers on the same generation (mirroring `generation-live-replay`'s existing "two concurrent subscribers" scenario): one has a real slow `Writable` that exceeds the byte limit and gets detached, the other keeps draining normally and receives every chunk plus the terminal event — confirms detaching one subscriber never affects another or the generation.
+- [x] 5.4 Extend `sse-subscription-metrics.spec.ts`'s `generation attachment` describe block with a case asserting the gauge returns to 0 when a subscriber is detached for backpressure (not just on `close`/terminal).
+
+## 6. Cross-cutting verification
+
+- [x] 6.1 Run `npm exec nx test chat-api` and confirm all new and existing specs pass, including `runtime-metrics.spec.ts`, `sse-subscription-metrics.spec.ts`, `conversation-generation.service.spec.ts`, and `completions.integration.spec.ts`.
+- [x] 6.2 Run `npm exec nx lint chat-api` and fix any findings.
+- [x] 6.3 Run `npm exec nx build chat-api` to confirm the Nest bundle still starts cleanly with the new shared helper.
+- [ ] 6.4 Manually verify via `npm run start:api` + `npm start`: open a conversation, start a completion, and close the tab mid-stream — confirm (via logs or a debugger) that the generation still completes and persists, matching `backend-owned-generation-persistence`'s existing manual-check precedent.
+- [x] 6.5 Update `apps/chat-api/README.md`'s SSE-handling section (if present) to document the drain-timeout and buffered-bytes constants and which handlers use which, then run `npm run validate:docs`.
+- [x] 6.6 Run `npm run openapi:check` to confirm no accidental OpenAPI drift (no DTO/endpoint shape changed in this work).

--- a/openspec/specs/backend-owned-generation-persistence/spec.md
+++ b/openspec/specs/backend-owned-generation-persistence/spec.md
@@ -55,7 +55,9 @@ The downstream HTTP connection closing (browser tab closed, page navigated away,
 
 Closing, refreshing, or navigating away from the browser connection that opened `POST /api/v1/conversations/completions` SHALL have no effect on the generation's outcome or persistence. `ConversationController.streamCompletion` SHALL continue consuming `ConversationStreamingService.streamCompletion`'s async generator to its natural terminal outcome after the downstream HTTP response closes; it MUST NOT abort the generation's `AbortController` and MUST NOT stop iterating merely because the response closed. It SHALL stop writing to the closed response (and MUST NOT attempt any further `res.write`/`res.end` calls against it) but otherwise treats the generation exactly as if the original client were still connected.
 
-When the upstream stream subsequently reaches a normal terminal event (`[DONE]`, a provider error, or an explicit Stop received before the disconnect), the backend persists the outcome per the existing outcome table in "Backend persists the conversation across the generation lifecycle" — a disconnect never substitutes a different, disconnect-specific outcome. Reopening the conversation (in the same or a different browser tab/session) after the generation finishes SHALL show the complete persisted response, not a truncated or error-marked one caused by the earlier disconnect.
+The same "stop writing but keep generating" treatment SHALL apply when the response is not closed but cannot keep up with output: after each `res.write(chunk)`, the handler SHALL check `res.writableLength`; if it exceeds `SSE_COMPLETION_MAX_BUFFERED_BYTES` (1 MiB), the handler SHALL mark the response detached (setting the same `isResponseDetached` flag used for a closed connection) and stop calling `res.write`/`res.end` against it for the remainder of the generation, without pausing, slowing, or aborting the generation loop itself.
+
+When the upstream stream subsequently reaches a normal terminal event (`[DONE]`, a provider error, or an explicit Stop received before the disconnect), the backend persists the outcome per the existing outcome table in "Backend persists the conversation across the generation lifecycle" — a disconnect or a backpressure-driven detachment never substitutes a different, disconnect-specific outcome. Reopening the conversation (in the same or a different browser tab/session) after the generation finishes SHALL show the complete persisted response, not a truncated or error-marked one caused by the earlier disconnect or detachment.
 
 This requirement applies only to `POST /api/v1/conversations/completions`. It does not apply to `POST /api/v1/client-channel/subscribe` (an ephemeral client subscription with no independent backend-owned lifecycle — see `client-channel-protocol`) or to `POST /api/v1/conversations/completions/attach` (an observer of an existing generation — see `generation-live-replay`), both of which correctly abort their own upstream work on disconnect because nothing else depends on that work continuing.
 
@@ -81,6 +83,18 @@ This requirement applies only to `POST /api/v1/conversations/completions`. It do
 
 - **WHEN** a generation is active for conversation A and the user navigates to conversation B and back, or to an unrelated page in the SPA, before the generation finishes
 - **THEN** the generation for conversation A continues unaffected and completes normally
+
+#### Scenario: A slow browser connection is detached without pausing generation
+
+- **GIVEN** a generation is actively streaming to a connected browser that reads slower than chunks are produced
+- **WHEN** `res.writableLength` exceeds `SSE_COMPLETION_MAX_BUFFERED_BYTES` after a write
+- **THEN** the backend stops writing further chunks to that response (marking it detached, the same as a closed connection) while the generation continues unaffected until its natural terminal outcome
+
+#### Scenario: The complete response is persisted after a backpressure-driven detachment
+
+- **GIVEN** the response was detached for backpressure as in the scenario above
+- **WHEN** the upstream subsequently reaches `[DONE]`
+- **THEN** the backend persists the full assembled assistant message exactly as it would for a client disconnect, and reopening the conversation shows the complete response
 
 ### Requirement: Generation finalizes on `[DONE]`, not on socket close
 

--- a/openspec/specs/client-channel-protocol/spec.md
+++ b/openspec/specs/client-channel-protocol/spec.md
@@ -8,6 +8,10 @@ TBD - created by archiving change interactive-toolset-login-chat. Update Purpose
 
 The backend SHALL expose `POST /api/v1/client-channel/subscribe` (NestJS domain `apps/chat-api/src/client-channel/`, `ClientChannelController`, `@Controller({ path: 'client-channel', version: '1' })`). The endpoint SHALL call `@epam/ai-dial-typescript-sdk`'s `subscribeClientChannel` using the bearer access token from the caller's encrypted BFF session (never a value supplied by the browser), and SHALL relay the upstream `text/event-stream` response body to the browser without buffering it in memory. The response SHALL echo the `X-DIAL-CLIENT-CHANNEL-ID` header returned by Core. If the browser already holds a channel id (reconnect), the frontend SHALL send it as a request header and the backend SHALL forward it to Core unchanged so Core can attempt to resume the same channel. The relayed SSE body MAY carry RPC events of different `method` values (e.g. `toolset/signin`, `external-service/signin`) — the backend SHALL relay every event body-for-body without inspecting or filtering on `method`; method-specific handling is entirely a frontend concern.
 
+The handler SHALL register its `res.on('close', ...)` listener, and construct the `AbortController` whose signal is passed to `ClientChannelService.subscribe`, before making that call — i.e. before the first `await` of upstream setup — so a browser disconnect that happens while the upstream subscribe call is still in flight aborts that call immediately instead of being observed only once the call resolves. The `dial_chat_sse_active{kind="client_channel"}` gauge contribution (see `observability-telemetry`) SHALL start before this call and be released exactly once when the handler settles, unchanged by this requirement.
+
+While relaying, the handler SHALL respect `res.write()`'s return value: when it returns `false`, the handler SHALL stop issuing further upstream reads until the response emits `'drain'`, bounded by the response closing, the upstream stream erroring, or an internal drain timeout (`SSE_DRAIN_TIMEOUT_MS`, 5000ms) — whichever happens first. If the drain timeout elapses without a `'drain'` event, the handler SHALL treat the connection as stalled: cancel the upstream reader and end the response, identical to a client disconnect.
+
 Request: no body. Optional request header `X-DIAL-CLIENT-CHANNEL-ID` (reconnect case).
 Response: `200 text/event-stream`, response header `X-DIAL-CLIENT-CHANNEL-ID`, SSE body of `RpcRequest` events framed as `data: <json>\n\n`.
 Generated-client impact: this endpoint is **not** exposed through the generated `@epam/chat-api-client` (SSE streaming is a documented generator gap, matching the existing `chat-stream.api.ts` precedent); the frontend calls it with a raw `fetch` in a new `apps/chat/src/server-api/client-channel.ts` adapter, same pattern as `streamCompletion`.
@@ -24,6 +28,10 @@ Generated-client impact: this endpoint is **not** exposed through the generated 
 - **WHEN** the browser closes the connection to `/api/v1/client-channel/subscribe` while events are streaming
 - **THEN** the backend aborts the upstream Core reader/fetch and releases any associated resources within the same request lifecycle, without waiting for a subsequent request to clean it up
 
+#### Scenario: Browser disconnects while the upstream subscribe call is still pending
+- **WHEN** the browser closes the connection to `/api/v1/client-channel/subscribe` before the upstream `subscribeClientChannel` call has resolved
+- **THEN** the backend's `AbortController` is aborted immediately (not only after the call eventually resolves), the pending `subscribeClientChannel` fetch is cancelled, and no reader, response headers, or keepalive work is started for the now-closed connection
+
 #### Scenario: Upstream Core connection fails
 - **WHEN** the upstream `subscribeClientChannel` call to Core fails or the upstream stream errors
 - **THEN** the backend closes the response stream to the browser so the frontend's `EventSource`/`fetch` reader observes the failure and can apply its own reconnect policy
@@ -31,6 +39,14 @@ Generated-client impact: this endpoint is **not** exposed through the generated 
 #### Scenario: Stream carries a mix of event methods
 - **WHEN** the relayed SSE body contains both a `toolset/signin` frame and an `external-service/signin` frame for the same channel
 - **THEN** the backend relays both frames unmodified and in order, leaving method-based dispatch entirely to the frontend
+
+#### Scenario: A slow browser applies backpressure
+- **WHEN** `res.write()` on the relayed response returns `false` because the browser is not reading fast enough
+- **THEN** the backend stops reading further bytes from the upstream Core stream until the response drains, an error occurs, the response closes, or `SSE_DRAIN_TIMEOUT_MS` elapses
+
+#### Scenario: A stalled browser connection is closed after the drain timeout
+- **WHEN** `res.write()` returns `false` and no `'drain'` event, close, or upstream error occurs within `SSE_DRAIN_TIMEOUT_MS`
+- **THEN** the backend cancels the upstream reader and ends the response, the same as it would for an explicit client disconnect
 
 ### Requirement: BFF proxies report and unsubscribe operations
 

--- a/openspec/specs/generation-live-replay/spec.md
+++ b/openspec/specs/generation-live-replay/spec.md
@@ -68,7 +68,21 @@ The endpoint SHALL support more than one concurrent subscriber for the same acti
 
 Unlike `ConversationController.streamCompletion` (which has no client-disconnect handling, by design, so a closed tab does not stop generation), the attach endpoint SHALL detect client disconnect (`res.on('close', ...)`) and remove its listener from the generation's emitter, so listener count reflects only currently-connected subscribers.
 
+The attach endpoint SHALL also detach a subscriber whose response cannot keep up with generation output, without pausing or slowing the generation itself (the generation continues to run and to update the retained assembled message regardless of any attached subscriber's write speed). On each `chunk`/terminal write, the handler SHALL check `res.writableLength` (Node's count of bytes currently buffered for that response) after calling `res.write()`; if it exceeds `SSE_ATTACH_MAX_BUFFERED_BYTES` (1 MiB), the handler SHALL treat the subscriber as unable to keep up and run the same cleanup as a client disconnect (remove its `chunk`/`terminal` listeners, clear its keepalive timer, end its response, release its `dial_chat_sse_active{kind="generation_attach"}` contribution) without emitting further chunks to it.
+
 #### Scenario: Client disconnects mid-attach
 
 - **WHEN** an attached client's connection closes before the generation reaches a terminal state
 - **THEN** the backend removes that subscriber's listener and performs no further writes to its (closed) response, and the generation itself continues unaffected
+
+#### Scenario: A slow attach subscriber is detached without affecting the generation
+
+- **GIVEN** an attach subscriber whose response cannot drain as fast as chunks are produced
+- **WHEN** that subscriber's buffered output (`res.writableLength`) exceeds `SSE_ATTACH_MAX_BUFFERED_BYTES` after a write
+- **THEN** the backend detaches that subscriber (removes its listeners, clears its keepalive timer, ends its response) while the generation and any other concurrently attached subscriber continue receiving chunks and the eventual terminal event unaffected
+
+#### Scenario: A well-behaved attach subscriber is never detached for backpressure
+
+- **GIVEN** an attach subscriber whose response reads chunks promptly (buffered output stays under `SSE_ATTACH_MAX_BUFFERED_BYTES`)
+- **WHEN** the generation produces any number of chunks before reaching a terminal state
+- **THEN** the subscriber receives every chunk and the terminal event, and is never detached for backpressure


### PR DESCRIPTION
## Summary
- Move `res.on('close', ...)`/`AbortController` registration before the first `await` of upstream setup in `client-channel/subscribe` and `conversations/watch`, so a browser disconnect during that await actually aborts the pending upstream call instead of being observed only after it resolves.
- Thread an `AbortSignal` through `ConversationStreamingService.watchConversation` into DIAL Core's `subscribeToResources` (previously accepted no signal at all).
- Add a shared `writeSseChunk`/`waitForDrain` helper (`apps/chat-api/src/common/utils/sse.ts`) so all four SSE-writing handlers respect `res.write()`'s backpressure return value instead of buffering indefinitely; a stalled connection is closed after `SSE_DRAIN_TIMEOUT_MS` (5s).
- Bound buffered output for the two backend-owned-generation handlers (`streamCompletion`, `attachToGeneration`) at 1 MiB per response/subscriber, detaching a slow client without pausing or aborting the generation itself.
- Synced the four affected capability specs (`client-channel-protocol`, `conversation-watch-sse`, `generation-live-replay`, `backend-owned-generation-persistence`) and archived the OpenSpec change.

## Test plan
- [x] `npm exec nx test chat-api` — 3087/3087 pass, including new/updated specs for the drain helper, early-abort behavior, and backpressure detachment
- [x] `npm exec nx lint chat-api` — no errors
- [x] `npm exec nx build chat-api` — builds cleanly
- [x] `npm run validate:docs` — passes (README SSE section updated)
- [x] `npm run openapi:check` — no contract drift (no DTO/endpoint shape changes)
- [ ] Manual verification against a running `start:api` + `start` stack (open a conversation, start a completion, close the tab mid-stream, confirm via logs the generation still completes and persists) — **not yet done**, flagged as a follow-up before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)