### PR TITLE
fix(chat): persist the regenerated model, bundle stage and citation files in export, send the clicked quick-reply, make transfer-queue cancel clickable, correct the Copy as Markdown label, let the model selector version use the free row width (Issue #8708, #8712, #8739, #8741, #8665, #8740)

### DIFF
--- a/apps/chat/src/components/DeploymentSelector/DeploymentSelectorPanel.tsx
+++ b/apps/chat/src/components/DeploymentSelector/DeploymentSelectorPanel.tsx
@@ -273,16 +273,6 @@ const DeploymentSelectorPanel: FC<Props> = ({
             />
           }
           label={
-            /*
-              The version is what tells same-named agents apart, so it is never
-              capped at a fraction of the row: it takes whatever width the name
-              leaves, and `flex-wrap` moves it onto a line of its own once the
-              pair genuinely stops fitting. Wrapping rather than truncating is
-              what keeps the value readable on touch, where the overflow
-              tooltip the row used to depend on cannot be opened at all.
-              `whitespace-normal` undoes the `truncate` MenuItem puts on the
-              row, which would otherwise keep the version on one nowrap line.
-            */
             <span className="flex min-w-0 flex-1 flex-wrap items-start gap-x-1.5 whitespace-normal">
               {query.trim() ? (
                 <Highlight

--- a/apps/chat/src/components/DeploymentSelector/DeploymentSelectorPanel.tsx
+++ b/apps/chat/src/components/DeploymentSelector/DeploymentSelectorPanel.tsx
@@ -273,7 +273,17 @@ const DeploymentSelectorPanel: FC<Props> = ({
             />
           }
           label={
-            <span className="flex min-w-0 flex-1 items-start gap-1.5">
+            /*
+              The version is what tells same-named agents apart, so it is never
+              capped at a fraction of the row: it takes whatever width the name
+              leaves, and `flex-wrap` moves it onto a line of its own once the
+              pair genuinely stops fitting. Wrapping rather than truncating is
+              what keeps the value readable on touch, where the overflow
+              tooltip the row used to depend on cannot be opened at all.
+              `whitespace-normal` undoes the `truncate` MenuItem puts on the
+              row, which would otherwise keep the version on one nowrap line.
+            */
+            <span className="flex min-w-0 flex-1 flex-wrap items-start gap-x-1.5 whitespace-normal">
               {query.trim() ? (
                 <Highlight
                   text={item.name}
@@ -287,12 +297,9 @@ const DeploymentSelectorPanel: FC<Props> = ({
                 />
               )}
               {item.version && (
-                /* Capped at 30% of the row so a long version truncates instead
-                   of squeezing the name out of the option. */
-                <EllipsisTooltip
-                  text={item.version}
-                  className="dial-tiny-text max-w-[30%] shrink-0 text-secondary"
-                />
+                <span className="dial-tiny-text min-w-0 break-words text-secondary">
+                  {item.version}
+                </span>
               )}
             </span>
           }

--- a/apps/chat/src/components/DeploymentSelector/tests/DeploymentSelectorPanel.spec.tsx
+++ b/apps/chat/src/components/DeploymentSelector/tests/DeploymentSelectorPanel.spec.tsx
@@ -45,27 +45,48 @@ const renderPanel = (
   );
 
 describe('DeploymentSelectorPanel — long version', () => {
-  it('caps the version at 30% of the row so it cannot overlap the name', () => {
-    renderPanel([
-      {
-        ...makeItem('model-1', CatalogEntityType.Model),
-        version: 'With Google Search Grounding',
-      },
-    ]);
+  const longVersionItem = {
+    ...makeItem('model-1', CatalogEntityType.Model),
+    version: 'With Google Search Grounding',
+  };
+
+  it('gives the version the row width the name leaves instead of a fixed fraction of it', () => {
+    renderPanel([longVersionItem]);
 
     const version = screen.getByText('With Google Search Grounding');
-    expect(version.className).toContain('max-w-[30%]');
-    expect(version.className).toContain('shrink-0');
+    /* Asserting CSS-level layout (not text/role) has no semantic query
+       equivalent — this repo's spec conventions carve out this exact case. */
+    expect(version.className).not.toContain('max-w-');
+    expect(version.className).not.toContain('truncate');
+  });
+
+  it('wraps the version onto its own line rather than truncating it to a hover-only tooltip', () => {
+    renderPanel([longVersionItem]);
+
+    const version = screen.getByText('With Google Search Grounding');
+    expect(version.className).toContain('break-words');
+    /* The wrap rule lives on the name+version wrapper, which the version text
+       node is the only stable handle on. */
+    expect(version.parentElement?.className).toContain('flex-wrap');
+  });
+
+  it('keeps the whole version in the row so it is readable without hovering', () => {
+    renderPanel([longVersionItem]);
+
+    expect(
+      screen.getByRole('menuitemradio', {
+        name: /model-1 With Google Search Grounding/,
+      }),
+    ).toBeTruthy();
   });
 
   it('renders no version element when the item has an empty version', () => {
     renderPanel([makeItem('model-1', CatalogEntityType.Model)]);
 
-    /* Asserting the absence of a CSS-level styling class (not text/role) has
-       no semantic query equivalent — this repo's spec conventions carve out
-       this exact case for container/document.querySelector. */
+    /* Absence of the version element is only observable through the class that
+       styles it, since an empty version has no text to query by. */
     // eslint-disable-next-line testing-library/no-node-access
-    expect(document.querySelector('.max-w-\\[30\\%\\]')).toBeNull();
+    expect(document.querySelector('.dial-tiny-text')).toBeNull();
   });
 });
 

--- a/apps/chat/src/i18n/locales/en.json
+++ b/apps/chat/src/i18n/locales/en.json
@@ -367,7 +367,7 @@
     "deleteMessage": "Delete message",
     "regenerateResponse": "Regenerate response",
     "copyResponse": "Copy response",
-    "copyAsMarkdown": "Copy markdown",
+    "copyAsMarkdown": "Copy as Markdown",
     "copyAsCsv": "Copy as CSV",
     "openInCanvas": "Open in canvas",
     "copyAsTxt": "Copy as TXT",

--- a/libs/chat-hooks/README.md
+++ b/libs/chat-hooks/README.md
@@ -936,7 +936,38 @@ const ChatPage = ({
 state updater, so a host may update its own state from it — for example dropping
 the deleted conversation from a list it renders.
 
-Also exports the standalone `attachmentsToDtos`/`attachmentToDto`, `createMessagePair`, `hasActiveToolConfig`/`isMessageChanged`/`isAnswerIncomplete`/`shouldRerunGenerationOnEdit`, and `getStarterConversationText`/`getStarterSubmitText` (the pure functions the hook is built on) for hosts that need the same logic outside the hook.
+Also exports the standalone `attachmentsToDtos`/`attachmentToDto`, `createMessagePair`, `hasActiveToolConfig`/`isMessageChanged`/`isAnswerIncomplete`/`shouldRerunGenerationOnEdit`, and `getStarterConversationText`/`getStarterDisplayText`/`getStarterSubmitText` (the pure functions the hook is built on) for hosts that need the same logic outside the hook.
+
+The three starter-text helpers share one precedence rule: a starter's own
+`dial:widgetOptions.populateText` always wins, and the schema property's shared
+`description` is only a fallback for a starter that carries no text of its own —
+otherwise every button in a described group would produce the same message.
+`getStarterSubmitText` additionally returns `''` for a submit button whose
+`populateText` is explicitly `null` ("submit no text"), and
+`getStarterDisplayText` falls back to `starter.title` in that case so the user's
+message bubble still shows the button label.
+
+```ts
+import {
+  getStarterDisplayText,
+  getStarterSubmitText,
+} from '@epam/ai-dial-chat-hooks';
+
+const starter = {
+  const: 0,
+  title: 'How does feature X work?',
+  'dial:widgetOptions': {
+    populateText:
+      'How does feature X work, and what are its configuration options?',
+    submit: true,
+    confirmationMessage: null,
+  },
+};
+
+// Both ignore the group description and use the starter's own populateText.
+getStarterSubmitText(starter, 'Follow-Up Questions');
+getStarterDisplayText(starter, 'Follow-Up Questions');
+```
 
 ### useAttachmentValidation
 

--- a/libs/chat-hooks/README.md
+++ b/libs/chat-hooks/README.md
@@ -145,8 +145,10 @@ const {
 // ./conversation
 import { getLastDeploymentId } from '@epam/ai-dial-chat-hooks/conversation';
 
-/* Returns the model deployment id from the most recent `model_changed`
-   status message, or null if the conversation never switched models. */
+/* Returns the deployment the conversation was last running on — scanning
+   backwards, a `model_changed` status message's `new_deployment_id` or a
+   message's own `deploymentId`, whichever comes later. Null when the
+   conversation records neither. */
 const newDeploymentId = getLastDeploymentId(conversation.messages);
 ```
 
@@ -2131,7 +2133,7 @@ const statusMessage = createDeploymentChangedMessage('gpt-4', 'gpt-4o');
 
 ### isMessageStreaming / getLastDeploymentId / messageHasStages / getLastUserMessageToolConfiguration / normalizeResponseFormat
 
-Pure predicates/lookups over a conversation's `Message[]`: whether a message is the actively-streaming assistant response, the last deployment a `model_changed` status message recorded, whether a message carries any stages, the last user message's persisted tool-configuration value, and normalizing a legacy `responseFormat` string to the current enum.
+Pure predicates/lookups over a conversation's `Message[]`: whether a message is the actively-streaming assistant response, the deployment the conversation was last running on (the later of a `model_changed` status message's `new_deployment_id` and a message's own `deploymentId`), whether a message carries any stages, the last user message's persisted tool-configuration value, and normalizing a legacy `responseFormat` string to the current enum.
 
 ```ts
 import { getLastDeploymentId } from '@epam/ai-dial-chat-hooks';

--- a/libs/chat-hooks/src/conversation/conversation-transfer/attachment-refs.ts
+++ b/libs/chat-hooks/src/conversation/conversation-transfer/attachment-refs.ts
@@ -18,8 +18,23 @@ export interface AttachmentReference {
 }
 
 /**
+ * Character set an anchor must stay within to be carried onto a rewritten
+ * reference. The only anchor anything here parses is `#page=<digits>`
+ * (`PDF_PAGE_REFERENCE_REGEX` in `libs/quotations/src/utils/reference-attachment.ts`);
+ * every other reader strips the fragment outright.
+ *
+ * An imported `.dial` archive is attacker-controllable input, and the anchor
+ * from one is re-appended to the upload URL that the import then persists
+ * into the conversation. Nothing downstream needs a character outside this
+ * set, so a fragment carrying one is dropped rather than stored.
+ */
+const SAFE_ANCHOR_PATTERN = /^#[\w.=%-]*$/;
+
+/**
  * Splits a DIAL file reference into the resource id and its trailing `#…`
- * anchor (e.g. the `#page=3` a PDF citation carries).
+ * anchor (e.g. the `#page=3` a PDF citation carries). An anchor outside
+ * {@link SAFE_ANCHOR_PATTERN} is reported as absent; the file id is returned
+ * either way, so the attachment itself is still transferred.
  *
  * The anchor is display metadata, not part of the stored resource path: the
  * download endpoint 404s on it, so it has to be stripped before a reference
@@ -30,9 +45,13 @@ export const splitFileIdAnchor = (
   url: string,
 ): { fileId: string; anchor: string } => {
   const anchorIndex = url.indexOf('#');
-  return anchorIndex < 0
-    ? { fileId: url, anchor: '' }
-    : { fileId: url.slice(0, anchorIndex), anchor: url.slice(anchorIndex) };
+  if (anchorIndex < 0) return { fileId: url, anchor: '' };
+
+  const anchor = url.slice(anchorIndex);
+  return {
+    fileId: url.slice(0, anchorIndex),
+    anchor: SAFE_ANCHOR_PATTERN.test(anchor) ? anchor : '',
+  };
 };
 
 /** A unique DIAL file reference found in a conversation's messages. */

--- a/libs/chat-hooks/src/conversation/conversation-transfer/attachment-refs.ts
+++ b/libs/chat-hooks/src/conversation/conversation-transfer/attachment-refs.ts
@@ -3,27 +3,99 @@ import type { Conversation } from '@epam/ai-dial-chat-shared';
 /** Whether `url` is a DIAL Core file reference (`files/{bucket}/{path}`). */
 const isDialFileId = (url: string): boolean => url.startsWith('files/');
 
+/**
+ * The reference fields shared by every attachment shape a conversation can
+ * carry — `MessageAttachment` on a message or a stage, and
+ * `AttachmentResource` on a citation's source.
+ */
+export interface AttachmentReference {
+  /** DIAL file id (`files/{bucket}/{path}`), optionally with a trailing `#…` anchor. */
+  url?: string;
+  /** Alternate reference resource, same shape as `url`. */
+  reference_url?: string;
+  /** Display name shown in the UI. */
+  title?: string;
+}
+
+/**
+ * Splits a DIAL file reference into the resource id and its trailing `#…`
+ * anchor (e.g. the `#page=3` a PDF citation carries).
+ *
+ * The anchor is display metadata, not part of the stored resource path: the
+ * download endpoint 404s on it, so it has to be stripped before a reference
+ * is resolved to `{bucket, path}` — and restored afterwards, so an imported
+ * citation still opens the page it cited.
+ */
+export const splitFileIdAnchor = (
+  url: string,
+): { fileId: string; anchor: string } => {
+  const anchorIndex = url.indexOf('#');
+  return anchorIndex < 0
+    ? { fileId: url, anchor: '' }
+    : { fileId: url.slice(0, anchorIndex), anchor: url.slice(anchorIndex) };
+};
+
 /** A unique DIAL file reference found in a conversation's messages. */
 export interface AttachmentRef {
   fileId: string;
 }
 
 /**
- * Collects unique attachment references across all messages. The same file
- * can be attached to more than one message (e.g. re-shared in a later
- * turn) — dedupe by `fileId` so it is only processed once.
+ * Visits every attachment a conversation's messages carry, in render order.
+ *
+ * Reading only `custom_content.attachments` misses the files an agent
+ * produces inside an execution stage and the source documents a citation
+ * points at, which is how app-generated files usually reach a conversation
+ * (issue #8708). The backend's share flow already grants access to all three
+ * (`collectConversationResourceUrls` in `apps/chat-api/src/share/share.service.ts`);
+ * export and import have to bundle and re-point the same set, or the imported
+ * conversation keeps referencing files in the exporting user's bucket.
+ */
+const forEachAttachmentReference = (
+  conversation: Conversation,
+  visit: (attachment: AttachmentReference) => void,
+): void => {
+  for (const message of conversation.messages) {
+    const customContent = message.custom_content;
+    if (!customContent) continue;
+
+    for (const attachment of customContent.attachments ?? []) {
+      visit(attachment);
+    }
+    for (const stage of customContent.stages ?? []) {
+      for (const attachment of stage.attachments ?? []) {
+        visit(attachment);
+      }
+    }
+    for (const annotation of customContent.annotations ?? []) {
+      const attachment = annotation.body?.source?.attachment;
+      if (attachment) visit(attachment);
+    }
+  }
+};
+
+/**
+ * Collects unique attachment references across all messages — message
+ * attachments, stage attachments, and citation source documents — with any
+ * `#…` anchor stripped. The same file can be referenced more than once (by a
+ * later turn, by a stage and the message it belongs to, or by several
+ * citations), so dedupe by file id and process it only once.
  */
 export const collectAttachmentRefs = (
   conversation: Conversation,
 ): AttachmentRef[] => {
   const fileIds = new Set<string>();
-  for (const message of conversation.messages) {
-    for (const attachment of message.custom_content?.attachments ?? []) {
-      const fileId = attachment.url ?? attachment.reference_url;
-      if (fileId != null && isDialFileId(fileId)) {
-        fileIds.add(fileId);
-      }
-    }
-  }
+
+  const addRef = (url: string | undefined): void => {
+    if (url == null) return;
+    const { fileId } = splitFileIdAnchor(url);
+    if (isDialFileId(fileId)) fileIds.add(fileId);
+  };
+
+  forEachAttachmentReference(conversation, (attachment) => {
+    addRef(attachment.url);
+    addRef(attachment.reference_url);
+  });
+
   return Array.from(fileIds, (fileId) => ({ fileId }));
 };

--- a/libs/chat-hooks/src/conversation/conversation-transfer/import-conversation.ts
+++ b/libs/chat-hooks/src/conversation/conversation-transfer/import-conversation.ts
@@ -5,11 +5,14 @@ import {
   truncateToUtf8Bytes,
 } from '@epam/ai-dial-chat-shared';
 import type {
+  Annotation,
   Conversation,
   ExportFolder,
   ExportFormat,
+  Stage,
 } from '@epam/ai-dial-chat-shared';
-import { collectAttachmentRefs } from './attachment-refs';
+import { collectAttachmentRefs, splitFileIdAnchor } from './attachment-refs';
+import type { AttachmentReference } from './attachment-refs';
 import type {
   AllocatedUploadPath,
   UploadPathAllocator,
@@ -281,10 +284,94 @@ export interface RewrittenAttachmentTarget {
 }
 
 /**
- * Rewrites every message's attachment `url`/`reference_url` referencing an
- * old file id to its new uploaded location, and its `title` when the target
- * carries a renamed one. Attachments not present in `targetMap` are left
- * untouched (immutable — returns a new conversation).
+ * Resolves one reference against `targetMap`, matching on the file id alone
+ * and carrying any `#…` anchor (e.g. a citation's `#page=3`) over to the new
+ * location, so an imported citation still opens the page it cited.
+ */
+const resolveRewrittenTarget = (
+  url: string | undefined,
+  targetMap: Map<string, RewrittenAttachmentTarget>,
+): RewrittenAttachmentTarget | undefined => {
+  if (!url) return undefined;
+  const { fileId, anchor } = splitFileIdAnchor(url);
+  const target = targetMap.get(fileId);
+  if (target == null) return undefined;
+  return { ...target, url: `${target.url}${anchor}` };
+};
+
+/**
+ * Returns the `url`/`reference_url`/`title` fields to overwrite on one
+ * attachment, or `undefined` when neither of its references was uploaded.
+ * Returning a patch rather than a whole attachment keeps the caller's own
+ * shape (a `MessageAttachment` or a citation's `AttachmentResource`) intact.
+ */
+const buildAttachmentPatch = (
+  attachment: AttachmentReference,
+  targetMap: Map<string, RewrittenAttachmentTarget>,
+): AttachmentReference | undefined => {
+  const urlTarget = resolveRewrittenTarget(attachment.url, targetMap);
+  const referenceTarget = resolveRewrittenTarget(
+    attachment.reference_url,
+    targetMap,
+  );
+  if (urlTarget == null && referenceTarget == null) return undefined;
+
+  const newTitle = urlTarget?.title ?? referenceTarget?.title;
+  return {
+    ...(urlTarget != null ? { url: urlTarget.url } : {}),
+    ...(referenceTarget != null ? { reference_url: referenceTarget.url } : {}),
+    ...(newTitle != null ? { title: newTitle } : {}),
+  };
+};
+
+/** Rewrites the attachments an agent produced inside each execution stage. */
+const rewriteStages = (
+  stages: Stage[],
+  targetMap: Map<string, RewrittenAttachmentTarget>,
+): Stage[] =>
+  stages.map((stage) =>
+    stage.attachments?.length
+      ? {
+          ...stage,
+          attachments: stage.attachments.map((attachment) => {
+            const patch = buildAttachmentPatch(attachment, targetMap);
+            return patch ? { ...attachment, ...patch } : attachment;
+          }),
+        }
+      : stage,
+  );
+
+/** Rewrites the source document each citation points at. */
+const rewriteAnnotations = (
+  annotations: Annotation[],
+  targetMap: Map<string, RewrittenAttachmentTarget>,
+): Annotation[] =>
+  annotations.map((annotation) => {
+    const source = annotation.body?.source;
+    if (source?.attachment == null) return annotation;
+
+    const patch = buildAttachmentPatch(source.attachment, targetMap);
+    if (patch == null) return annotation;
+
+    return {
+      ...annotation,
+      body: {
+        ...annotation.body,
+        source: {
+          ...source,
+          attachment: { ...source.attachment, ...patch },
+        },
+      },
+    };
+  });
+
+/**
+ * Rewrites every attachment reference a message carries — its own
+ * `custom_content.attachments`, the attachments of each execution stage, and
+ * the source document of each citation — from an old file id to its new
+ * uploaded location, and its `title` when the target carries a renamed one.
+ * References not present in `targetMap` are left untouched (immutable —
+ * returns a new conversation).
  */
 export const rewriteAttachmentUrls = (
   conversation: Conversation,
@@ -292,32 +379,30 @@ export const rewriteAttachmentUrls = (
 ): Conversation => ({
   ...conversation,
   messages: conversation.messages.map((message) => {
-    const attachments = message.custom_content?.attachments;
-    if (!attachments?.length) return message;
+    const customContent = message.custom_content;
+    if (!customContent) return message;
+
+    const { attachments, stages, annotations } = customContent;
+    if (!attachments?.length && !stages?.length && !annotations?.length) {
+      return message;
+    }
 
     return {
       ...message,
       custom_content: {
-        ...message.custom_content,
-        attachments: attachments.map((attachment) => {
-          const urlTarget = attachment.url
-            ? targetMap.get(attachment.url)
-            : undefined;
-          const referenceTarget = attachment.reference_url
-            ? targetMap.get(attachment.reference_url)
-            : undefined;
-          if (urlTarget == null && referenceTarget == null) return attachment;
-
-          const newTitle = urlTarget?.title ?? referenceTarget?.title;
-          return {
-            ...attachment,
-            ...(urlTarget != null ? { url: urlTarget.url } : {}),
-            ...(referenceTarget != null
-              ? { reference_url: referenceTarget.url }
-              : {}),
-            ...(newTitle != null ? { title: newTitle } : {}),
-          };
-        }),
+        ...customContent,
+        ...(attachments?.length
+          ? {
+              attachments: attachments.map((attachment) => {
+                const patch = buildAttachmentPatch(attachment, targetMap);
+                return patch ? { ...attachment, ...patch } : attachment;
+              }),
+            }
+          : {}),
+        ...(stages?.length ? { stages: rewriteStages(stages, targetMap) } : {}),
+        ...(annotations?.length
+          ? { annotations: rewriteAnnotations(annotations, targetMap) }
+          : {}),
       },
     };
   }),

--- a/libs/chat-hooks/src/conversation/conversation-transfer/tests/attachment-refs.spec.ts
+++ b/libs/chat-hooks/src/conversation/conversation-transfer/tests/attachment-refs.spec.ts
@@ -1,0 +1,165 @@
+import type { Conversation, Message } from '@epam/ai-dial-chat-shared';
+import { describe, expect, it } from 'vitest';
+import { collectAttachmentRefs, splitFileIdAnchor } from '../attachment-refs';
+
+const makeConversation = (messages: Message[]): Conversation => ({
+  id: 'bucket-a/gpt-4o__My Chat',
+  folderId: 'bucket-a',
+  name: 'My Chat',
+  model: { id: 'gpt-4o' },
+  prompt: '',
+  temperature: 0.5,
+  messages,
+  lastActivityDate: 1000,
+  updatedAt: 2000,
+  selectedAddons: [],
+  assistantModelId: 'gpt-4o',
+});
+
+const makeMessage = (customContent: Message['custom_content']): Message =>
+  ({
+    role: 'assistant',
+    content: '',
+    timestamp: '2026-07-10T00:00:00.000Z',
+    custom_content: customContent,
+  }) as Message;
+
+describe('splitFileIdAnchor', () => {
+  it('separates a trailing anchor from the file id', () => {
+    expect(splitFileIdAnchor('files/b/doc.pdf#page=3')).toEqual({
+      fileId: 'files/b/doc.pdf',
+      anchor: '#page=3',
+    });
+  });
+
+  it('reports an empty anchor when there is none', () => {
+    expect(splitFileIdAnchor('files/b/doc.pdf')).toEqual({
+      fileId: 'files/b/doc.pdf',
+      anchor: '',
+    });
+  });
+});
+
+describe('collectAttachmentRefs', () => {
+  it('collects message attachments', () => {
+    const conversation = makeConversation([
+      makeMessage({
+        attachments: [{ title: 'q1.pdf', url: 'files/b/reports/q1.pdf' }],
+      }),
+    ]);
+
+    expect(collectAttachmentRefs(conversation)).toEqual([
+      { fileId: 'files/b/reports/q1.pdf' },
+    ]);
+  });
+
+  it('collects files an agent produced inside an execution stage', () => {
+    const conversation = makeConversation([
+      makeMessage({
+        stages: [
+          {
+            index: 0,
+            name: 'Generate report',
+            status: null,
+            attachments: [
+              { title: 'chart.png', url: 'files/app-bucket/appdata/chart.png' },
+            ],
+          },
+        ],
+      }),
+    ]);
+
+    expect(collectAttachmentRefs(conversation)).toEqual([
+      { fileId: 'files/app-bucket/appdata/chart.png' },
+    ]);
+  });
+
+  it('collects the source document a citation points at, without its anchor', () => {
+    const conversation = makeConversation([
+      makeMessage({
+        annotations: [
+          {
+            body: {
+              source: {
+                type: 'attachment',
+                attachment: {
+                  type: 'application/pdf',
+                  url: 'files/b/sources/spec.pdf#page=7',
+                  title: 'spec.pdf',
+                },
+              },
+            },
+          },
+        ],
+      }),
+    ]);
+
+    expect(collectAttachmentRefs(conversation)).toEqual([
+      { fileId: 'files/b/sources/spec.pdf' },
+    ]);
+  });
+
+  it('collects both url and reference_url when they name different files', () => {
+    const conversation = makeConversation([
+      makeMessage({
+        attachments: [
+          {
+            title: 'q1.pdf',
+            url: 'files/b/reports/q1.pdf',
+            reference_url: 'files/b/sources/raw.csv',
+          },
+        ],
+      }),
+    ]);
+
+    expect(collectAttachmentRefs(conversation)).toEqual([
+      { fileId: 'files/b/reports/q1.pdf' },
+      { fileId: 'files/b/sources/raw.csv' },
+    ]);
+  });
+
+  it('dedupes a file referenced by a stage, a message, and a citation', () => {
+    const fileId = 'files/app-bucket/appdata/report.xlsx';
+    const conversation = makeConversation([
+      makeMessage({
+        attachments: [{ title: 'report.xlsx', url: fileId }],
+        stages: [
+          {
+            index: 0,
+            name: 'Build workbook',
+            status: null,
+            attachments: [{ title: 'report.xlsx', url: fileId }],
+          },
+        ],
+        annotations: [
+          {
+            body: {
+              source: {
+                type: 'attachment',
+                attachment: {
+                  type: 'application/vnd.ms-excel',
+                  url: `${fileId}#sheet=1`,
+                },
+              },
+            },
+          },
+        ],
+      }),
+    ]);
+
+    expect(collectAttachmentRefs(conversation)).toEqual([{ fileId }]);
+  });
+
+  it('ignores references that are not DIAL file ids', () => {
+    const conversation = makeConversation([
+      makeMessage({
+        attachments: [
+          { title: 'external', url: 'https://example.com/report.pdf' },
+          { title: 'inline', data: 'YmFzZTY0' },
+        ],
+      }),
+    ]);
+
+    expect(collectAttachmentRefs(conversation)).toEqual([]);
+  });
+});

--- a/libs/chat-hooks/src/conversation/conversation-transfer/tests/attachment-refs.spec.ts
+++ b/libs/chat-hooks/src/conversation/conversation-transfer/tests/attachment-refs.spec.ts
@@ -38,6 +38,13 @@ describe('splitFileIdAnchor', () => {
       anchor: '',
     });
   });
+
+  it('drops an anchor carrying characters no reader parses, keeping the file id', () => {
+    expect(splitFileIdAnchor('files/b/doc.pdf#"><script>')).toEqual({
+      fileId: 'files/b/doc.pdf',
+      anchor: '',
+    });
+  });
 });
 
 describe('collectAttachmentRefs', () => {

--- a/libs/chat-hooks/src/conversation/conversation-transfer/tests/import-conversation.spec.ts
+++ b/libs/chat-hooks/src/conversation/conversation-transfer/tests/import-conversation.spec.ts
@@ -497,6 +497,29 @@ describe('rewriteAttachmentUrls', () => {
     );
   });
 
+  it('does not carry an unparseable anchor onto the rewritten reference', () => {
+    const conversation = makeConversation({
+      messages: [
+        makeAttachmentMessage(
+          'files/old-bucket/reports/q1.pdf#"><script>',
+          'q1.pdf',
+        ),
+      ],
+    });
+    const targetMap = new Map([
+      [
+        'files/old-bucket/reports/q1.pdf',
+        { url: 'files/new-bucket/uploads/2026-07/q1.pdf' },
+      ],
+    ]);
+
+    const result = rewriteAttachmentUrls(conversation, targetMap);
+
+    expect(result.messages[0].custom_content?.attachments?.[0].url).toBe(
+      'files/new-bucket/uploads/2026-07/q1.pdf',
+    );
+  });
+
   it('leaves unmatched attachment references untouched', () => {
     const conversation = makeConversation({
       messages: [

--- a/libs/chat-hooks/src/conversation/conversation-transfer/tests/import-conversation.spec.ts
+++ b/libs/chat-hooks/src/conversation/conversation-transfer/tests/import-conversation.spec.ts
@@ -518,6 +518,92 @@ describe('rewriteAttachmentUrls', () => {
     );
   });
 
+  it('rewrites a file an agent produced inside an execution stage', () => {
+    const conversation = makeConversation({
+      messages: [
+        {
+          role: 'assistant' as Conversation['messages'][number]['role'],
+          content: '',
+          timestamp: '2026-07-10T00:00:00.000Z',
+          custom_content: {
+            stages: [
+              {
+                index: 0,
+                name: 'Generate report',
+                status: null,
+                attachments: [
+                  {
+                    title: 'chart.png',
+                    url: 'files/app-bucket/appdata/chart.png',
+                  },
+                ],
+              },
+            ],
+          },
+        },
+      ],
+    });
+    const targetMap = new Map([
+      [
+        'files/app-bucket/appdata/chart.png',
+        { url: 'files/new-bucket/uploads/2026-07/chart.png' },
+      ],
+    ]);
+
+    const result = rewriteAttachmentUrls(conversation, targetMap);
+
+    expect(
+      result.messages[0].custom_content?.stages?.[0].attachments?.[0].url,
+    ).toBe('files/new-bucket/uploads/2026-07/chart.png');
+  });
+
+  it("rewrites a citation's source document and keeps its page anchor", () => {
+    const conversation = makeConversation({
+      messages: [
+        {
+          role: 'assistant' as Conversation['messages'][number]['role'],
+          content: '',
+          timestamp: '2026-07-10T00:00:00.000Z',
+          custom_content: {
+            annotations: [
+              {
+                body: {
+                  source: {
+                    type: 'attachment' as const,
+                    attachment: {
+                      type: 'application/pdf',
+                      url: 'files/old-bucket/sources/spec.pdf#page=7',
+                      title: 'spec.pdf',
+                    },
+                  },
+                },
+              },
+            ],
+          },
+        },
+      ],
+    });
+    const targetMap = new Map([
+      [
+        'files/old-bucket/sources/spec.pdf',
+        {
+          url: 'files/new-bucket/uploads/2026-07/spec (1).pdf',
+          title: 'spec (1).pdf',
+        },
+      ],
+    ]);
+
+    const result = rewriteAttachmentUrls(conversation, targetMap);
+
+    expect(
+      result.messages[0].custom_content?.annotations?.[0].body?.source
+        ?.attachment,
+    ).toMatchObject({
+      url: 'files/new-bucket/uploads/2026-07/spec (1).pdf#page=7',
+      title: 'spec (1).pdf',
+    });
+  });
+
   it('leaves messages without attachments untouched', () => {
     const conversation = makeConversation({
       messages: [
@@ -632,6 +718,46 @@ describe('planAttachmentUploads', () => {
 
     expect(skippedNames).toEqual(['missing.pdf']);
     expect(plan.map((item) => item.allocated.fileName)).toEqual(['q1.pdf']);
+  });
+
+  it('plans an upload for a file referenced only from an execution stage', () => {
+    const conversation = makeConversation({
+      messages: [
+        {
+          role: 'assistant' as Conversation['messages'][number]['role'],
+          content: '',
+          timestamp: '2026-07-10T00:00:00.000Z',
+          custom_content: {
+            stages: [
+              {
+                index: 0,
+                name: 'Generate report',
+                status: null,
+                attachments: [
+                  {
+                    title: 'chart.png',
+                    url: 'files/app-bucket/appdata/chart.png',
+                  },
+                ],
+              },
+            ],
+          },
+        },
+      ],
+    });
+    const attachmentBytes = new Map([
+      ['appdata/chart.png', new Uint8Array([1])],
+    ]);
+    const allocator = createUploadPathAllocator({ date });
+
+    const { plan, skippedNames } = planAttachmentUploads(
+      conversation,
+      attachmentBytes,
+      allocator,
+    );
+
+    expect(skippedNames).toEqual([]);
+    expect(plan.map((item) => item.allocated.fileName)).toEqual(['chart.png']);
   });
 
   it('suffixes a name already present in a pre-filled allocator', () => {

--- a/libs/chat-hooks/src/conversation/message-utils.ts
+++ b/libs/chat-hooks/src/conversation/message-utils.ts
@@ -22,17 +22,29 @@ export const isMessageStreaming = (
   message.role === MessageRole.Assistant;
 
 /**
- * Returns the `new_deployment_id` from the last `model_changed` status message
- * in the list, or `null` if none exists.
+ * Returns the deployment the conversation was last running on: scanning
+ * backwards, the `new_deployment_id` of a `model_changed` status message or
+ * the `deploymentId` a message carries in its own right, whichever comes
+ * later. `null` when neither is present.
+ *
+ * Reading only the status messages loses the switch whenever a regenerate or
+ * an edit truncates past one: the marker is appended at the end of the
+ * timeline, so truncating at an earlier message drops it, and the model the
+ * user picked reverted on the next page load even though the answer had been
+ * regenerated on it (issue #8712). The assistant message the backend writes
+ * carries the deployment that produced it, which survives that truncation
+ * because it *is* the regenerated message.
  */
 export const getLastDeploymentId = (messages: Message[]): string | null => {
   for (let i = messages.length - 1; i >= 0; i--) {
     const msg = messages[i];
-    if (isStatusMessage(msg)) {
-      if (msg.custom_content?.event_type === StatusEvent.ModelChanged) {
-        return msg.custom_content.new_deployment_id;
-      }
+    if (
+      isStatusMessage(msg) &&
+      msg.custom_content?.event_type === StatusEvent.ModelChanged
+    ) {
+      return msg.custom_content.new_deployment_id;
     }
+    if (msg.deploymentId) return msg.deploymentId;
   }
   return null;
 };

--- a/libs/chat-hooks/src/conversation/tests/message-utils.spec.ts
+++ b/libs/chat-hooks/src/conversation/tests/message-utils.spec.ts
@@ -24,10 +24,11 @@ const userMessage = (content = 'hello'): Message => ({
   timestamp: '2024-01-01T00:00:00.000Z',
 });
 
-const assistantMessage = (content = 'hi'): Message => ({
+const assistantMessage = (content = 'hi', deploymentId?: string): Message => ({
   role: MessageRole.Assistant,
   content,
   timestamp: '2024-01-01T00:00:00.000Z',
+  ...(deploymentId != null ? { deploymentId } : {}),
 });
 
 const statusModelChanged = (newId: string): Message =>
@@ -79,8 +80,47 @@ describe('getLastDeploymentId', () => {
     expect(getLastDeploymentId([])).toBeNull();
   });
 
-  it('returns null when there are no model_changed status messages', () => {
+  it('returns null when no message records a deployment', () => {
     expect(getLastDeploymentId([userMessage(), assistantMessage()])).toBeNull();
+  });
+
+  it("returns an assistant message's own deploymentId", () => {
+    expect(
+      getLastDeploymentId([userMessage(), assistantMessage('hi', 'model-a')]),
+    ).toBe('model-a');
+  });
+
+  it('prefers a later assistant deploymentId over an earlier model_changed event', () => {
+    /*
+     * The regenerate-after-switch timeline once the truncation dropped the
+     * status marker that used to sit at the end (issue #8712): the regenerated
+     * answer is the only record of the model the user picked.
+     */
+    const messages: Message[] = [
+      userMessage(),
+      statusModelChanged('model-a'),
+      userMessage(),
+      assistantMessage('hi', 'model-b'),
+    ];
+    expect(getLastDeploymentId(messages)).toBe('model-b');
+  });
+
+  it('prefers a later model_changed event over an earlier assistant deploymentId', () => {
+    const messages: Message[] = [
+      userMessage(),
+      assistantMessage('hi', 'model-a'),
+      statusModelChanged('model-b'),
+    ];
+    expect(getLastDeploymentId(messages)).toBe('model-b');
+  });
+
+  it('skips messages that carry no deployment on the way back', () => {
+    const messages: Message[] = [
+      userMessage(),
+      assistantMessage('hi', 'model-a'),
+      userMessage(),
+    ];
+    expect(getLastDeploymentId(messages)).toBe('model-a');
   });
 
   it('returns the deployment id from the last model_changed event', () => {

--- a/libs/chat-hooks/src/conversation/useConversationExport/tests/useConversationExport.spec.ts
+++ b/libs/chat-hooks/src/conversation/useConversationExport/tests/useConversationExport.spec.ts
@@ -226,6 +226,63 @@ describe('useConversationExport', () => {
     expect(onWarning).not.toHaveBeenCalled();
   });
 
+  it('fetches the files an agent produced inside a stage and a citation cites', async () => {
+    const { result } = renderExport();
+    getConversation.mockResolvedValue(
+      makeConversation({
+        messages: [
+          {
+            role: 'assistant' as Conversation['messages'][number]['role'],
+            content: '',
+            timestamp: '2026-07-10T00:00:00.000Z',
+            custom_content: {
+              stages: [
+                {
+                  index: 0,
+                  name: 'Generate report',
+                  status: null,
+                  attachments: [
+                    { title: 'chart.png', url: 'files/app-bucket/chart.png' },
+                  ],
+                },
+              ],
+              annotations: [
+                {
+                  body: {
+                    source: {
+                      type: 'attachment' as const,
+                      attachment: {
+                        type: 'application/pdf',
+                        url: 'files/bucket-a/spec.pdf#page=7',
+                      },
+                    },
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      }),
+    );
+    downloadFileRaw.mockResolvedValue({
+      raw: { arrayBuffer: async () => new TextEncoder().encode('bin').buffer },
+    });
+
+    await act(() =>
+      result.current.exportSingle(
+        'bucket-a/gpt-4o__My Chat',
+        'My Chat',
+        ConversationExportMode.WithAttachments,
+      ),
+    );
+
+    expect(downloadFileRaw.mock.calls.map((call) => call[0])).toEqual([
+      { bucket: 'app-bucket', path: 'chart.png' },
+      { bucket: 'bucket-a', path: 'spec.pdf' },
+    ]);
+    expect(onWarning).not.toHaveBeenCalled();
+  });
+
   it('settles at Warning, still delivering the archive, when an attachment cannot be downloaded', async () => {
     const { result } = renderExport();
     getConversation.mockResolvedValue(

--- a/libs/chat-hooks/src/conversation/useConversationHandlers/starter-option.ts
+++ b/libs/chat-hooks/src/conversation/useConversationHandlers/starter-option.ts
@@ -23,6 +23,10 @@ export const getStarterConversationText = (
 /**
  * Returns submitted text for DIAL starter/form buttons.
  * For submit buttons, `populateText: null` explicitly means "submit no text".
+ * `description` (the schema property's shared intro/question text) is used only
+ * as a fallback when the starter carries no text of its own — it must never
+ * override a starter's own configured prompt, or every button in a group would
+ * submit the same message.
  */
 export const getStarterSubmitText = (
   starter: StarterOption,
@@ -34,5 +38,15 @@ export const getStarterSubmitText = (
     return '';
   }
 
-  return description ?? getStarterPopulateText(starter);
+  return getStarterConversationText(starter, description);
 };
+
+/**
+ * Returns the text shown in the user's message bubble for a selected
+ * starter/form button. Falls back to the button label for submit buttons that
+ * send no text of their own.
+ */
+export const getStarterDisplayText = (
+  starter: StarterOption,
+  description?: string,
+): string => getStarterSubmitText(starter, description) || starter.title;

--- a/libs/chat-hooks/src/conversation/useConversationHandlers/tests/starter-option.spec.ts
+++ b/libs/chat-hooks/src/conversation/useConversationHandlers/tests/starter-option.spec.ts
@@ -2,6 +2,7 @@ import type { StarterOption } from '@epam/ai-dial-chat-shared';
 import { describe, expect, it } from 'vitest';
 import {
   getStarterConversationText,
+  getStarterDisplayText,
   getStarterSubmitText,
 } from '../starter-option';
 
@@ -27,6 +28,48 @@ describe('getStarterSubmitText', () => {
     expect(getStarterSubmitText(createStarter('Scan this image'))).toBe(
       'Scan this image',
     );
+  });
+
+  it("prefers the starter's own populateText over the group description", () => {
+    expect(
+      getStarterSubmitText(createStarter('Scan this image'), 'Follow-Up'),
+    ).toBe('Scan this image');
+  });
+
+  it('submits distinct text for each button of a described group', () => {
+    const description = 'Follow-Up Questions';
+    const first = { ...createStarter('How does feature X work?'), const: 0 };
+    const second = { ...createStarter('How is feature Y priced?'), const: 1 };
+
+    expect(getStarterSubmitText(first, description)).toBe(
+      'How does feature X work?',
+    );
+    expect(getStarterSubmitText(second, description)).toBe(
+      'How is feature Y priced?',
+    );
+  });
+
+  it('falls back to the description for non-submit buttons without populateText', () => {
+    expect(
+      getStarterSubmitText(createStarter(null, false), 'Pick a number'),
+    ).toBe('Pick a number');
+  });
+});
+
+describe('getStarterDisplayText', () => {
+  it("shows the starter's own populateText rather than the group description", () => {
+    expect(
+      getStarterDisplayText(
+        createStarter('How does feature X work?'),
+        'Follow-Up Questions',
+      ),
+    ).toBe('How does feature X work?');
+  });
+
+  it('falls back to the button label when the starter submits no text', () => {
+    expect(
+      getStarterDisplayText(createStarter(null), 'Follow-Up Questions'),
+    ).toBe('Pick a number');
   });
 });
 

--- a/libs/chat-hooks/src/conversation/useConversationHandlers/tests/useConversationHandlers.spec.ts
+++ b/libs/chat-hooks/src/conversation/useConversationHandlers/tests/useConversationHandlers.spec.ts
@@ -415,6 +415,41 @@ describe('useConversationHandlers', () => {
       act(() => result.current.handlers.handleConfirmStarter());
       expect(result.current.startStream).toHaveBeenCalledOnce();
     });
+
+    it("submits the clicked starter's populateText, not the group description", () => {
+      const followUp = {
+        const: 0,
+        title: 'How does feature X work?',
+        'dial:widgetOptions': {
+          populateText:
+            'How does feature X work, and what are its configuration options?',
+          submit: true,
+          confirmationMessage: null,
+        },
+      } as StarterOption;
+      const { result } = renderHook(() => useHarness());
+
+      act(() =>
+        result.current.handlers.handleButtonSelect(
+          followUp,
+          'button',
+          'Follow-Up Questions',
+        ),
+      );
+
+      expect(result.current.startStream).toHaveBeenCalledWith(
+        'bucket/gpt-4o__Hello',
+        'How does feature X work, and what are its configuration options?',
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+      );
+      expect(result.current.conversation?.messages[0].content).toBe(
+        'How does feature X work, and what are its configuration options?',
+      );
+    });
   });
 
   describe('handleUploadAttachment', () => {

--- a/libs/chat-hooks/src/conversation/useConversationHandlers/useConversationHandlers.ts
+++ b/libs/chat-hooks/src/conversation/useConversationHandlers/useConversationHandlers.ts
@@ -27,7 +27,7 @@ import {
   hasActiveToolConfig,
   shouldRerunGenerationOnEdit,
 } from './message-utils';
-import { getStarterSubmitText } from './starter-option';
+import { getStarterDisplayText, getStarterSubmitText } from './starter-option';
 
 /** The exact `startStream` shape `useConversationStream` returns. */
 export type ConversationStreamStarter = (
@@ -414,7 +414,7 @@ export const useConversationHandlers = ({
     (starter: StarterOption, propertyKey?: string, description?: string) => {
       if (!conversationId || !conversation) return;
 
-      const displayText = description ?? starter.title;
+      const displayText = getStarterDisplayText(starter, description);
       const submitText = getStarterSubmitText(starter, description);
       const configurationValue = propertyKey
         ? { [propertyKey]: starter.const }

--- a/libs/chat-hooks/src/entry-points/conversation.ts
+++ b/libs/chat-hooks/src/entry-points/conversation.ts
@@ -34,6 +34,7 @@ export {
 } from '../conversation/useConversationHandlers/message-utils';
 export {
   getStarterConversationText,
+  getStarterDisplayText,
   getStarterSubmitText,
 } from '../conversation/useConversationHandlers/starter-option';
 export * from '../conversation/useConversationHandlers/useConversationHandlers';

--- a/libs/chat-hooks/src/index.ts
+++ b/libs/chat-hooks/src/index.ts
@@ -92,6 +92,7 @@ export {
 } from './conversation/useConversationHandlers/message-utils';
 export {
   getStarterConversationText,
+  getStarterDisplayText,
   getStarterSubmitText,
 } from './conversation/useConversationHandlers/starter-option';
 export * from './conversation/useConversationHandlers/useConversationHandlers';

--- a/libs/conversation-panel/src/components/ImportExportQueue/tests/ImportExportQueue.spec.tsx
+++ b/libs/conversation-panel/src/components/ImportExportQueue/tests/ImportExportQueue.spec.tsx
@@ -322,6 +322,21 @@ describe('ImportExportQueue', () => {
         screen.getByRole('img', { name: 'Exporting export.dial' }),
       ).toBeTruthy();
     });
+
+    /*
+     * A class assertion because the defect it guards is a hit-testing one, and
+     * jsdom does not hit-test: the faded spinner's own stacking context paints
+     * it over the button they share a grid cell with, so without this class the
+     * pointer never reaches cancel at all (issue #8665).
+     */
+    it('is not covered by the spinner it shares a cell with', () => {
+      renderQueue({ jobs: [makeJob({ fileName: 'export.dial' })] });
+
+      /* The queue root is the first live region; the row's spinner is the second. */
+      const [, spinner] = screen.getAllByRole('status');
+
+      expect(spinner.className).toContain('pointer-events-none');
+    });
   });
 
   describe('header', () => {

--- a/libs/conversation-panel/src/components/ImportExportQueueRow/ImportExportQueueRow.tsx
+++ b/libs/conversation-panel/src/components/ImportExportQueueRow/ImportExportQueueRow.tsx
@@ -67,22 +67,7 @@ export const ImportExportQueueRow: FC<ImportExportQueueRowProps> = ({
         contentClassName="!z-[80]"
       />
       {job.status === ConversationTransferJobStatus.InProgress && (
-        /*
-         * The spinner and the cancel control share one grid cell so revealing
-         * one and hiding the other shifts nothing. The button stays mounted and
-         * focusable at all times — hiding it until hover would put cancel out
-         * of reach of a keyboard.
-         */
         <div className={mergeClasses(STATUS_SLOT_CLASS, 'grid')}>
-          {/*
-           * `pointer-events-none` is what makes cancel clickable at all, not a
-           * tidying touch. Faded out, the spinner's opacity below 1 gives it a
-           * stacking context, and an unpositioned element that forms one paints
-           * in the same layer as positioned content — above the plain in-flow
-           * button it shares the cell with, whatever the DOM order. The
-           * transparent spinner then swallowed every hover and click aimed at
-           * the X, so the control looked live and did nothing (issue #8665).
-           */}
           <Spinner
             size={DIAL_ICON_SIZE.SM}
             ariaLabel={labels.jobProgressAriaLabel(job.fileName)}

--- a/libs/conversation-panel/src/components/ImportExportQueueRow/ImportExportQueueRow.tsx
+++ b/libs/conversation-panel/src/components/ImportExportQueueRow/ImportExportQueueRow.tsx
@@ -74,10 +74,19 @@ export const ImportExportQueueRow: FC<ImportExportQueueRowProps> = ({
          * of reach of a keyboard.
          */
         <div className={mergeClasses(STATUS_SLOT_CLASS, 'grid')}>
+          {/*
+           * `pointer-events-none` is what makes cancel clickable at all, not a
+           * tidying touch. Faded out, the spinner's opacity below 1 gives it a
+           * stacking context, and an unpositioned element that forms one paints
+           * in the same layer as positioned content — above the plain in-flow
+           * button it shares the cell with, whatever the DOM order. The
+           * transparent spinner then swallowed every hover and click aimed at
+           * the X, so the control looked live and did nothing (issue #8665).
+           */}
           <Spinner
             size={DIAL_ICON_SIZE.SM}
             ariaLabel={labels.jobProgressAriaLabel(job.fileName)}
-            className="col-start-1 row-start-1 opacity-100 transition-opacity group-focus-within:opacity-0 group-hover:opacity-0"
+            className="pointer-events-none col-start-1 row-start-1 opacity-100 transition-opacity group-focus-within:opacity-0 group-hover:opacity-0"
           />
           <GhostIconButton
             aria-label={labels.cancelJobAriaLabel(job.fileName)}

--- a/openspec/specs/canvas/spec.md
+++ b/openspec/specs/canvas/spec.md
@@ -65,7 +65,7 @@ All app-level strings are in `AttachmentCanvasI18nKeys` (`apps/chat/src/constant
 | `UnsupportedLabel` | `"Preview is not supported for this file"` |
 | `LoadErrorLabel` | `"Failed to load file"` |
 | `ForbiddenErrorLabel` | `"You don't have permission to access this file"` |
-| `CopyAsMarkdown` | `"Copy markdown"` |
+| `CopyAsMarkdown` | `"Copy as Markdown"` |
 | `Copied` | `"Copied!"` |
 | `HtmlFrameBlocked` | `"This page cannot be displayed in preview"` |
 | `HtmlOpenInNewTab` | `"Open in new tab"` |
@@ -205,7 +205,7 @@ Precedence (via `resolveAttachmentText`): inline base64 `attachment.data` (decod
 - Code blocks use the app's current theme (`codeBlockTheme` prop on `AttachmentCanvasContainer` → forwarded to `MarkdownRenderer`).
 - `MarkdownRenderer` uses logical Tailwind classes (`ps/pe`, `ms/me`, `border-s/e`) internally; no extra RTL handling needed at the canvas layer.
 
-#### Copy markdown button
+#### Copy as Markdown button
 
 - An `IconMarkdown` button is shown to the **left** of the download button in `rightActions` when `content.type === Markdown`.
 - After a successful click the icon switches to `IconCheck` for 2 s, then reverts. The toggle state is managed inside `AttachmentCanvas` (same pattern as `MessageActions`).

--- a/openspec/specs/catalog-model-selector/spec.md
+++ b/openspec/specs/catalog-model-selector/spec.md
@@ -188,3 +188,28 @@ This filter SHALL be memoised on the favorites list, and the search query SHALL 
 
 - **WHEN** the user types a query that would also match a favorited toolset
 - **THEN** the toolset is still absent, because filtering by type happens before the query is applied
+
+---
+
+### Requirement: The version label gets the row width the name leaves
+
+A selector row renders the entity name followed by its version label. Because favorited agents routinely repeat a name (`DIAL ChatHub`, `DIAL ChatHub v2`), the version is often the only part of the row that tells two entries apart, so it SHALL NOT be capped at a fixed fraction of the row width.
+
+`DeploymentSelectorPanel.tsx` SHALL lay the pair out in a wrapping flex line: the name keeps its natural width and truncates with its overflow tooltip when it alone exceeds the row, and the version takes the width the name leaves. When the pair no longer fits on one line, the version SHALL move onto a line of its own at full width rather than truncate — the row grows, and nothing is hidden behind a hover.
+
+The version SHALL therefore carry no `max-w-*` cap and no `truncate`. This is a deliberate departure from the shared `ItemHeader`/`AppIdentity` 30% rule, which stands for cards and headers where row height is fixed; a selector row is `h-auto` and can spend a second line.
+
+#### Scenario: A version that fits is shown in full
+
+- **WHEN** a row's name and version together fit the row width
+- **THEN** both render on one line in full, with no ellipsis on the version, whatever fraction of the row the version occupies
+
+#### Scenario: A version that does not fit wraps instead of truncating
+
+- **WHEN** a row's name and version together exceed the row width
+- **THEN** the version wraps onto its own line and stays fully readable without hovering, which is the only behaviour available on a touch device
+
+#### Scenario: An empty version renders no element
+
+- **WHEN** an item's `version` is an empty string
+- **THEN** no version element is rendered, and the row is the name alone

--- a/openspec/specs/chat-hooks-conversation-handlers/spec.md
+++ b/openspec/specs/chat-hooks-conversation-handlers/spec.md
@@ -74,6 +74,28 @@ under the current `conversationId`'s path.
 - **THEN** the starter is held as `pendingStarterContext` instead of being
   submitted immediately, until `handleConfirmStarter` is called
 
+### Requirement: Starter text comes from the clicked button, not the group
+`getStarterSubmitText` and `getStarterDisplayText` SHALL resolve a starter's
+own `dial:widgetOptions.populateText` in preference to the `description`
+passed alongside it. `description` is the schema property's shared
+intro/question text and is constant for every button in a group, so it SHALL
+be used only as a fallback for a starter that carries no text of its own.
+`getStarterSubmitText` SHALL keep returning `''` for a submit button whose
+`populateText` is explicitly `null`; `getStarterDisplayText` SHALL fall back
+to `starter.title` in that case. `submitStarter` SHALL derive the optimistic
+user message's content from `getStarterDisplayText`.
+
+#### Scenario: Each button of a described group submits its own text
+- **WHEN** `handleButtonSelect(starter, 'button', 'Follow-Up Questions')` is
+  called for two starters with different `populateText` values
+- **THEN** each call streams that starter's own `populateText`, and neither
+  streams `'Follow-Up Questions'`
+
+#### Scenario: Description still fills in for a starter with no text
+- **WHEN** a non-submit starter has `populateText: null` and a `description`
+  is supplied
+- **THEN** `getStarterSubmitText` returns the `description`
+
 ### Requirement: Injected model resolution and navigation outcome
 The hook SHALL accept a `resolveModelId` function in place of reading
 `DeploymentsContext`/a fixed-model override directly, and an

--- a/openspec/specs/conversation-deployment-selection/spec.md
+++ b/openspec/specs/conversation-deployment-selection/spec.md
@@ -326,3 +326,38 @@ This SHALL NOT change the existing requirement that `handleCreateConversation`/`
 
 - **WHEN** `ConversationRoute` mounts with no router-state `deploymentId` and `overlay.pendingModelId` is set (awaiting the overlay-pending-model effect in `app.tsx`)
 - **THEN** `restoreDefaultSelection()` is NOT called from `ConversationRoute`'s mount effect
+
+---
+
+### Requirement: Loading a conversation restores the deployment it was last running on
+
+`apps/chat/src/pages/Conversation/Conversation.tsx`'s `loadConversation` SHALL restore the model selector from `getLastDeploymentId(result.messages)` (`libs/chat-hooks/src/conversation/message-utils.ts`), falling back to `result.assistantModelId || result.model.id` only when that returns `null`.
+
+`getLastDeploymentId` SHALL scan the messages backwards and return the first of:
+
+1. a `model_changed` status message's `new_deployment_id`, or
+2. a message's own `deploymentId` (the backend stamps it on every assistant placeholder it creates, see `makeAssistantPlaceholder` in `apps/chat-api/src/conversations/utils/conversation-history-builder.ts`),
+
+whichever appears later in the timeline, and `null` when the conversation records neither.
+
+Both sources are required. The `model_changed` marker is appended at the **end** of the timeline when the user switches models, so a `regenerate` or an `edit` that truncates at an earlier message drops it — and `conversation.model.id` / `assistantModelId` are written once at creation and never updated, so the fallback then reports the conversation's *original* model. Reading only the markers therefore reverted the selector to the pre-switch model after a regenerate and a page refresh, even though the answer on screen had been produced by the newly picked one (issue #8712). The regenerated assistant message's own `deploymentId` survives that truncation because it *is* the regenerated message.
+
+`conversation.model.id` and `assistantModelId` keep their existing meaning — the deployment the conversation *started* on — and remain the seed for per-message icon attribution (`initialModelId`, see `conversation-history-panel`). Neither is rewritten by a completion.
+
+#### Scenario: Regenerating on a newly picked model survives a refresh
+
+- **GIVEN** a conversation created on model A with one answered turn
+- **WHEN** the user switches the selector to model B and regenerates the assistant message, then reloads the page
+- **THEN** the stored history is `[user, assistant(deploymentId: B)]` — the `model_changed` marker having been truncated away — and the selector is restored to B
+
+#### Scenario: A model switch with no message after it is still restored
+
+- **GIVEN** a conversation whose last message is a `model_changed` marker recording a switch to B
+- **WHEN** the conversation is loaded
+- **THEN** the selector is restored to B
+
+#### Scenario: A conversation that records no deployment falls back to its creation model
+
+- **GIVEN** a conversation whose messages carry neither a `model_changed` marker nor any `deploymentId`
+- **WHEN** the conversation is loaded
+- **THEN** the selector is restored to `assistantModelId || model.id`

--- a/openspec/specs/conversation-export/spec.md
+++ b/openspec/specs/conversation-export/spec.md
@@ -57,7 +57,7 @@ The system SHALL let a user export one conversation, without attachments, from t
 
 ### Requirement: Export a single conversation with attachments as a `.dial` ZIP
 
-The system SHALL let a user export one conversation, with attachments, producing a `.dial` ZIP archive (built with `fflate`) that contains the conversation's JSON v5 envelope plus every referenced attachment file. Each attachment SHALL be fetched through the existing file-download BFF endpoint (`GET /api/v1/files/download`), and placed inside the archive under a `res/<relative-path>/<filename>` layout. Attachment fetches SHALL run with a bounded parallelism of at most 5 concurrent requests. This path SHALL create a queue job (see the export-queue requirement) because it is a potentially long operation; the app remains fully usable while it runs. The downloaded file SHALL be named per the file-naming requirement.
+The system SHALL let a user export one conversation, with attachments, producing a `.dial` ZIP archive (built with `fflate`) that contains the conversation's JSON v5 envelope plus every referenced attachment file. The set of referenced files SHALL be collected from every place a message can carry one — `custom_content.attachments`, the attachments of each entry in `custom_content.stages` (how an agent returns a generated file), and the `body.source.attachment` of each entry in `custom_content.annotations` (a citation source document) — reading both `url` and `reference_url`, mirroring the set the backend share flow grants access to. A trailing `#…` display anchor (e.g. a PDF `#page=N`) SHALL be stripped before a reference is resolved to `{bucket, path}`, since it is not part of the stored resource path. Each attachment SHALL be fetched through the existing file-download BFF endpoint (`GET /api/v1/files/download`), and placed inside the archive under a `res/<relative-path>/<filename>` layout. Attachment fetches SHALL run with a bounded parallelism of at most 5 concurrent requests. This path SHALL create a queue job (see the export-queue requirement) because it is a potentially long operation; the app remains fully usable while it runs. The downloaded file SHALL be named per the file-naming requirement.
 
 #### Scenario: ZIP export bundles conversation and attachments
 
@@ -70,6 +70,18 @@ The system SHALL let a user export one conversation, with attachments, producing
 - **GIVEN** a conversation referencing 12 attachments
 - **WHEN** the ZIP export runs
 - **THEN** no more than 5 attachment download requests are in flight at any moment
+
+#### Scenario: Stage and citation files are bundled too
+
+- **GIVEN** a conversation whose assistant turn produced a file inside an execution stage and cites a source document through an annotation
+- **WHEN** the ZIP export runs
+- **THEN** both files are fetched and written under `res/…` alongside the message-level attachments
+
+#### Scenario: A reference carrying a display anchor resolves to the file itself
+
+- **GIVEN** a citation referencing `files/{bucket}/sources/spec.pdf#page=7`
+- **WHEN** the ZIP export runs
+- **THEN** the download is requested for `sources/spec.pdf` (without `#page=7`) and the archive entry is `res/sources/spec.pdf`
 
 #### Scenario: A failed attachment is skipped with a warning
 

--- a/openspec/specs/conversation-import/spec.md
+++ b/openspec/specs/conversation-import/spec.md
@@ -106,7 +106,7 @@ Before uploading, the system SHALL list the destination month folder once per im
 
 ### Requirement: Rewrite attachment references to new upload locations
 
-After re-uploading an archive attachment, the system SHALL rewrite the corresponding reference (`url`, and `reference_url` where present) to the uploaded file's returned `files/{bucket}/{path}` URL, so the imported conversation points at the newly uploaded files. The rewrite SHALL cover every place a message can carry a reference — `custom_content.attachments[]`, `custom_content.stages[].attachments[]`, and `custom_content.annotations[].body.source.attachment` — matching the set the export bundles. A reference is matched to its upload by file id alone, with any trailing `#…` display anchor (e.g. a PDF `#page=N`) stripped for the lookup and re-appended to the rewritten URL, so an imported citation still opens the page it cited. When the upload was suffixed to resolve a name collision, the system SHALL also rewrite the attachment's `title` to the suffixed file name, so the displayed name matches the file actually stored; an attachment uploaded under its original name SHALL keep its original `title` unchanged.
+After re-uploading an archive attachment, the system SHALL rewrite the corresponding reference (`url`, and `reference_url` where present) to the uploaded file's returned `files/{bucket}/{path}` URL, so the imported conversation points at the newly uploaded files. The rewrite SHALL cover every place a message can carry a reference — `custom_content.attachments[]`, `custom_content.stages[].attachments[]`, and `custom_content.annotations[].body.source.attachment` — matching the set the export bundles. A reference is matched to its upload by file id alone, with any trailing `#…` display anchor (e.g. a PDF `#page=N`) stripped for the lookup and re-appended to the rewritten URL, so an imported citation still opens the page it cited. An anchor is re-appended only when it stays within `/^#[\w.=%-]*$/`; an archive is untrusted input and the anchor from one is persisted into the conversation record, while the only anchor any reader parses is `#page=<digits>` — so an anchor outside that shape SHALL be discarded, leaving the rewritten reference unanchored. The file id SHALL still resolve either way, so the attachment itself is transferred regardless of its anchor. When the upload was suffixed to resolve a name collision, the system SHALL also rewrite the attachment's `title` to the suffixed file name, so the displayed name matches the file actually stored; an attachment uploaded under its original name SHALL keep its original `title` unchanged.
 
 A reference left unrewritten still points into the exporting user's bucket, which the importing user usually cannot read — the preview and the download then both fail, and the browser saves the error response under the attachment's file name (issue #8708). Missing one of the three reference sites is therefore a correctness defect, not a cosmetic one.
 
@@ -119,6 +119,11 @@ A reference left unrewritten still points into the exporting user's bucket, whic
 
 - **WHEN** a citation referencing `files/{oldBucket}/sources/spec.pdf#page=7` is uploaded as `spec.pdf`
 - **THEN** the rewritten reference is `files/{userBucket}/uploads/<YYYY-MM>/spec.pdf#page=7`
+
+#### Scenario: An anchor no reader parses is not carried onto the rewritten reference
+
+- **WHEN** an archive attachment references `files/{oldBucket}/reports/q1.pdf#"><script>` and is uploaded as `q1.pdf`
+- **THEN** the attachment is still uploaded and its reference rewritten to `files/{userBucket}/uploads/<YYYY-MM>/q1.pdf`, with no anchor
 
 #### Scenario: Reference rewrite
 

--- a/openspec/specs/conversation-import/spec.md
+++ b/openspec/specs/conversation-import/spec.md
@@ -106,7 +106,19 @@ Before uploading, the system SHALL list the destination month folder once per im
 
 ### Requirement: Rewrite attachment references to new upload locations
 
-After re-uploading an archive attachment, the system SHALL rewrite the corresponding `message.custom_content.attachments[].url` (and `reference_url` where present) to the uploaded file's returned `files/{bucket}/{path}` URL, so the imported conversation points at the newly uploaded files. When the upload was suffixed to resolve a name collision, the system SHALL also rewrite the attachment's `title` to the suffixed file name, so the displayed name matches the file actually stored; an attachment uploaded under its original name SHALL keep its original `title` unchanged.
+After re-uploading an archive attachment, the system SHALL rewrite the corresponding reference (`url`, and `reference_url` where present) to the uploaded file's returned `files/{bucket}/{path}` URL, so the imported conversation points at the newly uploaded files. The rewrite SHALL cover every place a message can carry a reference — `custom_content.attachments[]`, `custom_content.stages[].attachments[]`, and `custom_content.annotations[].body.source.attachment` — matching the set the export bundles. A reference is matched to its upload by file id alone, with any trailing `#…` display anchor (e.g. a PDF `#page=N`) stripped for the lookup and re-appended to the rewritten URL, so an imported citation still opens the page it cited. When the upload was suffixed to resolve a name collision, the system SHALL also rewrite the attachment's `title` to the suffixed file name, so the displayed name matches the file actually stored; an attachment uploaded under its original name SHALL keep its original `title` unchanged.
+
+A reference left unrewritten still points into the exporting user's bucket, which the importing user usually cannot read — the preview and the download then both fail, and the browser saves the error response under the attachment's file name (issue #8708). Missing one of the three reference sites is therefore a correctness defect, not a cosmetic one.
+
+#### Scenario: Stage and citation references are rewritten too
+
+- **WHEN** a `.dial` archive conversation carries a file produced inside an execution stage and a citation source document
+- **THEN** both references are rewritten to their new upload locations, not only the message-level attachments
+
+#### Scenario: A rewritten reference keeps its display anchor
+
+- **WHEN** a citation referencing `files/{oldBucket}/sources/spec.pdf#page=7` is uploaded as `spec.pdf`
+- **THEN** the rewritten reference is `files/{userBucket}/uploads/<YYYY-MM>/spec.pdf#page=7`
 
 #### Scenario: Reference rewrite
 


### PR DESCRIPTION
## Description of changes

Six independent bug fixes.

### Quick-reply buttons sent the group label instead of the question (#8739)

Follow-up buttons come from a message's `custom_content.form_schema`.
`getMessageStarterProps` threads the clicked starter **plus** the schema
property's shared `description` — the group label, e.g. `"Follow-Up Questions"` —
into `submitStarter`. There, `getStarterSubmitText` ended with:

```ts
return description ?? getStarterPopulateText(starter);
```

`description` is constant for the whole group, so it won over every starter's own
`dial:widgetOptions.populateText` whenever the schema carried one. Every button
in the group submitted the same string, matching neither its `title` nor its
`populateText` — exactly the reported symptom. The optimistic user bubble had the
same defect via `displayText = description ?? starter.title`.

The sibling helper `getStarterConversationText` — added in #7959 to fix this same
class of bug on the *start-a-conversation* path — already had the correct
precedence. The in-conversation follow-up path was never updated.

- `getStarterSubmitText` now delegates to `getStarterConversationText`, so a
  starter's own `populateText` always wins and `description` is only a fallback
  for a starter carrying no text of its own. Its `submit && populateText == null
  → ''` rule ("submit no text") is unchanged.
- New `getStarterDisplayText` mirrors the submitted text, so the user's message
  bubble shows what actually gets persisted, falling back to `starter.title` for
  submit buttons that send nothing.
- Exported from `index.ts` and the `conversation` entry point; documented in
  `libs/chat-hooks/README.md`; requirement + two scenarios added to
  `openspec/specs/chat-hooks-conversation-handlers/spec.md`.

Tests (the issue carries `add-test-coverage`): precedence of `populateText` over
`description`, two buttons of one described group producing distinct messages,
the non-submit `description` fallback, both `getStarterDisplayText` paths, and a
hook-level test asserting `startStream` and the optimistic message both carry the
clicked button's `populateText`.

### "Copy markdown" tooltip wording (#8741)

`copyAsMarkdown` in `en.json` is now `"Copy as Markdown"`, consistent with the
neighbouring `Copy as CSV` / `Copy as TXT` actions. `openspec/specs/canvas/spec.md`
updated in step.

### Transfer-queue cancel control was not clickable (#8665)

The in-progress row's spinner and its cancel button share one grid cell. Faded
out, the spinner's `opacity < 1` gives it a stacking context, and an unpositioned
element that forms one paints in the same layer as positioned content — above the
plain in-flow button, whatever the DOM order. The transparent spinner swallowed
every hover and click aimed at the X, so the control looked live and did nothing.
`pointer-events-none` on the spinner is what makes cancel reachable at all.

### Generated files were empty/corrupt after chat export + import (#8708)

Export and import walked only `message.custom_content.attachments`, missing the
two places app-generated files actually land:

- `custom_content.stages[].attachments` — how an agent returns a file it produced
- `custom_content.annotations[].body.source.attachment` — a citation's source document

Those files were never written into the `.dial` archive and never re-uploaded on
import, so `rewriteAttachmentUrls` left their URLs pointing at the **exporting**
user's bucket. The importing user then got 403/404 on every one: the in-app
preview failed, and the download saved the JSON error body under the attachment's
file name — which is what looked like an empty or corrupt file (Office formats
being ZIP containers is why the report says "broken ZIP container").

The backend share flow already grants access to all three reference sites
(`collectConversationResourceUrls` in `apps/chat-api/src/share/share.service.ts`);
export and import now cover the same set. They also read both `url` **and**
`reference_url`, instead of only the first of the two as before.

Second defect, same symptom: a reference carrying a `#…` display anchor
(`files/{bucket}/spec.pdf#page=7` — this app emits those, see
`resolveDialUrl`/`resolveMarkdownUrl`) was resolved to `{bucket, path}` with the
anchor still attached, so the download 404'd and the attachment was silently
skipped. The anchor is now stripped before resolving and re-appended when the
reference is rewritten, so an imported citation still opens the page it cited.

The anchor is re-appended only when it stays within `/^#[w.=%-]*$/`. An archive
is untrusted input and its anchor ends up persisted in the conversation record,
while the only anchor any reader parses is `#page=<digits>` — so a fragment
outside that shape is discarded (the file id still resolves, so the attachment
itself transfers either way). Raised by the security-review pass on this PR.

No public API change — the collector and the rewriter are internal to
`libs/chat-hooks`. Requirements and scenarios added to
`openspec/specs/conversation-export/spec.md` and
`openspec/specs/conversation-import/spec.md`.

Tests: a new `attachment-refs.spec.ts` (stage refs, citation refs, anchor
stripping, `url` + `reference_url`, cross-site dedupe, non-DIAL refs ignored);
stage and citation rewrite cases — including anchor preservation — in
`import-conversation.spec.ts`; a stage-only upload plan; and an export-hook test
asserting both a stage file and a cited document are fetched with the anchor
stripped.

Known and deliberately out of scope: the *without-attachments* export strips
message and stage attachment refs but leaves citation `source.attachment` URLs in
place, so those still point at the exporter's bucket after import — the same
class of leak #8663 addressed. Stripping them means dropping a required `url`
field and would break citation rendering, so it needs its own decision.

### Model switch silently reverted after regenerating and refreshing (#8712)

`loadConversation` restores the model selector from
`getLastDeploymentId(messages) ?? (assistantModelId || model.id)`.
`getLastDeploymentId` read only `model_changed` status messages — and that marker
is appended at the **end** of the timeline when the user switches models, so a
`regenerate` truncating at an earlier message drops it. `conversation.model.id`
and `assistantModelId` are written once at creation and never updated by a
completion, so the fallback then reported the conversation's *original* model.
The selector reverted on the next refresh even though the answer on screen had
been produced by the newly picked model. Sending a new message kept working only
because appending leaves the marker in place — which is exactly the contrast the
report noted.

The deployment is already persisted correctly: the backend stamps every assistant
placeholder with `deploymentId` (`makeAssistantPlaceholder` in
`conversation-history-builder.ts`), `applyChunkToMessage` carries it through, and
it survives the truncation because it *is* the regenerated message. Only the
reader was incomplete. `getLastDeploymentId` now scans backwards and returns
whichever of the two records comes later — a `model_changed` marker's
`new_deployment_id`, or a message's own `deploymentId`.

Client-only, no stored-data or endpoint change. `conversation.model.id` /
`assistantModelId` keep meaning "the deployment the conversation started on" and
stay the seed for per-message icon attribution (`initialModelId`), so the
`conversation-history-panel` requirement that depends on them is untouched.
Requirement + three scenarios added to
`openspec/specs/conversation-deployment-selection/spec.md`; both README
descriptions of the helper updated.

Tests (the issue carries `add-test-coverage`): an assistant message's own
`deploymentId`, a later assistant `deploymentId` beating an earlier
`model_changed` marker (the regenerate-after-switch timeline), a later marker
beating an earlier `deploymentId` (switch with nothing sent after it), skipping
messages that carry no deployment, and the existing null/fallback cases.

Known and out of scope: the backend's `isModelChange = model !== conversation.model.id`
check in `buildConversationHistory` compares against that same never-updated
creation model, so after one switch every later regenerate clears stateful-app
`custom_content.state` whether or not the deployment actually changed. Separate
defect, no user-visible symptom in this report.

### Model selector truncated the version while the row had unused width (#8740)

The selector row rendered the name as `flex-initial` and capped the version at
`max-w-[30%] shrink-0` — the bound added for #8300. Since the name never grew
past its natural width, the version truncated at ~30% of the row with the
remaining third sitting empty: in a Favorites list where `DIAL ChatHub` repeats
on every row, two entries both read `Anthropic C…` and could not be told apart,
and `GPT-4o 20…` / `GPT-4.1 20…` were cut before the snapshot date that is the
only difference between them. The version is the entire basis for the choice
there, and reading it meant hovering each row in turn for the overflow tooltip —
which a touch device cannot open at all.

The label wrapper is now a wrapping flex line, and the version a plain span with
no `max-w-*` cap and no `truncate`:

- it takes whatever width the name leaves, so the realistic rows render in full
  on one line at unchanged row height;
- when the pair genuinely stops fitting, `flex-wrap` moves the version onto a
  full-width line of its own instead of splitting characters between the two,
  so nothing is hidden behind a hover;
- `whitespace-normal` on the wrapper is required — `MenuItem` puts `truncate` on
  the row and its `nowrap` would otherwise inherit down and defeat the wrap.

The name keeps its single-line ellipsis and overflow tooltip: it is the
repeating, less informative half, and its full value stays in the row's
accessible name either way.

The shared `ItemHeader` / `AppIdentity` 30% rule is deliberately untouched — it
stands for cards and headers whose row height is fixed, while a selector row is
already `h-auto` and can spend a second line. Requirement + three scenarios
added to `openspec/specs/catalog-model-selector/spec.md`.

Tests (the issue carries `add-test-coverage`): the two 30%-cap regression tests
are replaced by four — no width cap and no `truncate` on the version, the wrap
rule on the wrapper, the whole version present in the row's accessible name
(readable without hovering), and the existing empty-version case. The layout
itself was checked against a faithful static copy of the row's real class
cascade at the panel's 360px width, before and after.

## Applicable issues

- fixes #8739
- fixes #8741
- fixes #8665
- fixes #8708
- fixes #8712
- fixes #8740

## UI changes

One layout change: a model-selector row whose name and version no longer fit on
one line now wraps the version onto a second line instead of truncating it, so
such a row is taller. Rows that already fit are unchanged.

Other user-visible behaviour changes:

- the Markdown table action tooltip now reads **Copy as Markdown** (was "Copy markdown");
- clicking a follow-up button now sends and displays that button's own question
  instead of the group label;
- the cancel control on an in-progress export/import row now responds to hover and click;
- a conversation exported "with attachments" now carries the files an agent
  generated inside a stage and the documents its citations point at, and those
  files open normally after import;
- after regenerating on a newly picked model, the model selector still shows that
  model when the page is reloaded;
- the model selector shows each entry's full version label instead of cutting it
  at a third of the row, so same-named agents can be told apart without hovering.

## Checklist

- [x] the pull request name ends with `(Issue #<ISSUE_ID>)` (comma-separated list of issues)
- [x] I confirm that I don't share any confidential information like API keys or any other secrets and private URLs
